### PR TITLE
Dispose track after race + get german localization running

### DIFF
--- a/src/BRSRC13/CORE/FW/genfile.c
+++ b/src/BRSRC13/CORE/FW/genfile.c
@@ -1,4 +1,5 @@
 #include "genfile.h"
+#include "datafile.h"
 #include "harness/trace.h"
 
 #include "CORE/V1DB/chunkids.h"
@@ -20,8 +21,8 @@ br_file_enum_member file_type_FM[10] = {
 br_file_enum file_type_F = { BR_ASIZE(file_type_FM), file_type_FM };
 
 br_file_struct_member file_info_FM[2] = {
-    { 15, offsetof(file_info, type), "type", &file_type_F },
-    { 5, offsetof(file_info, version), "version", NULL },
+    { DF_TYPE_ENUM_32,  offsetof(file_info, type), "type", &file_type_F },
+    { DF_TYPE_BR_UINT_32, offsetof(file_info, version), "version", NULL },
 };
 br_file_struct file_info_F = { "file_info", BR_ASIZE(file_info_FM), file_info_FM, sizeof(file_info) };
 

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3153,9 +3153,9 @@ void MultiFindFloorInBoxBU(int pNum_rays, br_vector3* a, br_vector3* b, br_vecto
     tFace_ref* face_ref;
     LOG_TRACE("(%d, %p, %p, %p, %p, %p, %p)", pNum_rays, a, b, nor, d, c, mat_ref);
 
-    for (i = 0; i < c->box_face_end; i++) {
+    for (i = c->box_face_start; i < c->box_face_end; i++) {
         face_ref = &gFace_list__car[i];
-        if (!gEliminate_faces || SLOBYTE(face_ref->flags) == 0) {
+        if (!gEliminate_faces || (face_ref->flags & 0x80) == 0x0) {
             MultiRayCheckSingleFace(pNum_rays, face_ref, a, b, &nor2, dist);
             for (j = 0; j < pNum_rays; ++j) {
                 if (d[j] > dist[j]) {

--- a/src/DETHRACE/common/cutscene.c
+++ b/src/DETHRACE/common/cutscene.c
@@ -63,7 +63,7 @@ void PlaySmackerFile(char* pSmack_name) {
 
         dr_dprintf("Trying to open smack file '%s'", the_path);
         s = smk_open_file(the_path, SMK_MODE_MEMORY);
-        if (!s) {
+        if (s == NULL) {
             dr_dprintf("Unable to open smack file - attempt to load smack from CD...");
             if (GetCDPathFromPathsTxtFile(the_path)) {
                 strcat(the_path, gDir_separator);
@@ -77,7 +77,7 @@ void PlaySmackerFile(char* pSmack_name) {
                 dr_dprintf("Can't get CD directory name");
             }
         }
-        if (s) {
+        if (s != NULL) {
             dr_dprintf("Smack file opened OK");
             smk_info_all(s, NULL, &f, &usf);
             smk_info_video(s, &w, &h, NULL);

--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -128,10 +128,11 @@ void DRPixelmapText(br_pixelmap* pPixelmap, int pX, int pY, tDR_font* pFont, cha
     LOG_TRACE9("(%p, %d, %d, %p, \"%s\", %d)", pPixelmap, pX, pY, pFont, pText, pRight_edge);
 
     len = strlen(pText);
+    ch = (unsigned char*)pText;
     if (pX >= 0 && pPixelmap->width >= pRight_edge && pY >= 0 && (pY + pFont->height) <= pPixelmap->height) {
         x = pX;
         for (i = 0; i < len; i++) {
-            chr = pText[i] - pFont->offset;
+            chr = ch[i] - pFont->offset;
             ch_width = pFont->width_table[chr];
             DRPixelmapRectangleOnscreenCopy(
                 gBack_screen,
@@ -148,7 +149,7 @@ void DRPixelmapText(br_pixelmap* pPixelmap, int pX, int pY, tDR_font* pFont, cha
     } else {
         x = pX;
         for (i = 0; i < len; i++) {
-            chr = pText[i] - pFont->offset;
+            chr = ch[i] - pFont->offset;
             ch_width = pFont->width_table[chr];
             DRPixelmapRectangleMaskedCopy(
                 gBack_screen,
@@ -1445,11 +1446,10 @@ void OoerrIveGotTextInMeBoxMissus(int pFont_index, char* pText, br_pixelmap* pPi
 
 // IDA: void __usercall TransBrPixelmapText(br_pixelmap *pPixelmap@<EAX>, int pX@<EDX>, int pY@<EBX>, br_uint_32 pColour@<ECX>, br_font *pFont, signed char *pText)
 void TransBrPixelmapText(br_pixelmap* pPixelmap, int pX, int pY, br_uint_32 pColour, br_font* pFont, signed char* pText) {
-    int i;
     int len;
     LOG_TRACE("(%p, %d, %d, %d, %p, %p)", pPixelmap, pX, pY, pColour, pFont, pText);
 
-    len = (TranslationMode() == 0 ? 0 : 2);
+    len = TranslationMode() ? 2 : 0;
     BrPixelmapText(pPixelmap, pX, pY - len, pColour, pFont, (char*)pText);
 }
 
@@ -1458,7 +1458,7 @@ void TransDRPixelmapText(br_pixelmap* pPixelmap, int pX, int pY, tDR_font* pFont
     LOG_TRACE("(%p, %d, %d, %p, \"%s\", %d)", pPixelmap, pX, pY, pFont, pText, pRight_edge);
 
     if (gAusterity_mode && FlicsPlayedFromDisk() && pFont != gCached_font) {
-        if (gCached_font && gCached_font - gFonts > 13) {
+        if (gCached_font != NULL && gCached_font - gFonts > 13) {
             DisposeFont(gCached_font - gFonts);
         }
         gCached_font = pFont;

--- a/src/DETHRACE/common/drfile.c
+++ b/src/DETHRACE/common/drfile.c
@@ -21,9 +21,6 @@ br_filesystem gFilesystem = {
 };
 br_filesystem* gOld_file_system;
 
-// Added by Jeff
-#define DR_MEMORY_FILESYSTEM 140
-
 // IDA: void* __cdecl DRStdioOpenRead(char *name, br_size_t n_magics, br_mode_test_cbfn *identify, int *mode_result)
 void* DRStdioOpenRead(char* name, br_size_t n_magics, br_mode_test_cbfn* identify, int* mode_result) {
     if (mode_result != NULL) {
@@ -58,7 +55,7 @@ br_size_t DRStdioWrite(void* buf, br_size_t size, unsigned int n, void* f) {
 void InstallDRFileCalls() {
     br_filesystem* temp_system;
     LOG_TRACE("()");
-    temp_system = BrMemAllocate(sizeof(br_filesystem), DR_MEMORY_FILESYSTEM);
+    temp_system = BrMemAllocate(sizeof(br_filesystem), kMem_temp_fs);
     gOld_file_system = BrFilesystemSet(temp_system);
     gFilesystem.attributes = gOld_file_system->attributes;
     gFilesystem.eof = gOld_file_system->eof;

--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1,5 +1,6 @@
 #include "flicplay.h"
 #include "brender/brender.h"
+#include "displays.h"
 #include "drmem.h"
 #include "errors.h"
 #include "globvars.h"
@@ -57,32 +58,32 @@ tFlic_spec gMain_flic_list[372] = {
     { "MAI2STIL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "MAI2COME.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "MAI2AWAY.FLI", 0, 1, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "MAINRCGY.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "MAINARGY.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "SVVYSTIL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "SVVYAWAY.FLI", 0, 1, 0, 0, 0, 0, NULL, 0u },
     { "BGBUTTFL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "BGBUTTGL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "SVVYOKIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "CANBUTIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "SAVECOME.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "SAVEAWAY.FLI", 0, 1, 0, 0, 0, 0, NULL, 0u },
     { "SMLBUTFL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "SMLBUTGL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "SMLBUTFL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "SMLBUTGL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "SAVECAIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "NRACCOME.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "NRACAWAY.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
@@ -173,17 +174,17 @@ tFlic_spec gMain_flic_list[372] = {
     { "OPTNGRIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "OPTNMSIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "NOPT11FL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "SNDOCOME.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "SNDOAWAY.FLI", 0, 1, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "DNEBUTIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "SNDOOLFL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "SNDOOLGL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "GRPHCOME.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "GRPHAWAY.FLI", 0, 1, 0, 0, 0, 0, NULL, 0u },
     { "NCHO00GL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
@@ -193,7 +194,7 @@ tFlic_spec gMain_flic_list[372] = {
     { "NCHO04GL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "NCHO05GL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "NCHO06GL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "CNTLCOME.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "CNTLAWAY.FLI", 0, 1, 0, 0, 0, 0, NULL, 0u },
     { "CNTLDNIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
@@ -202,7 +203,7 @@ tFlic_spec gMain_flic_list[372] = {
     { "CNTLMRIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "CNTLDNFL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "CNTLDNGL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "CNTLSTIL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "OTHRCOME.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "OTHRAWAY.FLI", 0, 1, 0, 0, 0, 0, NULL, 0u },
@@ -213,17 +214,17 @@ tFlic_spec gMain_flic_list[372] = {
     { "NCHO04FL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "NCHO05FL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "NCHO06FL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "STRTSTIL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "STRTCOME.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "STRTAWAY.FLI", 0, 1, 0, 0, 0, 0, NULL, 0u },
     { "CNTL00FL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "CNTL00GL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "STRTCRIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "STRTPSIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "STRTSRIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "STRTCCIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
@@ -235,31 +236,31 @@ tFlic_spec gMain_flic_list[372] = {
     { "NTSHSTEN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "NTSXSTIL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "VWSC2IN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "VWIN2OPP.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "VWOPP2SC.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "2BUTONFL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "2BUTONGL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "VWOPUPIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "VWOPDWFL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "VWOPDWGL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "VWOPDWIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "CHRCCOME.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "CHRCAWAY.FLI", 0, 1, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "CHCRCOME.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "CHCRAWAY.FLI", 0, 1, 0, 0, 0, 0, NULL, 0u },
     { "GRPH00GL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
@@ -276,14 +277,14 @@ tFlic_spec gMain_flic_list[372] = {
     { "GRPH11GL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "PARTCOME.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "PARTAWAY.FLI", 0, 1, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "PARTARGL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "PARTARIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "PARTPFIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "PARTOFIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "PARTEXIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "PARTSPIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "PARTARGL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
@@ -301,19 +302,19 @@ tFlic_spec gMain_flic_list[372] = {
     { "GRPH09FL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "GRPH10FL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "GRPH11FL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "PSRMCOME.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "PSRMAWAY.FLI", 0, 1, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "PSRMDIIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "RADBUTFL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "RADBUTGL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "RADBUTOF.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "RADBUTON.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "GRIDSTIL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "GRIDAWAY.FLI", 0, 1, 0, 0, 0, 0, NULL, 0u },
     { "GRIDLFFL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
@@ -322,28 +323,28 @@ tFlic_spec gMain_flic_list[372] = {
     { "GRIDRTFL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "GRIDRTGL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "GRIDRTIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "DARECOME.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "DAREACIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "DARECHIN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "SUM1STIL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "SUM1AWAY.FLI", 0, 1, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "SUM2STIL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "BGBUT8GL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "BGBUT8FL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
@@ -351,9 +352,9 @@ tFlic_spec gMain_flic_list[372] = {
     { "BKBUT8IN.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "BKBUTOFF.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "BKBUTON.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
-    { NULL, 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
+    { "", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "MAI2QTFL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "MAI2QTGL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
     { "MAI2LDFL.FLI", 0, 0, 0, 0, 0, 0, NULL, 0u },
@@ -512,15 +513,15 @@ int gFlic_bunch6[51] = {
 int gFlic_bunch7[7] = { 130, 131, 132, 42, 43, 135, 45 };
 int gFlic_bunch8[16] = { 290, 291, 292, 293, 294, 295, 296, 297, 42, 43, 154, 301, 42, 43, 304, 305 };
 tFlic_bunch gFlic_bunch[9] = {
-    { 29, gFlic_bunch0 },
-    { 31, gFlic_bunch1 },
-    { 8, gFlic_bunch2 },
-    { 13, gFlic_bunch3 },
-    { 22, gFlic_bunch4 },
-    { 5, gFlic_bunch5 },
-    { 51, gFlic_bunch6 },
-    { 7, gFlic_bunch7 },
-    { 16, gFlic_bunch8 }
+    { COUNT_OF(gFlic_bunch0), gFlic_bunch0 },
+    { COUNT_OF(gFlic_bunch1), gFlic_bunch1 },
+    { COUNT_OF(gFlic_bunch2), gFlic_bunch2 },
+    { COUNT_OF(gFlic_bunch3), gFlic_bunch3 },
+    { COUNT_OF(gFlic_bunch4), gFlic_bunch4 },
+    { COUNT_OF(gFlic_bunch5), gFlic_bunch5 },
+    { COUNT_OF(gFlic_bunch6), gFlic_bunch6 },
+    { COUNT_OF(gFlic_bunch7), gFlic_bunch7 },
+    { COUNT_OF(gFlic_bunch8), gFlic_bunch8 },
 };
 char gLast_flic_name[14];
 tU32 gPanel_flic_data_length[2];
@@ -652,7 +653,7 @@ void FlicPaletteAllocate() {
 void AssertFlicPixelmap(tFlic_descriptor_ptr pFlic_info, br_pixelmap* pDest_pixelmap) {
     LOG_TRACE("(%d, %p)", pFlic_info, pDest_pixelmap);
 
-    if (pDest_pixelmap) {
+    if (pDest_pixelmap != NULL) {
         pFlic_info->first_pixel = (tU8*)pDest_pixelmap->pixels
             + pFlic_info->x_offset
             + pFlic_info->y_offset * pDest_pixelmap->row_bytes;
@@ -682,25 +683,25 @@ int StartFlic(char* pFile_name, int pIndex, tFlic_descriptor_ptr pFlic_info, tU3
         } else {
             pFlic_info->bytes_in_buffer = total_size;
         }
-        if (!pFlic_info->data_start) {
+        if (pFlic_info->data_start == NULL) {
             pFlic_info->data_start = BrMemAllocate(pFlic_info->bytes_in_buffer, kMem_flic_data);
         }
 
         pFlic_info->data = pFlic_info->data_start;
         strcpy(gLast_flic_name, pFile_name);
-        fread(pFlic_info->data_start, 1u, pFlic_info->bytes_in_buffer, pFlic_info->f);
+        fread(pFlic_info->data_start, 1, pFlic_info->bytes_in_buffer, pFlic_info->f);
         pFlic_info->bytes_still_to_be_read = total_size - pFlic_info->bytes_in_buffer;
     } else {
         pFlic_info->f = NULL;
         pFlic_info->data = (char*)pData_ptr;
-        // TOOD: remove this - we added this line because of the padding hack in PlayNextFlicFrame2
+        // TODO: remove this - we added this line because of the padding hack in PlayNextFlicFrame2
         pFlic_info->data_start = (char*)pData_ptr;
     }
     pFlic_info->bytes_remaining = MemReadU32(&pFlic_info->data);
     magic_number = MemReadU16(&pFlic_info->data);
-    if (magic_number == 0xAF11) {
+    if (magic_number == 0xaf11) {
         pFlic_info->new_format = 0;
-    } else if (magic_number == 0xAF12) {
+    } else if (magic_number == 0xaf12) {
         pFlic_info->new_format = 1;
     } else {
         return -1;
@@ -719,20 +720,28 @@ int StartFlic(char* pFile_name, int pIndex, tFlic_descriptor_ptr pFlic_info, tU3
     pFlic_info->the_pixelmap = pDest_pixelmap;
 
     if (pX_offset == -1) {
-        pFlic_info->x_offset = (pDest_pixelmap->width - pFlic_info->width) / 2;
+        if (pDest_pixelmap != NULL) {
+            pFlic_info->x_offset = (pDest_pixelmap->width - pFlic_info->width) / 2;
+        } else {
+            pFlic_info->x_offset = 0;
+        }
     } else {
         pFlic_info->x_offset = pX_offset;
     }
     if (pY_offset == -1) {
-        pFlic_info->y_offset = (pDest_pixelmap->height - pFlic_info->height) / 2;
+        if (pDest_pixelmap != NULL) {
+            pFlic_info->y_offset = (pDest_pixelmap->height - pFlic_info->height) / 2;
+        } else {
+            pFlic_info->y_offset = 0;
+        }
     } else {
         pFlic_info->y_offset = pY_offset;
     }
 
-    if (pFrame_rate) {
+    if (pFrame_rate != 0) {
         pFlic_info->frame_period = 1000 / pFrame_rate;
     } else {
-        if (!claimed_speed) {
+        if (claimed_speed == 0) {
             FatalError(16, gLast_flic_name);
         }
         if (pFlic_info->new_format) {
@@ -742,11 +751,7 @@ int StartFlic(char* pFile_name, int pIndex, tFlic_descriptor_ptr pFlic_info, tU3
         }
     }
     pFlic_info->the_index = pIndex;
-    if (pDest_pixelmap) {
-        pFlic_info->first_pixel = (tU8*)pDest_pixelmap->pixels + pDest_pixelmap->row_bytes * pFlic_info->y_offset + pFlic_info->x_offset;
-    }
-    // LOG_DEBUG("first pixel %p %p", pFlic_info->first_pixel, pDest_pixelmap->pixels);
-    pFlic_info->the_pixelmap = pDest_pixelmap;
+    AssertFlicPixelmap(pFlic_info, pDest_pixelmap);
     return 0;
 }
 
@@ -1145,7 +1150,8 @@ void DoUncompressedTrans(tFlic_descriptor* pFlic_info, tU32 chunk_length) {
 // IDA: void __usercall DoMini(tFlic_descriptor *pFlic_info@<EAX>, tU32 chunk_length@<EDX>)
 void DoMini(tFlic_descriptor* pFlic_info, tU32 chunk_length) {
     LOG_TRACE("(%p, %d)", pFlic_info, chunk_length);
-    NOT_IMPLEMENTED();
+
+    MemSkipBytes(&pFlic_info->data, chunk_length - 6);
 }
 
 // IDA: void __usercall DrawTranslations(tFlic_descriptor *pFlic_info@<EAX>, int pLast_frame@<EDX>)
@@ -1156,7 +1162,34 @@ void DrawTranslations(tFlic_descriptor* pFlic_info, int pLast_frame) {
     int width;
     int right_edge;
     LOG_TRACE("(%p, %d)", pFlic_info, pLast_frame);
-    NOT_IMPLEMENTED();
+
+    for (i = 0; i < gTranslation_count; i++) {
+        trans = &gTranslations[i];
+        if (trans->flic_index == pFlic_info->the_index && (trans->every_frame || pLast_frame)) {
+            width = DRTextWidth(gTrans_fonts[trans->font_index], trans->text);
+            switch (trans->justification) {
+            case eJust_left:
+                x = trans->x;
+                right_edge = x + width;
+                break;
+            case eJust_right:
+                x = trans->x - width;
+                right_edge = x;
+                break;
+            case eJust_centre:
+                x = trans->x - width / 2;
+                right_edge = x + width / 2;
+                break;
+            }
+            TransDRPixelmapText(
+                pFlic_info->the_pixelmap,
+                x + (trans->global ? 0 : pFlic_info->x_offset),
+                trans->y + (trans->global ? 0 : pFlic_info->y_offset),
+                gTrans_fonts[trans->font_index],
+                trans->text,
+                right_edge);
+        }
+    }
 }
 
 // IDA: int __usercall PlayNextFlicFrame2@<EAX>(tFlic_descriptor *pFlic_info@<EAX>, int pPanel_flic@<EDX>)
@@ -1178,61 +1211,58 @@ int PlayNextFlicFrame2(tFlic_descriptor* pFlic_info, int pPanel_flic) {
     chunk_count = MemReadU16(&pFlic_info->data);
 
     MemSkipBytes(&pFlic_info->data, 8);
-    if (magic_bytes == 0xF1FA) {
+    if (magic_bytes == 0xf1fa) {
         for (chunk_counter = 0; chunk_counter < chunk_count; chunk_counter++) {
             chunk_length = MemReadU32(&pFlic_info->data);
             chunk_type = MemReadU16(&pFlic_info->data);
             switch (chunk_type) {
-            case 4u:
+            case 4:
                 DoColour256(pFlic_info, chunk_length);
                 break;
-            case 7u:
+            case 7:
                 if (gTransparency_on) {
                     DoDeltaTrans(pFlic_info, chunk_length);
                 } else {
                     DoDeltaX(pFlic_info, chunk_length);
                 }
                 break;
-            case 0xBu:
+            case 11:
                 DoColourMap(pFlic_info, chunk_length);
                 break;
-            case 0xCu:
+            case 12:
                 if (gTransparency_on) {
                     DoDifferenceTrans(pFlic_info, chunk_length);
                 } else {
                     DoDifferenceX(pFlic_info, chunk_length);
                 }
                 break;
-            case 0xD:
+            case 13:
                 DoBlack(pFlic_info, chunk_length);
                 break;
-            case 0xF:
+            case 15:
                 if (gTransparency_on) {
                     DoRunLengthTrans(pFlic_info, chunk_length);
                 } else {
                     DoRunLengthX(pFlic_info, chunk_length);
                 }
                 break;
-            case 0x10u:
+            case 16:
                 if (gTransparency_on) {
                     DoUncompressedTrans(pFlic_info, chunk_length);
                 } else {
                     DoUncompressed(pFlic_info, chunk_length);
                 }
                 break;
-            case 0x12u:
-                MemSkipBytes(&pFlic_info->data, chunk_length - 6);
+            case 18:
+                DoMini(pFlic_info, chunk_length);
                 break;
             default:
                 LOG_WARN("unrecognized chunk type");
                 MemSkipBytes(&pFlic_info->data, chunk_length - 6);
                 break;
             }
-            // TODO: something like // p &= 0xfffffffffffffffe;
-            int a = (pFlic_info->data - pFlic_info->data_start);
-            if (a % 2 == 1) {
-                pFlic_info->data++;
-            }
+            // Align on even byte
+            pFlic_info->data = (char*)((uintptr_t)(pFlic_info->data + 1) & (~(uintptr_t)1));
         }
     } else {
         LOG_WARN("not frame header");
@@ -1242,10 +1272,10 @@ int PlayNextFlicFrame2(tFlic_descriptor* pFlic_info, int pPanel_flic) {
     }
     pFlic_info->current_frame++;
     pFlic_info->frames_left--;
-    if (gTrans_enabled && gTranslation_count && !pPanel_flic) {
+    if (gTrans_enabled && gTranslation_count != 0 && !pPanel_flic) {
         DrawTranslations(pFlic_info, pFlic_info->frames_left == 0);
     }
-    if (pFlic_info->f && pFlic_info->bytes_still_to_be_read) {
+    if (pFlic_info->f != NULL && pFlic_info->bytes_still_to_be_read) {
         data_knocked_off = pFlic_info->data - pFlic_info->data_start;
         memcpy(pFlic_info->data_start, pFlic_info->data, pFlic_info->bytes_in_buffer - data_knocked_off);
         pFlic_info->data = pFlic_info->data_start;
@@ -1256,8 +1286,8 @@ int PlayNextFlicFrame2(tFlic_descriptor* pFlic_info, int pPanel_flic) {
         } else {
             read_amount = pFlic_info->bytes_still_to_be_read;
         }
-        if (read_amount) {
-            fread(&pFlic_info->data_start[pFlic_info->bytes_in_buffer], 1u, read_amount, pFlic_info->f);
+        if (read_amount != 0) {
+            fread(&pFlic_info->data_start[pFlic_info->bytes_in_buffer], 1, read_amount, pFlic_info->f);
         }
         pFlic_info->bytes_in_buffer += read_amount;
         pFlic_info->bytes_still_to_be_read -= read_amount;
@@ -1282,7 +1312,7 @@ int PlayFlic(int pIndex, tU32 pSize, tS8* pData_ptr, br_pixelmap* pDest_pixelmap
     LOG_TRACE("(%d, %u, %p, %p, %d, %d, %p, %d, %d)", pIndex, pSize, pData_ptr, pDest_pixelmap, pX_offset, pY_offset, DoPerFrame, pInterruptable, pFrame_rate);
 
     finished_playing = 0;
-    the_flic.data_start = 0;
+    the_flic.data_start = NULL;
     if (StartFlic(gMain_flic_list[pIndex].file_name, pIndex, &the_flic, pSize, pData_ptr, pDest_pixelmap, pX_offset, pY_offset, pFrame_rate)) {
         LOG_WARN("startflic returned error");
         return -1;
@@ -1300,7 +1330,7 @@ int PlayFlic(int pIndex, tU32 pSize, tS8* pData_ptr, br_pixelmap* pDest_pixelmap
         if (frame_period >= the_flic.frame_period) {
             finished_playing = PlayNextFlicFrame(&the_flic);
             DoPerFrame();
-            if (gDark_mode == 0) {
+            if (!gDark_mode) {
                 EnsurePaletteUp();
             }
             ServiceGame();
@@ -1331,14 +1361,15 @@ void ShowFlic(int pIndex) {
             gMain_flic_list[pIndex].interruptable,
             gMain_flic_list[pIndex].frame_rate);
     } while (gMain_flic_list[pIndex].repeat && !AnyKeyDown());
-    gLast_flic_name[0] = 0; // byte_10344C;
+    gLast_flic_name[0] = '\0'; // byte_10344C;
 }
 
 // IDA: void __cdecl InitFlics()
 void InitFlics() {
     int i;
     LOG_TRACE("()");
-    for (i = 0; i < 372; i++) {
+
+    for (i = 0; i < COUNT_OF(gMain_flic_list); i++) {
         gMain_flic_list[i].data_ptr = NULL;
     }
 }
@@ -1353,7 +1384,8 @@ int LoadFlic(int pIndex) {
     if (pIndex < 0) {
         return 0;
     }
-    if (gMain_flic_list[pIndex].data_ptr) {
+    if (gMain_flic_list[pIndex].data_ptr != NULL) {
+        MAMSLock((void**)&gMain_flic_list[pIndex].data_ptr);
         return 1;
     }
     if (gPlay_from_disk) {
@@ -1365,30 +1397,33 @@ int LoadFlic(int pIndex) {
     PathCat(the_path, the_path, gMain_flic_list[pIndex].file_name);
     f = DRfopen(the_path, "rb");
 
-    if (!f) {
+    if (f == NULL) {
         FatalError(13, gMain_flic_list[pIndex].file_name);
     }
 
     gMain_flic_list[pIndex].the_size = GetFileLength(f);
     gMain_flic_list[pIndex].data_ptr = BrMemAllocate(gMain_flic_list[pIndex].the_size, 0x90u);
 
-    if (gMain_flic_list[pIndex].data_ptr) {
-        fread(gMain_flic_list[pIndex].data_ptr, 1u, gMain_flic_list[pIndex].the_size, f);
-        strcpy(gLast_flic_name, gMain_flic_list[pIndex].file_name);
-        fclose(f);
-        return 1;
-    } else {
+    if (gMain_flic_list[pIndex].data_ptr == NULL) {
         if (AllocationErrorsAreFatal()) {
             FatalError(14, gMain_flic_list[pIndex].file_name);
         }
+#ifdef DETHRACE_FIX_BUGS
+        fclose(f);
+#endif
         return 0;
     }
+
+    fread(gMain_flic_list[pIndex].data_ptr, 1, gMain_flic_list[pIndex].the_size, f);
+    strcpy(gLast_flic_name, gMain_flic_list[pIndex].file_name);
+    fclose(f);
+    return 1;
 }
 
 // IDA: void __usercall UnlockFlic(int pIndex@<EAX>)
 void UnlockFlic(int pIndex) {
     if (pIndex >= 0) {
-        if (gMain_flic_list[pIndex].data_ptr) {
+        if (gMain_flic_list[pIndex].data_ptr != NULL) {
             MAMSUnlock((void**)&gMain_flic_list[pIndex].data_ptr);
         }
     }
@@ -1400,39 +1435,49 @@ int LoadFlicData(char* pName, tU8** pData, tU32* pData_length) {
     tPath_name the_path;
     LOG_TRACE("(\"%s\", %p, %p)", pName, pData, pData_length);
 
-    if (*pData) {
+    if (*pData != NULL) {
+        MAMSLock((void**)pData);
         return 1;
     }
-    if (!gPlay_from_disk) {
-        PossibleService();
-        PathCat(the_path, gApplication_path, "ANIM");
-        PathCat(the_path, the_path, pName);
-        f = DRfopen(the_path, "rb");
-        if (f == NULL) {
-            return 0;
-        }
-        *pData_length = GetFileLength(f);
-        *pData = BrMemAllocate(*pData_length, kMem_flic_data_2);
-        if (!*pData) {
-            fclose(f);
-            return 0;
-        }
-        fread(*pData, 1u, *pData_length, f);
-        fclose(f);
+    if (gPlay_from_disk) {
+        return 1;
     }
+    PossibleService();
+    PathCat(the_path, gApplication_path, "ANIM");
+    PathCat(the_path, the_path, pName);
+    f = DRfopen(the_path, "rb");
+    if (f == NULL) {
+        return 0;
+    }
+    *pData_length = GetFileLength(f);
+    *pData = BrMemAllocate(*pData_length, kMem_flic_data_2);
+    if (*pData == NULL) {
+        fclose(f);
+        return 0;
+    }
+    fread(*pData, 1, *pData_length, f);
+    fclose(f);
     return 1;
 }
 
 // IDA: void __usercall FreeFlic(int pIndex@<EAX>)
 void FreeFlic(int pIndex) {
     LOG_TRACE("(%d)", pIndex);
-    NOT_IMPLEMENTED();
+
+    PossibleService();
+    if (gMain_flic_list[pIndex].data_ptr != NULL) {
+        BrMemFree(gMain_flic_list[pIndex].data_ptr);
+        gMain_flic_list[pIndex].data_ptr = NULL;
+    }
 }
 
 // IDA: void __usercall ForceRunFlic(int pIndex@<EAX>)
 void ForceRunFlic(int pIndex) {
     LOG_TRACE("(%d)", pIndex);
-    NOT_IMPLEMENTED();
+
+        LoadFlic(pIndex);
+        ShowFlic(pIndex);
+        UnlockFlic(pIndex);
 }
 
 // IDA: void __usercall RunFlicAt(int pIndex@<EAX>, int pX@<EDX>, int pY@<EBX>)
@@ -1458,9 +1503,7 @@ void RunFlic(int pIndex) {
     LOG_TRACE("(%d)", pIndex);
 
     if (gPending_flic >= 0) {
-        LoadFlic(gPending_flic);
-        ShowFlic(gPending_flic);
-        UnlockFlic(gPending_flic);
+        ForceRunFlic(gPending_flic);
         gPending_flic = -1;
     }
     if (LoadFlic(pIndex)) {
@@ -1468,11 +1511,7 @@ void RunFlic(int pIndex) {
             gPending_flic = pIndex;
         } else {
             ShowFlic(pIndex);
-            if (pIndex >= 0) {
-                if (gMain_flic_list[pIndex].data_ptr) {
-                    MAMSUnlock((void**)&gMain_flic_list[pIndex].data_ptr);
-                }
-            }
+            UnlockFlic(pIndex);
         }
     }
 }
@@ -1490,6 +1529,7 @@ void PreloadBunchOfFlics(int pBunch_index) {
 // IDA: void __usercall UnlockBunchOfFlics(int pBunch_index@<EAX>)
 void UnlockBunchOfFlics(int pBunch_index) {
     int i;
+    LOG_TRACE("(%d)", pBunch_index);
 
     for (i = 0; i < gFlic_bunch[pBunch_index].count; i++) {
         UnlockFlic(gFlic_bunch[pBunch_index].indexes[i]);
@@ -1501,7 +1541,7 @@ void FlushAllFlics(int pBunch_index) {
     int i;
     LOG_TRACE("(%d)", pBunch_index);
 
-    for (i = 0; i < COUNT_OF(gMain_flic_list); i++) {
+    for (i = 0; i < COUNT_OF(gFlic_bunch); i++) {
         FreeFlic(i);
     }
 }
@@ -1584,8 +1624,8 @@ void FlushFlicQueue() {
     }
     the_flic = gFirst_flic;
     while (the_flic != NULL) {
-        old_flic = the_flic;
         EndFlic(the_flic);
+        old_flic = the_flic;
         the_flic = the_flic->next;
         BrMemFree(old_flic);
     }
@@ -1769,6 +1809,7 @@ br_pixelmap* GetPanelPixelmap(int pIndex) {
 
 // IDA: void __cdecl LoadInterfaceStrings()
 void LoadInterfaceStrings() {
+    FILE* f; // Added by DethRace
     char s[256];
     char s2[256];
     char* str;
@@ -1779,7 +1820,106 @@ void LoadInterfaceStrings() {
     int j;
     int len;
 
-    STUB();
+    gTranslation_count = 0;
+    PathCat(the_path, gApplication_path, "TRNSLATE.TXT");
+    f = fopen(the_path, "rt");
+    if (f == NULL) {
+        return;
+    }
+    while (!feof(f)) {
+        GetALineAndDontArgue(f, s);
+        gTranslation_count++;
+    }
+    rewind(f);
+    gTranslations = BrMemAllocate(gTranslation_count * sizeof(tTranslation_record), kMem_translations);
+    for (i = 0; i < gTranslation_count; i++) {
+        GetALineAndDontArgue(f, s);
+        str = strtok(s, "\t ,/");
+        strcpy(s2, str);
+        strtok(s2, ".");
+        strcat(s2, ".FLI");
+        gTranslations[i].flic_index = -1;
+        for (j = 0; j < COUNT_OF(gMain_flic_list); j++) {
+            if (strcmp(gMain_flic_list[j].file_name, s2) == 0) {
+                gTranslations[i].flic_index = j;
+                break;
+            }
+        }
+        if (gTranslations[i].flic_index < 0) {
+            FatalError(101, s2);
+        }
+        str[strlen(str)] = ',';
+        str = strtok(s, "\t ,/");
+        str = strtok(NULL, "\t ,/");
+        sscanf(str, "%d", &gTranslations[i].x);
+        str = strtok(NULL, "\t ,/");
+        sscanf(str, "%d", &gTranslations[i].y);
+        str = strtok(NULL, "\t ,/");
+        sscanf(str, "%d", &gTranslations[i].font_index);
+        str = strtok(NULL, "\t ,/");
+        sscanf(str, "%c", &ch);
+        switch (ch) {
+        case 'C':
+        case 'c':
+            gTranslations[i].justification = eJust_centre;
+            break;
+        case 'L':
+        case 'l':
+            gTranslations[i].justification = eJust_left;
+            break;
+        case 'R':
+        case 'r':
+            gTranslations[i].justification = eJust_right;
+            break;
+        }
+        str = strtok(NULL, "\t ,/");
+        sscanf(str, "%c", &ch);
+        gTranslations[i].global = ch == 'G' || ch == 'g';
+        gTranslations[i].every_frame = strlen(str) > 1 && (str[1] == 'E' || str[1] == 'e');
+        str += strlen(str) + 1;
+        comment = strstr(str, "//");
+        if (comment != NULL) {
+            *comment = '\0';
+        }
+        len = strlen(str);
+        for (j = len - 1; j >= 0 && (str[j] == ' ' || str[j] == '\t'); j--) {
+        }
+        str[j + 1] = '\0';
+        gTranslations[i].text = BrMemAllocate(strlen(str) + 1, kMem_translations_text);
+        strcpy(gTranslations[i].text, str);
+    }
+    LoadFont(2);
+    LoadFont(1);
+    LoadFont(3);
+    LoadFont(15);
+    LoadFont(14);
+    LoadFont(16);
+    LoadFont(13);
+    LoadFont(10);
+    LoadFont(12);
+    LoadFont(9);
+    LoadFont(11);
+    LoadFont(19);
+    LoadFont(18);
+    LoadFont(20);
+    LoadFont(17);
+    gTrans_fonts[0] = &gFonts[1];
+    gTrans_fonts[1] = &gFonts[15];
+    gTrans_fonts[2] = &gFonts[14];
+    gTrans_fonts[3] = &gFonts[16];
+    gTrans_fonts[4] = &gFonts[13];
+    gTrans_fonts[5] = &gFonts[10];
+    gTrans_fonts[6] = &gFonts[12];
+    gTrans_fonts[7] = &gFonts[9];
+    gTrans_fonts[8] = &gFonts[11];
+    gTrans_fonts[9] = &gFonts[19];
+    gTrans_fonts[10] = &gFonts[20];
+    gTrans_fonts[11] = &gFonts[18];
+    gTrans_fonts[12] = &gFonts[17];
+
+#ifdef DETHRACE_FIX_BUGS
+    fclose(f);
+#endif
 }
 
 // IDA: void __cdecl FlushInterfaceFonts()

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -2876,17 +2876,11 @@ void InitShadow() {
     }
     gFancy_shadow = 1;
     gShadow_material = BrMaterialFind("SHADOW.MAT");
-    gShadow_light_ray.v[0] = 0.0;
-    gShadow_light_ray.v[1] = -1.0;
-    gShadow_light_ray.v[2] = 0.0;
-    gShadow_light_z.v[0] = 0.0;
-    gShadow_light_z.v[1] = 0.0;
-    gShadow_light_z.v[2] = -1.0;
-    gShadow_light_x.v[1] = 0.0;
-    gShadow_light_x.v[2] = 0.0;
-    gShadow_light_x.v[0] = 1.0;
+    BrVector3Set(&gShadow_light_ray, 0.f, -1.f, 0.f);
+    BrVector3Set(&gShadow_light_z, -0.f, -0.f, -1.f);
+    BrVector3Set(&gShadow_light_x, 1.f, 0.f, 0.f);
 
-    gShadow_model = BrModelAllocate(NULL, 0, 0);
+    gShadow_model = BrModelAllocate("", 0, 0);
     gShadow_model->flags = BR_MODF_GENERATE_TAGS | BR_MODF_KEEP_ORIGINAL;
     gShadow_actor = BrActorAllocate(BR_ACTOR_MODEL, 0);
     gShadow_actor->model = gShadow_model;
@@ -2897,7 +2891,7 @@ void InitShadow() {
 br_uint_32 SaveShadeTable(br_pixelmap* pTable, void* pArg) {
     LOG_TRACE("(%p, %p)", pTable, pArg);
 
-    if (gSaved_table_count == 100) {
+    if (gSaved_table_count == COUNT_OF(gSaved_shade_tables)) {
         return 1;
     }
     gSaved_shade_tables[gSaved_table_count].original = pTable;
@@ -2921,7 +2915,9 @@ void DisposeSavedShadeTables() {
     int i;
     LOG_TRACE("()");
 
-    STUB();
+    for (i = 0; i < gSaved_table_count; i++) {
+        BrMemFree(gSaved_shade_tables[i].copy);
+    }
 }
 
 // IDA: void __cdecl ShadowMode()

--- a/src/DETHRACE/common/init.c
+++ b/src/DETHRACE/common/init.c
@@ -427,7 +427,7 @@ void InitGame(int pStart_race) {
     gNo_races_yet = 1;
     NetPlayerStatusChanged(ePlayer_status_loading);
     gProgram_state.current_race_index = pStart_race;
-    if (harness_game_info.mode == eGame_carmageddon_demo) {
+    if (harness_game_info.mode == eGame_carmageddon_demo || harness_game_info.mode == eGame_splatpack_demo) {
         gProgram_state.current_car.power_up_levels[0] = gDemo_armour;
         gProgram_state.current_car.power_up_levels[1] = gDemo_power;
         gProgram_state.current_car.power_up_levels[2] = gDemo_offensive;

--- a/src/DETHRACE/common/loading.c
+++ b/src/DETHRACE/common/loading.c
@@ -2351,11 +2351,11 @@ void LoadRaces(tRace_list_spec* pRace_list, int* pCount, int pRace_type_index) {
     *pCount = number_of_racers;
     fclose(f);
     j = 0;
-    if (harness_game_info.mode == eGame_carmageddon_demo) {
+    if (harness_game_info.mode == eGame_carmageddon_demo || harness_game_info.mode == eGame_splatpack_demo) {
         j = 99;
     }
     for (i = 0; i < number_of_racers; i++) {
-        if (harness_game_info.mode == eGame_carmageddon_demo) {
+        if (harness_game_info.mode == eGame_carmageddon_demo || harness_game_info.mode == eGame_splatpack_demo) {
             pRace_list[i].suggested_rank = gDemo_rank;
             pRace_list[i].rank_required = j;
             j -= 3;

--- a/src/DETHRACE/common/mainloop.c
+++ b/src/DETHRACE/common/mainloop.c
@@ -438,7 +438,7 @@ void CheckTimer() {
             RaceCompleted(eRace_over_out_of_time);
         }
 
-        if (harness_game_info.mode == eGame_carmageddon_demo) {
+        if (harness_game_info.mode == eGame_carmageddon_demo || harness_game_info.mode == eGame_splatpack_demo) {
             time_left = 240000 - GetRaceTime();
             time_in_seconds = (time_left + 500) / 1000;
             if (time_in_seconds != last_demo_time_in_seconds && time_in_seconds <= 10)

--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -720,7 +720,7 @@ void DisposeShrapnel() {
     gShrapnel_flags = 0;
     for (i = 0; i < COUNT_OF(gShrapnel_model); i++) {
         BrModelRemove(gShrapnel_model[i]);
-        BrModelFree(gShrapnel_model[0]);
+        BrModelFree(gShrapnel_model[i]);
     }
 }
 

--- a/src/DETHRACE/common/structur.c
+++ b/src/DETHRACE/common/structur.c
@@ -359,7 +359,7 @@ void SelectOpponents(tRace_info* pRace_info) {
     int had_scum;
     LOG_TRACE("(%p)", pRace_info);
 
-    if (harness_game_info.mode == eGame_carmageddon_demo) {
+    if (harness_game_info.mode == eGame_carmageddon_demo || harness_game_info.mode == eGame_splatpack_demo) {
         pRace_info->number_of_racers = OPPONENT_COUNT;
         for (i = 0; i < OPPONENT_COUNT; i++) {
             pRace_info->opponent_list[i].index = gDemo_opponents[i];

--- a/src/DETHRACE/common/utility.c
+++ b/src/DETHRACE/common/utility.c
@@ -232,7 +232,7 @@ br_scalar SRandomPosNeg(br_scalar pN) {
 }
 
 // IDA: char* __usercall GetALineWithNoPossibleService@<EAX>(FILE *pF@<EAX>, unsigned char *pS@<EDX>)
-char* GetALineWithNoPossibleService(FILE* pF, /*unsigned*/ char* pS) {
+char* GetALineWithNoPossibleService(FILE* pF, unsigned char* pS) {
     // Jeff removed "signed' to avoid compiler warnings..
     /*signed*/ char* result;
     /*signed*/ char s[256];
@@ -248,15 +248,13 @@ char* GetALineWithNoPossibleService(FILE* pF, /*unsigned*/ char* pS) {
         }
         if (s[0] == '@') {
             EncodeLine(&s[1]);
-            goto LABEL_5;
-        }
-        while (1) {
-            if (s[0] != ' ' && s[0] != '\t') {
-                break;
-            }
-        LABEL_5:
             len = strlen(s);
             memmove(s, &s[1], len);
+        } else {
+            while (s[0] == ' ' || s[0] == '\t') {
+                len = strlen(s);
+                memmove(s, &s[1], len);
+            }
         }
 
         while (1) {
@@ -287,10 +285,10 @@ char* GetALineWithNoPossibleService(FILE* pF, /*unsigned*/ char* pS) {
             result[len - 2] = 0;
         }
     }
-    strcpy(pS, s);
+    strcpy((char*)pS, s);
     len = strlen(s);
     for (i = 0; i < len; i++) {
-        if (pS[i] >= 0xE0u) {
+        if (pS[i] >= 0xe0) {
             pS[i] -= 32;
         }
     }
@@ -303,7 +301,7 @@ char* GetALineAndDontArgue(FILE* pF, char* pS) {
     // LOG_TRACE10("(%p, \"%s\")", pF, pS);
 
     PossibleService();
-    return GetALineWithNoPossibleService(pF, pS);
+    return GetALineWithNoPossibleService(pF, (unsigned char*)pS);
 }
 
 // IDA: void __usercall PathCat(char *pDestn_str@<EAX>, char *pStr_1@<EDX>, char *pStr_2@<EBX>)

--- a/src/DETHRACE/common/utility.h
+++ b/src/DETHRACE/common/utility.h
@@ -35,7 +35,7 @@ br_scalar SRandomBetween(br_scalar pA, br_scalar pB);
 
 br_scalar SRandomPosNeg(br_scalar pN);
 
-char* GetALineWithNoPossibleService(FILE* pF, /*unsigned*/ char* pS);
+char* GetALineWithNoPossibleService(FILE* pF, unsigned char* pS);
 
 char* GetALineAndDontArgue(FILE* pF, char* pS);
 

--- a/src/DETHRACE/pc-dos/dossys.c
+++ b/src/DETHRACE/pc-dos/dossys.c
@@ -241,7 +241,7 @@ void PDSetKeyArray(int* pKeys, int pMark) {
 int PDGetASCIIFromKey(int pKey) {
     LOG_TRACE("(%d)", pKey);
 
-    if (PDKeyDown3(KEY_LSHIFT)) {
+    if (PDKeyDown(KEY_LSHIFT)) {
         return gASCII_shift_table[pKey];
     } else {
         return gASCII_table[pKey];
@@ -292,18 +292,24 @@ void PDInitialiseSystem() {
 
     // Demo does not ship with KEYBOARD.COK file
     if (harness_game_info.mode != eGame_carmageddon_demo) {
-        PathCat(the_path, gApplication_path, "KEYBOARD.COK");
-        f = fopen(the_path, "rb");
-        if (!f) {
-            PDFatalError("This .exe must have KEYBOARD.COK in the DATA folder.");
-        }
+        // Some localized Carmageddon releases have a hardcoded keyboard look-up table
+        if (harness_game_info.defines.ascii_table == NULL) {
+            PathCat(the_path, gApplication_path, "KEYBOARD.COK");
+            f = fopen(the_path, "rb");
+            if (f == NULL) {
+                PDFatalError("This .exe must have KEYBOARD.COK in the DATA folder.");
+            }
 
-        fseek(f, 0, SEEK_END);
-        len = ftell(f);
-        rewind(f);
-        fread(gASCII_table, len / 2, 1, f);
-        fread(gASCII_shift_table, len / 2, 1, f);
-        fclose(f);
+            fseek(f, 0, SEEK_END);
+            len = ftell(f);
+            rewind(f);
+            fread(gASCII_table, len / 2, 1, f);
+            fread(gASCII_shift_table, len / 2, 1, f);
+            fclose(f);
+        } else {
+            memcpy(gASCII_table, harness_game_info.defines.ascii_table, sizeof(gASCII_table));
+            memcpy(gASCII_shift_table, harness_game_info.defines.ascii_shift_table, sizeof(gASCII_shift_table));
+        }
     }
 }
 

--- a/src/DETHRACE/pc-dos/dossys.c
+++ b/src/DETHRACE/pc-dos/dossys.c
@@ -291,25 +291,22 @@ void PDInitialiseSystem() {
     // gUpper_loop_limit = sub_A1940(v4, v5, v3, v6) / 2;
 
     // Demo's do not ship with KEYBOARD.COK file
-    if (harness_game_info.mode != eGame_carmageddon_demo && harness_game_info.mode != eGame_splatpack_demo) {
-        // Some localized Carmageddon releases have a hardcoded keyboard look-up table
-        if (harness_game_info.defines.ascii_table == NULL) {
-            PathCat(the_path, gApplication_path, "KEYBOARD.COK");
-            f = fopen(the_path, "rb");
-            if (f == NULL) {
-                PDFatalError("This .exe must have KEYBOARD.COK in the DATA folder.");
-            }
-
-            fseek(f, 0, SEEK_END);
-            len = ftell(f);
-            rewind(f);
-            fread(gASCII_table, len / 2, 1, f);
-            fread(gASCII_shift_table, len / 2, 1, f);
-            fclose(f);
-        } else {
-            memcpy(gASCII_table, harness_game_info.defines.ascii_table, sizeof(gASCII_table));
-            memcpy(gASCII_shift_table, harness_game_info.defines.ascii_shift_table, sizeof(gASCII_shift_table));
+    if (harness_game_info.defines.ascii_table == NULL) {
+        PathCat(the_path, gApplication_path, "KEYBOARD.COK");
+        f = fopen(the_path, "rb");
+        if (f == NULL) {
+            PDFatalError("This .exe must have KEYBOARD.COK in the DATA folder.");
         }
+
+        fseek(f, 0, SEEK_END);
+        len = ftell(f);
+        rewind(f);
+        fread(gASCII_table, len / 2, 1, f);
+        fread(gASCII_shift_table, len / 2, 1, f);
+        fclose(f);
+    } else {
+        memcpy(gASCII_table, harness_game_info.defines.ascii_table, sizeof(gASCII_table));
+        memcpy(gASCII_shift_table, harness_game_info.defines.ascii_shift_table, sizeof(gASCII_shift_table));
     }
 }
 

--- a/src/DETHRACE/pc-dos/dossys.c
+++ b/src/DETHRACE/pc-dos/dossys.c
@@ -290,8 +290,8 @@ void PDInitialiseSystem() {
     gJoystick_deadzone = 8000;
     // gUpper_loop_limit = sub_A1940(v4, v5, v3, v6) / 2;
 
-    // Demo does not ship with KEYBOARD.COK file
-    if (harness_game_info.mode != eGame_carmageddon_demo) {
+    // Demo's do not ship with KEYBOARD.COK file
+    if (harness_game_info.mode != eGame_carmageddon_demo && harness_game_info.mode != eGame_splatpack_demo) {
         // Some localized Carmageddon releases have a hardcoded keyboard look-up table
         if (harness_game_info.defines.ascii_table == NULL) {
             PathCat(the_path, gApplication_path, "KEYBOARD.COK");

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -52,17 +52,41 @@ static int german_ascii_shift_table[128] = {
 int Harness_ProcessCommandLine(int* argc, char* argv[]);
 
 void Harness_DetectGameMode() {
-    if (access("DATA/RACES/CITY01.TXT", F_OK) == -1 && access("DATA/RACES/CITYA1.TXT", F_OK) == -1) {
-        harness_game_info.defines.INTRO_SMK_FILE = "";
-        harness_game_info.defines.GERMAN_LOADSCRN = "COWLESS.PIX";
-        harness_game_info.mode = eGame_carmageddon_demo;
-        LOG_INFO("\"%s\"", "Carmageddon demo");
-    } else if (access("DATA/CUTSCENE/SPLINTRO.SMK", F_OK) != -1) {
-        harness_game_info.defines.INTRO_SMK_FILE = "SPLINTRO.SMK";
-        harness_game_info.defines.GERMAN_LOADSCRN = "LOADSCRN.PIX";
-        harness_game_info.mode = eGame_splatpack;
-        LOG_INFO("\"%s\"", "Splat Pack");
+    if (access("DATA/RACES/CASTLE.TXT", F_OK) != -1) {
+        // All splatpack edition have the castle track
+        if (access("DATA/RACES/CASTLE2.TXT", F_OK) != -1) {
+            // Only the full splat release has the castle2 track
+            harness_game_info.defines.INTRO_SMK_FILE = "SPLINTRO.SMK";
+            harness_game_info.defines.GERMAN_LOADSCRN = "LOADSCRN.PIX";
+            harness_game_info.mode = eGame_splatpack;
+            LOG_INFO("\"%s\"", "Splat Pack");
+        } else if (access("DATA/RACES/TINSEL.TXT", F_OK) != -1) {
+            // Only the the splat x-mas demo has the tinsel track
+            harness_game_info.defines.INTRO_SMK_FILE = "";
+            harness_game_info.defines.GERMAN_LOADSCRN = "";
+            harness_game_info.mode = eGame_splatpack_demo;
+            LOG_INFO("\"%s\"", "Splat Pack X-mas demo");
+        } else {
+            // Assume we're using the splatpack demo
+            harness_game_info.defines.INTRO_SMK_FILE = "";
+            harness_game_info.defines.GERMAN_LOADSCRN = "";
+            harness_game_info.mode = eGame_splatpack_demo;
+            LOG_INFO("\"%s\"", "Splat Pack demo");
+        }
+    } else if (access("DATA/RACES/CITYB3.TXT", F_OK) != -1) {
+        // All non-splatpack edition have the cityb3 track
+        if (access("DATA/CITYA1.TXT", F_OK) == -1) {
+            // The demo does not have the citya1 track
+            harness_game_info.defines.INTRO_SMK_FILE = "";
+            harness_game_info.defines.GERMAN_LOADSCRN = "COWLESS.PIX";
+            harness_game_info.mode = eGame_carmageddon_demo;
+            LOG_INFO("\"%s\"", "Carmageddon");
+        }
+        else {
+            goto carmageddon;
+        }
     } else {
+carmageddon:   
         if (access("DATA/CURSCENE/Mix_intr.smk", F_OK) == -1) {
             harness_game_info.defines.INTRO_SMK_FILE = "Mix_intr.smk";
         } else {
@@ -74,7 +98,7 @@ void Harness_DetectGameMode() {
     }
 
     harness_game_info.localization = eGameLocalization_none;
-    if (access("DATA/KEYBOARD.COK", F_OK) == -1 && access("DATA/TRNSLATE.TXT", F_OK) != -1) {
+    if (access("DATA/TRNSLATE.TXT", F_OK) != -1) {
         FILE *f = fopen("DATA/TRNSLATE.TXT", "rb");
         fseek(f, 0, SEEK_END);
         int filesize = ftell(f);
@@ -132,7 +156,7 @@ void Harness_Init(int* argc, char* argv[]) {
     }
 
     char* root_dir = getenv("DETHRACE_ROOT_DIR");
-    if (root_dir == NULL) {
+    if (!root_dir) {
         LOG_INFO("DETHRACE_ROOT_DIR is not set, assuming '.'");
     } else {
         printf("DETHRACE_ROOT_DIR: %s\n", root_dir);

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -36,17 +36,45 @@ tHarness_game_config harness_game_config;
 
 
 // German ASCII codes
-static int german_ascii_table[128] = {
+static int carmageddon_german_ascii_table[128] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107,
     108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 122, 121, 94, -33, -76, 8, 13, 13, 0, 45, 60, -10, -28, 46, 44, -4, 43, 35, 27,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -4, 56, -33, -76, 46, 0, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 };
-static int german_ascii_shift_table[128] = {
+static int carmageddon_german_ascii_shift_table[128] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 61, 33, 34, -89, 36, 37, 38, 47, 40, 41, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75,
     76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 90, 89, -80, 63, 96, 8, 13, 13, 0, 95, 62, -42, -60, 58, 44, -36, 42, 39, 27,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -4, 56, -33, -76, 46, 0, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+};
+
+// Demo ASCII codes
+static int demo_ascii_table[128] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107,
+    108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 122, 121, 94, -33, -76, 8, 13, 13, 0, 45, 60, -10, -28, 46, 44, -4, 43, 35, 27,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -4, 56, -33, -76, 46, 0, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+};
+static int demo_ascii_shift_table[128] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 61, 33, 34, -89, 36, 37, 38, 47, 40, 41, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75,
+    76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 90, 89, -80, 63, 96, 8, 13, 13, 0, 95, 62, -42, -60, 58, 44, -36, 42, 39, 27,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -4, 56, -33, -76, 46, 0, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+};
+
+// Splatpack Demo ASCII codes
+static int splatpack_xmasdemo_ascii_table[128] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75,
+    76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 96, 45, 61, 8, 13, 3, 9, 47, 92, 59, 39, 46, 44, 91, 93, 35, 27,
+    0, 127, 0, 0, 0, 0, 28, 29, 30, 31, 0, 47, 42, 45, 43, 46, 61, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32,
+};
+static int splatpack_xmasdemo_ascii_shift_table[128] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 41, 33, 34, 163, 36, 37, 94, 38, 42, 40, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75,
+    76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 172, 95, 43, 8, 13, 13, 0, 63, 124, 58, 64, 62, 44, 123, 125, 126, 27,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 47, 42, 45, 43, 46, 0, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 8,
 };
 
 int Harness_ProcessCommandLine(int* argc, char* argv[]);
@@ -86,7 +114,7 @@ void Harness_DetectGameMode() {
             goto carmageddon;
         }
     } else {
-carmageddon:   
+carmageddon:
         if (access("DATA/CURSCENE/Mix_intr.smk", F_OK) == -1) {
             harness_game_info.defines.INTRO_SMK_FILE = "Mix_intr.smk";
         } else {
@@ -116,12 +144,26 @@ carmageddon:
         free(buffer);
     }
 
-    switch (harness_game_info.localization) {
-    case eGameLocalization_none:
+    switch (harness_game_info.mode) {
+    case eGame_carmageddon:
+        switch (harness_game_info.localization) {
+        case eGameLocalization_german:
+            harness_game_info.defines.ascii_table = carmageddon_german_ascii_table;
+            harness_game_info.defines.ascii_shift_table = carmageddon_german_ascii_shift_table;
+            break;
+        default:
+            break;
+        }
         break;
-    case eGameLocalization_german:
-        harness_game_info.defines.ascii_table = german_ascii_table;
-        harness_game_info.defines.ascii_shift_table = german_ascii_shift_table;
+    case eGame_carmageddon_demo:
+        harness_game_info.defines.ascii_table = demo_ascii_table;
+        harness_game_info.defines.ascii_shift_table = demo_ascii_shift_table;
+        break;
+    case eGame_splatpack_demo:
+        harness_game_info.defines.ascii_table = splatpack_xmasdemo_ascii_table;
+        harness_game_info.defines.ascii_shift_table = splatpack_xmasdemo_ascii_shift_table;
+        break;
+    default:
         break;
     }
 }
@@ -156,7 +198,7 @@ void Harness_Init(int* argc, char* argv[]) {
     }
 
     char* root_dir = getenv("DETHRACE_ROOT_DIR");
-    if (!root_dir) {
+    if (root_dir == NULL) {
         LOG_INFO("DETHRACE_ROOT_DIR is not set, assuming '.'");
     } else {
         printf("DETHRACE_ROOT_DIR: %s\n", root_dir);

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -115,7 +115,7 @@ void Harness_DetectGameMode() {
         }
     } else {
 carmageddon:
-        if (access("DATA/CURSCENE/Mix_intr.smk", F_OK) == -1) {
+        if (access("DATA/CUTSCENE/Mix_intr.smk", F_OK) == -1) {
             harness_game_info.defines.INTRO_SMK_FILE = "Mix_intr.smk";
         } else {
             harness_game_info.defines.INTRO_SMK_FILE = "MIX_INTR.SMK";

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -103,12 +103,12 @@ void Harness_DetectGameMode() {
         }
     } else if (access("DATA/RACES/CITYB3.TXT", F_OK) != -1) {
         // All non-splatpack edition have the cityb3 track
-        if (access("DATA/CITYA1.TXT", F_OK) == -1) {
+        if (access("DATA/RACES/CITYA1.TXT", F_OK) == -1) {
             // The demo does not have the citya1 track
             harness_game_info.defines.INTRO_SMK_FILE = "";
             harness_game_info.defines.GERMAN_LOADSCRN = "COWLESS.PIX";
             harness_game_info.mode = eGame_carmageddon_demo;
-            LOG_INFO("\"%s\"", "Carmageddon");
+            LOG_INFO("\"%s\"", "Carmageddon demo");
         }
         else {
             goto carmageddon;
@@ -140,6 +140,9 @@ carmageddon:
         fclose(f);
         if (strstr(buffer, "NEUES SPIEL") != NULL) {
             harness_game_info.localization = eGameLocalization_german;
+            LOG_INFO("Language: \"%s\"", "German");
+        } else {
+            LOG_INFO("Language: unrecognized");
         }
         free(buffer);
     }

--- a/src/harness/include/harness/config.h
+++ b/src/harness/include/harness/config.h
@@ -5,16 +5,26 @@ typedef enum tHarness_game_type {
     eGame_none,
     eGame_carmageddon,
     eGame_splatpack,
-    eGame_carmageddon_demo
+    eGame_carmageddon_demo,
 } tHarness_game_type;
+
+typedef enum {
+    eGameLocalization_none,
+    eGameLocalization_german,
+} tHarness_game_localization;
 
 typedef struct tHarness_game_info {
     tHarness_game_type mode;
+    tHarness_game_localization localization;
     struct {
         // different between carmageddon and splatpack
         char* INTRO_SMK_FILE;
         // different between demo and full game
         char* GERMAN_LOADSCRN;
+        // built-in keyboard look-up table for certain localized Carmageddon releases
+        int *ascii_table;
+        // built-in shifted keyboard look-up table for certain localized Carmageddon releases
+        int *ascii_shift_table;
     } defines;
 } tHarness_game_info;
 

--- a/src/harness/include/harness/config.h
+++ b/src/harness/include/harness/config.h
@@ -6,6 +6,7 @@ typedef enum tHarness_game_type {
     eGame_carmageddon,
     eGame_splatpack,
     eGame_carmageddon_demo,
+    eGame_splatpack_demo,
 } tHarness_game_type;
 
 typedef enum {


### PR DESCRIPTION
This pr:
- implements `DisposeTrack` (+depending functions). It is now possible to start a 2nd race in the same DethRace execution
- implement functions to support localized carmageddon releases: tested with a German localization
- fixes demo + text input for demo's

@laenion Can you test this?
The german version has the following issues:
- In all races, the HUD is hidden behind terrain (uk version also has this problem in e.g. fridge racer)
- in maim street, the front culling is too aggressive (the terrain is shown too late)

There is also a visual glitch with the umlaut on "neues spiel über netzwerk".
Comparing the data structures sizing the interface, there appears to be no difference between the uk and german release.
Is this also present when running the windows/dos version?
(the umlaut remains visible when changing the active menu item)

~The splatpack + xmas demo version stil do not work.~

![Screenshot from 2022-03-20 19-03-59](https://user-images.githubusercontent.com/4138939/159176151-92462022-4847-4aef-b9f1-8f8565a85c65.png)

Closes #99
Closes #110