### PR TITLE
Don't grab the mouse when debugging

### DIFF
--- a/src/BRSRC13/CORE/V1DB/v1dbfile.c
+++ b/src/BRSRC13/CORE/V1DB/v1dbfile.c
@@ -969,7 +969,7 @@ int FopRead_TRANSFORM(br_datafile* df, br_uint_32 id, br_uint_32 length, br_uint
         }
     }
     if (t == 7) {
-        LOG_PANIC("transform type not found!")
+        LOG_PANIC("transform type not found!");
     }
     tp = (br_transform*)BrResAllocate(v1db.res, sizeof(br_transform), BR_MEMORY_TRANSFORM);
     tp->type = t;

--- a/src/harness/CMakeLists.txt
+++ b/src/harness/CMakeLists.txt
@@ -52,3 +52,17 @@ target_sources(harness PRIVATE
     platforms/null.h
     stack_trace_handler.h
 )
+
+if(WIN32)
+    target_sources(harness PRIVATE
+        platforms/platform_windows.c
+    )
+elseif(APPLE)
+target_sources(harness PRIVATE
+    platforms/platform_macosx.c
+)
+else()
+    target_sources(harness PRIVATE
+        platforms/platform_linux.c
+    )
+endif()

--- a/src/harness/include/harness/trace.h
+++ b/src/harness/include/harness/trace.h
@@ -10,6 +10,7 @@
 #endif
 
 extern int harness_debug_level;
+extern int PlatformIsDebuggerPresent(void);
 
 void Harness_Debug_PrintStack();
 
@@ -45,9 +46,14 @@ void debug_print_matrix4(const char* fmt, const char* fn, char* name, br_matrix4
 #define LOG_MATRIX4(msg, m) debug_print_matrix4("\033[0;34m[DEBUG] %s ", __FUNCTION__, msg, m)
 #define LOG_INFO(...) debug_printf("\033[0;34m[INFO] %s ", __FUNCTION__, __VA_ARGS__)
 #define LOG_WARN(...) debug_printf("\033[0;33m[WARN] %s ", __FUNCTION__, __VA_ARGS__)
-#define LOG_PANIC(...)                                                \
-    debug_printf("\033[0;31m[PANIC] %s ", __FUNCTION__, __VA_ARGS__); \
-    exit(1);
+#define LOG_PANIC(...)                                                       \
+    do {                                                                     \
+        debug_printf("\033[0;31m[PANIC] %s ", __FUNCTION__, __VA_ARGS__);    \
+        if (PlatformIsDebuggerPresent())                                     \
+            abort();                                                         \
+        else                                                                 \
+            exit(1);                                                         \
+    } while (0)
 
 #define LOG_WARN_ONCE(...)                                                   \
     static int warn_printed = 0;                                             \
@@ -56,13 +62,11 @@ void debug_print_matrix4(const char* fmt, const char* fn, char* name, br_matrix4
         warn_printed = 1;                                                    \
     }
 
-#define NOT_IMPLEMENTED()                                                         \
-    debug_printf("\033[0;31m[PANIC] %s ", __FUNCTION__, "%s", "not implemented"); \
-    exit(1);
+#define NOT_IMPLEMENTED()                                                    \
+    LOG_PANIC("not implemented")
 
-#define TELL_ME_IF_WE_PASS_THIS_WAY()                                                    \
-    debug_printf("\033[0;31m[PANIC] %s ", __FUNCTION__, "%s", "code path not expected"); \
-    exit(1);
+#define TELL_ME_IF_WE_PASS_THIS_WAY()                                        \
+    LOG_PANIC("code path not expected")
 
 #define STUB() \
     debug_printf("\033[0;31m[WARN] %s ", __FUNCTION__, "%s", "stubbed");

--- a/src/harness/platforms/platform.h
+++ b/src/harness/platforms/platform.h
@@ -1,0 +1,6 @@
+#ifndef HARNESS_PLATFORM_H
+#define HARNESS_PLATFORM_H
+
+int PlatformIsDebuggerPresent(void);
+
+#endif

--- a/src/harness/platforms/platform_linux.c
+++ b/src/harness/platforms/platform_linux.c
@@ -1,0 +1,45 @@
+#include "platforms/platform.h"
+
+#include <sys/stat.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <ctype.h>
+
+#define TRACER_PID_STRING "TracerPid:"
+
+int PlatformIsDebuggerPresent() {
+    char buf[4096];
+    int status_fd;
+    ssize_t num_read;
+    char* tracer_pid_ptr;
+    char* char_ptr;
+
+    status_fd = open("/proc/self/status", O_RDONLY);
+    if (status_fd == -1) {
+        return 0;
+    }
+
+    num_read = read(status_fd, buf, sizeof(buf) - 1);
+    close(status_fd);
+    if (num_read <= 0) {
+        return 0;
+    }
+
+    buf[num_read] = '\0';
+    tracer_pid_ptr = strstr(buf, TRACER_PID_STRING);
+    if (tracer_pid_ptr == NULL) {
+        return 0;
+    }
+
+    for (char_ptr = tracer_pid_ptr + sizeof(TRACER_PID_STRING) - 1; char_ptr <= buf + num_read; ++char_ptr)
+    {
+        if (isspace(*char_ptr)) {
+            continue;
+        } else {
+            return isdigit(*char_ptr) != 0 && *char_ptr != '0';
+        }
+    }
+
+    return 0;
+}

--- a/src/harness/platforms/platform_macosx.c
+++ b/src/harness/platforms/platform_macosx.c
@@ -1,0 +1,44 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/sysctl.h>
+
+
+// https://developer.apple.com/library/archive/qa/qa1361/_index.html
+// FIXME:
+//     Important: Because the definition of the kinfo_proc structure (in <sys/sysctl.h>) is conditionalized by __APPLE_API_UNSTABLE,
+//     you should restrict use of the above code to the debug build of your program.
+
+int PlatformIsDebuggerPresent()
+    // Returns true if the current process is being debugged (either 
+    // running under the debugger or has a debugger attached post facto).
+{
+    int                 junk;
+    int                 mib[4];
+    struct kinfo_proc   info;
+    size_t              size;
+
+    // Initialize the flags so that, if sysctl fails for some bizarre 
+    // reason, we get a predictable result.
+
+    info.kp_proc.p_flag = 0;
+
+    // Initialize mib, which tells sysctl the info we want, in this case
+    // we're looking for information about a specific process ID.
+
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_PROC;
+    mib[2] = KERN_PROC_PID;
+    mib[3] = getpid();
+
+    // Call sysctl.
+
+    size = sizeof(info);
+    junk = sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0);
+    assert(junk == 0);
+
+    // We're being debugged if the P_TRACED flag is set.
+
+    return ((info.kp_proc.p_flag & P_TRACED) != 0);
+}

