### PR TITLE
Fix prototype(s) + function uses

### DIFF
--- a/src/DETHRACE/common/intrface.c
+++ b/src/DETHRACE/common/intrface.c
@@ -517,7 +517,7 @@ int DoInterfaceScreen(tInterface_spec* pSpec, int pOptions, int pCurrent_choice)
                 DRS3StartSound(gEffects_outlet, 3007);
                 RunFlic(pSpec->end_flic_otherwise);
             } else if (pSpec->end_flic_otherwise < 0) {
-                FadePaletteDown(pSpec->end_flic_otherwise);
+                FadePaletteDown();
             }
             goto LABEL_230;
         } else {
@@ -525,7 +525,7 @@ int DoInterfaceScreen(tInterface_spec* pSpec, int pOptions, int pCurrent_choice)
                 DRS3StartSound(gEffects_outlet, 3007);
                 RunFlic(pSpec->end_flic_escaped);
             } else if (pSpec->end_flic_escaped < 0) {
-                FadePaletteDown(pSpec->end_flic_escaped);
+                FadePaletteDown();
             }
             goto LABEL_230;
         }
@@ -534,7 +534,7 @@ int DoInterfaceScreen(tInterface_spec* pSpec, int pOptions, int pCurrent_choice)
         DRS3StartSound(gEffects_outlet, 3007);
         RunFlic(pSpec->end_flic_go_ahead);
     } else if (pSpec->end_flic_go_ahead < 0) {
-        FadePaletteDown(pSpec->end_flic_go_ahead);
+        FadePaletteDown();
     }
 
 LABEL_230:

--- a/src/DETHRACE/common/mainmenu.c
+++ b/src/DETHRACE/common/mainmenu.c
@@ -326,7 +326,7 @@ int DoMainMenuInterface(tU32 pTime_out, int pContinue_allowed) {
         if (result != 7 && result && result != 1 && result != 2) {
             RunFlic(12);
         } else {
-            FadePaletteDown(result);
+            FadePaletteDown();
         }
         switch (result) {
         case 0:
@@ -355,7 +355,7 @@ int DoMainMenuInterface(tU32 pTime_out, int pContinue_allowed) {
         if (result != 4 && result != -1) {
             RunFlic(32);
         } else {
-            FadePaletteDown(result);
+            FadePaletteDown();
         }
         switch (result) {
         case 0:

--- a/src/DETHRACE/common/racesumm.c
+++ b/src/DETHRACE/common/racesumm.c
@@ -345,7 +345,7 @@ int SummCheckGameOver(int* pCurrent_choice, int* pCurrent_mode) {
             2, -1);
         ProcessFlicQueue(gFrame_period);
         PDScreenBufferSwap(0);
-        SoundService(0);
+        SoundService();
         WaitFor(300);
         DrawInBox(
             gCurrent_graf_data->summ1_credits_box_left,
@@ -356,7 +356,7 @@ int SummCheckGameOver(int* pCurrent_choice, int* pCurrent_mode) {
             2, 0);
         ProcessFlicQueue(gFrame_period);
         PDScreenBufferSwap(0);
-        SoundService(0);
+        SoundService();
         WaitFor(300);
     }
     S3StopAllOutletSounds();

--- a/src/S3/audio.c
+++ b/src/S3/audio.c
@@ -761,7 +761,7 @@ int S3ServiceChannel(tS3_channel* chan) {
     } else if (chan->type == eS3_ST_midi) {
         return !S3IsMIDIStopped(chan);
     } else if (chan->type == eS3_ST_cda) {
-        return S3IsCDAPlaying(chan);
+        return S3IsCDAPlaying();
     } else {
         return 0;
     }

--- a/src/S3/include/s3/s3.h
+++ b/src/S3/include/s3/s3.h
@@ -29,7 +29,7 @@ int S3Init(char* path, int low_memory_mode);
 void S3Disable();
 void S3Enable();
 
-int S3Set3DSoundEnvironment(float a1, float a2, float a3);
+void S3Set3DSoundEnvironment(float a1, float a2, float a3);
 tS3_sound_source_ptr S3CreateSoundSourceBR(br_vector3* pPosition, br_vector3* pVelocity, tS3_outlet_ptr pBound_outlet);
 int S3BindAmbientSoundToOutlet(tS3_outlet_ptr pOutlet, int pSound, tS3_sound_source_ptr source, float pMax_distance, int pPeriod, int pRepeats, int pVolume, int pPitch, int pSpeed);
 

--- a/src/harness/include/harness/hooks.h
+++ b/src/harness/include/harness/hooks.h
@@ -21,7 +21,7 @@ void Harness_Hook_DOSGfxBegin();
 void Harness_Hook_BrDevPaletteSetOld(br_pixelmap* pm);
 void Harness_Hook_BrDevPaletteSetEntryOld(int i, br_colour colour);
 void Harness_Hook_BrPixelmapDoubleBuffer(br_pixelmap* dst, br_pixelmap* src);
-void Harness_Hook_BrV1dbRendererBegin();
+void Harness_Hook_BrV1dbRendererBegin(br_v1db_state* v1db);
 void Harness_Hook_BrZbSceneRenderBegin(br_actor* world, br_actor* camera, br_pixelmap* colour_buffer, br_pixelmap* depth_buffer);
 void Harness_Hook_BrZbSceneRenderAdd(br_actor* tree);
 void Harness_Hook_renderFaces(br_actor* actor, br_model* model, br_material* material, br_token type);


### PR DESCRIPTION
- `FadePaletteDown` was used with an argument where it does not accept one
- `SoundService` does not accept an argument
- `Harness_Hook_BrV1dbRendererBegin` accepts `br_v1db_state* v1db`

There is still an issue with `S3IsCDAPlaying`, `S3IsCDAPlaying2` and `S3Set3DSoundEnvironment`.
But I'm hoping @dethrace-labs can address those.