### PR TITLE
Implements functions from diag.c.

### DIFF
--- a/src/BRSRC13/CORE/FW/diag.h
+++ b/src/BRSRC13/CORE/FW/diag.h
@@ -2,21 +2,21 @@
 #include "br_types.h"
 // Offset: 10
 // Size: 118
-void BrFailure(char *s, ...);
+void BrFailure(const char *s, ...);
 
 // Offset: 138
 // Size: 118
-void BrWarning(char *s, ...);
+void BrWarning(const char *s, ...);
 
 // Offset: 264
 // Size: 132
-void BrFatal(char *name, int line, char *s, ...);
+void BrFatal(const char *name, int line, const char *s, ...);
 
 // Offset: 406
 // Size: 95
-void _BrAssert(char *condition, char *file, unsigned int line);
+void _BrAssert(const char *condition, const char *file, unsigned int line);
 
 // Offset: 512
 // Size: 95
-void _BrUAssert(char *condition, char *file, unsigned int line);
+void _BrUAssert(const char *condition, const char *file, unsigned int line);
 


### PR DESCRIPTION
Implements the diagnostic logging functions. The asserts appear to have been hidden behind macros, one enabled only for the building of BRender itself to invoke _BrAssert and one only enabled for building a project using the library invoking _BrUAssert.