### PR TITLE
gl: Relax GLSL requirement from 3.3 to 3.1

### DIFF
--- a/src/harness/io_platforms/sdl_gl.c
+++ b/src/harness/io_platforms/sdl_gl.c
@@ -149,13 +149,11 @@ tRenderer* Window_Create(char* title, int width, int height, int pRender_width, 
         LOG_PANIC("SDL_INIT_VIDEO error: %s", SDL_GetError());
     }
 
-/*
     if (SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE) != 0) {
         LOG_PANIC("Failed to set SDL_GL_CONTEXT_PROFILE_MASK attribute. %s", SDL_GetError());
     };
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
-*/
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
 
     SDL_GL_SetSwapInterval(1);
 

--- a/src/harness/io_platforms/sdl_gl.c
+++ b/src/harness/io_platforms/sdl_gl.c
@@ -149,11 +149,13 @@ tRenderer* Window_Create(char* title, int width, int height, int pRender_width, 
         LOG_PANIC("SDL_INIT_VIDEO error: %s", SDL_GetError());
     }
 
+/*
     if (SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE) != 0) {
         LOG_PANIC("Failed to set SDL_GL_CONTEXT_PROFILE_MASK attribute. %s", SDL_GetError());
     };
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+*/
 
     SDL_GL_SetSwapInterval(1);
 

--- a/src/harness/renderers/gl/gl_renderer.c
+++ b/src/harness/renderers/gl/gl_renderer.c
@@ -223,7 +223,7 @@ void GLRenderer_Init(int width, int height, int pRender_width, int pRender_heigh
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT16, render_width, render_height, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT, 0);
-    glFramebufferTexture(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, depth_texture, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, depth_texture, 0);
 
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
         LOG_PANIC("Framebuffer is not complete!");

--- a/src/harness/renderers/gl/shaders.c
+++ b/src/harness/renderers/gl/shaders.c
@@ -1,5 +1,6 @@
 
-const char* vs_2d = "#version 330 core\n"
+const char* vs_2d = "#version 130\n"
+                    "#extension GL_ARB_explicit_attrib_location : require\n"
                     "layout (location = 0) in vec3 aPos;\n"
                     "layout (location = 1) in vec3 aColor;\n"
                     "layout (location = 2) in vec2 aTexCoord;\n"
@@ -10,7 +11,8 @@ const char* vs_2d = "#version 330 core\n"
                     "   TexCoord = aTexCoord;\n"
                     "}\0";
 
-const char* fs_2d = "#version 330 core\n"
+const char* fs_2d = "#version 130\n"
+                    "#extension GL_ARB_explicit_attrib_location : require\n"
                     "in vec2 TexCoord;\n"
                     "uniform usampler2D pixels;\n"
                     "uniform sampler2D palette;\n"
@@ -23,7 +25,8 @@ const char* fs_2d = "#version 330 core\n"
                     "  FragColor = texel;\n"
                     "}\n\0";
 
-const char* vs_3d = "#version 330 core\n"
+const char* vs_3d = "#version 130\n"
+                    "#extension GL_ARB_explicit_attrib_location : require\n"
                     "layout (location = 0) in vec3 aPos;\n"
                     "layout (location = 1) in vec3 aNormal;\n"
                     "layout (location = 2) in vec2 aUV;\n"
@@ -43,7 +46,8 @@ const char* vs_3d = "#version 330 core\n"
                     "   gl_Position = projection * view * vec4(FragPos, 1.0);\n"
                     "}\0";
 
-const char* fs_3d = "#version 330 core\n"
+const char* fs_3d = "#version 130\n"
+                    "#extension GL_ARB_explicit_attrib_location : require\n"
                     "in vec3 Normal;\n"
                     "in vec3 FragPos;\n"
                     "in vec2 TexCoord;\n"

--- a/src/harness/renderers/gl/shaders.c
+++ b/src/harness/renderers/gl/shaders.c
@@ -1,5 +1,5 @@
 
-const char* vs_2d = "#version 130\n"
+const char* vs_2d = "#version 140\n"
                     "#extension GL_ARB_explicit_attrib_location : require\n"
                     "layout (location = 0) in vec3 aPos;\n"
                     "layout (location = 1) in vec3 aColor;\n"
@@ -11,7 +11,7 @@ const char* vs_2d = "#version 130\n"
                     "   TexCoord = aTexCoord;\n"
                     "}\0";
 
-const char* fs_2d = "#version 130\n"
+const char* fs_2d = "#version 140\n"
                     "#extension GL_ARB_explicit_attrib_location : require\n"
                     "in vec2 TexCoord;\n"
                     "uniform usampler2D pixels;\n"
@@ -25,7 +25,7 @@ const char* fs_2d = "#version 130\n"
                     "  FragColor = texel;\n"
                     "}\n\0";
 
-const char* vs_3d = "#version 130\n"
+const char* vs_3d = "#version 140\n"
                     "#extension GL_ARB_explicit_attrib_location : require\n"
                     "layout (location = 0) in vec3 aPos;\n"
                     "layout (location = 1) in vec3 aNormal;\n"
@@ -46,7 +46,7 @@ const char* vs_3d = "#version 130\n"
                     "   gl_Position = projection * view * vec4(FragPos, 1.0);\n"
                     "}\0";
 
-const char* fs_3d = "#version 130\n"
+const char* fs_3d = "#version 140\n"
                     "#extension GL_ARB_explicit_attrib_location : require\n"
                     "in vec3 Normal;\n"
                     "in vec3 FragPos;\n"


### PR DESCRIPTION
With these changes, it is possible to start dethrace on
Pinebook Pro (Mali-T860 / Panfrost):

```
OpenGL vendor string: Panfrost
OpenGL renderer string: Mali-T860 (Panfrost)
OpenGL core profile version string: 3.1 Mesa 22.3.0-devel (git-d08bd9a8d8)
OpenGL core profile shading language version string: 1.40
```