### PR TITLE
Visual Studio Fixes

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -82,52 +82,6 @@ jobs:
           name: artifacts
           path: windows-${{ matrix.platform }}.zip
 
-  build-mingw:
-    runs-on: 'ubuntu-latest'
-    strategy:
-      matrix:
-        platform: [x86, amd64]
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Build
-        run: |
-          .github/scripts/build-mingw.sh
-        env:
-          MATRIX_PLATFORM: ${{ matrix.platform }}
-
-  build-mingw-msys2:
-    runs-on: 'windows-latest'
-    strategy:
-      matrix:
-        include:
-          - platform: x86
-            msystem: mingw32
-          - platform: amd64
-            msystem: mingw64
-    defaults:
-      run:
-        shell: msys2 {0}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-      - uses: msys2/setup-msys2@v2
-        with:
-          msystem: ${{ matrix.msystem }}
-      - name: Build
-        run: |
-          .github/scripts/build-mingw.sh
-        env:
-          MATRIX_PLATFORM: ${{ matrix.platform }}
-      - name: Test
-        run: |
-          cd build
-          ctest --verbose
-
 
   create-release:
     needs: [build-linux, build-macos, build-windows]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ if(NOT DEFINED CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo" FORCE)
 endif()
 
+set(DETHRACE_IDE_ARGUMENTS "" CACHE STRING "DethRace arguments (only used by MSVC when debugging")
+set(DETHRACE_IDE_ROOT_DIR "" CACHE PATH "DethRace rootdir (only used by MSVC when debugging)")
+
 set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
 
 project(dethrace C)

--- a/src/BRSRC13/CORE/FW/resource.c
+++ b/src/BRSRC13/CORE/FW/resource.c
@@ -35,7 +35,7 @@ resource_header* UserToRes(void* r) {
         p--;
     }
     if (((resource_header*)(p - (sizeof(resource_header) - 1)))->magic_num != 0xdeadbeef) {
-        LOG_PANIC("Bad resource header from user at %p. Was %X", r, ((resource_header*)p)->magic_num);
+        LOG_PANIC("Bad resource header from user at %p. Was 0x%x", r, ((resource_header*)p)->magic_num);
     }
     return (resource_header*)(p - (sizeof(resource_header) - 1));
 }
