### PR TITLE
remove unused Windows HANDLE

### DIFF
--- a/src/harness/os/windows.c
+++ b/src/harness/os/windows.c
@@ -49,7 +49,6 @@ void OS_Sleep(int delay_ms) {
 char* OS_GetFirstFileInDirectory(char* path) {
     char with_extension[256];
     WIN32_FIND_DATA find_data;
-    HANDLE hFind = NULL;
 
     strcpy(with_extension, path);
     strcat(with_extension, "\\*.???");


### PR DESCRIPTION
This unused `HANDLE` on `src/harness/os/windows.c` was failing the build on Windows.