### PR TITLE
Implement parts shop

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -1540,7 +1540,7 @@ void OoerrIveGotTextInMeBoxMissus(int pFont_index, char* pText, br_pixelmap* pPi
 }
 
 // IDA: void __usercall TransBrPixelmapText(br_pixelmap *pPixelmap@<EAX>, int pX@<EDX>, int pY@<EBX>, br_uint_32 pColour@<ECX>, br_font *pFont, signed char *pText)
-void TransBrPixelmapText(br_pixelmap* pPixelmap, int pX, int pY, br_uint_32 pColour, br_font* pFont, signed char* pText) {
+void TransBrPixelmapText(br_pixelmap* pPixelmap, int pX, int pY, br_uint_32 pColour, br_font* pFont, char* pText) {
     int len;
     LOG_TRACE("(%p, %d, %d, %d, %p, %p)", pPixelmap, pX, pY, pColour, pFont, pText);
 

--- a/src/DETHRACE/common/displays.h
+++ b/src/DETHRACE/common/displays.h
@@ -118,7 +118,7 @@ void DrawRRectangle(br_pixelmap* pPixelmap, int pLeft, int pTop, int pRight, int
 
 void OoerrIveGotTextInMeBoxMissus(int pFont_index, char* pText, br_pixelmap* pPixelmap, int pLeft, int pTop, int pRight, int pBottom, int pCentred);
 
-void TransBrPixelmapText(br_pixelmap* pPixelmap, int pX, int pY, br_uint_32 pColour, br_font* pFont, signed char* pText);
+void TransBrPixelmapText(br_pixelmap* pPixelmap, int pX, int pY, br_uint_32 pColour, br_font* pFont, char* pText);
 
 void TransDRPixelmapText(br_pixelmap* pPixelmap, int pX, int pY, tDR_font* pFont, char* pText, int pRight_edge);
 

--- a/src/DETHRACE/common/init.c
+++ b/src/DETHRACE/common/init.c
@@ -529,7 +529,7 @@ void InitRace() {
     ResetRecoveryVouchers();
     gMap_mode = 0;
     gProgram_state.cockpit_image_index = 0;
-    if (gNet_mode) {
+    if (gNet_mode != eNet_mode_none) {
         gNet_cash_headup = NewTextHeadupSlot(13, 0, 0, -6, "");
         gNet_ped_headup = NewTextHeadupSlot(14, 0, 0, -6, "");
     } else {

--- a/src/DETHRACE/common/loading.c
+++ b/src/DETHRACE/common/loading.c
@@ -2748,7 +2748,22 @@ void LoadParts() {
     int i;
     int j;
     LOG_TRACE("()");
-    NOT_IMPLEMENTED();
+
+    for (i = 0; i < eParts_count; i++) {
+        for (j = 0; j < gProgram_state.current_car.power_ups[i].number_of_parts; j++) {
+            if (gProgram_state.current_car.power_ups[i].info[j].data_ptr == NULL) {
+                PossibleService();
+                if (!LoadFlicData(
+                        gProgram_state.current_car.power_ups[i].info[j].part_name,
+                        &gProgram_state.current_car.power_ups[i].info[j].data_ptr,
+                        &gProgram_state.current_car.power_ups[i].info[j].data_length)) {
+                    FatalError(58);
+                }
+            } else {
+                MAMSLock((void**)&gProgram_state.current_car.power_ups[i].info[j].data_ptr);
+            }
+        }
+    }
 }
 
 // IDA: void __cdecl UnlockParts()
@@ -2756,7 +2771,14 @@ void UnlockParts() {
     int i;
     int j;
     LOG_TRACE("()");
-    NOT_IMPLEMENTED();
+
+    for (i = 0; i < eParts_count; i++) {
+        for (j = 0; j < gProgram_state.current_car.power_ups[i].number_of_parts; j++) {
+            if (gProgram_state.current_car.power_ups[i].info[j].data_ptr != NULL) {
+                MAMSUnlock((void**)&gProgram_state.current_car.power_ups[i].info[j].data_ptr);
+            }
+        }
+    }
 }
 
 // IDA: br_pixelmap* __cdecl LoadChromeFont()

--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -101,14 +101,14 @@ void DrawRaceList(int pOffset) {
                     y,
                     rank_colour,
                     gBig_font,
-                    (signed char*)rank_str);
+                    rank_str);
             }
             TransBrPixelmapText(gBack_screen,
                 gCurrent_graf_data->choose_race_name_left,
                 y,
                 text_colour,
                 gBig_font,
-                (signed char*)gRace_list[i].name);
+                gRace_list[i].name);
             if (gRace_list[i].been_there_done_that && gBullet_image != NULL) {
                 BrPixelmapRectangleCopy(gBack_screen,
                     gCurrent_graf_data->choose_race_bullet_left,
@@ -128,7 +128,7 @@ void DrawRaceList(int pOffset) {
             gCurrent_graf_data->choose_race_current_text_y,
             5,
             gBig_font,
-            (signed char*)rank_str);
+            rank_str);
     } else {
         sprintf(rank_str, "%s%d", GetMiscString(27), gProgram_state.rank);
         text_x = (gCurrent_graf_data->choose_race_left + gCurrent_graf_data->choose_race_right) / 2 - BrPixelmapTextWidth(gBack_screen, gBig_font, rank_str) / 2;
@@ -137,14 +137,14 @@ void DrawRaceList(int pOffset) {
             gCurrent_graf_data->choose_race_current_text_y,
             3,
             gBig_font,
-            (signed char*)GetMiscString(27));
+            GetMiscString(27));
         sprintf(rank_str, "%d", gProgram_state.rank);
         TransBrPixelmapText(gBack_screen,
             text_x + BrPixelmapTextWidth(gBack_screen, gBig_font, GetMiscString(27)),
             gCurrent_graf_data->choose_race_current_text_y,
             5,
             gBig_font,
-            (signed char*)rank_str);
+            rank_str);
     }
     BrPixelmapLine(gBack_screen,
         left_most,
@@ -368,7 +368,7 @@ void DrawCar(int pCurrent_choice, int pCurrent_mode) {
         gCurrent_graf_data->change_car_text_y,
         3,
         gFont_7,
-        (signed char*)s);
+        s);
     BrPixelmapLine(gBack_screen,
         gCurrent_graf_data->change_car_line_left,
         gCurrent_graf_data->change_car_line_y,
@@ -1069,7 +1069,7 @@ void SelectRaceDraw(int pCurrent_choice, int pCurrent_mode) {
                         y_coord,
                         0xC9u,
                         gFont_7,
-                        (signed char*)the_chunk->text[j]);
+                        the_chunk->text[j]);
                     y_coord += gFont_7->glyph_y + gFont_7->glyph_y / 2;
                 }
             }
