### PR TITLE
Implement all functions related to lists + registries

### DIFF
--- a/src/BRSRC13/CORE/FW/brlists.c
+++ b/src/BRSRC13/CORE/FW/brlists.c
@@ -6,13 +6,16 @@
 
 // IDA: void __cdecl BrNewList(br_list *list)
 void BrNewList(br_list* list) {
+    LOG_TRACE10("(%p)", list);
+
+    list->head = (br_node*)&list->_null;
     list->_null = NULL;
     list->tail = (br_node*)list;
-    list->head = (br_node*)&list->_null;
 }
 
 // IDA: void __cdecl BrAddHead(br_list *list, br_node *node)
 void BrAddHead(br_list* list, br_node* node) {
+    LOG_TRACE10("(%p, %p)", list, node);
     assert(node != NULL);
     assert(list != NULL);
     assert(list->head != NULL);
@@ -26,33 +29,55 @@ void BrAddHead(br_list* list, br_node* node) {
 
 // IDA: void __cdecl BrAddTail(br_list *list, br_node *node)
 void BrAddTail(br_list* list, br_node* node) {
-    LOG_TRACE("(%p, %p)", list, node);
-    NOT_IMPLEMENTED();
+    LOG_TRACE10("(%p, %p)", list, node);
+
+    node->next = (br_node*)&list->_null;
+    node->prev = list->tail;
+    list->tail->next = node;
+    list->tail = node;
 }
 
 // IDA: br_node* __cdecl BrRemHead(br_list *list)
 br_node* BrRemHead(br_list* list) {
     br_node* n;
-    LOG_TRACE("(%p)", list);
-    NOT_IMPLEMENTED();
+    LOG_TRACE10("(%p)", list);
+
+    n = list->head;
+    if (n == (br_node*)&list->_null) {
+        return NULL;
+    }
+    list->head = n->next;
+    n->next->prev = (br_node*)&list->head;
+    return n;
 }
 
 // IDA: br_node* __cdecl BrRemTail(br_list *list)
 br_node* BrRemTail(br_list* list) {
     br_node* n;
-    LOG_TRACE("(%p)", list);
-    NOT_IMPLEMENTED();
+    LOG_TRACE10("(%p)", list);
+
+    n = list->tail;
+    if (n == (br_node*)&list->head) {
+        return NULL;
+    }
+    list->tail = n->prev;
+    n->prev->next = (br_node*)&list->_null;
+    return n;
 }
 
 // IDA: void __cdecl BrInsert(br_list *list, br_node *here, br_node *node)
 void BrInsert(br_list* list, br_node* here, br_node* node) {
-    LOG_TRACE("(%p, %p, %p)", list, here, node);
-    NOT_IMPLEMENTED();
+    LOG_TRACE10("(%p, %p, %p)", list, here, node);
+
+    node->prev = here;
+    node->next = here->next;
+    here->next->prev = node;
+    here->next = node;
 }
 
 // IDA: br_node* __cdecl BrRemove(br_node *node)
 br_node* BrRemove(br_node* node) {
-    LOG_TRACE("(%p)", node);
+    LOG_TRACE10("(%p)", node);
 
     node->next->prev = node->prev;
     node->prev->next = node->next;
@@ -67,10 +92,11 @@ void BrSimpleNewList(br_simple_list* list) {
 
 // IDA: void __cdecl BrSimpleAddHead(br_simple_list *list, br_simple_node *node)
 void BrSimpleAddHead(br_simple_list* list, br_simple_node* node) {
+    LOG_TRACE10("(%p, %p)", list, node);
     node->next = list->head;
-    node->prev = (br_simple_node**)list;
-    if (node->next) {
-        node->next->prev = (br_simple_node**)node;
+    node->prev = (br_simple_node**)&list->head;
+    if (list->head != NULL) {
+        list->head->prev = &node->next;
     }
     list->head = node;
 }
@@ -78,20 +104,38 @@ void BrSimpleAddHead(br_simple_list* list, br_simple_node* node) {
 // IDA: br_simple_node* __cdecl BrSimpleRemHead(br_simple_list *list)
 br_simple_node* BrSimpleRemHead(br_simple_list* list) {
     br_simple_node* node;
-    LOG_TRACE("(%p)", list);
-    NOT_IMPLEMENTED();
+    LOG_TRACE10("(%p)", list);
+
+    node = list->head;
+    if (node != NULL) {
+        *node->prev = node->next;
+        if (node->next != NULL) {
+            node->next->prev = node->prev;
+        }
+        node->prev = NULL;
+        node->next = NULL;
+    }
+    return node;
 }
 
 // IDA: void __cdecl BrSimpleInsert(br_simple_list *list, br_simple_node *here, br_simple_node *node)
 void BrSimpleInsert(br_simple_list* list, br_simple_node* here, br_simple_node* node) {
-    LOG_TRACE("(%p, %p, %p)", list, here, node);
-    NOT_IMPLEMENTED();
+    LOG_TRACE10("(%p, %p, %p)", list, here, node);
+
+    node->prev = &here->next;
+    node->next = here->next;
+    if (here->next != NULL) {
+        here->next->prev = &node->next;
+    }
+    here->next = node;
 }
 
 // IDA: br_simple_node* __cdecl BrSimpleRemove(br_simple_node *node)
 br_simple_node* BrSimpleRemove(br_simple_node* node) {
+    LOG_TRACE10("(%p)", node);
+
     *node->prev = node->next;
-    if (node->next) {
+    if (node->next != NULL) {
         node->next->prev = node->prev;
     }
     node->next = NULL;

--- a/src/BRSRC13/CORE/FW/register.c
+++ b/src/BRSRC13/CORE/FW/register.c
@@ -8,6 +8,8 @@
 
 // IDA: void* __usercall BrRegistryNew@<EAX>(br_registry *reg@<EAX>)
 void* BrRegistryNew(br_registry* reg) {
+    LOG_TRACE10("(%p)", reg);
+
     BrNewList(&reg->list);
     reg->count = 0;
     return reg;
@@ -16,13 +18,22 @@ void* BrRegistryNew(br_registry* reg) {
 // IDA: void* __usercall BrRegistryClear@<EAX>(br_registry *reg@<EAX>)
 void* BrRegistryClear(br_registry* reg) {
     br_registry_entry* e;
-    LOG_TRACE("(%p)", reg);
-    NOT_IMPLEMENTED();
+    LOG_TRACE10("(%p)", reg);
+
+    e = (br_registry_entry*)reg->list.head;
+    while (e->node.next != NULL) {
+        BrRemove(&e->node);
+        BrResFree(e);
+        e = (br_registry_entry*)reg->list.head;
+    }
+    reg->count = 0;
+    return reg;
 }
 
 // IDA: void* __usercall BrRegistryAdd@<EAX>(br_registry *reg@<EAX>, void *item@<EDX>)
 void* BrRegistryAdd(br_registry* reg, void* item) {
     br_registry_entry* e;
+    LOG_TRACE10("(%p, %p)", reg, item);
 
     e = (br_registry_entry*)BrResAllocate(fw.res, sizeof(br_registry_entry), BR_MEMORY_REGISTRY);
     e->item = (char**)item;
@@ -33,34 +44,37 @@ void* BrRegistryAdd(br_registry* reg, void* item) {
 
 // IDA: int __usercall BrRegistryAddMany@<EAX>(br_registry *reg@<EAX>, void **items@<EDX>, int n@<EBX>)
 int BrRegistryAddMany(br_registry* reg, void** items, int n) {
+    br_registry_entry* e;
     int i;
-    LOG_TRACE("(%p, %p, %d)", reg, items, n);
-    NOT_IMPLEMENTED();
+    LOG_TRACE10("(%p, %p, %d)", reg, items, n);
+
+    for(i = 0; i < n; i++) {
+        e = BrResAllocate(fw.res, sizeof(br_registry_entry), BR_MEMORY_REGISTRY);
+        e->item = ((char ***)items)[i];
+        BrAddHead(&reg->list, (br_node *)&e->node);
+        reg->count++;
+    }
+    return n;
 }
 
 // IDA: void* __usercall BrRegistryRemove@<EAX>(br_registry *reg@<EAX>, void *item@<EDX>)
 void* BrRegistryRemove(br_registry* reg, void* item) {
     br_registry_entry* e;
     void* r;
-    LOG_TRACE("(%p, %p)", reg, item);
+    LOG_TRACE10("(%p, %p)", reg, item);
 
     e = (br_registry_entry*)reg->list.head;
-    if (e->item) {
-        while (e) {
-            if (e->item == item) {
-                break;
-            }
-            e = (br_registry_entry*)e->node.next;
-        }
+    while ((e->node.next != NULL) && (e->item != item)) {
+        e = (br_registry_entry*)e->node.next;
     }
-    if (e) {
-        BrRemove((br_node*)e);
-        r = e->item;
-        BrResFree(e);
-        reg->count--;
-        return r;
+    if (e->node.next == NULL) {
+        return NULL;
     }
-    return NULL;
+    BrRemove((br_node*)e);
+    r = e->item;
+    BrResFree(e);
+    reg->count--;
+    return r;
 }
 
 // IDA: int __usercall BrRegistryRemoveMany@<EAX>(br_registry *reg@<EAX>, void **items@<EDX>, int n@<EBX>)
@@ -68,7 +82,15 @@ int BrRegistryRemoveMany(br_registry* reg, void** items, int n) {
     int i;
     int r;
     LOG_TRACE("(%p, %p, %d)", reg, items, n);
-    NOT_IMPLEMENTED();
+
+    r = 0;
+    for (; n != 0; n--) {
+        if (BrRegistryRemove(reg, *items) != NULL) {
+            r++;
+        }
+        items++;
+    }
+    return r;
 }
 
 // IDA: void* __usercall BrRegistryFind@<EAX>(br_registry *reg@<EAX>, char *pattern@<EDX>)
@@ -77,20 +99,14 @@ void* BrRegistryFind(br_registry* reg, char* pattern) {
     LOG_TRACE8("(%p, \"%s\")", reg, pattern);
 
     e = (br_registry_entry*)reg->list.head;
-    if (e->item) {
-        // as a char**, e->item[1] actually points to `identifier` field in a br_* struct etc
-        while (!BrNamePatternMatch(pattern, e->item[1])) {
-            e = (br_registry_entry*)e->node.next;
-            if (!e->node.next) {
-                if (reg->find_failed_hook) {
-                    return reg->find_failed_hook(pattern);
-                }
-                return NULL;
-            }
+    while (e->node.next != NULL) {
+        // 2nd element of item must be char pointer.
+        if (BrNamePatternMatch(pattern, e->item[1]) != 0) {
+            return e->item;
         }
-        return e->item;
+        e = (br_registry_entry*)e->node.next;
     }
-    if (reg->find_failed_hook) {
+    if (reg->find_failed_hook != NULL) {
         return reg->find_failed_hook(pattern);
     }
     return NULL;
@@ -101,7 +117,18 @@ int BrRegistryFindMany(br_registry* reg, char* pattern, void** items, int max) {
     br_registry_entry* e;
     int n;
     LOG_TRACE("(%p, \"%s\", %p, %d)", reg, pattern, items, max);
-    NOT_IMPLEMENTED();
+
+    n = 0;
+    e = (br_registry_entry*)reg->list.head;
+    while ((e->node.next != NULL) && (n < max)) {
+        if (BrNamePatternMatch(pattern, e->item[1]) != 0) {
+            *items = e->item;
+            items++;
+            n++;
+        }
+        e = (br_registry_entry*)e->node.next;
+    }
+    return n;
 }
 
 // IDA: int __usercall BrRegistryCount@<EAX>(br_registry *reg@<EAX>, char *pattern@<EDX>)
@@ -109,45 +136,48 @@ int BrRegistryCount(br_registry* reg, char* pattern) {
     br_registry_entry* e;
     int n;
     LOG_TRACE("(%p, \"%s\")", reg, pattern);
-    NOT_IMPLEMENTED();
+
+    if (pattern == NULL) {
+        return reg->count;
+    }
+    n = 0;
+    e = (br_registry_entry*)reg->list.head;
+    while (e->node.next != NULL) {
+        if (BrNamePatternMatch(pattern, e->item[1]) != 0) {
+            n++;
+        }
+        e = (br_registry_entry*)e->node.next;
+    }
+    return n;
 }
 
 // IDA: int __usercall BrRegistryEnum@<EAX>(br_registry *reg@<EAX>, char *pattern@<EDX>, br_enum_cbfn *callback@<EBX>, void *arg@<ECX>)
 int BrRegistryEnum(br_registry* reg, char* pattern, br_enum_cbfn* callback, void* arg) {
     br_registry_entry* e;
     int r;
+    LOG_TRACE("(%p, \"%s\", %p, %p)", reg, pattern, callback, arg);
 
-    e = (br_registry_entry*)reg->list.tail;
-    if (!pattern) {
-        if (e->node.prev) {
-            while (1) {
-                r = callback(e->item, arg);
-                if (r) {
-                    break;
-                }
-                e = (br_registry_entry*)e->node.prev;
-                if (!e->node.prev) {
-                    return 0;
-                }
-            }
-            return 0;
-        }
-        return 0;
-    }
-    if (!e->node.prev) {
-        return 0;
-    }
-    while (1) {
-        // as a char**, e->item[1] actually points to `identifier` field in a br_* struct etc
-        if (BrNamePatternMatch(pattern, e->item[1])) {
+    if (pattern == NULL) {
+        e = (br_registry_entry*)reg->list.tail;
+        while (e->node.prev != NULL) {
             r = callback(e->item, arg);
-            if (r) {
-                break;
+            if (r != 0) {
+                return r;
             }
+            e = (br_registry_entry*)e->node.prev;
         }
-        e = (br_registry_entry*)e->node.prev;
-        if (!e->node.prev) {
-            return 0;
+    } else {
+        e = (br_registry_entry*)reg->list.tail;
+        while (e->node.prev != NULL) {
+            // as a char**, e->item[1] actually points to `identifier` field in a br_* struct etc
+            r = BrNamePatternMatch(pattern, e->item[1]);
+            if (r != 0) {
+                r = callback(e->item, arg);
+                if (r != 0) {
+                    return r;
+                }
+            }
+            e = (br_registry_entry*)e->node.prev;
         }
     }
     return 0;
@@ -156,17 +186,17 @@ int BrRegistryEnum(br_registry* reg, char* pattern, br_enum_cbfn* callback, void
 // IDA: void* __usercall BrRegistryNewStatic@<EAX>(br_registry *reg@<EAX>, br_registry_entry *base@<EDX>, int limit@<EBX>)
 void* BrRegistryNewStatic(br_registry* reg, br_registry_entry* base, int limit) {
     LOG_TRACE("(%p, %p, %d)", reg, base, limit);
-    NOT_IMPLEMENTED();
+    return NULL;
 }
 
 // IDA: void* __usercall BrRegistryAddStatic@<EAX>(br_registry *reg@<EAX>, br_registry_entry *base@<EDX>, void *item@<EBX>)
 void* BrRegistryAddStatic(br_registry* reg, br_registry_entry* base, void* item) {
     LOG_TRACE("(%p, %p, %p)", reg, base, item);
-    NOT_IMPLEMENTED();
+    return NULL;
 }
 
 // IDA: void* __usercall BrRegistryRemoveStatic@<EAX>(br_registry *reg@<EAX>, void *item@<EDX>)
 void* BrRegistryRemoveStatic(br_registry* reg, void* item) {
     LOG_TRACE("(%p, %p)", reg, item);
-    NOT_IMPLEMENTED();
+    return NULL;
 }

--- a/test/BRSRC13/test_brlists.c
+++ b/test/BRSRC13/test_brlists.c
@@ -4,7 +4,273 @@
 #include <stdlib.h>
 #include <string.h>
 
-void test_brlists_BrSimpleList() {
+static void test_brlists_BrNewList() {
+    br_list* list = calloc(1, sizeof(br_list));
+
+    BrNewList(list);
+    TEST_ASSERT_NOT_NULL(list->head);
+    TEST_ASSERT_NULL(list->_null);
+    TEST_ASSERT_NOT_NULL(list->tail);
+
+    free(list);
+}
+
+static void test_brlists_BrAddHead() {
+    br_list* list = calloc(1, sizeof(br_list));
+    br_node* one = calloc(1, sizeof(br_node));
+    br_node* two = calloc(1, sizeof(br_node));
+
+    BrNewList(list);
+
+    BrAddHead(list, one);
+    TEST_ASSERT_EQUAL_PTR(one, list->head);
+    TEST_ASSERT_EQUAL_PTR(one, list->tail);
+    TEST_ASSERT_EQUAL_PTR(one->prev, (br_node*)&list->head);
+    TEST_ASSERT_EQUAL_PTR(one->next, (br_node*)&list->_null);
+
+    BrAddHead(list, two);
+    TEST_ASSERT_EQUAL_PTR(two, list->head);
+    TEST_ASSERT_EQUAL_PTR(one, list->tail);
+    TEST_ASSERT_EQUAL_PTR(two->prev, (br_node*)&list->head);
+    TEST_ASSERT_EQUAL_PTR(two->next, one);
+    TEST_ASSERT_EQUAL_PTR(one->prev, two);
+    TEST_ASSERT_EQUAL_PTR(one->next, (br_node*)&list->_null);
+
+    free(list);
+    free(one);
+    free(two);
+}
+
+static void test_brlists_BrAddTail() {
+    br_list* list = calloc(1, sizeof(br_list));
+    br_node* one = calloc(1, sizeof(br_node));
+    br_node* two = calloc(1, sizeof(br_node));
+
+    BrNewList(list);
+
+    BrAddTail(list, one);
+    TEST_ASSERT_EQUAL_PTR(one, list->head);
+    TEST_ASSERT_EQUAL_PTR(one, list->tail);
+    TEST_ASSERT_EQUAL_PTR(one->prev, (br_node*)&list->head);
+    TEST_ASSERT_EQUAL_PTR(one->next, (br_node*)&list->_null);
+
+    BrAddTail(list, two);
+    TEST_ASSERT_EQUAL_PTR(one, list->head);
+    TEST_ASSERT_EQUAL_PTR(two, list->tail);
+    TEST_ASSERT_EQUAL_PTR(two->prev, one);
+    TEST_ASSERT_EQUAL_PTR(two->next, (br_node*)&list->_null);
+    TEST_ASSERT_EQUAL_PTR(one->prev, (br_node*)&list->head);
+    TEST_ASSERT_EQUAL_PTR(one->next, two);
+
+    free(list);
+    free(one);
+    free(two);
+}
+
+static void test_brlists_BrRemHead() {
+    br_list* list = calloc(1, sizeof(br_list));
+    br_node* one = calloc(1, sizeof(br_node));
+    br_node* two = calloc(1, sizeof(br_node));
+    br_node* removed;
+
+    BrNewList(list);
+
+    removed = BrRemHead(list);
+    TEST_ASSERT_NULL(removed);
+
+    BrAddTail(list, one);
+    BrAddTail(list, two);
+    TEST_ASSERT_EQUAL_PTR(one, list->head);
+
+    removed = BrRemHead(list);
+    TEST_ASSERT_EQUAL_PTR(one, removed);
+    TEST_ASSERT_EQUAL_PTR(two, list->head);
+    TEST_ASSERT_EQUAL_PTR(two, list->tail);
+    TEST_ASSERT_EQUAL_PTR((br_node*)&list->head, two->prev);
+    TEST_ASSERT_EQUAL_PTR((br_node*)&list->_null, two->next);
+
+    removed = BrRemHead(list);
+    TEST_ASSERT_EQUAL_PTR(two, removed);
+    TEST_ASSERT_EQUAL_PTR((br_node*)&list->_null, list->head);
+    TEST_ASSERT_EQUAL_PTR((br_node*)&list->head, list->tail);
+
+    free(list);
+    free(one);
+    free(two);
+}
+
+static void test_brlists_BrRemTail() {
+    br_list* list = calloc(1, sizeof(br_list));
+    br_node* one = calloc(1, sizeof(br_node));
+    br_node* two = calloc(1, sizeof(br_node));
+    br_node* removed;
+
+    BrNewList(list);
+
+    removed = BrRemTail(list);
+    TEST_ASSERT_NULL(removed);
+
+    BrAddTail(list, one);
+    BrAddTail(list, two);
+    TEST_ASSERT_EQUAL_PTR(two, list->tail);
+
+    removed = BrRemTail(list);
+    TEST_ASSERT_EQUAL_PTR(two, removed);
+    TEST_ASSERT_EQUAL_PTR(one, list->head);
+    TEST_ASSERT_EQUAL_PTR(one, list->tail);
+    TEST_ASSERT_EQUAL_PTR((br_node*)&list->head, one->prev);
+    TEST_ASSERT_EQUAL_PTR((br_node*)&list->_null, one->next);
+
+    removed = BrRemHead(list);
+    TEST_ASSERT_EQUAL_PTR(one, removed);
+    TEST_ASSERT_EQUAL_PTR((br_node*)&list->_null, list->head);
+    TEST_ASSERT_EQUAL_PTR((br_node*)&list->head, list->tail);
+
+    free(list);
+    free(one);
+    free(two);
+}
+
+static void test_brlists_BrInsert() {
+    br_list* list = calloc(1, sizeof(br_list));
+    br_node* one = calloc(1, sizeof(br_node));
+    br_node* two = calloc(1, sizeof(br_node));
+    br_node* three = calloc(1, sizeof(br_node));
+
+    BrNewList(list);
+
+    BrInsert(list, (br_node*)&list->head, one);
+    TEST_ASSERT_EQUAL_PTR(one, list->head);
+    TEST_ASSERT_EQUAL_PTR(one, list->tail);
+    TEST_ASSERT_EQUAL_PTR((br_node*)&list->head, one->prev);
+    TEST_ASSERT_EQUAL_PTR((br_node*)&list->_null, one->next);
+
+    BrInsert(list, one, two);
+    TEST_ASSERT_EQUAL_PTR(two, one->next);
+    TEST_ASSERT_EQUAL_PTR(two, list->tail);
+    TEST_ASSERT_EQUAL_PTR(one, two->prev);
+    TEST_ASSERT_EQUAL_PTR(two, one->next);
+
+    BrInsert(list, one, three);
+    TEST_ASSERT_EQUAL_PTR(three, one->next);
+    TEST_ASSERT_EQUAL_PTR(three, two->prev);
+    TEST_ASSERT_EQUAL_PTR(one, three->prev);
+    TEST_ASSERT_EQUAL_PTR(two, three->next);
+
+    free(list);
+    free(one);
+    free(two);
+    free(three);
+}
+
+static void test_brlists_BrRemove() {
+    br_list* list = calloc(1, sizeof(br_list));
+    br_node* one = calloc(1, sizeof(br_node));
+    br_node* two = calloc(1, sizeof(br_node));
+    br_node* three = calloc(1, sizeof(br_node));
+    br_node *removed;
+
+    BrNewList(list);
+    BrAddTail(list, one);
+    TEST_ASSERT_EQUAL_PTR(one, list->head);
+    TEST_ASSERT_EQUAL_PTR(one, list->tail);
+
+    removed = BrRemove(one);
+    TEST_ASSERT_EQUAL_PTR(one, removed);
+    TEST_ASSERT_EQUAL_PTR((br_node*)&list->_null, list->head);
+    TEST_ASSERT_EQUAL_PTR((br_node*)&list->head, list->tail);
+
+    BrAddTail(list, one);
+    BrAddTail(list, two);
+    BrAddTail(list, three);
+
+    removed = BrRemove(two);
+    TEST_ASSERT_EQUAL_PTR(two, removed);
+    TEST_ASSERT_EQUAL_PTR(three, one->next);
+    TEST_ASSERT_EQUAL_PTR(one, three->prev);
+
+    removed = BrRemove(three);
+    TEST_ASSERT_EQUAL_PTR(three, removed);
+    TEST_ASSERT_EQUAL_PTR((br_node*)&list->_null, one->next);
+    TEST_ASSERT_EQUAL_PTR(one, list->tail);
+
+    removed = BrRemove(one);
+    TEST_ASSERT_EQUAL_PTR(one, removed);
+    TEST_ASSERT_EQUAL_PTR((br_node*)&list->_null, list->head);
+    TEST_ASSERT_EQUAL_PTR((br_node*)&list->head, list->tail);
+
+    free(list);
+    free(one);
+    free(two);
+    free(three);
+}
+
+static void test_brlists_BrSimpleNewList() {
+    br_simple_list* list = calloc(1, sizeof(br_simple_list));
+
+    BrSimpleNewList(list);
+    TEST_ASSERT_NULL(list->head);
+
+    free(list);
+}
+
+static void test_brlists_BrSimpleAddHead() {
+    br_simple_list* list = calloc(1, sizeof(br_simple_list));
+    br_simple_node* one = calloc(1, sizeof(br_simple_node));
+    br_simple_node* two = calloc(1, sizeof(br_simple_node));
+
+    BrSimpleNewList(list);
+
+    BrSimpleAddHead(list, one);
+    TEST_ASSERT_EQUAL_PTR(one, list->head);
+    TEST_ASSERT_EQUAL_PTR(&list->head, one->prev);
+    TEST_ASSERT_NULL(one->next);
+
+    BrSimpleAddHead(list, two);
+    TEST_ASSERT_EQUAL_PTR(two, list->head);
+    TEST_ASSERT_EQUAL_PTR(&list->head, two->prev);
+    TEST_ASSERT_EQUAL_PTR(one, two->next);
+    TEST_ASSERT_EQUAL_PTR(two, one->prev);
+
+    free(list);
+    free(one);
+    free(two);
+}
+
+static void test_brlists_BrSimpleRemHead() {
+    br_simple_list* list = calloc(1, sizeof(br_simple_list));
+    br_simple_node* one = calloc(1, sizeof(br_simple_node));
+    br_simple_node* two = calloc(1, sizeof(br_simple_node));
+    br_simple_node* removed;
+
+    BrSimpleNewList(list);
+    BrSimpleAddHead(list, one);
+    BrSimpleAddHead(list, two);
+
+    TEST_ASSERT_EQUAL_PTR(two, list->head);
+    TEST_ASSERT_EQUAL_PTR(two, one->prev);
+    TEST_ASSERT_EQUAL_PTR((br_simple_node**)&list->head, two->prev);
+    TEST_ASSERT_EQUAL_PTR(one, two->next);
+
+    removed = BrSimpleRemHead(list);
+    TEST_ASSERT_EQUAL(two, removed);
+    TEST_ASSERT_EQUAL_PTR(one, list->head);
+    TEST_ASSERT_EQUAL_PTR((br_simple_node**)&list->head, one->prev);
+    TEST_ASSERT_NULL(two->prev);
+    TEST_ASSERT_NULL(two->next);
+
+    removed = BrSimpleRemHead(list);
+    TEST_ASSERT_EQUAL(one, removed);
+    TEST_ASSERT_NULL(list->head);
+    TEST_ASSERT_NULL(one->prev);
+    TEST_ASSERT_NULL(one->next);
+
+    free(list);
+    free(one);
+    free(two);
+}
+
+static void test_brlists_BrSimpleInsert() {
     br_simple_list* list = calloc(1, sizeof(br_simple_list));
     br_simple_node* one = calloc(1, sizeof(br_simple_node));
     br_simple_node* two = calloc(1, sizeof(br_simple_node));
@@ -14,32 +280,69 @@ void test_brlists_BrSimpleList() {
     TEST_ASSERT_NULL(list->head);
 
     BrSimpleAddHead(list, one);
-    // expected 1->null
     TEST_ASSERT_EQUAL_PTR(one, list->head);
+    TEST_ASSERT_EQUAL_PTR((br_simple_node**)&list->head, one->prev);
     TEST_ASSERT_NULL(one->next);
-    TEST_ASSERT_EQUAL_PTR(list, one->prev);
+
+    BrSimpleInsert(list, one, two);
+    TEST_ASSERT_EQUAL_PTR(one, list->head);
+    TEST_ASSERT_EQUAL_PTR((br_simple_node**)&list->head, one->prev);
+    TEST_ASSERT_EQUAL_PTR(two, one->next);
+    TEST_ASSERT_EQUAL_PTR(one, two->prev);
+    TEST_ASSERT_NULL(two->next);
+
+    BrSimpleInsert(list, one, three);
+    TEST_ASSERT_EQUAL_PTR(three, one->next);
+    TEST_ASSERT_EQUAL_PTR(three, two->prev);
+    TEST_ASSERT_EQUAL_PTR(one, three->prev);
+    TEST_ASSERT_EQUAL_PTR(two, three->next);
+
+    free(list);
+    free(one);
+    free(two);
+    free(three);
+}
+
+static void test_brlists_BrSimpleRemove() {
+    br_simple_list* list = calloc(1, sizeof(br_simple_list));
+    br_simple_node* one = calloc(1, sizeof(br_simple_node));
+    br_simple_node* two = calloc(1, sizeof(br_simple_node));
+    br_simple_node* three = calloc(1, sizeof(br_simple_node));
+    br_simple_node *removed;
+
+    BrSimpleNewList(list);
+    BrSimpleAddHead(list, one);
+    TEST_ASSERT_EQUAL_PTR(one, list->head);
+    TEST_ASSERT_EQUAL_PTR((br_simple_node**)&list->head, one->prev);
+    TEST_ASSERT_NULL(one->next);
+
+    removed = BrSimpleRemove(one);
+    TEST_ASSERT_EQUAL_PTR(one, removed);
+    TEST_ASSERT_NULL(one->next);
+    TEST_ASSERT_NULL(one->prev);
+    TEST_ASSERT_NULL(list->head);
+
+    BrSimpleAddHead(list, one);
+    BrSimpleAddHead(list, two);
+
+    removed = BrSimpleRemove(two);
+    TEST_ASSERT_EQUAL_PTR(two, removed);
+    TEST_ASSERT_NULL(two->next);
+    TEST_ASSERT_NULL(two->prev);
+    TEST_ASSERT_EQUAL_PTR(one, list->head);
+    TEST_ASSERT_EQUAL_PTR((br_simple_node**)&list->head, one->prev);
 
     BrSimpleAddHead(list, two);
-    // expected 2->1->null
-    TEST_ASSERT_EQUAL_PTR(two, list->head);
-    TEST_ASSERT_EQUAL_PTR(one, two->next);
-    TEST_ASSERT_EQUAL_PTR(list, two->prev);
-
-    TEST_ASSERT_EQUAL_PTR(two, one->prev);
-    TEST_ASSERT_NULL(one->next);
-
     BrSimpleAddHead(list, three);
-    // expected 3->2->1->null
-    TEST_ASSERT_EQUAL_PTR(two, one->prev);
 
+    removed = BrSimpleRemove(two);
+    TEST_ASSERT_EQUAL_PTR(two, removed);
+    TEST_ASSERT_NULL(two->next);
+    TEST_ASSERT_NULL(two->prev);
     TEST_ASSERT_EQUAL_PTR(three, list->head);
-    TEST_ASSERT_EQUAL_PTR(two, three->next);
-    TEST_ASSERT_EQUAL_PTR(list, three->prev);
-
-    TEST_ASSERT_EQUAL_PTR(three, two->prev);
-    TEST_ASSERT_EQUAL_PTR(one, two->next);
-
-    TEST_ASSERT_EQUAL_PTR(two, one->prev);
+    TEST_ASSERT_EQUAL_PTR(one, three->next);
+    TEST_ASSERT_EQUAL_PTR((br_simple_node*)&list->head, three->prev);
+    TEST_ASSERT_EQUAL_PTR(three, one->prev);
     TEST_ASSERT_NULL(one->next);
 
     free(list);
@@ -48,36 +351,17 @@ void test_brlists_BrSimpleList() {
     free(three);
 }
 
-void test_brlists_BrSimpleRemove() {
-    br_simple_list list;
-    br_simple_node one;
-    br_simple_node two;
-    br_simple_node three;
-
-    BrSimpleNewList(&list);
-    TEST_ASSERT_NULL(list.head);
-    BrSimpleAddHead(&list, &one);
-    TEST_ASSERT_NOT_NULL(list.head);
-    BrSimpleRemove(&one);
-
-    // removed the only item, so head points to null
-    TEST_ASSERT_NULL(list.head);
-    TEST_ASSERT_NULL(one.next);
-    TEST_ASSERT_NULL(one.prev);
-
-    BrSimpleAddHead(&list, &one);
-    BrSimpleAddHead(&list, &two);
-    BrSimpleAddHead(&list, &three);
-    BrSimpleRemove(&two);
-
-    // we removed the middle element, so we are left with head -> 3 -> 1 and list <- 3 <- 1
-    TEST_ASSERT_EQUAL_PTR(&three, list.head);
-    TEST_ASSERT_EQUAL_PTR(three.next, &one);
-    TEST_ASSERT_EQUAL_PTR(one.prev, &three);
-    TEST_ASSERT_EQUAL_PTR(three.prev, &list);
-}
-
 void test_brlists_suite() {
-    RUN_TEST(test_brlists_BrSimpleList);
+    RUN_TEST(test_brlists_BrNewList);
+    RUN_TEST(test_brlists_BrAddHead);
+    RUN_TEST(test_brlists_BrAddTail);
+    RUN_TEST(test_brlists_BrRemHead);
+    RUN_TEST(test_brlists_BrRemTail);
+    RUN_TEST(test_brlists_BrInsert);
+    RUN_TEST(test_brlists_BrRemove);
+    RUN_TEST(test_brlists_BrSimpleNewList);
+    RUN_TEST(test_brlists_BrSimpleAddHead);
+    RUN_TEST(test_brlists_BrSimpleRemHead);
+    RUN_TEST(test_brlists_BrSimpleInsert);
     RUN_TEST(test_brlists_BrSimpleRemove);
 }

--- a/test/BRSRC13/test_register.c
+++ b/test/BRSRC13/test_register.c
@@ -66,7 +66,6 @@ static void test_register_BrRegistryAdd_BrRegistryRemove() {
     TEST_ASSERT_EQUAL_PTR(&item2, result);
     TEST_ASSERT_EQUAL_INT(0, reg.count);
 
-    // Cannot execute BrRegistryRemove on an empty br_registry
     result = BrRegistryRemove(&reg, &item2);
     TEST_ASSERT_NULL(result);
     TEST_ASSERT_EQUAL_INT(0, reg.count);

--- a/test/BRSRC13/test_register.c
+++ b/test/BRSRC13/test_register.c
@@ -1,68 +1,503 @@
 #include "tests.h"
 
 #include "CORE/FW/register.h"
+#include <string.h>
 
-void test_register_BrRegistryFind() {
+
+typedef struct {
+    br_uint_32 _reserved;
+    char *identifier;
+} test_element;
+
+static void test_register_BrRegistryNew() {
     br_registry reg;
-    br_model m;
-    br_model m2;
-    br_registry_entry* e;
-    reg.find_failed_hook = NULL;
-    m.identifier = "test-identifier1";
-    m2.identifier = "test-identifier2";
+    br_registry *result;
 
-    BrRegistryNew(&reg);
-    BrRegistryAdd(&reg, &m);
-    BrRegistryAdd(&reg, &m2);
-    TEST_ASSERT_EQUAL_INT(2, reg.count);
-    e = (br_registry_entry*)reg.list.head;
-    TEST_ASSERT_EQUAL_PTR(&m2, e->item);
-    TEST_ASSERT_EQUAL_STRING("test-identifier2", e->item[1]);
+    memset(&reg, 0, sizeof(reg));
 
-    TEST_ASSERT_NOT_NULL(e->node.next);
-    e = (br_registry_entry*)e->node.next;
-    TEST_ASSERT_EQUAL_PTR(&m, e->item);
-
-    TEST_ASSERT_NULL(BrRegistryFind(&reg, "not-found"));
-    TEST_ASSERT_NOT_NULL(BrRegistryFind(&reg, "test-identifier2"));
-    TEST_ASSERT_NOT_NULL(BrRegistryFind(&reg, "test-identifier1"));
+    result = BrRegistryNew(&reg);
+    TEST_ASSERT_EQUAL_PTR(&reg, result);
+    TEST_ASSERT_EQUAL_INT(0, reg.count);
 }
 
-void test_register_BrRegistryRemove() {
+static void test_register_BrRegistryAdd_BrRegistryRemove() {
     br_registry reg;
-    br_model m;
-    br_model m2;
-    br_model m3;
-    br_registry_entry* e;
-    reg.find_failed_hook = NULL;
-    m.identifier = "test-identifier1";
-    m2.identifier = "test-identifier2";
+    void *result;
+
+    memset(&reg, 0, sizeof(reg));
+
+    test_element item1 = { .identifier = "item1", };
+    test_element item2 = { .identifier = "item2", };
+    test_element item3 = { .identifier = "item3", };
 
     BrRegistryNew(&reg);
-    BrRegistryAdd(&reg, &m);
-    BrRegistryAdd(&reg, &m2);
 
+    result = BrRegistryAdd(&reg, &item1);
+    TEST_ASSERT_EQUAL_PTR(&item1, result);
+    TEST_ASSERT_EQUAL_INT(1, reg.count);
+    TEST_ASSERT_EQUAL_PTR(&item1, ((br_registry_entry*)reg.list.head)->item);
+
+    result = BrRegistryAdd(&reg, &item2);
+    TEST_ASSERT_EQUAL_PTR(&item2, result);
+    TEST_ASSERT_EQUAL_INT(2, reg.count);
+    TEST_ASSERT_EQUAL_PTR(&item2, ((br_registry_entry*)reg.list.head)->item);
+
+    result = BrRegistryAdd(&reg, &item3);
+    TEST_ASSERT_EQUAL_PTR(&item3, result);
+    TEST_ASSERT_EQUAL_INT(3, reg.count);
+    TEST_ASSERT_EQUAL_PTR(&item3, ((br_registry_entry*)reg.list.head)->item);
+
+    result = BrRegistryRemove(&reg, &item1);
+    TEST_ASSERT_EQUAL_PTR(&item1, result);
+    TEST_ASSERT_EQUAL_INT(2, reg.count);
+    TEST_ASSERT_EQUAL_PTR(&item3, ((br_registry_entry*)reg.list.head)->item);
+
+    result = BrRegistryRemove(&reg, &item1);
+    TEST_ASSERT_NULL(result);
+    TEST_ASSERT_EQUAL_INT(2, reg.count);
+    TEST_ASSERT_EQUAL_PTR(&item3, ((br_registry_entry*)reg.list.head)->item);
+
+    result = BrRegistryRemove(&reg, &item3);
+    TEST_ASSERT_EQUAL_PTR(&item3, result);
+    TEST_ASSERT_EQUAL_INT(1, reg.count);
+    TEST_ASSERT_EQUAL_PTR(&item2, ((br_registry_entry*)reg.list.head)->item);
+
+    result = BrRegistryRemove(&reg, &item2);
+    TEST_ASSERT_EQUAL_PTR(&item2, result);
+    TEST_ASSERT_EQUAL_INT(0, reg.count);
+
+    // Cannot execute BrRegistryRemove on an empty br_registry
+    result = BrRegistryRemove(&reg, &item2);
+    TEST_ASSERT_NULL(result);
+    TEST_ASSERT_EQUAL_INT(0, reg.count);
+}
+
+static void test_register_offsets() {
+    // offset of identifier of structs that can be put in a registry,
+    // **MUST** be accessible as the 2nd element in a char pointer array.
+    TEST_ASSERT_EQUAL_INT(sizeof(void*), offsetof(test_element, identifier));
+
+    TEST_ASSERT_EQUAL_INT(sizeof(void*), offsetof(br_device, identifier));
+    TEST_ASSERT_EQUAL_INT(sizeof(void*), offsetof(br_device_pixelmap, pm_identifier));
+    TEST_ASSERT_EQUAL_INT(sizeof(void*), offsetof(br_material, identifier));
+    TEST_ASSERT_EQUAL_INT(sizeof(void*), offsetof(br_model, identifier));
+    TEST_ASSERT_EQUAL_INT(sizeof(void*), offsetof(br_pixelmap, identifier));
+}
+
+static void *impl_test_find_failed_hook(char *pattern) {
+    return pattern;
+}
+
+static void test_register_BrRegistryFind() {
+    br_registry reg;
+    void *result;
+    char *itemTxt = "item";
+    test_element item1 = { .identifier = "item1", };
+    test_element item2 = { .identifier = "item2", };
+    test_element item3 = { .identifier = "item3", };
+
+    memset(&reg, 0, sizeof(reg));
+
+    BrRegistryNew(&reg);
+
+     result = BrRegistryFind(&reg, "item1");
+     TEST_ASSERT_NULL(result);
+
+     reg.find_failed_hook = impl_test_find_failed_hook;
+     result = BrRegistryFind(&reg, itemTxt);
+     TEST_ASSERT_EQUAL_PTR(itemTxt, result);
+     reg.find_failed_hook = NULL;
+
+    result = BrRegistryAdd(&reg, &item1);
+    TEST_ASSERT_EQUAL_PTR(&item1, result);
+    result = BrRegistryFind(&reg, "item1");
+    TEST_ASSERT_EQUAL_PTR(&item1, result);
+    result = BrRegistryFind(&reg, "item*");
+    TEST_ASSERT_EQUAL_PTR(&item1, result);
+    result = BrRegistryFind(&reg, "item");
+    TEST_ASSERT_NULL(result);
+
+    reg.find_failed_hook = impl_test_find_failed_hook;
+    result = BrRegistryFind(&reg, itemTxt);
+    TEST_ASSERT_EQUAL_PTR(itemTxt, result);
+    reg.find_failed_hook = NULL;
+
+    result = BrRegistryAdd(&reg, &item2);
+    TEST_ASSERT_EQUAL_PTR(&item2, result);
+    result = BrRegistryAdd(&reg, &item3);
+    TEST_ASSERT_EQUAL_PTR(&item3, result);
+
+    TEST_ASSERT_EQUAL_INT(3, reg.count);
+
+    result = BrRegistryFind(&reg, "item1");
+    TEST_ASSERT_EQUAL_PTR(&item1, result);
+    result = BrRegistryFind(&reg, "item2");
+    TEST_ASSERT_EQUAL_PTR(&item2, result);
+    result = BrRegistryFind(&reg, "item3");
+    TEST_ASSERT_EQUAL_PTR(&item3, result);
+    result = BrRegistryFind(&reg, "item*");
+    TEST_ASSERT_EQUAL_PTR(&item3, result);
+
+    result = BrRegistryRemove(&reg, &item1);
+    TEST_ASSERT_EQUAL_PTR(&item1, result);
     TEST_ASSERT_EQUAL_INT(2, reg.count);
 
-    // try removing non-existing item
-    TEST_ASSERT_NULL(BrRegistryRemove(&reg, &m3));
-    // remove first item
-    TEST_ASSERT_EQUAL_PTR(&m, BrRegistryRemove(&reg, &m));
-    TEST_ASSERT_EQUAL_INT(1, reg.count);
-    e = (br_registry_entry*)reg.list.head;
-    TEST_ASSERT_EQUAL_PTR(&m2, e->item);
-    TEST_ASSERT_NULL(e->node.next->next);
+    result = BrRegistryFind(&reg, "item1");
+    TEST_ASSERT_NULL(result);
+    result = BrRegistryFind(&reg, "item2");
+    TEST_ASSERT_EQUAL_PTR(&item2, result);
+    result = BrRegistryFind(&reg, "item3");
+    TEST_ASSERT_EQUAL_PTR(&item3, result);
+    result = BrRegistryFind(&reg, "item*");
+    TEST_ASSERT_EQUAL_PTR(&item3, result);
 
-    // now add it back, try remove last item
-    BrRegistryAdd(&reg, &m);
-    TEST_ASSERT_EQUAL_PTR(&m2, BrRegistryRemove(&reg, &m2));
+    result = BrRegistryRemove(&reg, &item2);
+    TEST_ASSERT_EQUAL_PTR(&item2, result);
+    result = BrRegistryRemove(&reg, &item3);
+    TEST_ASSERT_EQUAL_PTR(&item3, result);
+
+    TEST_ASSERT_EQUAL_INT(0, reg.count);
+}
+
+static void test_register_BrRegistryClear() {
+    br_registry reg;
+    void *result;
+    test_element item1 = { .identifier = "item1", };
+    test_element item2 = { .identifier = "item2", };
+    test_element item3 = { .identifier = "item3", };
+
+    memset(&reg, 0, sizeof(reg));
+
+    BrRegistryNew(&reg);
+    TEST_ASSERT_EQUAL_INT(0, reg.count);
+
+    result = BrRegistryClear(&reg);
+    TEST_ASSERT_EQUAL_PTR(&reg, result);
+    TEST_ASSERT_EQUAL_INT(0, reg.count);
+
+    result = BrRegistryAdd(&reg, &item1);
+    result = BrRegistryAdd(&reg, &item2);
+    result = BrRegistryAdd(&reg, &item3);
+    TEST_ASSERT_EQUAL_INT(3, reg.count);
+    result = BrRegistryFind(&reg, "item1");
+    TEST_ASSERT_EQUAL_PTR(&item1, result);
+    result = BrRegistryFind(&reg, "item2");
+    TEST_ASSERT_EQUAL_PTR(&item2, result);
+    result = BrRegistryFind(&reg, "item3");
+    TEST_ASSERT_EQUAL_PTR(&item3, result);
+
+    result = BrRegistryClear(&reg);
+    TEST_ASSERT_EQUAL_PTR(&reg, result);
+    TEST_ASSERT_EQUAL_INT(0, reg.count);
+
+    result = BrRegistryFind(&reg, "item1");
+    TEST_ASSERT_NULL(result);
+    result = BrRegistryFind(&reg, "item2");
+    TEST_ASSERT_NULL(result);
+    result = BrRegistryFind(&reg, "item3");
+    TEST_ASSERT_NULL(result);
+}
+
+static void test_register_BrRegistryAddMany() {
+    br_registry reg;
+    void *result;
+    int nb;
+    test_element item1 = { .identifier = "item1", };
+    test_element item1b = { .identifier = "item1b", };
+    test_element item2 = { .identifier = "item2", };
+    test_element item3 = { .identifier = "item3", };
+    test_element item4 = { .identifier = "item4", };
+    test_element *itemsAdd[] = { &item1, &item2, &item3, &item1b, };
+
+    memset(&reg, 0, sizeof(reg));
+
+    BrRegistryNew(&reg);
+
+    TEST_ASSERT_EQUAL_INT(0, reg.count);
+    BrRegistryAddMany(&reg, (void**)&itemsAdd, BR_ASIZE(itemsAdd));
+    TEST_ASSERT_EQUAL_INT(4, reg.count);
+    result = BrRegistryFind(&reg, "item1");
+    TEST_ASSERT_EQUAL_PTR(&item1, result);
+    result = BrRegistryFind(&reg, "item2");
+    TEST_ASSERT_EQUAL_PTR(&item2, result);
+    result = BrRegistryFind(&reg, "item3");
+    TEST_ASSERT_EQUAL_PTR(&item3, result);
+    result = BrRegistryFind(&reg, "item4");
+    TEST_ASSERT_NULL(result);
+    result = BrRegistryFind(&reg, "item1b");
+    TEST_ASSERT_EQUAL_PTR(&item1b, result);
+
+    BrRegistryClear(&reg);
+}
+
+static void test_register_BrRegistryRemoveMany() {
+    br_registry reg;
+    void *result;
+    int nb;
+    test_element item1 = { .identifier = "item1", };
+    test_element item2 = { .identifier = "item2", };
+    test_element item3 = { .identifier = "item3", };
+    test_element item4 = { .identifier = "item4", };
+    test_element *itemsAdd[] = { &item1, &item2, &item3, };
+    test_element *itemsRemove[] = { &item1, &item2, &item4, };
+
+    memset(&reg, 0, sizeof(reg));
+
+    BrRegistryNew(&reg);
+
+    nb = BrRegistryRemoveMany(&reg, (void**)&itemsRemove, BR_ASIZE(itemsRemove));
+    TEST_ASSERT_EQUAL(0, nb);
+
+    TEST_ASSERT_EQUAL_INT(0, reg.count);
+    BrRegistryAddMany(&reg, (void**)&itemsAdd, BR_ASIZE(itemsAdd));
+    TEST_ASSERT_EQUAL_INT(3, reg.count);
+    result = BrRegistryFind(&reg, "item1");
+    TEST_ASSERT_EQUAL_PTR(&item1, result);
+    result = BrRegistryFind(&reg, "item2");
+    TEST_ASSERT_EQUAL_PTR(&item2, result);
+    result = BrRegistryFind(&reg, "item3");
+    TEST_ASSERT_EQUAL_PTR(&item3, result);
+    result = BrRegistryFind(&reg, "item4");
+    TEST_ASSERT_NULL(result);
+
+    nb = BrRegistryRemoveMany(&reg, (void**)&itemsRemove, BR_ASIZE(itemsRemove));
+    TEST_ASSERT_EQUAL(2, nb);
     TEST_ASSERT_EQUAL_INT(1, reg.count);
-    e = (br_registry_entry*)reg.list.head;
-    TEST_ASSERT_EQUAL_PTR(&m, e->item);
-    TEST_ASSERT_NULL(e->node.next->next);
+    result = BrRegistryFind(&reg, "item1");
+    TEST_ASSERT_NULL(result);
+    result = BrRegistryFind(&reg, "item2");
+    TEST_ASSERT_NULL(result);
+    result = BrRegistryFind(&reg, "item3");
+    TEST_ASSERT_EQUAL_PTR(&item3, result);
+    result = BrRegistryFind(&reg, "item4");
+    TEST_ASSERT_NULL(result);
+
+    BrRegistryClear(&reg);
+
+    nb = BrRegistryRemoveMany(&reg, (void**)&itemsRemove, BR_ASIZE(itemsRemove));
+    TEST_ASSERT_EQUAL(0, nb);
+}
+
+static void test_register_BrRegistryFindMany() {
+    br_registry reg;
+    int result;
+    int nb;
+    test_element item1a = { .identifier = "item1a", };
+    test_element item1b = { .identifier = "item1b", };
+    test_element item2a = { .identifier = "item2a", };
+    test_element item2b = { .identifier = "item2b", };
+    test_element* itemBuffer[5];
+
+    memset(&reg, 0, sizeof(reg));
+
+    BrRegistryNew(&reg);
+    TEST_ASSERT_EQUAL_INT(0, reg.count);
+
+    memset(itemBuffer, 0, sizeof(itemBuffer));
+    result = BrRegistryFindMany(&reg, "item1a", (void**)itemBuffer, BR_ASIZE(itemBuffer));
+    TEST_ASSERT_EQUAL_INT(0, result);
+
+    BrRegistryAdd(&reg, &item1a);
+    BrRegistryAdd(&reg, &item1b);
+    BrRegistryAdd(&reg, &item2a);
+    BrRegistryAdd(&reg, &item2b);
+    TEST_ASSERT_EQUAL_INT(4, reg.count);
+
+    memset(itemBuffer, 0, sizeof(itemBuffer));
+    result = BrRegistryFindMany(&reg, "item", (void**)itemBuffer, BR_ASIZE(itemBuffer));
+    TEST_ASSERT_EQUAL_INT(0, result);
+
+    memset(itemBuffer, 0, sizeof(itemBuffer));
+    result = BrRegistryFindMany(&reg, "item1a", (void**)itemBuffer, BR_ASIZE(itemBuffer));
+    TEST_ASSERT_EQUAL_INT(1, result);
+    TEST_ASSERT_EQUAL_PTR(&item1a, itemBuffer[0]);
+    TEST_ASSERT_NULL(itemBuffer[1]);
+    TEST_ASSERT_NULL(itemBuffer[2]);
+    TEST_ASSERT_NULL(itemBuffer[3]);
+    TEST_ASSERT_NULL(itemBuffer[4]);
+
+    memset(itemBuffer, 0, sizeof(itemBuffer));
+    result = BrRegistryFindMany(&reg, "item1?", (void**)itemBuffer, BR_ASIZE(itemBuffer));
+    TEST_ASSERT_EQUAL_INT(2, result);
+    TEST_ASSERT_EQUAL_PTR(&item1b, itemBuffer[0]);
+    TEST_ASSERT_EQUAL_PTR(&item1a, itemBuffer[1]);
+    TEST_ASSERT_NULL(itemBuffer[2]);
+    TEST_ASSERT_NULL(itemBuffer[3]);
+    TEST_ASSERT_NULL(itemBuffer[4]);
+
+    memset(itemBuffer, 0, sizeof(itemBuffer));
+    result = BrRegistryFindMany(&reg, "item?a", (void**)itemBuffer, BR_ASIZE(itemBuffer));
+    TEST_ASSERT_EQUAL_INT(2, result);
+    TEST_ASSERT_EQUAL_PTR(&item2a, itemBuffer[0]);
+    TEST_ASSERT_EQUAL_PTR(&item1a, itemBuffer[1]);
+    TEST_ASSERT_NULL(itemBuffer[2]);
+    TEST_ASSERT_NULL(itemBuffer[3]);
+    TEST_ASSERT_NULL(itemBuffer[4]);
+
+    memset(itemBuffer, 0, sizeof(itemBuffer));
+    result = BrRegistryFindMany(&reg, "item*", (void**)itemBuffer, BR_ASIZE(itemBuffer));
+    TEST_ASSERT_EQUAL_INT(4, result);
+    TEST_ASSERT_EQUAL_PTR(&item2b, itemBuffer[0]);
+    TEST_ASSERT_EQUAL_PTR(&item2a, itemBuffer[1]);
+    TEST_ASSERT_EQUAL_PTR(&item1b, itemBuffer[2]);
+    TEST_ASSERT_EQUAL_PTR(&item1a, itemBuffer[3]);
+    TEST_ASSERT_NULL(itemBuffer[4]);
+
+    memset(itemBuffer, 0, sizeof(itemBuffer));
+    result = BrRegistryFindMany(&reg, "item*", (void**)itemBuffer, 2);
+    TEST_ASSERT_EQUAL_INT(2, result);
+    TEST_ASSERT_EQUAL_PTR(&item2b, itemBuffer[0]);
+    TEST_ASSERT_EQUAL_PTR(&item2a, itemBuffer[1]);
+    TEST_ASSERT_NULL(itemBuffer[2]);
+    TEST_ASSERT_NULL(itemBuffer[3]);
+    TEST_ASSERT_NULL(itemBuffer[4]);
+
+    BrRegistryClear(&reg);
+    TEST_ASSERT_EQUAL_INT(0, reg.count);
+
+    memset(itemBuffer, 0, sizeof(itemBuffer));
+    result = BrRegistryFindMany(&reg, "item", (void**)itemBuffer, BR_ASIZE(itemBuffer));
+    TEST_ASSERT_EQUAL_INT(0, result);
+}
+
+static void test_register_BrRegistryCount() {
+    br_registry reg;
+    int result;
+    int nb;
+    test_element item1a = { .identifier = "item1a", };
+    test_element item1b = { .identifier = "item1b", };
+    test_element item2a = { .identifier = "item2a", };
+    test_element item2b = { .identifier = "item2b", };
+
+    memset(&reg, 0, sizeof(reg));
+
+    BrRegistryNew(&reg);
+    TEST_ASSERT_EQUAL_INT(0, reg.count);
+
+    result = BrRegistryCount(&reg, "item1a");
+    TEST_ASSERT_EQUAL_INT(0, result);
+
+    BrRegistryAdd(&reg, &item1a);
+    BrRegistryAdd(&reg, &item1b);
+    BrRegistryAdd(&reg, &item2a);
+    BrRegistryAdd(&reg, &item2b);
+    TEST_ASSERT_EQUAL_INT(4, reg.count);
+
+    result = BrRegistryCount(&reg, "item1a");
+    TEST_ASSERT_EQUAL_INT(1, result);
+    result = BrRegistryCount(&reg, "item?a");
+    TEST_ASSERT_EQUAL_INT(2, result);
+    result = BrRegistryCount(&reg, "item*");
+    TEST_ASSERT_EQUAL_INT(4, result);
+    result = BrRegistryCount(&reg, "item*b");
+    TEST_ASSERT_EQUAL_INT(2, result);
+
+    BrRegistryClear(&reg);
+    TEST_ASSERT_EQUAL_INT(0, reg.count);
+
+    result = BrRegistryCount(&reg, "item1a");
+    TEST_ASSERT_EQUAL_INT(0, result);
+}
+
+typedef struct {
+    test_element* buffer[5];
+    int bufferSize;
+    int bufferCapacity;
+
+    int stopAfter;          // callback returns non-zero value when this value reaches 0
+    test_element* stopIf;   // callback returns non-zero value this item equals item
+} test_enum_cbfn_data;
+
+static br_uint_32 impl_test_enum_cbfn(void* item, void* user) {
+    test_enum_cbfn_data* userData = (test_enum_cbfn_data*)user;
+    if (userData->bufferSize < userData->bufferCapacity) {
+        userData->buffer[userData->bufferSize] = (test_element*)item;
+        userData->bufferSize++;
+    }
+    userData->stopAfter--;
+    if (userData->stopAfter == 0) {
+        return 1;
+    }
+    if (item == (void*)userData->stopIf) {
+        return 1;
+    }
+    return 0;
+}
+
+static void test_register_BrRegistryEnum() {
+    br_registry reg;
+    int result;
+    test_enum_cbfn_data cbfn_data;
+    test_element item1a = { .identifier = "item1a", };
+    test_element item1b = { .identifier = "item1b", };
+    test_element item2a = { .identifier = "item2a", };
+    test_element item2b = { .identifier = "item2b", };
+
+    memset(&reg, 0, sizeof(reg));
+
+    BrRegistryNew(&reg);
+    TEST_ASSERT_EQUAL_INT(0, reg.count);
+
+    memset(&cbfn_data, 0, sizeof(cbfn_data));
+    cbfn_data.bufferCapacity = 4;
+    cbfn_data.stopAfter = 99;
+    result = BrRegistryEnum(&reg, "item*", &impl_test_enum_cbfn, &cbfn_data);
+    TEST_ASSERT_EQUAL_INT(0, result);
+    TEST_ASSERT_EQUAL_INT(0, cbfn_data.bufferSize);
+
+    memset(&cbfn_data, 0, sizeof(cbfn_data));
+    result = BrRegistryEnum(&reg, "item*", &impl_test_enum_cbfn, &cbfn_data);
+    TEST_ASSERT_EQUAL_INT(0, result);
+    TEST_ASSERT_EQUAL_INT(0, cbfn_data.bufferSize);
+
+    BrRegistryAdd(&reg, &item1a);
+    BrRegistryAdd(&reg, &item1b);
+    BrRegistryAdd(&reg, &item2a);
+    BrRegistryAdd(&reg, &item2b);
+    TEST_ASSERT_EQUAL_INT(4, reg.count);
+
+    memset(&cbfn_data, 0, sizeof(cbfn_data));
+    cbfn_data.bufferCapacity = 5;
+    cbfn_data.stopAfter = 99;
+    result = BrRegistryEnum(&reg, "item*", &impl_test_enum_cbfn, &cbfn_data);
+    TEST_ASSERT_EQUAL_INT(0, result);
+    TEST_ASSERT_EQUAL_INT(4, cbfn_data.bufferSize);
+
+    memset(&cbfn_data, 0, sizeof(cbfn_data));
+    cbfn_data.bufferCapacity = 2;
+    cbfn_data.stopAfter = 99;
+    result = BrRegistryEnum(&reg, "item*", &impl_test_enum_cbfn, &cbfn_data);
+    TEST_ASSERT_EQUAL_INT(0, result);
+    TEST_ASSERT_EQUAL_INT(2, cbfn_data.bufferSize);
+
+    memset(&cbfn_data, 0, sizeof(cbfn_data));
+    cbfn_data.bufferCapacity = 5;
+    cbfn_data.stopAfter = 2;
+    result = BrRegistryEnum(&reg, "item*", &impl_test_enum_cbfn, &cbfn_data);
+    TEST_ASSERT_EQUAL_INT(1, result);
+    TEST_ASSERT_EQUAL_INT(2, cbfn_data.bufferSize);
+
+    memset(&cbfn_data, 0, sizeof(cbfn_data));
+    cbfn_data.bufferCapacity = 5;
+    cbfn_data.stopAfter = 99;
+    cbfn_data.stopIf = &item2a;
+    result = BrRegistryEnum(&reg, "item*", &impl_test_enum_cbfn, &cbfn_data);
+    TEST_ASSERT_EQUAL_INT(1, result);
+    TEST_ASSERT_EQUAL_INT(3, cbfn_data.bufferSize);
+
+    BrRegistryClear(&reg);
+    TEST_ASSERT_EQUAL_INT(0, reg.count);
 }
 
 void test_register_suite() {
+    RUN_TEST(test_register_BrRegistryNew);
+    RUN_TEST(test_register_BrRegistryAdd_BrRegistryRemove);
+    RUN_TEST(test_register_offsets);
     RUN_TEST(test_register_BrRegistryFind);
-    RUN_TEST(test_register_BrRegistryRemove);
+    RUN_TEST(test_register_BrRegistryClear);
+    RUN_TEST(test_register_BrRegistryAddMany);
+    RUN_TEST(test_register_BrRegistryRemoveMany);
+    RUN_TEST(test_register_BrRegistryFindMany);
+    RUN_TEST(test_register_BrRegistryCount);
+    RUN_TEST(test_register_BrRegistryEnum);
 }


### PR DESCRIPTION
This pr implements all functions related to double linked lists, simple lists and registries.

The changes to the registry also fixes a bug:
the current implement does not allow to perform a `BrRegistryRemove` or `BrRegistryFind` on an empty registry.