### PR TITLE
Flush buffers in EndScene

### DIFF
--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -346,6 +346,7 @@ void Harness_Hook_renderFaces(br_actor* actor, br_model* model, br_material* mat
 }
 
 void Harness_Hook_BrZbSceneRenderEnd() {
+    renderer->FlushBuffers(last_colour_buffer, last_depth_buffer);
     renderer->EndScene();
 }
 
@@ -353,7 +354,6 @@ void Harness_Hook_BrZbSceneRenderEnd() {
 void Harness_Hook_BrPixelmapDoubleBuffer(br_pixelmap* dst, br_pixelmap* src) {
 
     // draw the current colour_buffer (2d screen) contents
-    renderer->FlushBuffers(last_colour_buffer, last_depth_buffer);
     Harness_RenderScreen(dst, src);
 
     int delay_ms = Harness_CalculateFrameDelay();


### PR DESCRIPTION
- Moves `FlushBuffers` to `EndScene` instead of `BrPixelmapDoubleBuffer`. In races without depth effects, flushing the 3d scene was happening _after_ 2d rendering, causing the 3d scene to appear in front of the HUD
- Fixes #125 

<img width="752" alt="Screen Shot 2022-05-02 at 8 47 42 AM" src="https://user-images.githubusercontent.com/78985374/166164007-08e2d4dd-b0b9-4d56-84d7-7053da41eb79.png">