@@ -1089,7 +1089,7 @@ void SelectRaceDraw(int pCurrent_choice, int pCurrent_mode) {
                         y_coord,
                         0xC9u,
                         gFont_7,
-                        (signed char*)the_chunk->text[k]);
+                        the_chunk->text[k]);
                     y_coord += gFont_7->glyph_y + gFont_7->glyph_y / 2;
                 }
             }
@@ -1515,7 +1515,7 @@ void DrawGrid(int pOffset, int pDraw_it) {
                     gCurrent_graf_data->grid_numbers_top,
                     gGrid_number_colour[i],
                     gBig_font,
-                    (signed char*)numbers_str[i]);
+                    numbers_str[i]);
             }
             str_x += BrPixelmapTextWidth(gBack_screen, gBig_font, numbers_str[i]);
         }
@@ -1650,7 +1650,7 @@ void ChallengeStart() {
     BrPixelmapFree(the_map);
     the_map = DRPixelmapAllocate(gScreen->type, gCurrent_graf_data->dare_text_width, gCurrent_graf_data->dare_mugshot_height, 0, 0);
     BrPixelmapFill(the_map, 0);
-    TransBrPixelmapText(the_map, 0, 0, 1u, gBig_font, (signed char*)gOpponents[gChallenger_index__racestrt].abbrev_name);
+    TransBrPixelmapText(the_map, 0, 0, 1u, gBig_font, gOpponents[gChallenger_index__racestrt].abbrev_name);
     PathCat(the_path, gApplication_path, "DARES.TXT");
     f = DRfopen(the_path, "rt");
     if (!f) {
@@ -1667,7 +1667,7 @@ void ChallengeStart() {
     line_count = GetAnInt(f);
     for (i = 0; i < line_count; i++) {
         GetALineAndDontArgue(f, s);
-        TransBrPixelmapText(the_map, 0, 2 * (i + 1) * gBig_font->glyph_y, 0x86u, gBig_font, (signed char*)s);
+        TransBrPixelmapText(the_map, 0, 2 * (i + 1) * gBig_font->glyph_y, 0x86u, gBig_font, s);
     }
     fclose(f);
     BrPixelmapLine(the_map, 0, gBig_font->glyph_y + 2, the_map->width, gBig_font->glyph_y + 2, 45);

--- a/src/DETHRACE/common/world.c
+++ b/src/DETHRACE/common/world.c
@@ -305,17 +305,17 @@ int LoadNPixelmaps(tBrender_storage* pStorage_space, FILE* pF, int pCount) {
         PathCat(the_path, the_path, "PIXELMAP");
         PathCat(the_path, the_path, str);
         AllowOpenToFail();
-        total = DRPixelmapLoadMany(the_path, temp_array, 200);
-        if (!total) {
+        total = DRPixelmapLoadMany(the_path, temp_array, COUNT_OF(temp_array));
+        if (total == 0) {
             PathCat(the_path, gApplication_path, "PIXELMAP");
             PathCat(the_path, the_path, str);
             total = DRPixelmapLoadMany(the_path, temp_array, 200);
-            if (!total) {
+            if (total == 0) {
                 FatalError(79);
             }
         }
         for (j = 0; j < total; j++) {
-            if (temp_array[j]) {
+            if (temp_array[j] != NULL) {
                 switch (AddPixelmapToStorage(pStorage_space, (br_pixelmap**)temp_array[j])) {
                 case eStorage_not_enough_room:
                     FatalError(67);
@@ -2281,7 +2281,7 @@ void LoadTrack(char* pFile_name, tTrack_spec* pTrack_spec, tRace_info* pRace_inf
     PathCat(the_path, gApplication_path, "RACES");
     PathCat(the_path, the_path, pFile_name);
     f = DRfopen(the_path, "rt");
-    if (!f) {
+    if (f == NULL) {
         FatalError(50);
     }
     GetALineAndDontArgue(f, s);


### PR DESCRIPTION
Since we now/soon will have aggressive opponents, I guess it's time to be able to empty our account and buy APO.

![DUMP0000](https://user-images.githubusercontent.com/4138939/189020565-ee02d958-2cf9-4bdd-81d2-572016b13d4d.png)

![DUMP0001](https://user-images.githubusercontent.com/4138939/189020569-575c2494-1347-48ac-aa1b-494bd3c8a4f1.png)


- Implement `DoAutoParts` and `DoPartsShop` dialog
- Change last argument of `TransBrPixelmapText` from `signed char*` to `char*`.
  The latter makes more sense: `signed char` and `unsigned char` are types for numbers, char is for character data.
  Removing the `signed` makes it possible to remove a few casts.
- Replaced some conditional tests to test against the proper types (no functional change)