### PR TITLE
Fix address sanitizer error when loading "Industrial Action"

### DIFF
--- a/src/BRSRC13/include/brender/brender.h
+++ b/src/BRSRC13/include/brender/brender.h
@@ -142,6 +142,8 @@ void* BrResAllocate(void* vparent, br_size_t size, br_uint_8 res_class);
 br_resource_class* BrResClassAdd(br_resource_class* rclass);
 void* BrResRemove(void* vres);
 void BrResFree(void* vres);
+br_uint_32 BrResCheck(void* vres, int no_tag);
+br_uint_32 BrResSize(void* vres);
 char* BrResStrDup(void* vparent, char* str);
 
 // BrTable

--- a/src/DETHRACE/common/utility.c
+++ b/src/DETHRACE/common/utility.c
@@ -443,6 +443,30 @@ br_pixelmap* PurifiedPixelmap(br_pixelmap* pSrc) {
     NOT_IMPLEMENTED();
 }
 
+#if defined(DETHRACE_FIX_BUGS)
+static void align_pixelmap(br_pixelmap* pm) {
+    int i;
+    br_uint_16 original_row_bytes;
+    br_uint_16 new_row_bytes;
+    br_uint_8* original_pixels;
+    br_uint_8* new_pixels;
+
+    original_row_bytes = pm->row_bytes;
+    if (original_row_bytes % sizeof(int) == 0 || pm->height <= 1) {
+        return;
+    }
+    new_row_bytes = (original_row_bytes + sizeof(int) - 1) & ~(sizeof(int) - 1);
+    original_pixels = pm->pixels;
+    new_pixels = BrResAllocate(pm, new_row_bytes * pm->height, BR_MEMORY_PIXELS);
+    for (i = 0; i < pm->height; i++) {
+        memcpy(new_pixels + i * new_row_bytes, original_pixels + i * original_row_bytes, original_row_bytes);
+    }
+    BrResFree(original_pixels);
+    pm->pixels = new_pixels;
+    pm->row_bytes = new_row_bytes;
+}
+#endif
+
 // IDA: br_pixelmap* __usercall DRPixelmapLoad@<EAX>(char *pFile_name@<EAX>)
 br_pixelmap* DRPixelmapLoad(char* pFile_name) {
     br_pixelmap* the_map;
@@ -453,7 +477,11 @@ br_pixelmap* DRPixelmapLoad(char* pFile_name) {
     if (the_map != NULL) {
         the_map->origin_x = 0;
         the_map->origin_y = 0;
+#if defined(DETHRACE_FIX_BUGS)
+        align_pixelmap(the_map);
+#else
         the_map->row_bytes = (the_map->row_bytes + sizeof(int) - 1) & ~(sizeof(int) - 1);
+#endif
     }
     return the_map;
 }
@@ -469,7 +497,11 @@ br_uint_32 DRPixelmapLoadMany(char* pFile_name, br_pixelmap** pPixelmaps, br_uin
     number_loaded = BrPixelmapLoadMany(pFile_name, pPixelmaps, pNum);
     for (i = 0; i < number_loaded; i++) {
         the_map = pPixelmaps[i];
-        the_map->row_bytes = (the_map->row_bytes + 3) & 0xFFFC;
+#if defined(DETHRACE_FIX_BUGS)
+        align_pixelmap(the_map);
+#else
+        the_map->row_bytes = (the_map->row_bytes + sizeof(int) - 1) & ~(sizeof(int) - 1);
+#endif
         the_map->base_x = 0;
         the_map->base_y = 0;
     }

--- a/src/DETHRACE/common/utility.c
+++ b/src/DETHRACE/common/utility.c
@@ -443,30 +443,6 @@ br_pixelmap* PurifiedPixelmap(br_pixelmap* pSrc) {
     NOT_IMPLEMENTED();
 }
 
-#if defined(DETHRACE_FIX_BUGS)
-static void align_pixelmap(br_pixelmap* pm) {
-    int i;
-    br_uint_16 original_row_bytes;
-    br_uint_16 new_row_bytes;
-    br_uint_8* original_pixels;
-    br_uint_8* new_pixels;
-
-    original_row_bytes = pm->row_bytes;
-    if (original_row_bytes % sizeof(int) == 0 || pm->height <= 1) {
-        return;
-    }
-    new_row_bytes = (original_row_bytes + sizeof(int) - 1) & ~(sizeof(int) - 1);
-    original_pixels = pm->pixels;
-    new_pixels = BrResAllocate(pm, new_row_bytes * pm->height, BR_MEMORY_PIXELS);
-    for (i = 0; i < pm->height; i++) {
-        memcpy(new_pixels + i * new_row_bytes, original_pixels + i * original_row_bytes, original_row_bytes);
-    }
-    BrResFree(original_pixels);
-    pm->pixels = new_pixels;
-    pm->row_bytes = new_row_bytes;
-}
-#endif
-
 // IDA: br_pixelmap* __usercall DRPixelmapLoad@<EAX>(char *pFile_name@<EAX>)
 br_pixelmap* DRPixelmapLoad(char* pFile_name) {
     br_pixelmap* the_map;
@@ -477,10 +453,8 @@ br_pixelmap* DRPixelmapLoad(char* pFile_name) {
     if (the_map != NULL) {
         the_map->origin_x = 0;
         the_map->origin_y = 0;
-#if defined(DETHRACE_FIX_BUGS)
-        align_pixelmap(the_map);
-#else
-        the_map->row_bytes = (the_map->row_bytes + sizeof(int) - 1) & ~(sizeof(int) - 1);
+#if !defined(DETHRACE_FIX_BUGS)
+        the_map->row_bytes = (the_map->row_bytes + sizeof(int32_t) - 1) & ~(sizeof(int32_t) - 1);
 #endif
     }
     return the_map;
@@ -497,10 +471,8 @@ br_uint_32 DRPixelmapLoadMany(char* pFile_name, br_pixelmap** pPixelmaps, br_uin
     number_loaded = BrPixelmapLoadMany(pFile_name, pPixelmaps, pNum);
     for (i = 0; i < number_loaded; i++) {
         the_map = pPixelmaps[i];
-#if defined(DETHRACE_FIX_BUGS)
-        align_pixelmap(the_map);
-#else
-        the_map->row_bytes = (the_map->row_bytes + sizeof(int) - 1) & ~(sizeof(int) - 1);
+#if !defined(DETHRACE_FIX_BUGS)
+        the_map->row_bytes = (the_map->row_bytes + sizeof(int32_t) - 1) & ~(sizeof(int32_t) - 1);
 #endif
         the_map->base_x = 0;
         the_map->base_y = 0;


### PR DESCRIPTION
The map "Industrial Action" references a pixelmap whose width is not a multiple of 4.
However, DethRace overrides the row stride to a multiple of 4 [here](https://github.com/dethrace-labs/dethrace/blob/f99be5f57a251f124a648fdca309460671ba93ab/src/DETHRACE/common/utility.c#L456) and [here](https://github.com/dethrace-labs/dethrace/blob/f99be5f57a251f124a648fdca309460671ba93ab/src/DETHRACE/common/utility.c#L472).
As a result of this, the GL renderer will do a buffer overread when [reading the pixels here](https://github.com/dethrace-labs/dethrace/blob/f99be5f57a251f124a648fdca309460671ba93ab/src/harness/renderers/gl/gl_renderer.c#L598-L604).


- To fix this, a helper function `align_pixelmap` is introduced that aligns each row.
- This pr also contains a patch for `resource.c` that extracts the "magic check" out of `UserToRes`.
  This is done to allow `BrResCheck` to not fail when run on a non-resource memory block.
  (I used this function while troubleshooting the Address Sanitizer error above)