### PR TITLE
Add support for fullscreen + never grab mouse + resize window

### DIFF
--- a/src/harness/io_platforms/sdl_gl.c
+++ b/src/harness/io_platforms/sdl_gl.c
@@ -172,11 +172,6 @@ tRenderer* Window_Create(char* title, int width, int height, int pRender_width, 
         LOG_PANIC("Failed to create window");
     }
 
-    // Don't grab the mouse when a debugger is present
-    if (!OS_IsDebuggerPresent()) {
-        SDL_SetRelativeMouseMode(SDL_TRUE);
-    }
-
     sdl_window_scale.x = ((float)pRender_width) / width;
     sdl_window_scale.y = ((float)pRender_height) / height;
 

--- a/src/harness/io_platforms/sdl_gl.c
+++ b/src/harness/io_platforms/sdl_gl.c
@@ -292,13 +292,13 @@ void Input_GetMousePosition(int* pX, int* pY) {
     gl_renderer.GetViewport(&vp_x, &vp_y, &vp_w, &vp_h);
     if (*pX < vp_x) {
         *pX = vp_x;
-    } else if (*pX > vp_x + vp_w) {
-        *pX = vp_x + vp_w;
+    } else if (*pX >= vp_x + vp_w) {
+        *pX = vp_x + vp_w - 1;
     }
     if (*pY < vp_y) {
         *pY = vp_y;
-    } else if (*pY > vp_y + vp_h) {
-        *pY = vp_y + vp_h;
+    } else if (*pY >= vp_y + vp_h) {
+        *pY = vp_y + vp_h - 1;
     }
     *pX -= vp_x;
     *pY -= vp_y;

--- a/src/harness/io_platforms/sdl_gl.c
+++ b/src/harness/io_platforms/sdl_gl.c
@@ -134,6 +134,8 @@ int is_full_screen = 0;
 // From gl_renderer.c
 extern int window_width;
 extern int window_height;
+extern int render_width;
+extern int render_height;
 
 tRenderer gl_renderer = {
     GLRenderer_Init,
@@ -166,7 +168,7 @@ tRenderer* Window_Create(char* title, int width, int height, int pRender_width, 
         SDL_WINDOWPOS_CENTERED,
         SDL_WINDOWPOS_CENTERED,
         width, height,
-        SDL_WINDOW_OPENGL);
+        SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
 
     if (window == NULL) {
         LOG_PANIC("Failed to create window");
@@ -216,7 +218,6 @@ void Window_PollEvents() {
                     if (is_only_key_modifier(event.key.keysym.mod, KMOD_ALT)) {
                         is_full_screen = !is_full_screen;
                         SDL_SetWindowFullscreen(window, is_full_screen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
-                        SDL_GetWindowSize(window, &window_width, &window_height);
                     }
                 }
             }
@@ -233,6 +234,15 @@ void Window_PollEvents() {
             sdl_key_state[3] = sdl_key_state[2];
             break;
 
+        case SDL_WINDOWEVENT:
+            switch (event.window.event) {
+            case SDL_WINDOWEVENT_SIZE_CHANGED:
+                SDL_GetWindowSize(window, &window_width, &window_height);
+                sdl_window_scale.x = (float)render_width / window_width;
+                sdl_window_scale.y = (float)render_height / window_height;
+                break;
+            }
+            break;
         case SDL_QUIT:
             LOG_PANIC("QuitGame");
             break;

--- a/src/harness/renderers/gl/gl_renderer.c
+++ b/src/harness/renderers/gl/gl_renderer.c
@@ -339,7 +339,22 @@ void GLRenderer_EndScene() {
 }
 
 void GLRenderer_FullScreenQuad(uint8_t* screen_buffer, int width, int height) {
-    glViewport(0, 0, window_width, window_height);
+    const float target_aspect_ratio = (float)render_width / render_height;
+    const float aspect_ratio = (float)window_width / window_height;
+    int vp_width;
+    int vp_height;
+
+    vp_width = window_width;
+    vp_height = window_height;
+    if (aspect_ratio != target_aspect_ratio) {
+        if (aspect_ratio > target_aspect_ratio) {
+            vp_width = window_height * target_aspect_ratio + .5f;
+        } else {
+            vp_height = window_width / target_aspect_ratio + .5f;
+        }
+    }
+
+    glViewport((window_width - vp_width) / 2, (window_height - vp_height) / 2, vp_width, vp_height);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glDisable(GL_DEPTH_TEST);
 

--- a/src/harness/renderers/gl/gl_renderer.h
+++ b/src/harness/renderers/gl/gl_renderer.h
@@ -44,5 +44,9 @@ void GLRenderer_BufferMaterial(br_material* mat);
 void GLRenderer_BufferModel(br_model* model);
 void GLRenderer_ClearBuffers();
 void GLRenderer_FlushBuffers(br_pixelmap* color_buffer, br_pixelmap* depth_buffer);
+void GLRenderer_GetRenderSize(int* width, int* height);
+void GLRenderer_GetWindowSize(int* width, int* height);
+void GLRenderer_SetWindowSize(int width, int height);
+void GLRenderer_GetViewport(int* x, int* y, int* width, int* height);
 
 #endif

--- a/src/harness/renderers/null.h
+++ b/src/harness/renderers/null.h
@@ -12,6 +12,10 @@ void Null_BufferTexture(br_pixelmap* pm) {}
 void Null_BufferMaterial(br_material* mat) {}
 void Null_BufferModel(br_model* model) {}
 void Null_FlushBuffers(br_pixelmap* color_buffer, br_pixelmap* depth_buffer) {}
+void Null_GetRenderSize(int* width, int* height) { *width = 640; *height = 480; }
+void Null_GetWindowSize(int* width, int* height) { *width = 640; *height = 480; }
+void Null_SetWindowSize(int width, int height) {}
+void Null_GetViewportSize(int* x, int* y, int* width, int* height) { *x = 0; *y = 0; *width = 640; *height = 480; }
 
 tRenderer null_renderer = {
     Null_Init,
@@ -24,5 +28,9 @@ tRenderer null_renderer = {
     Null_BufferTexture,
     Null_BufferMaterial,
     Null_BufferModel,
-    Null_FlushBuffers
+    Null_FlushBuffers,
+    Null_GetRenderSize,
+    Null_GetWindowSize,
+    Null_SetWindowSize,
+    Null_GetViewportSize
 };

--- a/src/harness/renderers/renderer.h
+++ b/src/harness/renderers/renderer.h
@@ -15,7 +15,10 @@ typedef struct tRenderer {
     void (*BufferMaterial)(br_material* mat);
     void (*BufferModel)(br_model* model);
     void (*FlushBuffers)(br_pixelmap* color_buffer, br_pixelmap* depth_buffer);
-
+    void (*GetRenderSize)(int* width, int* height);
+    void (*GetWindowSize)(int* width, int* height);
+    void (*SetWindowSize)(int width, int height);
+    void (*GetViewport)(int* x, int* y, int* width, int* height);
 } tRenderer;
 
 #endif


### PR DESCRIPTION
- Switch to full screen (and back to windowed mode) when pressing <kbd>ALT</kbd>+<kbd>ENTER</kbd>
- Never grab the mouse (see discussion in discord)

The only issue I have with the current implementation is that it does not preserve aspect ratio.
I [tried the approach of this SO question](https://stackoverflow.com/questions/28587643/sdl2-how-to-keep-aspect-ratio-when-resizing-the-window), but the behavior is weird when going full screen and back. It also breaks when going full screen because it can resize the window to dimensions bigger then the screen size.

Instead, we probably just need to modify the gl renderer to draw its thing in the correct aspect ratio centrally and add black bars left and right. ==> This is what I ended up adding in this pr.

Fixes #72