### PR TITLE
Fix PDKeyDown2

### DIFF
--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -125,8 +125,8 @@ tKey_down_result PDKeyDown2(int pKey_index) {
     if (gLast_key_down == pKey_index) {
         gLast_key_down_time = 0;
         gLast_key_down = -1;
-        return tKey_down_no;
     }
+    return tKey_down_no;
 }
 
 // IDA: int __usercall PDKeyDown@<EAX>(int pKey_index@<EAX>)


### PR DESCRIPTION
The return value of `PDKeyDown2` was undefined. For me it resulted in always reporting that a key was pressed, leading to strange.... behavior in the UI :)