@@ -212,6 +212,7 @@ br_uint_32 BrResChildEnum(void* vres, br_resenum_cbfn* callback, void* arg) {
     LOG_TRACE("(%p, %p, %p)", vres, callback, arg);
 
     res = UserToRes(vres);
+    r = 0;
     for (rp = (resource_header*)res->children.head; rp != NULL; rp = (resource_header*)rp->node.next) {
         r = callback(ResToUser(rp), arg);
         if (r != 0) {

--- a/src/DETHRACE/CMakeLists.txt
+++ b/src/DETHRACE/CMakeLists.txt
@@ -181,3 +181,17 @@ else()
     target_link_options(dethrace PRIVATE /subsystem:windows /ENTRY:mainCRTStartup)
     target_compile_definitions(dethrace PRIVATE -D_CRT_SECURE_NO_WARNINGS -DSDL_MAIN_HANDLED)
 endif()
+
+if(DETHRACE_IDE_ROOT_DIR)
+    set_target_properties(dethrace PROPERTIES
+        VS_DEBUGGER_ENVIRONMENT "DETHRACE_ROOT_DIR=${DETHRACE_IDE_ROOT_DIR}"
+    )
+endif()
+if(DETHRACE_IDE_ARGUMENTS)
+    message(STATUS "before: ${DETHRACE_IDE_ARGUMENTS}")
+    separate_arguments(DETHRACE_IDE_ARGUMENTS NATIVE_COMMAND "${DETHRACE_IDE_ARGUMENTS}")
+    message(STATUS "after: ${DETHRACE_IDE_ARGUMENTS}")
+    set_target_properties(dethrace PROPERTIES
+        VS_DEBUGGER_COMMAND_ARGUMENTS "${DETHRACE_IDE_ARGUMENTS}"
+    )
+endif()

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -4748,6 +4748,9 @@ int CollideCamera2(br_vector3* car_pos, br_vector3* cam_pos, br_vector3* old_cam
     tFace_ref face_list[3];
     LOG_TRACE("(%p, %p, %p, %d)", car_pos, cam_pos, old_camera_pos, manual_move);
 
+#ifdef DETHRACE_FIX_BUGS
+    ts2 = 0.f;
+#endif
     hither = ((br_camera*)gCamera->type_data)->hither_z * 3.0;
     gCamera_has_collided = 0;
     for (i = 0; i < 1; i++) {

--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -356,7 +356,7 @@ void DoHeadups(tU32 pThe_time) {
     }
 
     the_headup = gHeadups;
-    for (i = 0; i < 15; i++) {
+    for (i = 0; i < COUNT_OF(gHeadups); i++) {
         the_headup = &gHeadups[i];
         if (the_headup->type
             && (gProgram_state.which_view == eView_forward || !the_headup->cockpit_anchored)

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -614,14 +614,14 @@ void InitializePalettes() {
     gCurrent_palette_pixels = BrMemAllocate(0x400u, kMem_cur_pal_pixels);
     gCurrent_palette = DRPixelmapAllocate(BR_PMT_RGBX_888, 1u, 256, gCurrent_palette_pixels, 0);
     gRender_palette = BrTableFind("DRRENDER.PAL");
-    if (!gRender_palette) {
+    if (gRender_palette == NULL) {
         FatalError(10);
     }
     gOrig_render_palette = BrPixelmapAllocateSub(gRender_palette, 0, 0, gRender_palette->width, gRender_palette->height);
     gOrig_render_palette->pixels = BrMemAllocate(0x400u, kMem_render_pal_pixels);
     memcpy(gOrig_render_palette->pixels, gRender_palette->pixels, 0x400u);
     gFlic_palette = BrTableFind("DRACEFLC.PAL");
-    if (!gFlic_palette) {
+    if (gFlic_palette == NULL) {
         FatalError(10);
     }
     DRSetPalette(gFlic_palette);
@@ -656,7 +656,7 @@ void ClearWobbles() {
     LOG_TRACE("()");
 
     for (i = 0; i < COUNT_OF(gWobble_array); ++i) {
-        gWobble_array[i].amplitude_x = 0.0;
+        gWobble_array[i].time_started = 0;
     }
 }
 
@@ -1690,7 +1690,7 @@ void RenderAFrame(int pDepth_mask_on) {
             DrawPowerups(the_time);
         }
     }
-    if (gNet_mode) {
+    if (gNet_mode != eNet_mode_none) {
         DisplayUserMessage();
     }
     if (gAction_replay_mode && !gAR_fudge_headups) {

--- a/src/DETHRACE/common/loading.c
+++ b/src/DETHRACE/common/loading.c
@@ -36,7 +36,7 @@
 #include <errno.h>
 
 #define HITHER_MULTIPLIER 2.0f
-#define AMBIENT_MULTIPLIER 0.0099999998f
+#define AMBIENT_MULTIPLIER 0.01f
 #define NBR_FUNK_GROVE_FLAGS 30
 
 tHeadup_info gHeadup_image_info[31] = {
@@ -328,7 +328,7 @@ void LoadGeneralParameters() {
         }
 
         for (i = 0; i < strlen(gDecode_string); i++) {
-            gDecode_string[i] -= 50;
+            gDecode_string[i] += 50;
         }
     }
     PathCat(the_path, gApplication_path, "GENERAL.TXT");
@@ -461,7 +461,7 @@ br_pixelmap* LoadPixelmap(char* pName) {
     LOG_TRACE("(\"%s\")", pName);
 
     end = strrchr(pName, '.');
-    if (!end) {
+    if (end == NULL) {
         end = &pName[strlen(pName)];
     }
 
@@ -472,7 +472,7 @@ br_pixelmap* LoadPixelmap(char* pName) {
         PathCat(the_path, the_path, pName);
         AllowOpenToFail();
         pm = DRPixelmapLoad(the_path);
-        if (!pm) {
+        if (pm == NULL) {
             PathCat(the_path, gApplication_path, "PIXELMAP");
             PathCat(the_path, the_path, pName);
             pm = DRPixelmapLoad(the_path);
@@ -490,9 +490,9 @@ br_uint_32 LoadPixelmaps(char* pFile_name, br_pixelmap** pPixelmaps, br_uint_16 
     PathCat(path, path, "PIXELMAP");
 
     PathCat(path, path, pFile_name);
-    gAllow_open_to_fail = 1;
+    AllowOpenToFail();
     count = DRPixelmapLoadMany(path, pPixelmaps, pNum);
-    if (!count) {
+    if (count == 0) {
         PathCat(path, gApplication_path, "PIXELMAP");
         PathCat(path, path, pFile_name);
         count = DRPixelmapLoadMany(path, pPixelmaps, pNum);
@@ -736,7 +736,7 @@ void UnlockInterfaceStuff() {
         }
     }
     PossibleService();
-    for (i = 0; i < 18; i++) {
+    for (i = 0; i < COUNT_OF(gCursor_giblet_images); i++) {
         if (gCursor_giblet_images[i]) {
             BrPixelmapFree(gCursor_giblet_images[i]);
             gCursor_giblet_images[i] = NULL;
@@ -1742,14 +1742,14 @@ void LoadCar(char* pCar_name, tDriver pDriver, tCar_spec* pCar_spec, int pOwner,
         PathCat(the_path, the_path, "CARS");
         PathCat(the_path, the_path, gBasic_car_names[0]);
         g = DRfopen(the_path, "rt");
-        if (!g)
+        if (g == NULL)
             FatalError(104);
     }
     GetAString(f, s);
     strcpy(pCar_spec->name, s);
     if (strcmp(s, pCar_name) != 0)
-        FatalError(115);
-    if (*pDriver_name) {
+        FatalError(115, pCar_name);
+    if (*pDriver_name != '\0') {
         memcpy(pCar_spec->driver_name, pDriver_name, sizeof(pCar_spec->driver_name));
         pCar_spec->driver_name[31] = 0;
     } else {
@@ -1792,27 +1792,30 @@ void LoadCar(char* pCar_name, tDriver pDriver, tCar_spec* pCar_spec, int pOwner,
             PossibleService();
         }
         LoadSpeedo(g, 0, pCar_spec);
-        if (gAusterity_mode)
+        if (gAusterity_mode) {
             GetALineAndDontArgue(g, s);
-        else
+        } else {
             LoadSpeedo(g, 1, pCar_spec);
+        }
         PossibleService();
         LoadTacho(g, 0, pCar_spec);
-        if (gAusterity_mode)
+        if (gAusterity_mode) {
             GetALineAndDontArgue(g, s);
-        else
+        } else {
             LoadTacho(g, 1, pCar_spec);
+        }
         PossibleService();
         LoadGear(g, 0, pCar_spec);
-        if (gAusterity_mode)
+        if (gAusterity_mode) {
             GetALineAndDontArgue(g, s);
-        else
+        } else {
             LoadGear(g, 1, pCar_spec);
+        }
         PossibleService();
         GetALineAndDontArgue(g, s);
         str = strtok(s, "\t ,/");
         sscanf(str, "%d", &pCar_spec->number_of_hands_images);
-        for (j = 0; pCar_spec->number_of_hands_images > j; ++j) {
+        for (j = 0; j < pCar_spec->number_of_hands_images; j++) {
             GetALineAndDontArgue(g, s);
             str = strtok(s, "\t ,/");
             sscanf(str, "%d", &pCar_spec->lhands_x[j]);
@@ -1898,7 +1901,7 @@ void LoadCar(char* pCar_name, tDriver pDriver, tCar_spec* pCar_spec, int pOwner,
                 }
                 str = strtok(NULL, "\t ,/");
                 pCar_spec->damage_units[j].images = LoadPixelmap(str);
-                if (!pCar_spec->damage_units[j].images)
+                if (pCar_spec->damage_units[j].images == NULL)
                     FatalError(27);
             }
             pCar_spec->damage_units[j].damage_level = 0;
@@ -2385,7 +2388,7 @@ void UnlockOpponentMugshot(int pIndex) {
     LOG_TRACE("(%d)", pIndex);
 
     if (pIndex >= 0) {
-        if (gOpponents[pIndex].mug_shot_image_data) {
+        if (gOpponents[pIndex].mug_shot_image_data != NULL) {
             MAMSUnlock((void**)&gOpponents[pIndex].mug_shot_image_data);
         }
     }
@@ -2394,8 +2397,9 @@ void UnlockOpponentMugshot(int pIndex) {
 // IDA: void __usercall LoadOpponentMugShot(int pIndex@<EAX>)
 void LoadOpponentMugShot(int pIndex) {
     LOG_TRACE("(%d)", pIndex);
+
     PossibleService();
-    if (pIndex >= 0 && !gOpponents[pIndex].mug_shot_image_data) {
+    if (pIndex >= 0 && gOpponents[pIndex].mug_shot_image_data == NULL) {
         if (!LoadFlicData(
                 gOpponents[pIndex].mug_shot_name,
                 &gOpponents[pIndex].mug_shot_image_data,
@@ -2411,7 +2415,7 @@ void DisposeOpponentGridIcon(tRace_info* pRace_info, int pIndex) {
     LOG_TRACE("(%p, %d)", pRace_info, pIndex);
 
     if (pRace_info->opponent_list[pIndex].index >= 0) {
-        if (pRace_info->opponent_list[pIndex].car_spec->grid_icon_image) {
+        if (pRace_info->opponent_list[pIndex].car_spec->grid_icon_image != NULL) {
             BrPixelmapFree(pRace_info->opponent_list[pIndex].car_spec->grid_icon_image);
             pRace_info->opponent_list[pIndex].car_spec->grid_icon_image = NULL;
         }
@@ -2423,7 +2427,7 @@ void LoadOpponentGridIcon(tRace_info* pRace_info, int pIndex) {
     LOG_TRACE("(%p, %d)", pRace_info, pIndex);
 
     PossibleService();
-    if (pRace_info->opponent_list[pIndex].index >= 0 && !pRace_info->opponent_list[pIndex].car_spec->grid_icon_image) {
+    if (pRace_info->opponent_list[pIndex].index >= 0 && pRace_info->opponent_list[pIndex].car_spec->grid_icon_image == NULL) {
         pRace_info->opponent_list[pIndex].car_spec->grid_icon_image = LoadPixelmap(pRace_info->opponent_list[pIndex].car_spec->grid_icon_names[0]);
         if (!pRace_info->opponent_list[pIndex].car_spec->grid_icon_image) {
             FatalError(57);
@@ -2449,15 +2453,10 @@ void LoadRaceInfo(int pRace_index, tRace_info* pRace_info) {
     LOG_TRACE("(%d, %p)", pRace_index, pRace_info);
 
     f = OpenRaceFile();
-    temp_index = pRace_index;
-    while (1) {
-        if (!temp_index) {
-            break;
-        }
+    for (temp_index = pRace_index; temp_index != 0; temp_index--) {
         PossibleService();
         GetALineAndDontArgue(f, s);
         SkipRestOfRace(f);
-        temp_index--;
     }
     GetALineAndDontArgue(f, pRace_info->name);
     pRace_info->rank_required = gRace_list[pRace_index].rank_required;
@@ -2520,7 +2519,7 @@ void DisposeRaceInfo(tRace_info* pRace_info) {
     tText_chunk* the_chunk;
     LOG_TRACE("(%p)", pRace_info);
 
-    if (!gNet_mode) {
+    if (gNet_mode == eNet_mode_none) {
         the_chunk = pRace_info->text_chunks;
         for (i = 0; i < pRace_info->text_chunk_count; i++) {
             PossibleService();
@@ -2556,7 +2555,7 @@ void LoadGridIcons(tRace_info* pRace_info) {
     int i;
     LOG_TRACE("(%p)", pRace_info);
 
-    for (i = 0; pRace_info->number_of_racers > i; ++i) {
+    for (i = 0; i < pRace_info->number_of_racers; ++i) {
         LoadOpponentGridIcon(pRace_info, i);
     }
     gProgram_state.current_car.grid_icon_image = LoadPixelmap(gProgram_state.current_car.grid_icon_names[gProgram_state.frank_or_anniness + 1]);
@@ -2568,7 +2567,7 @@ void DisposeGridIcons(tRace_info* pRace_info) {
     int i;
     LOG_TRACE("(%p)", pRace_info);
 
-    for (i = 0; pRace_info->number_of_racers > i; i++) {
+    for (i = 0; i < pRace_info->number_of_racers; i++) {
         DisposeOpponentGridIcon(pRace_info, i);
     }
     BrPixelmapFree(gProgram_state.current_car.grid_icon_image);
@@ -2601,14 +2600,14 @@ void LoadOpponents() {
     for (i = 0; i < gNumber_of_racers; i++) {
         PossibleService();
         GetALineAndDontArgue(f, gOpponents[i].name);
-        if (!strcmp(gOpponents[i].name, "END")) {
+        if (strcmp(gOpponents[i].name, "END") == 0) {
             FatalError(55);
         }
 
         GetALineAndDontArgue(f, gOpponents[i].abbrev_name);
         gOpponents[i].car_number = GetAnInt(f);
         gOpponents[i].strength_rating = GetAnInt(f);
-        gOpponents[i].network_availability = GetALineAndInterpretCommand(f, gNet_avail_names, 4);
+        gOpponents[i].network_availability = GetALineAndInterpretCommand(f, gNet_avail_names, COUNT_OF(gNet_avail_names));
 
         GetALineAndDontArgue(f, s);
         str = strtok(s, "\t ,/");
@@ -2673,7 +2672,7 @@ br_font* LoadBRFont(char* pName) {
     the_font = BrMemAllocate(sizeof(br_font), kMem_br_font);
 
     // we read 0x18 bytes as that is the size of the struct in 32 bit code.
-    fread(the_font, 0x18, 1u, f);
+    fread(the_font, 0x18, 1, f);
     the_font->flags = BrSwap32(the_font->flags);
 
     // swap endianness
@@ -2862,6 +2861,7 @@ void GetFourInts(FILE* pF, int* pF1, int* pF2, int* pF3, int* pF4) {
 // IDA: br_scalar __usercall GetAScalar@<ST0>(FILE *pF@<EAX>)
 br_scalar GetAScalar(FILE* pF) {
     LOG_TRACE("(%p)", pF);
+
     return GetAFloat(pF);
 }
 
@@ -2944,8 +2944,8 @@ void GetPairOfFloatPercents(FILE* pF, float* pF1, float* pF2) {
     sscanf(str, "%f", pF1);
     str = strtok(NULL, "\t ,/");
     sscanf(str, "%f", pF2);
-    *pF1 = *pF1 / 100.0;
-    *pF2 = *pF2 / 100.0;
+    *pF1 = *pF1 / 100.0f;
+    *pF2 = *pF2 / 100.0f;
 }
 
 // IDA: void __usercall GetThreeFloatPercents(FILE *pF@<EAX>, float *pF1@<EDX>, float *pF2@<EBX>, float *pF3@<ECX>)
@@ -2961,9 +2961,9 @@ void GetThreeFloatPercents(FILE* pF, float* pF1, float* pF2, float* pF3) {
     sscanf(str, "%f", pF2);
     str = strtok(NULL, "\t ,/");
     sscanf(str, "%f", pF3);
-    *pF1 = *pF1 / 100.0;
-    *pF2 = *pF2 / 100.0;
-    *pF3 = *pF3 / 100.0;
+    *pF1 = *pF1 / 100.0f;
+    *pF2 = *pF2 / 100.0f;
+    *pF3 = *pF3 / 100.0f;
 }
 
 // IDA: void __usercall GetAString(FILE *pF@<EAX>, char *pString@<EDX>)
@@ -3033,7 +3033,7 @@ void LoadMiscStrings() {
 
     PathCat(the_path, gApplication_path, "TEXT.TXT");
     f = DRfopen(the_path, "rt");
-    if (!f) {
+    if (f == NULL) {
         FatalError(99);
     }
     for (i = 0; i < 250; i++) {
@@ -3164,12 +3164,14 @@ FILE* OldDRfopen(char* pFilename, char* pMode) {
 // IDA: void __cdecl AllowOpenToFail()
 void AllowOpenToFail() {
     LOG_TRACE("()");
+
     gAllow_open_to_fail = 1;
 }
 
 // IDA: void __cdecl DoNotAllowOpenToFail()
 void DoNotAllowOpenToFail() {
     LOG_TRACE("()");
+
     gAllow_open_to_fail = 0;
 }
 
@@ -3182,7 +3184,7 @@ FILE* DRfopen(char* pFilename, char* pMode) {
 
     result = OldDRfopen(pFilename, pMode);
 
-    if (!result && !gAllow_open_to_fail) {
+    if (result == NULL && !gAllow_open_to_fail) {
         if (GetCDPathFromPathsTxtFile(CD_dir) && !PDCheckDriveExists(CD_dir)) {
             if (gMisc_strings[0]) {
                 PDFatalError(GetMiscString(243));
@@ -3193,7 +3195,7 @@ FILE* DRfopen(char* pFilename, char* pMode) {
             PDFatalError(msg);
         }
     }
-    if (!result) {
+    if (result == NULL) {
         LOG_WARN("failed for %d", errno);
     }
     return result;
@@ -3210,7 +3212,7 @@ int GetCDPathFromPathsTxtFile(char* pPath_name) {
     if (!got_it_already) {
         sprintf(paths_txt, "%s%s%s", gApplication_path, gDir_separator, "PATHS.TXT");
         paths_txt_fp = fopen(paths_txt, "rt");
-        if (!paths_txt_fp) {
+        if (paths_txt_fp == NULL) {
             return 0;
         }
         GetALineAndDontArgue(paths_txt_fp, cd_pathname);
@@ -3417,7 +3419,7 @@ int RestoreOptions() {
 
     PathCat(the_path, gApplication_path, "OPTIONS.TXT");
     f = DRfopen(the_path, "rt");
-    if (!f) {
+    if (f == NULL) {
         LOG_WARN("Failed to open OPTIONS.TXT");
         return 0;
     }

--- a/src/DETHRACE/common/mainloop.c
+++ b/src/DETHRACE/common/mainloop.c
@@ -389,7 +389,7 @@ void UpdateFramePeriod(tU32* pCamera_period) {
         }
     } else {
         // The following makes the timer go too fast when the real frame rate is high (=low frame period)
-#ifndef BRENDER_FIX_BUGS
+#ifndef DETHRACE_FIX_BUGS
         gFrame_period = 10;
 #endif
         gLast_tick_count = new_tick_count;

--- a/src/DETHRACE/common/mainloop.c
+++ b/src/DETHRACE/common/mainloop.c
@@ -388,7 +388,10 @@ void UpdateFramePeriod(tU32* pCamera_period) {
             gLast_tick_count = new_tick_count;
         }
     } else {
+        // The following makes the timer go too fast when the real frame rate is high (=low frame period)
+#ifndef BRENDER_FIX_BUGS
         gFrame_period = 10;
+#endif
         gLast_tick_count = new_tick_count;
     }
     if (*pCamera_period >= 10) {

--- a/src/DETHRACE/common/pratcam.c
+++ b/src/DETHRACE/common/pratcam.c
@@ -195,7 +195,7 @@ void NewPratcamSequence(int pSequence_index, int pStart_chunk) {
 // IDA: void __usercall ChangeAmbientPratcamNow(int pIndex@<EAX>, int pStart_chunk@<EDX>)
 void ChangeAmbientPratcamNow(int pIndex, int pStart_chunk) {
     LOG_TRACE("(%d, %d)", pIndex, pStart_chunk);
-    NOT_IMPLEMENTED();
+    STUB();
 }
 
 // IDA: void __usercall ChangeAmbientPratcam(int pIndex@<EAX>)

--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -1782,6 +1782,9 @@ void CreateSplash(tCar_spec* pCar, tU32 pTime) {
 
     back_val[0] = 0.0;
     back_val[1] = 0.0;
+#ifdef DETHRACE_FIX_BUGS
+    BrVector3Set(&p, 0.f, 0.f, 0.f);
+#endif
     if (pCar->v.v[2] * pCar->v.v[2] + pCar->v.v[1] * pCar->v.v[1] + pCar->v.v[0] * pCar->v.v[0] >= 1.0) {
         BrMatrix34TApplyV(&normal_car_space, &pCar->water_normal, &pCar->car_master_actor->t.t.mat);
         BrMatrix34ApplyP(&tv, &pCar->bounds[0].min, &pCar->car_master_actor->t.t.mat);

--- a/src/DETHRACE/pc-dos/dosnet.c
+++ b/src/DETHRACE/pc-dos/dosnet.c
@@ -364,7 +364,7 @@ void PDNetObtainSystemUserName(char* pName, int pMax_length) {
     }
     while (1) {
         pName = strpbrk(pName, "_=(){}[]<>!$%^&*/:@~;'#,?\\|`\"");
-        if (*pName == '\0') {
+        if (pName == NULL || *pName == '\0') {
             break;
         }
         *pName = '-';

--- a/src/DETHRACE/pc-dos/dossys.c
+++ b/src/DETHRACE/pc-dos/dossys.c
@@ -528,11 +528,7 @@ void PDForEveryFile(char* pThe_path, void (*pAction_routine)(char*)) {
     if (d) {
         while ((entry = readdir(d)) != NULL) {
             // only files, and only files that don't start with '.'
-#ifdef _WIN32
-            if ((GetFileAttributesA(pThe_path) & FILE_ATTRIBUTE_DIRECTORY) != FILE_ATTRIBUTE_DIRECTORY) {
-#else
             if (entry->d_type == DT_REG && entry->d_name[0] != '.') {
-#endif
                 PathCat(found_path, pThe_path, entry->d_name);
                 pAction_routine(found_path);
             }

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -1,4 +1,3 @@
-
 #include "harness.h"
 #include "brender_emu/renderer_impl.h"
 #include "include/harness/config.h"
@@ -85,7 +84,7 @@ void Harness_Init(int* argc, char* argv[]) {
     }
 
     char* root_dir = getenv("DETHRACE_ROOT_DIR");
-    if (!root_dir) {
+    if (root_dir == NULL) {
         LOG_INFO("DETHRACE_ROOT_DIR is not set, assuming '.'");
     } else {
         printf("DETHRACE_ROOT_DIR: %s\n", root_dir);

--- a/test/BRSRC13/test_resource.c
+++ b/test/BRSRC13/test_resource.c
@@ -151,17 +151,20 @@ static void test_resource_BrResSize_BrResSizeTotal() {
     br_uint_32 size_child2;
 
     vparent = BrResAllocate(NULL, 0, BR_MEMORY_ANCHOR);
+    TEST_ASSERT_NOT_NULL(vparent);
     size_parent = BrResSize(vparent);
     TEST_ASSERT_GREATER_THAN_UINT32(0, size_parent);
     TEST_ASSERT_EQUAL_UINT32(size_parent, BrResSizeTotal(vparent));
 
     child1 = BrResAllocate(vparent, 10, BR_MEMORY_DATAFILE);
+    TEST_ASSERT_NOT_NULL(child1);
     size_child1 = BrResSize(child1);
     TEST_ASSERT_GREATER_THAN_UINT32(0, size_child1);
     TEST_ASSERT_EQUAL(size_parent, BrResSize(vparent));
     TEST_ASSERT_EQUAL(size_parent + size_child1, BrResSizeTotal(vparent));
 
     child2 = BrResAllocate(child1, 10, BR_MEMORY_DATAFILE);
+    TEST_ASSERT_NOT_NULL(child2);
     size_child2 = BrResSize(child2);
     TEST_ASSERT_GREATER_THAN_UINT32(0, size_child2);
     TEST_ASSERT_EQUAL(size_parent, BrResSize(vparent));


### PR DESCRIPTION
- Fixes runtime errors when using debug runtime (`-MDd`/`-MTd`)
- Add 2 cmake options (`DETHRACE_IDE_ROOT_DIR` and  `DETHRACE_IDE_ARGUMENTS`) to enable debugging within MSVC.
- Fix the race timer counting down too fast when not frame limiting: the game would floor the frame period to 10ms.

Other fixes:
- fix bug in `ClearWobbles` + typo in `LoadGeneralParameters`
- use floats instead of doubles in varous places
- compare against `NULL`s
- stub `ChangeAmbientPratcamNow` so the game doesn't abort anymore when finishing/timing out.