### PR TITLE
Implements "noncar" physics

### DIFF
--- a/src/BRSRC13/include/brender/br_inline_funcs.h
+++ b/src/BRSRC13/include/brender/br_inline_funcs.h
@@ -62,13 +62,6 @@
         (v1)->v[2] = (v2)->v[2] * (v3)->v[2]; \
     } while (0)
 
-#define BrVector3Div(v1, v2, v3)              \
-    do {                                      \
-        (v1)->v[0] = (v2)->v[0] / (v3)->v[0]; \
-        (v1)->v[1] = (v2)->v[1] / (v3)->v[1]; \
-        (v1)->v[2] = (v2)->v[2] / (v3)->v[2]; \
-    } while (0)
-
 #define BrVector3Accumulate(v1, v2) \
     do {                            \
         (v1)->v[0] += (v2)->v[0];   \

--- a/src/BRSRC13/include/brender/br_inline_funcs.h
+++ b/src/BRSRC13/include/brender/br_inline_funcs.h
@@ -3,9 +3,10 @@
 
 #include "br_defs.h"
 
-#define BrVector2Set(v1, s1, s2) do {   \
-        (v1)->v[0] = (s1);              \
-        (v1)->v[1] = (s2);              \
+#define BrVector2Set(v1, s1, s2) \
+    do {                         \
+        (v1)->v[0] = (s1);       \
+        (v1)->v[1] = (s2);       \
     } while (0)
 
 #define BrVector3Length(v1) BR_LENGTH3((v1)->v[0], (v1)->v[1], (v1)->v[2])
@@ -52,6 +53,20 @@
         (v1)->v[0] = (v2)->v[0] - (v3)->v[0]; \
         (v1)->v[1] = (v2)->v[1] - (v3)->v[1]; \
         (v1)->v[2] = (v2)->v[2] - (v3)->v[2]; \
+    } while (0)
+
+#define BrVector3Mul(v1, v2, v3)              \
+    do {                                      \
+        (v1)->v[0] = (v2)->v[0] * (v3)->v[0]; \
+        (v1)->v[1] = (v2)->v[1] * (v3)->v[1]; \
+        (v1)->v[2] = (v2)->v[2] * (v3)->v[2]; \
+    } while (0)
+
+#define BrVector3Div(v1, v2, v3)              \
+    do {                                      \
+        (v1)->v[0] = (v2)->v[0] / (v3)->v[0]; \
+        (v1)->v[1] = (v2)->v[1] / (v3)->v[1]; \
+        (v1)->v[2] = (v2)->v[2] / (v3)->v[2]; \
     } while (0)
 
 #define BrVector3Accumulate(v1, v2) \