--- a/src/harness/platforms/platform_windows.c
+++ b/src/harness/platforms/platform_windows.c
@@ -1,0 +1,5 @@
+#include <windows.h>
+
+int PlatformIsDebuggerPresent() {
+    return IsDebuggerPresent();
+}

--- a/src/harness/sdl/gl_renderer.c
+++ b/src/harness/sdl/gl_renderer.c
@@ -5,6 +5,7 @@
 #include "gl_renderer_shaders.h"
 #include "harness.h"
 #include "harness/trace.h"
+#include "platforms/platform.h"
 
 #include <cglm/cglm.h>
 #include <glad/glad.h>
@@ -264,7 +265,11 @@ void GLRenderer_CreateWindow(char* title, int width, int height, int pRender_wid
     if (!window) {
         LOG_PANIC("Failed to create window");
     }
-    SDL_SetRelativeMouseMode(SDL_TRUE);
+
+    // Don't grab the mouse when a debugger is present
+    if (!PlatformIsDebuggerPresent()) {
+        SDL_SetRelativeMouseMode(SDL_TRUE);
+    }
 
     // SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN);
 


### PR DESCRIPTION
This pr adds 2 main features to make our life easier:
- don't grab the mouse when a debugger is attached.
This means that, when debugging in an IDE, the mouse won't be hidden.
Right now, the mouse is hidden when some breakpoint is hit which is annoying.
- do `abort()` instead of `exit(1)` on a panic when a debugger is attached,
such that you are thrown right to the correct spot when e.g. an unimplemented function is encountered.

I copied the code to detect a debugger on Macos from this apple faq page: https://developer.apple.com/library/archive/qa/qa1361/_index.html
There is an important note about the code not working on a release build.
Since I don't own an apple (and you do), can you take a look at this and fix it?
You probably might have to `#ifdef _DEBUG` this function and return `0` when building a release binary.

This is another way to detect a debugger on Macos
https://zgcoder.net/ramblings/osx-debugger-detection/#mach-exception-handlers

Since gdb is not really used by apply, perhaps this 2nd method should be used instead.