--- a/src/BRSRC13/include/brender/br_types.h
+++ b/src/BRSRC13/include/brender/br_types.h
@@ -715,11 +715,11 @@ typedef br_pixelmap* dev_clone_cbfn(br_device*, br_pixelmap*);
 typedef void dev_free_cbfn(br_device*, br_pixelmap*);
 
 typedef struct br_resource_class { // size: 20
-    br_uint_32 reserved; // @0
-    char* identifier; // @4
-    br_uint_8 res_class; // @8
+    br_uint_32 reserved;           // @0
+    char* identifier;              // @4
+    br_uint_8 res_class;           // @8
     br_resourcefree_cbfn* free_cb; // @12
-    br_uint_32 alignment; // @16
+    br_uint_32 alignment;          // @16
 } br_resource_class;
 
 typedef struct br_filesystem {
@@ -957,31 +957,31 @@ typedef struct br_quat {
     br_scalar w;
 } br_quat;
 
-typedef struct br_transform { // size: 0x34
-    br_uint_16 type; // @0x0
-    union { // size: 0x30
-        br_matrix34 mat; // @0x0
-        struct { // size: 0x30
-            br_euler e; // @0x0
+typedef struct br_transform {  // size: 0x34
+    br_uint_16 type;           // @0x0
+    union {                    // size: 0x30
+        br_matrix34 mat;       // @0x0
+        struct {               // size: 0x30
+            br_euler e;        // @0x0
             br_scalar _pad[7]; // @0x8
-            br_vector3 t; // @0x24
-        } euler; // @0x0
-        struct { // size: 0x30
-            br_quat q; // @0x0
+            br_vector3 t;      // @0x24
+        } euler;               // @0x0
+        struct {               // size: 0x30
+            br_quat q;         // @0x0
             br_scalar _pad[5]; // @0x10
-            br_vector3 t; // @0x24
-        } quat; // @0x0
-        struct { // size: 0x30
-            br_vector3 look; // @0x0
-            br_vector3 up; // @0xc
+            br_vector3 t;      // @0x24
+        } quat;                // @0x0
+        struct {               // size: 0x30
+            br_vector3 look;   // @0x0
+            br_vector3 up;     // @0xc
             br_scalar _pad[3]; // @0x18
-            br_vector3 t; // @0x24
-        } look_up; // @0x0
-        struct { // size: 0x30
+            br_vector3 t;      // @0x24
+        } look_up;             // @0x0
+        struct {               // size: 0x30
             br_scalar _pad[9]; // @0x0
-            br_vector3 t; // @0x24
-        } translate; // @0x0
-    } t; // @0x4
+            br_vector3 t;      // @0x24
+        } translate;           // @0x0
+    } t;                       // @0x4
 } br_transform;
 
 typedef struct br_pixelmap {
@@ -1127,24 +1127,24 @@ typedef struct br_associative_array_tag {
     br_uint_16 max_elements;
 } br_associative_array;
 
-typedef struct br_device { // size: 68
-    br_uint_32 magic; // @0
-    char* identifier; // @4
-    br_font* default_font; // @8
-    br_uint_32 qualifier; // @12
-    dev_fill_cbfn* fill; // @16
-    dev_rectangle_copy_cbfn* rectangle_copy; // @20
-    dev_rectangle_fill_cbfn* rectangle_fill; // @24
+typedef struct br_device {                               // size: 68
+    br_uint_32 magic;                                    // @0
+    char* identifier;                                    // @4
+    br_font* default_font;                               // @8
+    br_uint_32 qualifier;                                // @12
+    dev_fill_cbfn* fill;                                 // @16
+    dev_rectangle_copy_cbfn* rectangle_copy;             // @20
+    dev_rectangle_fill_cbfn* rectangle_fill;             // @24
     dev_dirty_rectangle_copy_cbfn* dirty_rectangle_copy; // @28
     dev_dirty_rectangle_fill_cbfn* dirty_rectangle_fill; // @32
-    dev_plot_cbfn* plot; // @36
-    dev_copy_cbfn* copy; // @40
-    dev_line_cbfn* line; // @44
-    dev_copy_bits_cbfn* copy_bits; // @48
-    dev_double_buffer_cbfn* double_buffer; // @52
-    dev_match_cbfn* match; // @56
-    dev_clone_cbfn* clone; // @60
-    dev_free_cbfn* free; // @64
+    dev_plot_cbfn* plot;                                 // @36
+    dev_copy_cbfn* copy;                                 // @40
+    dev_line_cbfn* line;                                 // @44
+    dev_copy_bits_cbfn* copy_bits;                       // @48
+    dev_double_buffer_cbfn* double_buffer;               // @52
+    dev_match_cbfn* match;                               // @56
+    dev_clone_cbfn* clone;                               // @60
+    dev_free_cbfn* free;                                 // @64
 } br_device;
 
 typedef struct br_outfcty_desc {
@@ -1163,28 +1163,28 @@ typedef struct br_outfcty_desc {
 typedef struct br_renderer_facility br_renderer_facility;
 
 typedef struct br_device_pixelmap_dispatch br_device_pixelmap_dispatch;
-typedef struct br_device_pixelmap { // size: 0x44
+typedef struct br_device_pixelmap {        // size: 0x44
     br_device_pixelmap_dispatch* dispatch; // @0x0
-    char* pm_identifier; // @0x4
-    void* pm_pixels; // @0x8
-    br_uint_32 pm_pixels_qualifier; // @0xc
-    br_pixelmap* pm_map; // @0x10
-    br_colour_range pm_src_key; // @0x14
-    br_colour_range pm_dst_key; // @0x1c
-    br_uint_32 pm_key; // @0x24
-    br_int_16 pm_row_bytes; // @0x28
-    br_int_16 pm_mip_offset; // @0x2a
-    br_uint_8 pm_type; // @0x2c
-    br_uint_8 pm_flags; // @0x2d
-    br_uint_16 pm_copy_function; // @0x2e
-    br_uint_16 pm_base_x; // @0x30
-    br_uint_16 pm_base_y; // @0x32
-    br_uint_16 pm_width; // @0x34
-    br_uint_16 pm_height; // @0x36
-    br_int_16 pm_origin_x; // @0x38
-    br_int_16 pm_origin_y; // @0x3a
-    void* pm_user; // @0x3c
-    void* pm_stored; // @0x40
+    char* pm_identifier;                   // @0x4
+    void* pm_pixels;                       // @0x8
+    br_uint_32 pm_pixels_qualifier;        // @0xc
+    br_pixelmap* pm_map;                   // @0x10
+    br_colour_range pm_src_key;            // @0x14
+    br_colour_range pm_dst_key;            // @0x1c
+    br_uint_32 pm_key;                     // @0x24
+    br_int_16 pm_row_bytes;                // @0x28
+    br_int_16 pm_mip_offset;               // @0x2a
+    br_uint_8 pm_type;                     // @0x2c
+    br_uint_8 pm_flags;                    // @0x2d
+    br_uint_16 pm_copy_function;           // @0x2e
+    br_uint_16 pm_base_x;                  // @0x30
+    br_uint_16 pm_base_y;                  // @0x32
+    br_uint_16 pm_width;                   // @0x34
+    br_uint_16 pm_height;                  // @0x36
+    br_int_16 pm_origin_x;                 // @0x38
+    br_int_16 pm_origin_y;                 // @0x3a
+    void* pm_user;                         // @0x3c
+    void* pm_stored;                       // @0x40
 } br_device_pixelmap;
 
 typedef struct br_primitive_library br_primitive_library;
@@ -1197,41 +1197,32 @@ typedef struct br_renderer {
     br_renderer_dispatch* dispatch;
 } br_renderer;
 
-typedef struct br_material { // size: 0x9c
-    br_uint_32 _reserved; // @0x0
-    char* identifier; // @0x4
-    br_colour colour; // @0x8
-    br_uint_8 opacity; // @0xc
-    br_ufraction ka; // @0x10
-    br_ufraction kd; // @0x14
-    br_ufraction ks; // @0x18
-    br_scalar power; // @0x1c
-    br_uint_32 flags; // @0x20
-    br_matrix23 map_transform; // @0x24
-    br_uint_8 index_base; // @0x3c
-    br_uint_8 index_range; // @0x3d
-    br_pixelmap* colour_map; // @0x40
-    br_pixelmap* screendoor; // @0x44
-    br_pixelmap* index_shade; // @0x48
-    br_pixelmap* index_blend; // @0x4c
-    br_pixelmap* index_fog; // @0x50
-    br_token_value* extra_surf; // @0x54
-    br_token_value* extra_prim; // @0x58
-    br_scalar fog_min; // @0x5c
-    br_scalar fog_max; // @0x60
-    br_colour fog_colour; // @0x64
-    br_uint_32 flags_ext; // @0x68
-    br_pixelmap* colour_map_1; // @0x6c
-    br_matrix23 map_transform_1; // @0x70
-    br_int_8 mip_modifier; // @0x88
-    br_uint_8 min_mip; // @0x89
-    br_uint_8 max_mip; // @0x8a
-    br_uint_8 alpha_mode; // @0x8b
-    br_uint_8 zbuffer_mode; // @0x8c
-    br_uint_8 zbuffer_compare; // @0x8d
-    br_int_32 subdivide_tolerance; // @0x90
-    void* user; // @0x94
-    void* stored; // @0x98
+typedef struct br_material {       // size: 0x74
+    br_uint_32 _reserved;          // @0x0
+    char* identifier;              // @0x4
+    br_colour colour;              // @0x8
+    br_uint_8 opacity;             // @0xc
+    br_ufraction ka;               // @0x10
+    br_ufraction kd;               // @0x14
+    br_ufraction ks;               // @0x18
+    br_scalar power;               // @0x1c
+    br_uint_32 flags;              // @0x20
+    br_matrix23 map_transform;     // @0x24
+    br_uint_8 index_base;          // @0x3c
+    br_uint_8 index_range;         // @0x3d
+    br_pixelmap* colour_map;       // @0x40
+    br_pixelmap* screendoor;       // @0x44
+    br_pixelmap* index_shade;      // @0x48
+    br_pixelmap* index_blend;      // @0x4c
+    br_pixelmap* index_fog;        // @0x50
+    br_token_value* extra_surf;    // @0x54
+    br_token_value* extra_prim;    // @0x58
+    br_scalar fog_min;             // @0x5c
+    br_scalar fog_max;             // @0x60
+    br_colour fog_colour;          // @0x64
+    br_int_32 subdivide_tolerance; // @0x68
+    void* user;                    // @0x6c
+    void* stored;                  // @0x70
 } br_material;
 
 typedef struct br_vertex {
@@ -1370,41 +1361,39 @@ typedef struct br_tri_strip {
     br_strip_face_data* face_data;
 } br_tri_strip;
 
-typedef struct br_actor { // size: 0x64
-    br_actor* next; // @0x0
-    br_actor** prev; // @0x4
-    br_actor* children; // @0x8
-    br_actor* parent; // @0xc
-    br_uint_16 depth; // @0x10
-    br_uint_8 type; // @0x12
-    char* identifier; // @0x14
-    br_model* model; // @0x18
-    br_material* material; // @0x1c
+typedef struct br_actor {   // size: 0x64
+    br_actor* next;         // @0x0
+    br_actor** prev;        // @0x4
+    br_actor* children;     // @0x8
+    br_actor* parent;       // @0xc
+    br_uint_16 depth;       // @0x10
+    br_uint_8 type;         // @0x12
+    char* identifier;       // @0x14
+    br_model* model;        // @0x18
+    br_material* material;  // @0x1c
     br_uint_8 render_style; // @0x20
-    void* render_data; // @0x24
-    br_transform t; // @0x28
-    void* type_data; // @0x5c
-    void* user; // @0x60
+    void* render_data;      // @0x24
+    br_transform t;         // @0x28
+    void* type_data;        // @0x5c
+    void* user;             // @0x60
 } br_actor;
 
-typedef struct br_model { // size: 0x5c
-    br_uint_32 _reserved; // @0x0
-    char* identifier; // @0x4
-    br_vertex* vertices; // @0x8
-    br_face* faces; // @0xc
-    br_uint_16 nvertices; // @0x10
-    br_uint_16 nfaces; // @0x12
-    br_vector3 pivot; // @0x14
-    br_uint_16 flags; // @0x20
+typedef struct br_model {         // size: 0x54
+    br_uint_32 _reserved;         // @0x0
+    char* identifier;             // @0x4
+    br_vertex* vertices;          // @0x8
+    br_face* faces;               // @0xc
+    br_uint_16 nvertices;         // @0x10
+    br_uint_16 nfaces;            // @0x12
+    br_vector3 pivot;             // @0x14
+    br_uint_16 flags;             // @0x20
     br_model_custom_cbfn* custom; // @0x24
-    void* user; // @0x28
-    br_angle crease_angle; // @0x2c
-    br_scalar radius; // @0x30
-    br_bounds bounds; // @0x34
-    void* prepared; // @0x4c
-    void* stored; // @0x50
-    br_uint_16 nprimitive_lists; // @0x54
-    br_primitive_list* primitive_list; // @0x58
+    void* user;                   // @0x28
+    br_angle crease_angle;        // @0x2c
+    br_scalar radius;             // @0x30
+    br_bounds bounds;             // @0x34
+    void* prepared;               // @0x4c
+    void* stored;                 // @0x50
 } br_model;
 
 typedef struct br_camera {
@@ -1499,13 +1488,13 @@ typedef struct br_simple_list {
 } br_simple_list;
 
 typedef struct br_registry_entry { // size: 12
-    br_node node; // @0
-    char** item; // @8
+    br_node node;                  // @0
+    char** item;                   // @8
 } br_registry_entry;
 
-typedef struct br_registery { // size: 20
-    br_list list; // @0
-    int count; // @12
+typedef struct br_registery {              // size: 20
+    br_list list;                          // @0
+    int count;                             // @12
     br_find_failed_cbfn* find_failed_hook; // @16
 } br_registry;
 
@@ -1573,91 +1562,91 @@ typedef struct br_open_device {
     br_image* image;
 } br_open_device;
 
-typedef struct br_framework_state { // size: 1136
-    br_boolean active; // @0
-    br_registry reg_resource_classes; // @4
+typedef struct br_framework_state {               // size: 1136
+    br_boolean active;                            // @0
+    br_registry reg_resource_classes;             // @4
     br_resource_class* resource_class_index[256]; // @24
-    br_list tokens; // @1048
-    br_token next_free_token; // @1060
-    br_filesystem* fsys; // @1064
-    br_allocator* mem; // @1068
-    br_diaghandler* diag; // @1072
-    int open_mode; // @1076
-    void* res; // @1080
-    void* scratch_ptr; // @1084
-    br_size_t scratch_size; // @1088
-    br_size_t scratch_last; // @1092
-    int scratch_inuse; // @1096
-    br_error last_error_type; // @1100
-    void** last_error_value; // @1104
-    br_list images; // @1108
-    br_open_device* dev_slots; // @1120
-    br_int_32 ndev_slots; // @1124
-    br_associative_array* sys_config; // @1128
-    br_boolean bAlreadyLoadedDrivers; // @1132
+    br_list tokens;                               // @1048
+    br_token next_free_token;                     // @1060
+    br_filesystem* fsys;                          // @1064
+    br_allocator* mem;                            // @1068
+    br_diaghandler* diag;                         // @1072
+    int open_mode;                                // @1076
+    void* res;                                    // @1080
+    void* scratch_ptr;                            // @1084
+    br_size_t scratch_size;                       // @1088
+    br_size_t scratch_last;                       // @1092
+    int scratch_inuse;                            // @1096
+    br_error last_error_type;                     // @1100
+    void** last_error_value;                      // @1104
+    br_list images;                               // @1108
+    br_open_device* dev_slots;                    // @1120
+    br_int_32 ndev_slots;                         // @1124
+    br_associative_array* sys_config;             // @1128
+    br_boolean bAlreadyLoadedDrivers;             // @1132
 } br_framework_state;
 
 // br_framework_state defined by "C:\DETHRACE\source\common\finteray.c" module
-typedef struct br_framework_state2 { // size: 0x14d4
-    br_surface_fn* surface_fn; // @0x0
-    br_surface_fn* surface_fn_after_map; // @0x4
-    br_surface_fn* surface_fn_after_copy; // @0x8
-    br_face_surface_fn* face_surface_fn; // @0xc
-    br_matrix23 map_transform; // @0x10
-    br_scalar index_base; // @0x28
-    br_scalar index_range; // @0x2c
-    br_matrix4 model_to_screen; // @0x30
-    br_matrix4 view_to_screen; // @0x70
-    br_matrix34 model_to_view; // @0xb0
-    br_matrix34 view_to_model; // @0xe0
-    br_matrix34 model_to_environment; // @0x110
-    struct { // size: 0x34
-        br_matrix34 m; // @0x0
-        br_actor* a; // @0x30
-    } camera_path[16]; // @0x140
-    int vtos_type; // @0x480
-    br_vector3 eye_m; // @0x484
-    br_vector3 eye_m_normalised; // @0x490
-    br_material* material; // @0x49c
-    br_active_light active_lights_model[16]; // @0x4a0
-    br_active_light active_lights_view[16]; // @0x9e0
-    br_uint_16 nactive_lights_model; // @0xf20
-    br_uint_16 nactive_lights_view; // @0xf22
-    int light_is_1md; // @0xf24
-    br_vector3 eye_l; // @0xf28
-    br_active_clip_plane active_clip_planes[6]; // @0xf34
-    br_uint_16 nactive_clip_planes; // @0xf94
-    br_actor* enabled_lights[16]; // @0xf98
-    br_actor* enabled_clip_planes[6]; // @0xfd8
-    br_actor* enabled_environment; // @0xff0
-    br_pixelmap* output; // @0xff4
-    br_scalar vp_width; // @0xff8
-    br_scalar vp_height; // @0xffc
-    br_scalar vp_ox; // @0x1000
-    br_scalar vp_oy; // @0x1004
-    int rendering; // @0x1008
-    br_registry reg_models; // @0x100c
-    br_registry reg_materials; // @0x1020
-    br_registry reg_textures; // @0x1034
-    br_registry reg_tables; // @0x1048
-    br_registry reg_resource_classes; // @0x105c
+typedef struct br_framework_state2 {              // size: 0x14d4
+    br_surface_fn* surface_fn;                    // @0x0
+    br_surface_fn* surface_fn_after_map;          // @0x4
+    br_surface_fn* surface_fn_after_copy;         // @0x8
+    br_face_surface_fn* face_surface_fn;          // @0xc
+    br_matrix23 map_transform;                    // @0x10
+    br_scalar index_base;                         // @0x28
+    br_scalar index_range;                        // @0x2c
+    br_matrix4 model_to_screen;                   // @0x30
+    br_matrix4 view_to_screen;                    // @0x70
+    br_matrix34 model_to_view;                    // @0xb0
+    br_matrix34 view_to_model;                    // @0xe0
+    br_matrix34 model_to_environment;             // @0x110
+    struct {                                      // size: 0x34
+        br_matrix34 m;                            // @0x0
+        br_actor* a;                              // @0x30
+    } camera_path[16];                            // @0x140
+    int vtos_type;                                // @0x480
+    br_vector3 eye_m;                             // @0x484
+    br_vector3 eye_m_normalised;                  // @0x490
+    br_material* material;                        // @0x49c
+    br_active_light active_lights_model[16];      // @0x4a0
+    br_active_light active_lights_view[16];       // @0x9e0
+    br_uint_16 nactive_lights_model;              // @0xf20
+    br_uint_16 nactive_lights_view;               // @0xf22
+    int light_is_1md;                             // @0xf24
+    br_vector3 eye_l;                             // @0xf28
+    br_active_clip_plane active_clip_planes[6];   // @0xf34
+    br_uint_16 nactive_clip_planes;               // @0xf94
+    br_actor* enabled_lights[16];                 // @0xf98
+    br_actor* enabled_clip_planes[6];             // @0xfd8
+    br_actor* enabled_environment;                // @0xff0
+    br_pixelmap* output;                          // @0xff4
+    br_scalar vp_width;                           // @0xff8
+    br_scalar vp_height;                          // @0xffc
+    br_scalar vp_ox;                              // @0x1000
+    br_scalar vp_oy;                              // @0x1004
+    int rendering;                                // @0x1008
+    br_registry reg_models;                       // @0x100c
+    br_registry reg_materials;                    // @0x1020
+    br_registry reg_textures;                     // @0x1034
+    br_registry reg_tables;                       // @0x1048
+    br_registry reg_resource_classes;             // @0x105c
     br_resource_class* resource_class_index[256]; // @0x1070
-    br_model_update_cbfn* model_update; // @0x1470
-    br_material_update_cbfn* material_update; // @0x1474
-    br_table_update_cbfn* table_update; // @0x1478
-    br_map_update_cbfn* map_update; // @0x147c
-    br_filesystem* fsys; // @0x1480
-    br_allocator* mem; // @0x1484
-    br_errorhandler* err; // @0x1488
-    int open_mode; // @0x148c
-    void* res; // @0x1490
-    br_model* default_model; // @0x1494
-    br_material* default_material; // @0x1498
-    fw_fn_table fn_table; // @0x149c
-    void* scratch_ptr; // @0x14c4
-    br_size_t scratch_size; // @0x14c8
-    br_size_t scratch_last; // @0x14cc
-    int scratch_inuse; // @0x14d0
+    br_model_update_cbfn* model_update;           // @0x1470
+    br_material_update_cbfn* material_update;     // @0x1474
+    br_table_update_cbfn* table_update;           // @0x1478
+    br_map_update_cbfn* map_update;               // @0x147c
+    br_filesystem* fsys;                          // @0x1480
+    br_allocator* mem;                            // @0x1484
+    br_errorhandler* err;                         // @0x1488
+    int open_mode;                                // @0x148c
+    void* res;                                    // @0x1490
+    br_model* default_model;                      // @0x1494
+    br_material* default_material;                // @0x1498
+    fw_fn_table fn_table;                         // @0x149c
+    void* scratch_ptr;                            // @0x14c4
+    br_size_t scratch_size;                       // @0x14c8
+    br_size_t scratch_last;                       // @0x14cc
+    int scratch_inuse;                            // @0x14d0
 } br_framework_state2;
 
 typedef br_error br_exception;
@@ -1807,63 +1796,63 @@ typedef struct br_buffer_stored {
     br_buffer_stored_dispatch* dispatch;
 } br_buffer_stored;
 
-typedef struct br_device_pixelmap_dispatch { // size: 0xe0
-    void (*__reserved0)(br_object*); // @0x0
-    void (*__reserved1)(br_object*); // @0x4
-    void (*__reserved2)(br_object*); // @0x8
-    void (*__reserved3)(br_object*); // @0xc
-    void (*_free)(br_object*); // @0x10
-    char* (*_identifier)(br_object*); // @0x14
-    br_token (*_type)(br_object*); // @0x18
-    br_boolean (*_isType)(br_object*, br_token); // @0x1c
-    br_device* (*_device)(br_object*); // @0x20
-    br_int_32 (*_space)(br_object*); // @0x24
-    br_tv_template* (*_templateQuery)(br_object*); // @0x28
-    br_error (*_query)(br_object*, br_uint_32*, br_token); // @0x2c
-    br_error (*_queryBuffer)(br_object*, br_uint_32*, void*, br_size_t, br_token); // @0x30
-    br_error (*_queryMany)(br_object*, br_token_value*, void*, br_size_t, br_int_32*); // @0x34
-    br_error (*_queryManySize)(br_object*, br_size_t*, br_token_value*); // @0x38
-    br_error (*_queryAll)(br_object*, br_token_value*, br_size_t); // @0x3c
-    br_error (*_queryAllSize)(br_object*, br_size_t*); // @0x40
-    br_error (*_validSource)(br_device_pixelmap*, br_boolean*, br_object*); // @0x44
-    br_error (*_resize)(br_device_pixelmap*, br_int_32, br_int_32); // @0x48
-    br_error (*_match)(br_device_pixelmap*, br_device_pixelmap**, br_token_value*); // @0x4c
-    br_error (*_allocateSub)(br_device_pixelmap*, br_device_pixelmap**, br_rectangle*); // @0x50
-    br_error (*_copy)(br_device_pixelmap*, br_device_pixelmap*); // @0x54
-    br_error (*_copyTo)(br_device_pixelmap*, br_device_pixelmap*); // @0x58
-    br_error (*_copyFrom)(br_device_pixelmap*, br_device_pixelmap*); // @0x5c
-    br_error (*_fill)(br_device_pixelmap*, br_uint_32); // @0x60
-    br_error (*_doubleBuffer)(br_device_pixelmap*, br_device_pixelmap*); // @0x64
-    br_error (*_copyDirty)(br_device_pixelmap*, br_device_pixelmap*, br_rectangle*, br_int_32); // @0x68
-    br_error (*_copyToDirty)(br_device_pixelmap*, br_device_pixelmap*, br_rectangle*, br_int_32); // @0x6c
-    br_error (*_copyFromDirty)(br_device_pixelmap*, br_device_pixelmap*, br_rectangle*, br_int_32); // @0x70
-    br_error (*_fillDirty)(br_device_pixelmap*, br_uint_32, br_rectangle*, br_int_32); // @0x74
-    br_error (*_doubleBufferDirty)(br_device_pixelmap*, br_device_pixelmap*, br_rectangle*, br_int_32); // @0x78
-    br_error (*_rectangle)(br_device_pixelmap*, br_rectangle*, br_uint_32); // @0x7c
-    br_error (*_rectangle2)(br_device_pixelmap*, br_rectangle*, br_uint_32, br_uint_32); // @0x80
-    br_error (*_rectangleCopy)(br_device_pixelmap*, br_point*, br_device_pixelmap*, br_rectangle*); // @0x84
-    br_error (*_rectangleCopyTo)(br_device_pixelmap*, br_point*, br_device_pixelmap*, br_rectangle*); // @0x88
-    br_error (*_rectangleCopyFrom)(br_device_pixelmap*, br_point*, br_device_pixelmap*, br_rectangle*); // @0x8c
-    br_error (*_rectangleStretchCopy)(br_device_pixelmap*, br_rectangle*, br_device_pixelmap*, br_rectangle*); // @0x90
-    br_error (*_rectangleStretchCopyTo)(br_device_pixelmap*, br_rectangle*, br_device_pixelmap*, br_rectangle*); // @0x94
+typedef struct br_device_pixelmap_dispatch {                                                                       // size: 0xe0
+    void (*__reserved0)(br_object*);                                                                               // @0x0
+    void (*__reserved1)(br_object*);                                                                               // @0x4
+    void (*__reserved2)(br_object*);                                                                               // @0x8
+    void (*__reserved3)(br_object*);                                                                               // @0xc
+    void (*_free)(br_object*);                                                                                     // @0x10
+    char* (*_identifier)(br_object*);                                                                              // @0x14
+    br_token (*_type)(br_object*);                                                                                 // @0x18
+    br_boolean (*_isType)(br_object*, br_token);                                                                   // @0x1c
+    br_device* (*_device)(br_object*);                                                                             // @0x20
+    br_int_32 (*_space)(br_object*);                                                                               // @0x24
+    br_tv_template* (*_templateQuery)(br_object*);                                                                 // @0x28
+    br_error (*_query)(br_object*, br_uint_32*, br_token);                                                         // @0x2c
+    br_error (*_queryBuffer)(br_object*, br_uint_32*, void*, br_size_t, br_token);                                 // @0x30
+    br_error (*_queryMany)(br_object*, br_token_value*, void*, br_size_t, br_int_32*);                             // @0x34
+    br_error (*_queryManySize)(br_object*, br_size_t*, br_token_value*);                                           // @0x38
+    br_error (*_queryAll)(br_object*, br_token_value*, br_size_t);                                                 // @0x3c
+    br_error (*_queryAllSize)(br_object*, br_size_t*);                                                             // @0x40
+    br_error (*_validSource)(br_device_pixelmap*, br_boolean*, br_object*);                                        // @0x44
+    br_error (*_resize)(br_device_pixelmap*, br_int_32, br_int_32);                                                // @0x48
+    br_error (*_match)(br_device_pixelmap*, br_device_pixelmap**, br_token_value*);                                // @0x4c
+    br_error (*_allocateSub)(br_device_pixelmap*, br_device_pixelmap**, br_rectangle*);                            // @0x50
+    br_error (*_copy)(br_device_pixelmap*, br_device_pixelmap*);                                                   // @0x54
+    br_error (*_copyTo)(br_device_pixelmap*, br_device_pixelmap*);                                                 // @0x58
+    br_error (*_copyFrom)(br_device_pixelmap*, br_device_pixelmap*);                                               // @0x5c
+    br_error (*_fill)(br_device_pixelmap*, br_uint_32);                                                            // @0x60
+    br_error (*_doubleBuffer)(br_device_pixelmap*, br_device_pixelmap*);                                           // @0x64
+    br_error (*_copyDirty)(br_device_pixelmap*, br_device_pixelmap*, br_rectangle*, br_int_32);                    // @0x68
+    br_error (*_copyToDirty)(br_device_pixelmap*, br_device_pixelmap*, br_rectangle*, br_int_32);                  // @0x6c
+    br_error (*_copyFromDirty)(br_device_pixelmap*, br_device_pixelmap*, br_rectangle*, br_int_32);                // @0x70
+    br_error (*_fillDirty)(br_device_pixelmap*, br_uint_32, br_rectangle*, br_int_32);                             // @0x74
+    br_error (*_doubleBufferDirty)(br_device_pixelmap*, br_device_pixelmap*, br_rectangle*, br_int_32);            // @0x78
+    br_error (*_rectangle)(br_device_pixelmap*, br_rectangle*, br_uint_32);                                        // @0x7c
+    br_error (*_rectangle2)(br_device_pixelmap*, br_rectangle*, br_uint_32, br_uint_32);                           // @0x80
+    br_error (*_rectangleCopy)(br_device_pixelmap*, br_point*, br_device_pixelmap*, br_rectangle*);                // @0x84
+    br_error (*_rectangleCopyTo)(br_device_pixelmap*, br_point*, br_device_pixelmap*, br_rectangle*);              // @0x88
+    br_error (*_rectangleCopyFrom)(br_device_pixelmap*, br_point*, br_device_pixelmap*, br_rectangle*);            // @0x8c
+    br_error (*_rectangleStretchCopy)(br_device_pixelmap*, br_rectangle*, br_device_pixelmap*, br_rectangle*);     // @0x90
+    br_error (*_rectangleStretchCopyTo)(br_device_pixelmap*, br_rectangle*, br_device_pixelmap*, br_rectangle*);   // @0x94
     br_error (*_rectangleStretchCopyFrom)(br_device_pixelmap*, br_rectangle*, br_device_pixelmap*, br_rectangle*); // @0x98
-    br_error (*_rectangleFill)(br_device_pixelmap*, br_rectangle*, br_uint_32); // @0x9c
-    br_error (*_pixelSet)(br_device_pixelmap*, br_point*, br_uint_32); // @0xa0
-    br_error (*_line)(br_device_pixelmap*, br_point*, br_point*, br_uint_32); // @0xa4
-    br_error (*_copyBits)(br_device_pixelmap*, br_point*, br_uint_8*, br_uint_16, br_rectangle*, br_uint_32); // @0xa8
-    br_error (*_text)(br_device_pixelmap*, br_point*, br_font*, char*, br_uint_32); // @0xac
-    br_error (*_textBounds)(br_device_pixelmap*, br_rectangle*, br_font*, char*); // @0xb0
-    br_error (*_rowSize)(br_device_pixelmap*, br_size_t*); // @0xb4
-    br_error (*_rowSet)(br_device_pixelmap*, void*, br_size_t, br_uint_32); // @0xb8
-    br_error (*_rowQuery)(br_device_pixelmap*, void*, br_size_t, br_uint_32); // @0xbc
-    br_error (*_pixelQuery)(br_device_pixelmap*, br_uint_32*, br_point*); // @0xc0
-    br_error (*_pixelAddressQuery)(br_device_pixelmap*, void**, br_uint_32*, br_point*); // @0xc4
-    br_error (*_pixelAddressSet)(br_device_pixelmap*, void*, br_uint_32*); // @0xc8
-    br_error (*_originSet)(br_device_pixelmap*, br_point*); // @0xcc
-    br_error (*_flush)(br_device_pixelmap*); // @0xd0
-    br_error (*_synchronise)(br_device_pixelmap*, br_token, br_boolean); // @0xd4
-    br_error (*_directLock)(br_device_pixelmap*, br_boolean); // @0xd8
-    br_error (*_directUnlock)(br_device_pixelmap*); // @0xdc
+    br_error (*_rectangleFill)(br_device_pixelmap*, br_rectangle*, br_uint_32);                                    // @0x9c
+    br_error (*_pixelSet)(br_device_pixelmap*, br_point*, br_uint_32);                                             // @0xa0
+    br_error (*_line)(br_device_pixelmap*, br_point*, br_point*, br_uint_32);                                      // @0xa4
+    br_error (*_copyBits)(br_device_pixelmap*, br_point*, br_uint_8*, br_uint_16, br_rectangle*, br_uint_32);      // @0xa8
+    br_error (*_text)(br_device_pixelmap*, br_point*, br_font*, char*, br_uint_32);                                // @0xac
+    br_error (*_textBounds)(br_device_pixelmap*, br_rectangle*, br_font*, char*);                                  // @0xb0
+    br_error (*_rowSize)(br_device_pixelmap*, br_size_t*);                                                         // @0xb4
+    br_error (*_rowSet)(br_device_pixelmap*, void*, br_size_t, br_uint_32);                                        // @0xb8
+    br_error (*_rowQuery)(br_device_pixelmap*, void*, br_size_t, br_uint_32);                                      // @0xbc
+    br_error (*_pixelQuery)(br_device_pixelmap*, br_uint_32*, br_point*);                                          // @0xc0
+    br_error (*_pixelAddressQuery)(br_device_pixelmap*, void**, br_uint_32*, br_point*);                           // @0xc4
+    br_error (*_pixelAddressSet)(br_device_pixelmap*, void*, br_uint_32*);                                         // @0xc8
+    br_error (*_originSet)(br_device_pixelmap*, br_point*);                                                        // @0xcc
+    br_error (*_flush)(br_device_pixelmap*);                                                                       // @0xd0
+    br_error (*_synchronise)(br_device_pixelmap*, br_token, br_boolean);                                           // @0xd4
+    br_error (*_directLock)(br_device_pixelmap*, br_boolean);                                                      // @0xd8
+    br_error (*_directUnlock)(br_device_pixelmap*);                                                                // @0xdc
 } br_device_pixelmap_dispatch;
 
 typedef struct br_buffer_stored_dispatch {
@@ -1997,11 +1986,11 @@ typedef struct br_file_struct {
 } br_file_struct;
 
 typedef struct br_file_primitives br_file_primitives;
-typedef struct br_datafile { // size: 0x10
-    void* h; // @0x0
+typedef struct br_datafile {   // size: 0x10
+    void* h;                   // @0x0
     br_file_primitives* prims; // @0x4
-    br_token scalar_type; // @0x8
-    void* res; // @0xc
+    br_token scalar_type;      // @0x8
+    void* res;                 // @0xc
 } br_datafile;
 
 typedef struct br_file_primitives {
@@ -2128,52 +2117,52 @@ typedef struct br_v1db_enable {
     br_actor** enabled;
 } br_v1db_enable;
 
-typedef struct br_v1db_state { // size: 0x504
-    br_boolean active; // @0x0
-    br_boolean zs_active; // @0x4
-    br_boolean zb_active; // @0x8
-    br_int_32 rendering; // @0xc
-    br_renderer* renderer; // @0x10
-    br_renderer* query_renderer; // @0x14
-    br_geometry* format_model; // @0x18
-    br_geometry* format_buckets; // @0x1c
+typedef struct br_v1db_state {             // size: 0x504
+    br_boolean active;                     // @0x0
+    br_boolean zs_active;                  // @0x4
+    br_boolean zb_active;                  // @0x8
+    br_int_32 rendering;                   // @0xc
+    br_renderer* renderer;                 // @0x10
+    br_renderer* query_renderer;           // @0x14
+    br_geometry* format_model;             // @0x18
+    br_geometry* format_buckets;           // @0x1c
     br_geometry_lighting* format_lighting; // @0x20
-    br_matrix4 model_to_screen; // @0x24
-    br_matrix34 model_to_view; // @0x64
-    br_boolean model_to_screen_valid; // @0x94
-    br_uint_32 ttype; // @0x98
-    br_actor* render_root; // @0x9c
-    struct { // size: 0x38
-        br_matrix34 m; // @0x0
-        br_actor* a; // @0x30
-        br_uint_8 transform_type; // @0x34
-    } camera_path[16]; // @0xa0
-    br_v1db_enable enabled_lights; // @0x420
-    br_v1db_enable enabled_clip_planes; // @0x434
+    br_matrix4 model_to_screen;            // @0x24
+    br_matrix34 model_to_view;             // @0x64
+    br_boolean model_to_screen_valid;      // @0x94
+    br_uint_32 ttype;                      // @0x98
+    br_actor* render_root;                 // @0x9c
+    struct {                               // size: 0x38
+        br_matrix34 m;                     // @0x0
+        br_actor* a;                       // @0x30
+        br_uint_8 transform_type;          // @0x34
+    } camera_path[16];                     // @0xa0
+    br_v1db_enable enabled_lights;         // @0x420
+    br_v1db_enable enabled_clip_planes;    // @0x434
     br_v1db_enable enabled_horizon_planes; // @0x448
-    br_int_32 max_light; // @0x45c
-    br_int_32 max_clip; // @0x460
-    br_actor* enabled_environment; // @0x464
-    br_registry reg_models; // @0x468
-    br_registry reg_materials; // @0x47c
-    br_registry reg_textures; // @0x490
-    br_registry reg_tables; // @0x4a4
-    void* res; // @0x4b8
-    br_model* default_model; // @0x4bc
-    br_material* default_material; // @0x4c0
-    void* default_render_data; // @0x4c4
-    br_order_table* default_order_table; // @0x4c8
-    br_order_table* primary_order_table; // @0x4cc
-    br_order_table* order_table_list; // @0x4d0
-    br_primitive_heap heap; // @0x4d4
-    br_primitive_cbfn* primitive_call; // @0x4e0
-    br_renderbounds_cbfn* bounds_call; // @0x4e4
-    br_vector2 origin; // @0x4e8
-    br_scalar vp_ox; // @0x4f0
-    br_scalar vp_oy; // @0x4f4
-    br_scalar vp_width; // @0x4f8
-    br_scalar vp_height; // @0x4fc
-    br_pixelmap* colour_buffer; // @0x500
+    br_int_32 max_light;                   // @0x45c
+    br_int_32 max_clip;                    // @0x460
+    br_actor* enabled_environment;         // @0x464
+    br_registry reg_models;                // @0x468
+    br_registry reg_materials;             // @0x47c
+    br_registry reg_textures;              // @0x490
+    br_registry reg_tables;                // @0x4a4
+    void* res;                             // @0x4b8
+    br_model* default_model;               // @0x4bc
+    br_material* default_material;         // @0x4c0
+    void* default_render_data;             // @0x4c4
+    br_order_table* default_order_table;   // @0x4c8
+    br_order_table* primary_order_table;   // @0x4cc
+    br_order_table* order_table_list;      // @0x4d0
+    br_primitive_heap heap;                // @0x4d4
+    br_primitive_cbfn* primitive_call;     // @0x4e0
+    br_renderbounds_cbfn* bounds_call;     // @0x4e4
+    br_vector2 origin;                     // @0x4e8
+    br_scalar vp_ox;                       // @0x4f0
+    br_scalar vp_oy;                       // @0x4f4
+    br_scalar vp_width;                    // @0x4f8
+    br_scalar vp_height;                   // @0x4fc
+    br_pixelmap* colour_buffer;            // @0x500
 } br_v1db_state;
 
 typedef struct br_renderer_facility_dispatch {
@@ -2426,11 +2415,11 @@ typedef struct br_tv_custom {
 } br_tv_custom;
 
 typedef struct br_token_entry { // size: 24
-    br_node node; // @0
-    char* identifier; // @8
-    br_int_32 type; // @12
-    br_token token; // @16
-    br_int_32 base_length; // @20
+    br_node node;               // @0
+    char* identifier;           // @8
+    br_int_32 type;             // @12
+    br_token token;             // @16
+    br_int_32 base_length;      // @20
 } br_token_entry;
 
 typedef struct br_exception_handler br_exception_handler;
@@ -2652,14 +2641,14 @@ typedef struct section_header {
 
 #pragma pack(push, 1)
 typedef struct resource_header { // size: 24
-    br_simple_node node; // @0
-    br_simple_list children; // @8
-    br_uint_8 size_l; // @12
-    br_uint_8 size_m; // @13
-    br_uint_8 size_h; // @14
-    br_uint_8 class; // @15
-    void* magic_ptr; // @16
-    br_uint_32 magic_num; // @20
+    br_simple_node node;         // @0
+    br_simple_list children;     // @8
+    br_uint_8 size_l;            // @12
+    br_uint_8 size_m;            // @13
+    br_uint_8 size_h;            // @14
+    br_uint_8 class;             // @15
+    void* magic_ptr;             // @16
+    br_uint_32 magic_num;        // @20
 } resource_header;
 #pragma pack(pop)
 
@@ -2892,42 +2881,42 @@ enum {
  */
 enum {
     /*
-	 * Each pixel is an index into a colour map
-	 */
+     * Each pixel is an index into a colour map
+     */
     BR_PMT_INDEX_1,
     BR_PMT_INDEX_2,
     BR_PMT_INDEX_4,
     BR_PMT_INDEX_8,
 
     /*
-	 * True colour RGB
-	 */
-    BR_PMT_RGB_555, /* 16 bits per pixel */
-    BR_PMT_RGB_565, /* 16 bits per pixel */
-    BR_PMT_RGB_888, /* 24 bits per pixel */
-    BR_PMT_RGBX_888, /* 32 bits per pixel */
+     * True colour RGB
+     */
+    BR_PMT_RGB_555,   /* 16 bits per pixel */
+    BR_PMT_RGB_565,   /* 16 bits per pixel */
+    BR_PMT_RGB_888,   /* 24 bits per pixel */
+    BR_PMT_RGBX_888,  /* 32 bits per pixel */
     BR_PMT_RGBA_8888, /* 32 bits per pixel */
 
     /*
-	 * YUV
-	 */
+     * YUV
+     */
     BR_PMT_YUYV_8888, /* YU YV YU YV ... */
     BR_PMT_YUV_888,
 
     /*
-	 * Depth
-	 */
+     * Depth
+     */
     BR_PMT_DEPTH_16,
     BR_PMT_DEPTH_32,
 
     /*
-	 * Opacity
-	 */
+     * Opacity
+     */
     BR_PMT_ALPHA_8,
 
     /*
-	 * Opacity + Index
-	 */
+     * Opacity + Index
+     */
     BR_PMT_INDEXA_88
 };
 
@@ -2996,17 +2985,17 @@ enum {
  * Bits for br_model->flags
  */
 enum {
-    BR_MODF_DONT_WELD = 0x0001, /* Vertices with same x,y,z cannot be merged	*/
-    BR_MODF_KEEP_ORIGINAL = 0x0002, /* Don't release model->faces/vertices during ModelUpdate() */
-    BR_MODF_GENERATE_TAGS = 0x0004, /* Allocate and fill in the face and vertex tag structures */
-    BR_MODF_QUICK_UPDATE = 0x0010, /* ModelUpdate is fast - but may produce slower models */
-    BR_MODF_CUSTOM = 0x0020, /* Invoke custom callback for this model */
-    BR_MODF_PREPREPARED = 0x0040, /* Model structure is pre-prepared - update performs no work */
-    BR_MODF_UPDATEABLE = 0x0080, /* Added by Jeff from Errols code */
-    BR_MODF_CREASE = 0x0100, /* Create creases in smoothing along edges if face<->face angle is g.t model->crease */
+    BR_MODF_DONT_WELD = 0x0001,      /* Vertices with same x,y,z cannot be merged	*/
+    BR_MODF_KEEP_ORIGINAL = 0x0002,  /* Don't release model->faces/vertices during ModelUpdate() */
+    BR_MODF_GENERATE_TAGS = 0x0004,  /* Allocate and fill in the face and vertex tag structures */
+    BR_MODF_QUICK_UPDATE = 0x0010,   /* ModelUpdate is fast - but may produce slower models */
+    BR_MODF_CUSTOM = 0x0020,         /* Invoke custom callback for this model */
+    BR_MODF_PREPREPARED = 0x0040,    /* Model structure is pre-prepared - update performs no work */
+    BR_MODF_UPDATEABLE = 0x0080,     /* Added by Jeff from Errols code */
+    BR_MODF_CREASE = 0x0100,         /* Create creases in smoothing along edges if face<->face angle is g.t model->crease */
     BR_MODF_CUSTOM_NORMALS = 0x0200, /* Uses vertex normals from br_vertex structure */
-    BR_MODF_CUSTOM_BOUNDS = 0x0400, /* Bounding box is already set up				*/
-    //BR_MODF_FACES_ONLY = 0x0800, /* Model will only be used to render faces (not edges or points) */
+    BR_MODF_CUSTOM_BOUNDS = 0x0400,  /* Bounding box is already set up				*/
+    // BR_MODF_FACES_ONLY = 0x0800, /* Model will only be used to render faces (not edges or points) */
 
     MODF_USES_DEFAULT = 0x8000
 };

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -5979,18 +5979,19 @@ int GetEdgeEdgeCollisions(br_bounds* pB1, br_bounds* pB2, br_matrix34* pM21, br_
     int n;
     LOG_TRACE("(%p, %p, %p, %p, %p, %p, %p, %p, %p, %d)", pB1, pB2, pM21, pM12, pMo21, pMo12, pM1o1, pPoint_list, pNorm_list, pMax);
 
+    // EdgeEdge final version
     n = 0;
     if (pMax < 1) {
         return 0;
     }
-    for (i = 0; i < 4; ++i) {
+    for (i = 0; i < 4; i++) {
         if (i == 3) {
             tp1 = pB2->min;
         } else {
             tp1 = pB2->max;
             tp1.v[i] = pB2->min.v[i];
         }
-        for (j = 0; j < 3; ++j) {
+        for (j = 0; j < 3; j++) {
             tp2 = tp1;
             if (pB2->max.v[j] == tp2.v[j]) {
                 tp2.v[j] = pB2->min.v[j];
@@ -6001,182 +6002,102 @@ int GetEdgeEdgeCollisions(br_bounds* pB1, br_bounds* pB2, br_matrix34* pM21, br_
             BrMatrix34ApplyP(&p1, &tp1, pM21);
             BrMatrix34ApplyP(&p2, &tp2, pM21);
             plane1 = LineBoxColl(&p1, &p2, pB1, &hp1);
-            if (plane1) {
-                plane2 = LineBoxColl(&p2, &p1, pB1, &hp2);
-                if (plane1 != 8 && plane2 != 8 && plane2) {
-                    p1.v[0] = hp2.v[0] + hp1.v[0];
-                    p1.v[1] = hp2.v[1] + hp1.v[1];
-                    p1.v[2] = hp2.v[2] + hp1.v[2];
-                    p1.v[0] = p1.v[0] * 0.5;
-                    p1.v[1] = p1.v[1] * 0.5;
-                    p1.v[2] = p1.v[2] * 0.5;
-                    BrMatrix34ApplyP(&tp3, &p1, pM12);
-                    BrMatrix34ApplyP(&p2, &tp3, pMo21);
-                    plane3 = LineBoxColl(&p2, &p1, pB1, &hp3);
-                    if (plane3 != 8) {
-                        if (plane3) {
-                            goto LABEL_25;
-                        }
-                    }
-                    tp3.v[0] = p2.v[0] - p1.v[0];
-                    tp3.v[1] = p2.v[1] - p1.v[1];
-                    tp3.v[2] = p2.v[2] - p1.v[2];
-                    ts = sqrtf(tp3.v[2] * tp3.v[2] + tp3.v[0] * tp3.v[0] + tp3.v[1] * tp3.v[1]);
-                    ts = ts / 0.0099999998;
-                    if (ts != 0.0f) {
-                        tp3.v[0] = tp3.v[0] / ts;
-                        tp3.v[1] = tp3.v[1] / ts;
-                        tp3.v[2] = tp3.v[2] / ts;
-                        p2.v[0] = tp3.v[0] + p2.v[0];
-                        p2.v[1] = p2.v[1] + tp3.v[1];
-                        p2.v[2] = tp3.v[2] + p2.v[2];
-                        plane3 = LineBoxColl(&p2, &p1, pB1, &hp3);
-                        if (plane3 != 8) {
-                            if (plane3) {
-                            LABEL_25:
-                                BrMatrix34ApplyP(&shp1, &hp1, pM12);
-                                BrMatrix34ApplyP(&shp2, &hp2, pM12);
-                                if ((plane1 ^ plane2) != 4 && (plane3 == plane1 || plane3 == plane2)) {
-                                    if (n >= pMax) {
-                                        return n;
-                                    }
-                                    GetBoundsEdge(&pPoint_list[2 * n], &edge, pB1, plane1, plane2, &p2, &hp1, &hp2, 0);
-                                    shp1.v[0] = shp2.v[0] + shp1.v[0];
-                                    shp1.v[1] = shp2.v[1] + shp1.v[1];
-                                    shp1.v[2] = shp1.v[2] + shp2.v[2];
-                                    pPoint_list[2 * n + 1].v[0] = shp1.v[0] * 0.5;
-                                    pPoint_list[2 * n + 1].v[1] = shp1.v[1] * 0.5;
-                                    pPoint_list[2 * n + 1].v[2] = shp1.v[2] * 0.5;
-                                    p1.v[0] = hp1.v[0] - hp2.v[0];
-                                    p1.v[1] = hp1.v[1] - hp2.v[1];
-                                    p1.v[2] = hp1.v[2] - hp2.v[2];
-                                    p2.v[0] = edge.v[1] * p1.v[2] - edge.v[2] * p1.v[1];
-                                    p2.v[1] = edge.v[2] * p1.v[0] - p1.v[2] * edge.v[0];
-                                    p2.v[2] = p1.v[1] * edge.v[0] - edge.v[1] * p1.v[0];
-                                    // v15 = sqrtf(p2.v[0] * p2.v[0] + p2.v[1] * p2.v[1] + p2.v[2] * p2.v[2]);
-                                    // if (v17 | v18) {
-                                    //     p2.v[0] = 1.0;
-                                    //     p2.v[1] = 0.0;
-                                    //     p2.v[2] = 0.0;
-                                    // } else {
-                                    //     v27 = v15;
-                                    //     v19 = 1.0 / v27;
-                                    //     v28 = v19;
-                                    //     p2.v[0] = v19 * p2.v[0];
-                                    //     p2.v[1] = p2.v[1] * v28;
-                                    //     p2.v[2] = p2.v[2] * v28;
-                                    // }
-                                    BrVector3Normalise(&p2, &p2);
-                                    p1.v[0] = pB1->max.v[0] + pB1->min.v[0];
-                                    p1.v[1] = pB1->max.v[1] + pB1->min.v[1];
-                                    p1.v[2] = pB1->max.v[2] + pB1->min.v[2];
-                                    p1.v[0] = p1.v[0] * 0.5;
-                                    p1.v[1] = p1.v[1] * 0.5;
-                                    p1.v[2] = p1.v[2] * 0.5;
-                                    p1.v[0] = pPoint_list[2 * n].v[0] - p1.v[0];
-                                    p1.v[1] = pPoint_list[2 * n].v[1] - p1.v[1];
-                                    p1.v[2] = pPoint_list[2 * n].v[2] - p1.v[2];
-                                    if (p2.v[0] * p1.v[0] + p2.v[1] * p1.v[1] + p2.v[2] * p1.v[2] > 0.0) {
-                                        p2.v[0] = -p2.v[0];
-                                        p2.v[1] = -p2.v[1];
-                                        p2.v[2] = -p2.v[2];
-                                    }
-                                    BrMatrix34ApplyV(&p1, &p2, pM12);
-                                    BrMatrix34TApplyV(&pNorm_list[2 * n], &p1, pMo12);
-                                    BrMatrix34TApplyV(&pNorm_list[2 * n + 1], &p2, pMo21);
-                                    pNorm_list[2 * n + 1].v[0] = -pNorm_list[2 * n + 1].v[0];
-                                    pNorm_list[2 * n + 1].v[1] = -pNorm_list[2 * n + 1].v[1];
-                                    pNorm_list[2 * n + 1].v[2] = -pNorm_list[2 * n + 1].v[2];
-                                    ++n;
-                                } else if ((plane1 ^ plane2) == 4) {
-                                    if (pMax - 1 <= n) {
-                                        return n;
-                                    }
-                                    GetBoundsEdge(&pPoint_list[2 * n], &edge, pB1, plane1, plane3, &p2, &hp1, &hp2, 0);
-                                    GetBoundsEdge(
-                                        &pPoint_list[2 * n + 2],
-                                        &edge,
-                                        pB1,
-                                        plane2,
-                                        plane3,
-                                        &p2,
-                                        &hp1,
-                                        &hp2,
-                                        0);
-                                    pPoint_list[2 * n + 1] = shp1;
-                                    pPoint_list[2 * n + 3] = shp2;
-                                    p1.v[0] = hp1.v[0] - hp2.v[0];
-                                    p1.v[1] = hp1.v[1] - hp2.v[1];
-                                    p1.v[2] = hp1.v[2] - hp2.v[2];
-                                    BrMatrix34ApplyV(&p2, &p1, pM12);
-                                    BrMatrix34ApplyV(&p1, &p2, pMo21);
-                                    p2.v[0] = edge.v[1] * p1.v[2] - edge.v[2] * p1.v[1];
-                                    p2.v[1] = edge.v[2] * p1.v[0] - p1.v[2] * edge.v[0];
-                                    p2.v[2] = p1.v[1] * edge.v[0] - edge.v[1] * p1.v[0];
-                                    // v20 = sqrtf(p2.v[0] * p2.v[0] + p2.v[1] * p2.v[1] + p2.v[2] * p2.v[2]);
-                                    // if (v22 | v23) {
-                                    //     pNorm_list[2 * n].v[0] = 1.0;
-                                    //     pNorm_list[2 * n].v[1] = 0.0;
-                                    //     pNorm_list[2 * n].v[2] = 0.0;
-                                    // } else {
-                                    //     v25 = v20;
-                                    //     v24 = 1.0 / v25;
-                                    //     v26 = v24;
-                                    //     pNorm_list[2 * n].v[0] = v24 * p2.v[0];
-                                    //     pNorm_list[2 * n].v[1] = p2.v[1] * v26;
-                                    //     pNorm_list[2 * n].v[2] = p2.v[2] * v26;
-                                    // }
-                                    BrVector3Normalise(&pNorm_list[2 * n], &p2);
-                                    GetPlaneNormal(&edge, plane3);
-                                    if (pNorm_list[2 * n].v[2] * edge.v[2] + pNorm_list[2 * n].v[1] * edge.v[1] + pNorm_list[2 * n].v[0] * edge.v[0] < 0.0) {
-                                        pNorm_list[2 * n].v[0] = -pNorm_list[2 * n].v[0];
-                                        pNorm_list[2 * n].v[1] = -pNorm_list[2 * n].v[1];
-                                        pNorm_list[2 * n].v[2] = -pNorm_list[2 * n].v[2];
-                                    }
-                                    BrMatrix34ApplyV(&pNorm_list[2 * n + 1], &pNorm_list[2 * n], pMo12);
-                                    pNorm_list[2 * n + 1].v[0] = -pNorm_list[2 * n + 1].v[0];
-                                    pNorm_list[2 * n + 1].v[1] = -pNorm_list[2 * n + 1].v[1];
-                                    pNorm_list[2 * n + 1].v[2] = -pNorm_list[2 * n + 1].v[2];
-                                    BrMatrix34ApplyV(&tp3, &pNorm_list[2 * n], pM12);
-                                    BrMatrix34ApplyV(&pNorm_list[2 * n], &tp3, pMo21);
-                                    pNorm_list[2 * n + 2] = pNorm_list[2 * n];
-                                    pNorm_list[2 * n + 3].v[0] = pNorm_list[2 * n + 1].v[0];
-                                    pNorm_list[2 * n + 3].v[1] = pNorm_list[2 * n + 1].v[1];
-                                    pNorm_list[2 * n + 3].v[2] = pNorm_list[2 * n + 1].v[2];
-                                    n += 2;
-                                } else {
-                                    if (pMax - 1 <= n) {
-                                        return n;
-                                    }
-                                    GetBoundsEdge(&pPoint_list[2 * n], &edge, pB1, plane1, plane3, &p2, &hp1, &hp2, 0);
-                                    GetBoundsEdge(
-                                        &pPoint_list[2 * n + 2],
-                                        &edge,
-                                        pB1,
-                                        plane2,
-                                        plane3,
-                                        &p2,
-                                        &hp1,
-                                        &hp2,
-                                        0);
-                                    BrMatrix34ApplyP(&pPoint_list[2 * n + 1], &hp1, pM12);
-                                    BrMatrix34ApplyP(&pPoint_list[2 * n + 3], &hp2, pM12);
-                                    GetPlaneNormal(&pNorm_list[2 * n], plane3);
-                                    BrMatrix34ApplyV(&pNorm_list[2 * n + 2], &pNorm_list[2 * n], pM1o1);
-                                    BrMatrix34ApplyV(&pNorm_list[2 * n + 1], &pNorm_list[2 * n + 2], pMo12);
-                                    pNorm_list[2 * n] = pNorm_list[2 * n + 2];
-                                    pNorm_list[2 * n + 1].v[0] = -pNorm_list[2 * n + 1].v[0];
-                                    pNorm_list[2 * n + 1].v[1] = -pNorm_list[2 * n + 1].v[1];
-                                    pNorm_list[2 * n + 1].v[2] = -pNorm_list[2 * n + 1].v[2];
-                                    pNorm_list[2 * n + 3].v[0] = pNorm_list[2 * n + 1].v[0];
-                                    pNorm_list[2 * n + 3].v[1] = pNorm_list[2 * n + 1].v[1];
-                                    pNorm_list[2 * n + 3].v[2] = pNorm_list[2 * n + 1].v[2];
-                                    n += 2;
-                                }
-                            }
-                        }
-                    }
+            if (plane1 == 0) {
+                continue;
+            }
+            plane2 = LineBoxColl(&p2, &p1, pB1, &hp2);
+            if (plane1 == 8 || plane2 == 8 || plane2 == 0) {
+                continue;
+            }
+            // if (plane1 != 8 && plane2 != 8 && plane2) {
+            BrVector3Add(&p1, &hp1, &hp2);
+            BrVector3Scale(&p1, &p1, 0.5f);
+            BrMatrix34ApplyP(&tp3, &p1, pM12);
+            BrMatrix34ApplyP(&p2, &tp3, pMo21);
+            plane3 = LineBoxColl(&p2, &p1, pB1, &hp3);
+            // if (plane3 != 8 && plane3 != 0) {
+            //     goto LABEL_25;
+            // }
+            if (plane3 == 8 || plane3 == 0) {
+                BrVector3Sub(&tp3, &p2, &p1);
+                ts = BrVector3Length(&tp3);
+                ts = ts / 0.01f;
+                if (ts == 0.0f) {
+                    continue;
                 }
+                BrVector3InvScale(&tp3, &tp3, ts);
+                BrVector3Accumulate(&p2, &tp3);
+                plane3 = LineBoxColl(&p2, &p1, pB1, &hp3);
+                if (plane3 == 8) {
+                    continue;
+                }
+            }
+            if (plane3 == 0) {
+                continue;
+            }
+
+            BrMatrix34ApplyP(&shp1, &hp1, pM12);
+            BrMatrix34ApplyP(&shp2, &hp2, pM12);
+            if ((plane1 ^ plane2) != 4 && (plane3 == plane1 || plane3 == plane2)) {
+                if (n >= pMax) {
+                    return n;
+                }
+                GetBoundsEdge(&pPoint_list[2 * n], &edge, pB1, plane1, plane2, &p2, &hp1, &hp2, 0);
+                BrVector3Accumulate(&shp1, &shp2);
+                BrVector3Scale(&pPoint_list[2 * n + 1], &shp1, 0.5f);
+                BrVector3Sub(&p1, &hp1, &hp2);
+                BrVector3Cross(&p2, &edge, &p1);
+                BrVector3Normalise(&p2, &p2);
+                BrVector3Add(&p1, &pB1->max, &pB1->min);
+                BrVector3Scale(&p1, &p1, 0.5f);
+                BrVector3Sub(&p1, &pPoint_list[2 * n], &p1);
+                if (BrVector3Dot(&p1, &p2) > 0.0) {
+                    BrVector3Negate(&p2, &p2);
+                }
+                BrMatrix34ApplyV(&p1, &p2, pM12);
+                BrMatrix34TApplyV(&pNorm_list[2 * n], &p1, pMo12);
+                BrMatrix34TApplyV(&pNorm_list[2 * n + 1], &p2, pMo21);
+                BrVector3Negate(&pNorm_list[2 * n + 1], &pNorm_list[2 * n + 1]);
+                n++;
+            } else if ((plane1 ^ plane2) == 4) {
+                if (pMax - 1 <= n) {
+                    return n;
+                }
+                GetBoundsEdge(&pPoint_list[2 * n], &edge, pB1, plane1, plane3, &p2, &hp1, &hp2, 0);
+                GetBoundsEdge(&pPoint_list[2 * n + 2], &edge, pB1, plane2, plane3, &p2, &hp1, &hp2, 0);
+                pPoint_list[2 * n + 1] = shp1;
+                pPoint_list[2 * n + 3] = shp2;
+                BrVector3Sub(&p1, &hp1, &hp2);
+                BrMatrix34ApplyV(&p2, &p1, pM12);
+                BrMatrix34ApplyV(&p1, &p2, pMo21);
+                BrVector3Cross(&p2, &edge, &p1);
+                BrVector3Normalise(&pNorm_list[2 * n], &p2);
+                GetPlaneNormal(&edge, plane3);
+                if (BrVector3Dot(&pNorm_list[2 * n], &edge) < 0.0f) {
+                    BrVector3Negate(&pNorm_list[2 * n], &pNorm_list[2 * n]);
+                }
+                BrMatrix34ApplyV(&pNorm_list[2 * n + 1], &pNorm_list[2 * n], pMo12);
+                BrVector3Negate(&pNorm_list[2 * n + 1], &pNorm_list[2 * n + 1]);
+                BrMatrix34ApplyV(&tp3, &pNorm_list[2 * n], pM12);
+                BrMatrix34ApplyV(&pNorm_list[2 * n], &tp3, pMo21);
+                pNorm_list[2 * n + 2] = pNorm_list[2 * n];
+                pNorm_list[2 * n + 3] = pNorm_list[2 * n + 1];
+                n += 2;
+            } else {
+                if (pMax - 1 <= n) {
+                    return n;
+                }
+                GetBoundsEdge(&pPoint_list[2 * n], &edge, pB1, plane1, plane3, &p2, &hp1, &hp2, 0);
+                GetBoundsEdge(&pPoint_list[2 * n + 2], &edge, pB1, plane2, plane3, &p2, &hp1, &hp2, 0);
+                BrMatrix34ApplyP(&pPoint_list[2 * n + 1], &hp1, pM12);
+                BrMatrix34ApplyP(&pPoint_list[2 * n + 3], &hp2, pM12);
+                GetPlaneNormal(&pNorm_list[2 * n], plane3);
+                BrMatrix34ApplyV(&pNorm_list[2 * n + 2], &pNorm_list[2 * n], pM1o1);
+                BrMatrix34ApplyV(&pNorm_list[2 * n + 1], &pNorm_list[2 * n + 2], pMo12);
+                pNorm_list[2 * n] = pNorm_list[2 * n + 2];
+                BrVector3Negate(&pNorm_list[2 * n + 1], &pNorm_list[2 * n + 1]);
+                pNorm_list[2 * n + 3] = pNorm_list[2 * n + 1];
+                n += 2;
             }
         }
     }

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -1213,7 +1213,7 @@ void ResetCarSpecialVolume(tCollision_info* pCar) {
     cast_v.v[1] = 200.0f;
     cast_v.v[2] = 0.0f;
     DisablePlingMaterials();
-    FindFace(&pCar->car_master_actor->t.t.euler.t, &cast_v, &norm, &t, &material);
+    FindFace(&pCar->car_master_actor->t.t.translate.t, &cast_v, &norm, &t, &material);
     EnablePlingMaterials();
     if (t < 100.0f && material != NULL) {
         mat_id = material->identifier;

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3295,9 +3295,9 @@ void AddCollPoint(br_scalar dist, br_vector3* p, br_vector3* norm, br_vector3* r
 br_scalar SinglePointColl(br_scalar* f, br_matrix4* m, br_scalar* d) {
     LOG_TRACE("(%p, %p, %p)", f, m, d);
 
-    *f = *d / m->m[0][0];
-    if (*f < 0.0) {
-        *f = 0.0;
+    f[0] = d[0] / m->m[0][0];
+    if (f[0] < 0.0f) {
+        f[0] = 0.0;
     }
     return fabsf(m->m[0][0]);
 }
@@ -3309,15 +3309,15 @@ br_scalar TwoPointColl(br_scalar* f, br_matrix4* m, br_scalar* d, br_vector3* ta
 
     ts = m->m[1][1] * m->m[0][0] - m->m[0][1] * m->m[1][0];
     if (fabs(ts) >= 0.000001) {
-        *f = (m->m[1][1] * *d - m->m[0][1] * d[1]) / ts;
-        f[1] = (m->m[1][0] * *d - m->m[0][0] * d[1]) / -ts;
+        f[0] = (m->m[1][1] * d[0] - m->m[0][1] * d[1]) / ts;
+        f[1] = (m->m[1][0] * d[0] - m->m[0][0] * d[1]) / -ts;
     }
-    if (f[1] >= 0.0 && fabs(ts) >= 0.000001) {
-        if (*f < 0.0) {
+    if (f[1] >= 0.0f && fabs(ts) >= 0.000001f) {
+        if (f[0] < 0.0f) {
             m->m[0][0] = m->m[1][1];
-            *tau = tau[1];
-            *n = n[1];
-            *d = d[1];
+            tau[0] = tau[1];
+            n[0] = n[1];
+            d = d[1];
             ts = SinglePointColl(f, m, d);
             f[1] = 0.0;
         }
@@ -6582,19 +6582,19 @@ br_scalar TwoPointCollB(br_scalar* f, br_matrix4* m, br_scalar* d, br_vector3* t
 
     ts = m->m[1][1] * m->m[0][0] - m->m[0][1] * m->m[1][0];
     if (fabsf(ts) > 0.000001f) {
-        *f = (m->m[1][1] * *d - m->m[0][1] * d[1]) / ts;
-        f[1] = (m->m[1][0] * *d - m->m[0][0] * d[1]) / -ts;
+        f[0] = (m->m[1][1] * d[0] - m->m[0][1] * d[1]) / ts;
+        f[1] = (m->m[1][0] * d[0] - m->m[0][0] * d[1]) / -ts;
     }
-    if (f[1] >= 0.0) {
-        if (*f < 0.0) {
+    if (f[1] >= 0.0f) {
+        if (f[0] < 0.0f) {
             m->m[0][0] = m->m[1][1];
-            *tau = tau[1];
+            tau[0] = tau[1];
             tau[4] = tau[5];
-            *n = n[2];
+            n[0] = n[2];
             n[1] = n[3];
-            *d = d[1];
+            d[0] = d[1];
             ts = SinglePointColl(f, m, d);
-            f[1] = 0.0;
+            f[1] = 0.0f;
         }
     } else {
         ts = SinglePointColl(f, m, d);
@@ -6633,15 +6633,15 @@ br_scalar ThreePointCollRecB(br_scalar* f, br_matrix4* m, br_scalar* d, br_vecto
     m->m[1][0] = m->m[j][i];
     m->m[0][1] = m->m[i][j];
     m->m[1][1] = m->m[0][5 * j];
-    *tau = tau[i];
+    tau[0] = tau[i];
     tau[1] = tau[j];
     tau[4] = tau[i + 4];
     tau[5] = tau[j + 4];
-    *n = n[2 * i];
+    n[0] = n[2 * i];
     n[2] = n[2 * j];
     n[1] = n[2 * i + 1];
     n[3] = n[2 * j + 1];
-    *d = d[i];
+    d[0] = d[i];
     d[1] = d[j];
     ts = TwoPointCollB(f, m, d, tau, n);
     f[2] = 0.0;
@@ -6657,7 +6657,7 @@ br_scalar FourPointCollB(br_scalar* f, br_matrix4* m, br_scalar* d, br_vector3* 
     LOG_TRACE("(%p, %p, %p, %p, %p)", f, m, d, tau, n);
 
     ts = ThreePointColl(f, m, d);
-    if (*f >= 0.0 && f[1] >= 0.0 && f[2] >= 0.0) {
+    if (*f >= 0.0f && f[1] >= 0.0f && f[2] >= 0.0f) {
         return ts;
     }
     if (*f >= 0.0) {
@@ -6669,23 +6669,19 @@ br_scalar FourPointCollB(br_scalar* f, br_matrix4* m, br_scalar* d, br_vector3* 
     } else {
         l = 0;
     }
-    for (i = l; i < 3; ++i) {
-        for (j = 0; j < 4; ++j) {
+    for (i = l; i < 3; i++) {
+        for (j = 0; j < 4; j++) {
             m->m[i][j] = m->m[i + 1][j];
         }
         d[i] = d[i + 1];
         tau[i] = tau[i + 1];
-        tau[i + 4].v[0] = tau[i + 5].v[0];
-        tau[i + 4].v[1] = tau[i + 5].v[1];
-        tau[i + 4].v[2] = tau[i + 5].v[2];
+        tau[i + 4] = tau[i + 5];
         n[2 * i] = n[2 * i + 2];
-        n[2 * i + 1].v[0] = n[2 * i + 3].v[0];
-        n[2 * i + 1].v[1] = n[2 * i + 3].v[1];
-        n[2 * i + 1].v[2] = n[2 * i + 3].v[2];
+        n[2 * i + 1] = n[2 * i + 3];
         d[i] = d[i + 1];
     }
-    for (i = l; i < 3; ++i) {
-        for (j = 0; j < 3; ++j) {
+    for (i = l; i < 3; i++) {
+        for (j = 0; j < 3; j++) {
             m->m[j][i] = m->m[j][i + 1];
         }
     }
@@ -6912,19 +6908,19 @@ int DoPullActorFromWorld(br_actor* pActor) {
     LOG_TRACE("(%p)", pActor);
 
     non_car = NULL;
-    num = pActor->identifier[2] + 2 * (5 * pActor->identifier[1] - 240) - '0';
+    num = pActor->identifier[2] + 2 * (5 * pActor->identifier[1] - 240) - 48;
     if (gNon_car_spec_list[num]) {
         non_car = &gProgram_state.non_cars[gNon_car_spec_list[num] + 4];
     }
     if (non_car && non_car->collision_info.driver == eDriver_non_car) {
         non_car = gProgram_state.non_cars;
-        for (i = 0; i < 5; i++) {
+        for (i = 0; i < NONCAR_UNUSED_SLOTS; i++) {
             if (non_car->collision_info.driver == eDriver_non_car_unused_slot) {
                 break;
             }
             non_car++;
         }
-        if (i == 5) {
+        if (i == c) {
             non_car = NULL;
         } else {
             memcpy(non_car, &gProgram_state.non_cars[gNon_car_spec_list[num] + 4], sizeof(tNon_car_spec));
@@ -6938,7 +6934,7 @@ int DoPullActorFromWorld(br_actor* pActor) {
         BrActorRemove(pActor);
         BrActorAdd(gNon_track_actor, pActor);
         c->car_master_actor = pActor;
-        c->car_ID = pActor->identifier[7] - '0' + 25 * (4 * pActor->identifier[5] - 192) + 2 * (5 * pActor->identifier[6] - 240);
+        c->car_ID = pActor->identifier[7] - 48 + 25 * (4 * pActor->identifier[5] - 192) + 2 * (5 * pActor->identifier[6] - 240);
         gActive_non_car_list[gNum_active_non_cars] = non_car;
         gNum_active_non_cars++;
         gActive_car_list[gNum_cars_and_non_cars] = (tCar_spec*)non_car;
@@ -7005,7 +7001,6 @@ void CheckForDeAttachmentOfNonCars(tU32 pTime) {
             c->doing_nothing_flag = 1;
         }
         if (TestForNan(&c->car_master_actor->t.t.mat.m[3][1])) {
-            LOG_DEBUG("NAN!! %f", c->car_master_actor->t.t.mat.m[3][1]);
             BrVector3Set(&c->omega, 0.0f, 0.0f, 0.0f);
             BrMatrix34Identity(&c->car_master_actor->t.t.mat);
             c->car_master_actor->t.t.mat.m[3][0] = 2000.0f;

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3317,7 +3317,7 @@ br_scalar TwoPointColl(br_scalar* f, br_matrix4* m, br_scalar* d, br_vector3* ta
             m->m[0][0] = m->m[1][1];
             tau[0] = tau[1];
             n[0] = n[1];
-            d = d[1];
+            d[0] = d[1];
             ts = SinglePointColl(f, m, d);
             f[1] = 0.0;
         }
@@ -3572,7 +3572,7 @@ int FindFloorInBoxBU2(br_vector3* a, br_vector3* b, br_vector3* nor, br_scalar* 
         if (!gEliminate_faces || SLOBYTE(face_ref->flags) >= 0) {
             CheckSingleFace(face_ref, a, b, &nor2, &dist);
             if (*d > dist) {
-                if (face_ref->material->user == DOUBLESIDED_FLAG || (face_ref->material->flags & 0x1800) != 0) {
+                if (face_ref->material->user == DOUBLESIDED_USER_FLAG || (face_ref->material->flags & 0x1800) != 0) {
                     tv.v[0] = c->pos.v[0] - a->v[0];
                     tv.v[1] = c->pos.v[1] - a->v[1];
                     tv.v[2] = c->pos.v[2] - a->v[2];
@@ -6920,7 +6920,7 @@ int DoPullActorFromWorld(br_actor* pActor) {
             }
             non_car++;
         }
-        if (i == c) {
+        if (i == NONCAR_UNUSED_SLOTS) {
             non_car = NULL;
         } else {
             memcpy(non_car, &gProgram_state.non_cars[gNon_car_spec_list[num] + 4], sizeof(tNon_car_spec));

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -2894,9 +2894,7 @@ void AddFrictionCarToCar(tCollision_info* car1, tCollision_info* car2, br_vector
         max_friction->v[1] = 0.0f;
         max_friction->v[2] = 0.0f;
     } else {
-        v_diff1.v[0] /= v_diff;
-        v_diff1.v[1] /= v_diff;
-        v_diff1.v[2] /= v_diff;
+        BrVector3InvScale(&v_diff1, &v_diff1, v_diff);
         BrMatrix34ApplyV(&tv, &v_diff1, &car1->oldmat);
         BrMatrix34TApplyV(&v_diff2, &tv, &car2->oldmat);
         BrVector3Negate(&v_diff2, &v_diff2);
@@ -5990,7 +5988,6 @@ int GetEdgeEdgeCollisions(br_bounds* pB1, br_bounds* pB2, br_matrix34* pM21, br_
             if (plane1 == 8 || plane2 == 8 || plane2 == 0) {
                 continue;
             }
-            // if (plane1 != 8 && plane2 != 8 && plane2) {
             BrVector3Add(&p1, &hp1, &hp2);
             BrVector3Scale(&p1, &p1, 0.5f);
             BrMatrix34ApplyP(&tp3, &p1, pM12);
@@ -6241,8 +6238,8 @@ int DoCollide(tCollision_info* car1, tCollision_info* car2, br_vector3* r, br_ve
     for (i = 0; i < k; ++i) {
         BrVector3Cross(&tau1[i], &r[2 * i], &n[2 * i]);
         BrVector3Cross(&tau2[i], &r[2 * i + 1], &n[2 * i + 1]);
-        BrVector3Div(&tau1[i], &tau1[i], &car1->I);
-        BrVector3Div(&tau2[i], &tau2[i], &car2->I);
+        Vector3Div(&tau1[i], &tau1[i], &car1->I);
+        Vector3Div(&tau2[i], &tau2[i], &car2->I);
         BrVector3Cross(&tv, &car1->omega, &r[2 * i]);
         BrVector3Accumulate(&tv, &car1->velocity_car_space);
         d[i] = -BrVector3Dot(&n[2 * i], &tv);
@@ -6563,7 +6560,7 @@ br_scalar FourPointCollB(br_scalar* f, br_matrix4* m, br_scalar* d, br_vector3* 
         return ts;
     }
     if (f[0] < 0.0f) {
-         l = 0;
+        l = 0;
     } else if (f[1] < 0.0f) {
         l = 1;
     } else {

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -6296,7 +6296,7 @@ int DoCollide(tCollision_info* car1, tCollision_info* car2, br_vector3* r, br_ve
                 BrVector3Cross(&tv, &tau2[j], &r[2 * i + 1]);
                 BrVector3InvScale(&norm, &n[2 * j + 1], car2->M);
                 BrVector3Accumulate(&tv, &norm);
-                M.m[i][j] = BrVector3Dot(&n[2 * i + 1], &tv);
+                M.m[i][j] += BrVector3Dot(&n[2 * i + 1], &tv);
             }
             M.m[i][j] *= factor;
         }
@@ -6396,7 +6396,7 @@ int DoCollide(tCollision_info* car1, tCollision_info* car2, br_vector3* r, br_ve
     }
     BrVector3InvScale(&pos1, &pos1, tforce);
     BrVector3InvScale(&pos2, &pos2, tforce);
-    if (!pPass) {
+    if (pPass == 0) {
         if (car1_point > -1 && move_car1) {
             f[car1_point] = f[car1_point] / car1->M;
             BrVector3Scale(&n[2 * car1_point], &n[2 * car1_point], f[car1_point]);

--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -21,7 +21,7 @@ float gWobble_spam_y[8] = { 0.0f, -0.15f, 0.4f, 0.15f, -0.4f, 0.25f, 0.0f, -0.25
 float gWobble_spam_z[8] = { 0.4f, -0.25f, 0.0f, 0.25f, 0.0f, 0.15f, -0.4f, -0.15f };
 br_scalar gWheel_circ_to_width = 0.16f;
 tU8 gSmoke_damage_step[12] = { 20u, 20u, 0u, 10u, 10u, 10u, 10u, 10u, 10u, 10u, 10u, 10u };
-int gSteal_ranks[5];
+int gSteal_ranks[5] = { 0, 89, 72, 55, 38 };
 
 // IDA: int __usercall ReadCrushData@<EAX>(FILE *pF@<EAX>, tCrush_data *pCrush_data@<EDX>)
 int ReadCrushData(FILE* pF, tCrush_data* pCrush_data) {
@@ -541,7 +541,7 @@ void CheckPiledriverBonus(tCar_spec* pCar, br_vector3* pImpact_point, br_vector3
     br_scalar dp;
     LOG_TRACE("(%p, %p, %p)", pCar, pImpact_point, pEnergy);
 
-    STUB();
+    STUB_ONCE();
 }
 
 // IDA: tImpact_location __usercall CalcModifiedLocation@<EAX>(tCar_spec *pCar@<EAX>)
@@ -837,7 +837,7 @@ int DoCrashEarnings(tCar_spec* pCar1, tCar_spec* pCar2) {
     tNet_message* message;
     LOG_TRACE("(%p, %p)", pCar1, pCar2);
 
-    STUB();
+    STUB_ONCE();
 }
 
 // IDA: void __usercall DoWheelDamage(tU32 pFrame_period@<EAX>)

--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -811,8 +811,6 @@ int NewTextHeadupSlot2(int pSlot_index, int pFlash_rate, int pLifetime, int pFon
 int NewTextHeadupSlot(int pSlot_index, int pFlash_rate, int pLifetime, int pFont_index, char* pText) {
     LOG_TRACE("(%d, %d, %d, %d, \"%s\")", pSlot_index, pFlash_rate, pLifetime, pFont_index, pText);
 
-    LOG_DEBUG("(%d, %d, %d, %d, \"%s\")", pSlot_index, pFlash_rate, pLifetime, pFont_index, pText);
-
     return NewTextHeadupSlot2(pSlot_index, pFlash_rate, pLifetime, pFont_index, pText, 1);
 }
 

--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -1210,12 +1210,10 @@ int SphereBoxIntersection(br_bounds* pB, br_vector3* pC, br_scalar pR_squared, b
     for (i = 0; i < 3; ++i) {
         if (pC->v[i] <= pB->min.v[i]) {
             pHit_point->v[i] = pB->min.v[i];
+        } else if (pC->v[i] > pB->max.v[i]) {
+            pHit_point->v[i] = pB->max.v[i];
         } else {
-            if (pC->v[i] <= pB->max.v[i]) {
-                pHit_point->v[i] = pC->v[i];
-            } else {
-                pHit_point->v[i] = pB->max.v[i];
-            }
+            pHit_point->v[i] = pC->v[i];
         }
         d += (pC->v[i] - pHit_point->v[i]) * (pC->v[i] - pHit_point->v[i]);
     }

--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -1211,10 +1211,16 @@ int SphereBoxIntersection(br_bounds* pB, br_vector3* pC, br_scalar pR_squared, b
         if (pC->v[i] <= pB->min.v[i]) {
             pHit_point->v[i] = pB->min.v[i];
         } else {
+            // if (pC->v[i] <= pB->max.v[i]) {
+            //     pB->max.v[i] = pC->v[i];
+            // }
+            // pHit_point->v[i] = pB->max.v[i];
+
             if (pC->v[i] <= pB->max.v[i]) {
-                pB->max.v[i] = pC->v[i];
+                pHit_point->v[i] = pC->v[i];
+            } else {
+                pHit_point->v[i] = pB->max.v[i];
             }
-            pHit_point->v[i] = pB->max.v[i];
         }
         d += (pC->v[i] - pHit_point->v[i]) * (pC->v[i] - pHit_point->v[i]);
     }

--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -24,7 +24,7 @@ tFace_ref* gPling_face;
 // IDA: int __cdecl BadDiv(br_scalar a, br_scalar b)
 // Suffix added to avoid duplicate symbol
 int BadDiv__finteray(br_scalar a, br_scalar b) {
-    //LOG_TRACE("(%f, %f)", a, b);
+    // LOG_TRACE("(%f, %f)", a, b);
 
     return fabs(b) < 1.0 && fabs(a) > fabs(b) * BR_SCALAR_MAX;
 }
@@ -38,8 +38,8 @@ void DRVector2AccumulateScale__finteray(br_vector2* a, br_vector2* b, br_scalar 
     a->v[1] = b->v[1] * s + a->v[1];
 }
 
-//IDA: int __usercall PickBoundsTestRay@<EAX>(br_bounds *b@<EAX>, br_vector3 *rp@<EDX>, br_vector3 *rd@<EBX>, br_scalar t_near, br_scalar t_far, br_scalar *new_t_near, br_scalar *new_t_far)
-// Suffix added to avoid duplicate symbol
+// IDA: int __usercall PickBoundsTestRay@<EAX>(br_bounds *b@<EAX>, br_vector3 *rp@<EDX>, br_vector3 *rd@<EBX>, br_scalar t_near, br_scalar t_far, br_scalar *new_t_near, br_scalar *new_t_far)
+//  Suffix added to avoid duplicate symbol
 int PickBoundsTestRay__finteray(br_bounds* b, br_vector3* rp, br_vector3* rd, br_scalar t_near, br_scalar t_far, br_scalar* new_t_near, br_scalar* new_t_far) {
     int i;
     float s;
@@ -182,8 +182,8 @@ int DRSceneRayPick2D(br_actor* world, br_vector3* pPosition, br_vector3* pDir, d
     return ActorRayPick2D(world, pPosition, pDir, NULL, NULL, callback);
 }
 
-//IDA: int __usercall DRModelPick2D@<EAX>(br_model *model@<EAX>, br_material *material@<EDX>, br_vector3 *ray_pos@<EBX>, br_vector3 *ray_dir@<ECX>, br_scalar t_near, br_scalar t_far, dr_modelpick2d_cbfn *callback, void *arg)
-// Suffix added to avoid duplicate symbol
+// IDA: int __usercall DRModelPick2D@<EAX>(br_model *model@<EAX>, br_material *material@<EDX>, br_vector3 *ray_pos@<EBX>, br_vector3 *ray_dir@<ECX>, br_scalar t_near, br_scalar t_far, dr_modelpick2d_cbfn *callback, void *arg)
+//  Suffix added to avoid duplicate symbol
 int DRModelPick2D__finteray(br_model* model, br_material* material, br_vector3* ray_pos, br_vector3* ray_dir, br_scalar t_near, br_scalar t_far, dr_modelpick2d_cbfn* callback, void* arg) {
     DR_FACE* fp;
     int f;
@@ -388,7 +388,7 @@ void FindFace(br_vector3* pPosition, br_vector3* pDir, br_vector3* nor, br_scala
 // IDA: void __cdecl EnablePlingMaterials()
 void EnablePlingMaterials() {
     LOG_TRACE("()");
-    
+
     gPling_materials = 1;
 }
 
@@ -1205,7 +1205,20 @@ int SphereBoxIntersection(br_bounds* pB, br_vector3* pC, br_scalar pR_squared, b
     int i;
     br_scalar d;
     LOG_TRACE("(%p, %p, %f, %p)", pB, pC, pR_squared, pHit_point);
-    NOT_IMPLEMENTED();
+
+    d = 0.0f;
+    for (i = 0; i < 3; ++i) {
+        if (pC->v[i] <= pB->min.v[i]) {
+            pHit_point->v[i] = pB->min.v[i];
+        } else {
+            if (pC->v[i] <= pB->max.v[i]) {
+                pB->max.v[i] = pC->v[i];
+            }
+            pHit_point->v[i] = pB->max.v[i];
+        }
+        d += (pC->v[i] - pHit_point->v[i]) * (pC->v[i] - pHit_point->v[i]);
+    }
+    return pR_squared >= d;
 }
 
 // IDA: int __usercall LineBoxCollWithSphere@<EAX>(br_vector3 *o@<EAX>, br_vector3 *p@<EDX>, br_bounds *pB@<EBX>, br_vector3 *pHit_point@<ECX>)
@@ -1213,7 +1226,23 @@ int LineBoxCollWithSphere(br_vector3* o, br_vector3* p, br_bounds* pB, br_vector
     int i;
     int plane;
     LOG_TRACE("(%p, %p, %p, %p)", o, p, pB, pHit_point);
-    NOT_IMPLEMENTED();
+
+    plane = LineBoxColl(o, p, pB, pHit_point);
+    if (plane) {
+        return plane;
+    }
+    if (!SphereBoxIntersection(pB, p, 0.000025f, pHit_point)) {
+        return 0;
+    }
+    for (i = 0; i < 3; ++i) {
+        if (pB->max.v[i] == pHit_point->v[i] && p->v[i] <= o->v[i]) {
+            return i + 1;
+        }
+        if (pHit_point->v[i] == pB->min.v[i] && p->v[i] >= (o->v[i])) {
+            return i + 5;
+        }
+    }
+    return 0;
 }
 
 // IDA: int __usercall CompVert@<EAX>(int v1@<EAX>, int v2@<EDX>)

--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -1211,11 +1211,6 @@ int SphereBoxIntersection(br_bounds* pB, br_vector3* pC, br_scalar pR_squared, b
         if (pC->v[i] <= pB->min.v[i]) {
             pHit_point->v[i] = pB->min.v[i];
         } else {
-            // if (pC->v[i] <= pB->max.v[i]) {
-            //     pB->max.v[i] = pC->v[i];
-            // }
-            // pHit_point->v[i] = pB->max.v[i];
-
             if (pC->v[i] <= pB->max.v[i]) {
                 pHit_point->v[i] = pC->v[i];
             } else {

--- a/src/DETHRACE/common/loading.c
+++ b/src/DETHRACE/common/loading.c
@@ -20,6 +20,9 @@
 #include "globvrpb.h"
 #include "grafdata.h"
 #include "graphics.h"
+#include "harness/config.h"
+#include "harness/hooks.h"
+#include "harness/trace.h"
 #include "init.h"
 #include "input.h"
 #include "newgame.h"
@@ -31,16 +34,14 @@
 #include "spark.h"
 #include "utility.h"
 #include "world.h"
-#include "harness/config.h"
-#include "harness/hooks.h"
-#include "harness/trace.h"
 #include <errno.h>
 
 #define HITHER_MULTIPLIER 2.0f
 #define AMBIENT_MULTIPLIER 0.01f
 #define NBR_FUNK_GROVE_FLAGS 30
 
-tHeadup_info gHeadup_image_info[32] = {  // Modified by DethRace to fit the "demo timeout" fancy head-up.
+tHeadup_info gHeadup_image_info[32] = {
+    // Modified by DethRace to fit the "demo timeout" fancy head-up.
     { "LADY.PIX", eNet_or_otherwise },
     { "GENT.PIX", eNet_or_otherwise },
     { "CODGER.PIX", eNet_or_otherwise },
@@ -72,7 +73,7 @@ tHeadup_info gHeadup_image_info[32] = {  // Modified by DethRace to fit the "dem
     { "UBROKE.PIX", eNet_only },
     { "ULOST.PIX", eNet_only },
     { "UWON.PIX", eNet_only },
-    { "DTIMEOUT.PIX", eNot_net },   // Only used by the demo, not present in the full version
+    { "DTIMEOUT.PIX", eNot_net }, // Only used by the demo, not present in the full version
 };
 char* gYour_car_names[2][6];
 char* gDrivable_car_names[6];
@@ -809,7 +810,7 @@ tS8* ConvertPixToStripMap(br_pixelmap* pThe_br_map) {
 
     for (i = 0; i < pThe_br_map->height; i++) {
         next_byte = (tU8*)pThe_br_map->pixels + i * pThe_br_map->row_bytes; // points to start of this line
-        new_line_length = 2; // leave space at the start of the line to store number of chunks and first chunk length
+        new_line_length = 2;                                                // leave space at the start of the line to store number of chunks and first chunk length
         j = 0;
         counter = 0;
         total = 0;
@@ -1194,7 +1195,7 @@ void ReadNonCarMechanicsData(FILE* pF, tNon_car_spec* non_car) {
     GetThreeFloats(pF, &non_car->free_cmpos.v[0], &non_car->free_cmpos.v[1], &non_car->free_cmpos.v[2]);
     GetThreeFloats(pF, &non_car->attached_cmpos.v[0], &non_car->attached_cmpos.v[1], &non_car->attached_cmpos.v[2]);
     GetThreeFloats(pF, &non_car->collision_info.bounds[1].min.v[0], &non_car->collision_info.bounds[1].min.v[1], &non_car->collision_info.bounds[1].min.v[2]);
-    GetThreeFloats(pF, &non_car->collision_info.bounds[1].max.v[0], &non_car->collision_info.bounds[1].max.v[1], &non_car->collision_info.bounds[1].max.v[1]);
+    GetThreeFloats(pF, &non_car->collision_info.bounds[1].max.v[0], &non_car->collision_info.bounds[1].max.v[1], &non_car->collision_info.bounds[1].max.v[2]);
     non_car->collision_info.extra_point_num = GetAnInt(pF);
     if (non_car->collision_info.extra_point_num > 6) {
         sprintf(s, "%d", non_car->collision_info.index);

--- a/src/DETHRACE/common/loading.c
+++ b/src/DETHRACE/common/loading.c
@@ -1603,7 +1603,6 @@ int RemoveDoubleSided(br_model* pModel) {
             }
         }
         if (num_double_sided_faces > 0) {
-            LOG_DEBUG("nbr dbl side %d, %p", num_double_sided_faces, pModel);
             faces = BrResAllocate(pModel, sizeof(br_face) * (num_double_sided_faces + pModel->nfaces), kMem_misc);
             memcpy(faces, pModel->faces, sizeof(br_face) * pModel->nfaces);
             orig_nfaces = pModel->nfaces;

--- a/src/DETHRACE/common/loading.c
+++ b/src/DETHRACE/common/loading.c
@@ -1597,7 +1597,7 @@ int RemoveDoubleSided(br_model* pModel) {
         for (i = 0; i < pModel->nfaces; i++) {
             face = &pModel->faces[i];
             if (face->material) {
-                if (face->material->user == DOUBLESIDED_FLAG) {
+                if (face->material->user == DOUBLESIDED_USER_FLAG) {
                     num_double_sided_faces++;
                 }
             }
@@ -1609,7 +1609,7 @@ int RemoveDoubleSided(br_model* pModel) {
             orig_nfaces = pModel->nfaces;
             face = pModel->faces;
             for (i = 0; i < orig_nfaces; i++) {
-                if (face->material && face->material->user == DOUBLESIDED_FLAG) {
+                if (face->material && face->material->user == DOUBLESIDED_USER_FLAG) {
                     faces[pModel->nfaces].vertices[0] = face->vertices[1];
                     faces[pModel->nfaces].vertices[1] = face->vertices[0];
                     faces[pModel->nfaces].vertices[2] = face->vertices[2];
@@ -2041,7 +2041,7 @@ void LoadCar(char* pCar_name, tDriver pDriver, tCar_spec* pCar_spec, int pOwner,
                     }
                 }
                 if (!its_a_floorpan) {
-                    pStorage_space->materials[i]->user = DOUBLESIDED_FLAG;
+                    pStorage_space->materials[i]->user = DOUBLESIDED_USER_FLAG;
                 }
                 pStorage_space->materials[i]->flags &= 0xFFFFEFFF;
             }
@@ -2083,7 +2083,6 @@ void LoadCar(char* pCar_name, tDriver pDriver, tCar_spec* pCar_spec, int pOwner,
         if (!pCar_spec->car_model_actors[i].actor) {
             FatalError(71);
         }
-        // LOG_DEBUG("actor %s, model %s", pCar_spec->car_model_actors[i].actor->identifier, pCar_spec->car_model_actors[i].actor->model->identifier);
         LinkModelsToActor(
             pCar_spec->car_model_actors[i].actor,
             &pStorage_space->models[old_model_count],

--- a/src/DETHRACE/common/loading.c
+++ b/src/DETHRACE/common/loading.c
@@ -1617,7 +1617,7 @@ int RemoveDoubleSided(br_model* pModel) {
                     faces[pModel->nfaces].material = face->material;
                     pModel->nfaces++;
                 }
-                ++face;
+                face++;
             }
             BrResFree(pModel->faces);
             pModel->faces = faces;

--- a/src/DETHRACE/common/loading.c
+++ b/src/DETHRACE/common/loading.c
@@ -1597,7 +1597,7 @@ int RemoveDoubleSided(br_model* pModel) {
         for (i = 0; i < pModel->nfaces; i++) {
             face = &pModel->faces[i];
             if (face->material) {
-                if (face->material->colour_map_1 == DOUBLESIDED_FLAG_COLOR_MAP) {
+                if (face->material->user == DOUBLESIDED_FLAG) {
                     num_double_sided_faces++;
                 }
             }
@@ -1609,7 +1609,7 @@ int RemoveDoubleSided(br_model* pModel) {
             orig_nfaces = pModel->nfaces;
             face = pModel->faces;
             for (i = 0; i < orig_nfaces; i++) {
-                if (face->material && face->material->colour_map_1 == DOUBLESIDED_FLAG_COLOR_MAP) {
+                if (face->material && face->material->user == DOUBLESIDED_FLAG) {
                     faces[pModel->nfaces].vertices[0] = face->vertices[1];
                     faces[pModel->nfaces].vertices[1] = face->vertices[0];
                     faces[pModel->nfaces].vertices[2] = face->vertices[2];
@@ -2041,12 +2041,12 @@ void LoadCar(char* pCar_name, tDriver pDriver, tCar_spec* pCar_spec, int pOwner,
                     }
                 }
                 if (!its_a_floorpan) {
-                    pStorage_space->materials[i]->colour_map_1 = DOUBLESIDED_FLAG_COLOR_MAP;
+                    pStorage_space->materials[i]->user = DOUBLESIDED_FLAG;
                 }
                 pStorage_space->materials[i]->flags &= 0xFFFFEFFF;
             }
             pStorage_space->materials[i]->index_shade = gShade_list[0];
-            BrMaterialUpdate(pStorage_space->materials[i], 0x7FFF);
+            BrMaterialUpdate(pStorage_space->materials[i], BR_MATU_ALL);
         }
         PossibleService();
     }

--- a/src/DETHRACE/common/world.c
+++ b/src/DETHRACE/common/world.c
@@ -2275,10 +2275,10 @@ void LoadTrack(char* pFile_name, tTrack_spec* pTrack_spec, tRace_info* pRace_inf
     for (i = 0; gTrack_storage_space.materials_count > i; ++i) {
         PossibleService();
         if (gTrack_storage_space.materials[i]->flags & (BR_MATF_LIGHT | BR_MATF_PRELIT | BR_MATF_SMOOTH)) {
-            gTrack_storage_space.materials[i]->flags &= 0xFFFFFFF8;
+            gTrack_storage_space.materials[i]->flags &= ~(BR_MATF_LIGHT | BR_MATF_PRELIT | BR_MATF_SMOOTH);
             if (gTrack_storage_space.materials[i]->flags & BR_MATF_TWO_SIDED) {
                 gTrack_storage_space.materials[i]->user = DOUBLESIDED_USER_FLAG;
-                gTrack_storage_space.materials[i]->flags &= 0xFFFFEFFF;
+                gTrack_storage_space.materials[i]->flags &= ~BR_MATF_TWO_SIDED;
             }
             BrMaterialUpdate(gTrack_storage_space.materials[i], BR_MATU_RENDERING);
         }

--- a/src/DETHRACE/common/world.c
+++ b/src/DETHRACE/common/world.c
@@ -22,7 +22,6 @@
 #include "spark.h"
 #include "trig.h"
 #include "utility.h"
-#include "brender/brender.h"
 
 #include <string.h>
 
@@ -682,7 +681,7 @@ int LoadNTrackModels(tBrender_storage* pStorage_space, FILE* pF, int pCount) {
                     default:
                         break;
                     }
-                    //RemoveDoubleSided(temp_array[j]);
+                    // RemoveDoubleSided(temp_array[j]);
                     BrModelAdd(temp_array[j]);
                     LOG_DEBUG("added track model %s %d, %d", temp_array[j]->identifier, temp_array[j]->nfaces, temp_array[j]->nvertices);
                     new_ones++;
@@ -1960,9 +1959,21 @@ void SetWallTexturingLevel(tWall_texturing_level pLevel) {
 // IDA: void __usercall ReallySetWallTexturingLevel(tWall_texturing_level pLevel@<EAX>)
 void ReallySetWallTexturingLevel(tWall_texturing_level pLevel) {
     static tPMFMCB* tweaker[3][3] = {
-        { NULL,              WallUntexToLinear, WallUntexToPersp, },
-        { WallLinearToUntex, NULL,              WallLinearToPersp, },
-        { WallPerspToUntex,  WallPerspToLinear, NULL, },
+        {
+            NULL,
+            WallUntexToLinear,
+            WallUntexToPersp,
+        },
+        {
+            WallLinearToUntex,
+            NULL,
+            WallLinearToPersp,
+        },
+        {
+            WallPerspToUntex,
+            WallPerspToLinear,
+            NULL,
+        },
     };
     LOG_TRACE("(%d)", pLevel);
 
@@ -2005,7 +2016,7 @@ void DisposeTexturingMaterials() {
     default:
         break;
     }
-    
+
     if (gWall_texturing_level != eWTL_full || gRoad_texturing_level != eRTL_full) {
         ProcessFaceMaterials(gProgram_state.track_spec.the_actor, DisposeSuffixedMaterials);
     }
@@ -2267,8 +2278,8 @@ void LoadTrack(char* pFile_name, tTrack_spec* pTrack_spec, tRace_info* pRace_inf
         PossibleService();
         if (gTrack_storage_space.materials[i]->flags & 7) {
             gTrack_storage_space.materials[i]->flags &= 0xFFFFFFF8;
-            if (gTrack_storage_space.materials[i]->flags & 0x1000) {
-                gTrack_storage_space.materials[i]->colour_map_1 = (br_pixelmap*)12345;
+            if (gTrack_storage_space.materials[i]->flags & BR_MATF_TWO_SIDED) {
+                gTrack_storage_space.materials[i]->user = DOUBLESIDED_FLAG;
                 gTrack_storage_space.materials[i]->flags &= 0xFFFFEFFF;
             }
             BrMaterialUpdate(gTrack_storage_space.materials[i], BR_MATU_RENDERING);
@@ -3625,12 +3636,9 @@ tSpecial_volume* FindSpecialVolume(br_vector3* pP, tSpecial_volume* pLast_vol) {
     LOG_TRACE("(%p, %p)", pP, pLast_vol);
 
     for (i = 0, v = gProgram_state.special_volumes; i < gProgram_state.special_volume_count; i++, v++) {
-        if (!v->no_mat &&
-                v->bounds.min.v[0] < pP->v[0] && pP->v[0] < v->bounds.max.v[0] &&
-                v->bounds.min.v[1] < pP->v[1] && pP->v[1] < v->bounds.max.v[1] &&
-                v->bounds.min.v[2] < pP->v[2] && pP->v[2] < v->bounds.max.v[2]) {
+        if (!v->no_mat && v->bounds.min.v[0] < pP->v[0] && pP->v[0] < v->bounds.max.v[0] && v->bounds.min.v[1] < pP->v[1] && pP->v[1] < v->bounds.max.v[1] && v->bounds.min.v[2] < pP->v[2] && pP->v[2] < v->bounds.max.v[2]) {
             BrMatrix34ApplyP(&p, pP, &v->inv_mat);
-            if (-1.f < p.v[0] && p.v[0] < 1.f &&  -1.f < p.v[1] && p.v[1] < 1.f && -1.f < p.v[2] && p.v[2] < 1.f) {
+            if (-1.f < p.v[0] && p.v[0] < 1.f && -1.f < p.v[1] && p.v[1] < 1.f && -1.f < p.v[2] && p.v[2] < 1.f) {
                 return v;
             }
         }
@@ -4129,11 +4137,12 @@ br_material* GetExternalMat() {
     return BrMaterialFind("SPECVOL2.MAT");
 }
 
-#define DrVertexSet(V, X, Y, Z) do {        \
-    (V)[0] = (X);                           \
-    (V)[1] = (Y);                           \
-    (V)[2] = (Z);                           \
-} while (0)
+#define DrVertexSet(V, X, Y, Z) \
+    do {                        \
+        (V)[0] = (X);           \
+        (V)[1] = (Y);           \
+        (V)[2] = (Z);           \
+    } while (0)
 
 // IDA: void __usercall BuildSpecVolModel(tSpecial_volume *pSpec@<EAX>, int pIndex@<EDX>, br_material *pInt_mat@<EBX>, br_material *pExt_mat@<ECX>)
 void BuildSpecVolModel(tSpecial_volume* pSpec, int pIndex, br_material* pInt_mat, br_material* pExt_mat) {
@@ -4194,9 +4203,9 @@ void BuildSpecVolModel(tSpecial_volume* pSpec, int pIndex, br_material* pInt_mat
         model->faces[i].vertices[0] = model->faces[i].vertices[1];
         model->faces[i].vertices[1] = temp;
     }
-    model->faces[ 5].material = model->faces[ 4].material = model->faces[ 1].material = model->faces[ 0].material = DRMaterialClone(pExt_mat);
-    model->faces[11].material = model->faces[10].material = model->faces[ 9].material = model->faces[ 8].material = DRMaterialClone(pExt_mat);
-    model->faces[ 7].material = model->faces[ 6].material = model->faces[ 3].material = model->faces[ 2].material = DRMaterialClone(pExt_mat);
+    model->faces[5].material = model->faces[4].material = model->faces[1].material = model->faces[0].material = DRMaterialClone(pExt_mat);
+    model->faces[11].material = model->faces[10].material = model->faces[9].material = model->faces[8].material = DRMaterialClone(pExt_mat);
+    model->faces[7].material = model->faces[6].material = model->faces[3].material = model->faces[2].material = DRMaterialClone(pExt_mat);
     model->faces[17].material = model->faces[16].material = model->faces[13].material = model->faces[12].material = DRMaterialClone(pInt_mat);
     model->faces[23].material = model->faces[22].material = model->faces[21].material = model->faces[20].material = DRMaterialClone(pInt_mat);
     model->faces[19].material = model->faces[18].material = model->faces[15].material = model->faces[14].material = DRMaterialClone(pInt_mat);

--- a/src/DETHRACE/common/world.c
+++ b/src/DETHRACE/common/world.c
@@ -658,7 +658,6 @@ int LoadNTrackModels(tBrender_storage* pStorage_space, FILE* pF, int pCount) {
         }
         for (j = 0; j < total; j++) {
             if (temp_array[j]) {
-                LOG_DEBUG("adding track model %s %d, %d", temp_array[j]->identifier, temp_array[j]->nfaces, temp_array[j]->nvertices);
                 switch (AddModelToStorage(pStorage_space, temp_array[j])) {
                 case eStorage_not_enough_room:
                     FatalError(70);
@@ -681,9 +680,8 @@ int LoadNTrackModels(tBrender_storage* pStorage_space, FILE* pF, int pCount) {
                     default:
                         break;
                     }
-                    // RemoveDoubleSided(temp_array[j]);
+                    RemoveDoubleSided(temp_array[j]);
                     BrModelAdd(temp_array[j]);
-                    LOG_DEBUG("added track model %s %d, %d", temp_array[j]->identifier, temp_array[j]->nfaces, temp_array[j]->nvertices);
                     new_ones++;
                 }
             }
@@ -2276,10 +2274,10 @@ void LoadTrack(char* pFile_name, tTrack_spec* pTrack_spec, tRace_info* pRace_inf
     }
     for (i = 0; gTrack_storage_space.materials_count > i; ++i) {
         PossibleService();
-        if (gTrack_storage_space.materials[i]->flags & 7) {
+        if (gTrack_storage_space.materials[i]->flags & (BR_MATF_LIGHT | BR_MATF_PRELIT | BR_MATF_SMOOTH)) {
             gTrack_storage_space.materials[i]->flags &= 0xFFFFFFF8;
             if (gTrack_storage_space.materials[i]->flags & BR_MATF_TWO_SIDED) {
-                gTrack_storage_space.materials[i]->user = DOUBLESIDED_FLAG;
+                gTrack_storage_space.materials[i]->user = DOUBLESIDED_USER_FLAG;
                 gTrack_storage_space.materials[i]->flags &= 0xFFFFEFFF;
             }
             BrMaterialUpdate(gTrack_storage_space.materials[i], BR_MATU_RENDERING);

--- a/src/DETHRACE/common/world.c
+++ b/src/DETHRACE/common/world.c
@@ -2583,7 +2583,7 @@ void LoadTrack(char* pFile_name, tTrack_spec* pTrack_spec, tRace_info* pRace_inf
     gProgram_state.non_cars = non_car;
     gProgram_state.num_non_car_spaces = num_non_cars + NONCAR_UNUSED_SLOTS;
     for (i = 0; i < COUNT_OF(gNon_car_spec_list); ++i) {
-        gNon_car_spec_list[i] = 0;
+        gNon_car_spec_list[i] = '\0';
     }
     for (i = 0; i < NONCAR_UNUSED_SLOTS; i++) {
         non_car->collision_info.driver = eDriver_non_car_unused_slot;

--- a/src/DETHRACE/constants.h
+++ b/src/DETHRACE/constants.h
@@ -261,20 +261,20 @@ typedef enum keymapcodes {
     // The following items are meant to be used standalone
     //
 
-    KEYMAP_COCKPIT = 45,      // default C
-    KEYMAP_SAVE = 28,         // default F2
-    KEYMAP_LOAD = 29,         // default F3
-    KEYMAP_MOVE_UP = 30,      // default UP
-    KEYMAP_MOVE_DOWN = 31,    // default DOWN
-    KEYMAP_MOVE_LEFT = 32,    // default LEFT
-    KEYMAP_MOVE_RIGHT = 33,   // default RIGHT
-    KEYMAP_MIRROR = 34,       // default M
-    KEYMAP_PRATCAM = 35,      // default P
-    KEYMAP_LOOK_LEFT = 50,    // default Q
-    KEYMAP_LOOK_FORWARD = 51, // default W
-    KEYMAP_LOOK_RIGHT = 52,   // default E
-    KEYMAP_SOUND = 36,        // default S
-    KEYMAP_REPAIR = 44,       // default BACKSPACE
+    KEYMAP_COCKPIT = 45,        // default C
+    KEYMAP_SAVE = 28,           // default F2
+    KEYMAP_LOAD = 29,           // default F3
+    KEYMAP_MOVE_UP = 30,        // default UP
+    KEYMAP_MOVE_DOWN = 31,      // default DOWN
+    KEYMAP_MOVE_LEFT = 32,      // default LEFT
+    KEYMAP_MOVE_RIGHT = 33,     // default RIGHT
+    KEYMAP_MIRROR = 34,         // default M
+    KEYMAP_PRATCAM = 35,        // default P
+    KEYMAP_LOOK_LEFT = 50,      // default Q
+    KEYMAP_LOOK_FORWARD = 51,   // default W
+    KEYMAP_LOOK_RIGHT = 52,     // default E
+    KEYMAP_SOUND = 36,          // default S
+    KEYMAP_REPAIR = 44,         // default BACKSPACE
     KEYMAP_PEDESTRIANS = 54,    // default KP_MINUS
     KEYMAP_F4 = 17,             // default F4
     KEYMAP_F5 = 18,             // default F5
@@ -351,6 +351,6 @@ typedef enum keymapcodes {
 
 #define SHADOW_MAX_RENDER_DISTANCE 36.0f
 
-#define DOUBLESIDED_FLAG_COLOR_MAP (br_pixelmap*)12345
+#define DOUBLESIDED_FLAG (void*)12345
 
 #endif

--- a/src/DETHRACE/constants.h
+++ b/src/DETHRACE/constants.h
@@ -345,12 +345,12 @@ typedef enum keymapcodes {
 
 #define TIME_CONV_THING 0.0005f
 
-#define OPPONENT_COUNT 0
+#define OPPONENT_COUNT 5
 
 #define WORLD_SCALE 6.9f
 
 #define SHADOW_MAX_RENDER_DISTANCE 36.0f
 
-#define DOUBLESIDED_FLAG (void*)12345
+#define DOUBLESIDED_USER_FLAG (void*)12345
 
 #endif

--- a/src/DETHRACE/constants.h
+++ b/src/DETHRACE/constants.h
@@ -345,7 +345,7 @@ typedef enum keymapcodes {
 
 #define TIME_CONV_THING 0.0005f
 
-#define OPPONENT_COUNT 5
+#define OPPONENT_COUNT 0
 
 #define WORLD_SCALE 6.9f
 

--- a/src/DETHRACE/macros.h
+++ b/src/DETHRACE/macros.h
@@ -17,5 +17,6 @@
 #define DEG_TO_RAD(degrees) ((degrees)*3.141592653589793 / 180.0)
 
 #define V11MODEL(model) (((v11model*)model->prepared))
+#define CAR(c) ((tCar_spec*)c)
 
 #endif

--- a/src/DETHRACE/macros.h
+++ b/src/DETHRACE/macros.h
@@ -10,6 +10,7 @@
 
 #define STR_STARTS_WITH(haystack, needle) strncmp(haystack, needle, strlen(needle))
 #define STR_ENDS_WITH(haystack, needle) strcmp(haystack + strlen(haystack) - strlen(needle), needle)
+#define MIN(a, b) ((a) < (b) ? a : b)
 #define MAX(a, b) ((a) > (b) ? a : b)
 #define COUNT_OF(array) (sizeof((array)) / sizeof((array)[0]))
 #define LEN(array) (sizeof((array)) / sizeof((array)[0]))
@@ -18,5 +19,12 @@
 
 #define V11MODEL(model) (((v11model*)model->prepared))
 #define CAR(c) ((tCar_spec*)c)
+
+#define Vector3Div(v1, v2, v3)                \
+    do {                                      \
+        (v1)->v[0] = (v2)->v[0] / (v3)->v[0]; \
+        (v1)->v[1] = (v2)->v[1] / (v3)->v[1]; \
+        (v1)->v[2] = (v2)->v[2] / (v3)->v[2]; \
+    } while (0)
 
 #endif

--- a/src/harness/renderers/gl/gl_renderer.c
+++ b/src/harness/renderers/gl/gl_renderer.c
@@ -138,13 +138,13 @@ void SetupFullScreenRectGeometry() {
     float vertices[] = {
         // positions          // colors           // texture coords
         1.0f, -1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, // top right
-        1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, // bottom right
+        1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f,  // bottom right
         -1.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, // bottom left
         -1.0f, -1.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f // top left
     };
     unsigned int indices[] = {
         0, 1, 3, // first triangle
-        1, 2, 3 // second triangle
+        1, 2, 3  // second triangle
     };
 
     GLuint vbo;
@@ -195,6 +195,7 @@ void GLRenderer_Init(int width, int height, int pRender_width, int pRender_heigh
     glDepthFunc(GL_LESS);
     glClearColor(0, 0, 0, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT);
+    glDisable(GL_CULL_FACE);
 
     // textures
     glGenTextures(1, &screen_texture);
@@ -463,16 +464,12 @@ void setActiveMaterial(tStored_material* material) {
     if (material->shade_table) {
         GLRenderer_SetShadeTable(material->shade_table);
     }
+
     if ((material->flags & BR_MATF_LIGHT) && !(material->flags & BR_MATF_PRELIT) && material->shade_table) {
         // TODO: light value shouldn't always be 0? Works for shadows, not sure about other things.
         glUniform1i(uniforms_3d.light_value, 0);
     } else {
         glUniform1i(uniforms_3d.light_value, -1);
-    }
-    if (material->flags & BR_MATF_ALWAYS_VISIBLE) {
-        glDisable(GL_CULL_FACE);
-    } else {
-        glEnable(GL_CULL_FACE);
     }
 
     if (material->pixelmap) {


### PR DESCRIPTION
`NonCars` are what the game calls pieces of the track that you can interact with. For example, streetlights can be bent and snapped off, benches can be pushed around etc.

- Implements all the physics functions required for this to work
- Uncomments `RemoveDoubleSided`
- Fixes auto-generated `br_material` and `br_model` structs to align better with real usage
- Culling globally disabled in `gl_renderer` to fix issues with streetlights not rendering from all angles. This matches what we know of the 3dfx version, for example.

https://user-images.githubusercontent.com/78985374/166161286-42c78d9d-edb5-4844-8689-7d5af8a858e2.mp4
