### PR TITLE
Fix IRandomBetween returning out-of-range numbers

### DIFF
--- a/src/DETHRACE/common/utility.c
+++ b/src/DETHRACE/common/utility.c
@@ -195,8 +195,14 @@ int IRandomBetween(int pA, int pB) {
     int num;
     char s[32];
 
-    num = (pB + 1 - pA) * (rand() / (double)RAND_MAX) + pA;
-    return num;
+    num = rand();
+#if RAND_MAX == 0x7fff
+//  If RAND_MAX == 0x7fff, then `num` can be seen as a fixed point number with 15 fractional and 17 integral bits
+    return pA + ((num * (pB + 1 - pA)) >> 15);
+#else
+//  If RAND_MAX != 0x7fff, then use floating numbers (alternative is using modulo)
+    return pA + (int)((pB + 1 - pA) * (num / ((float)RAND_MAX + 1)));
+#endif
 }
 
 // IDA: int __usercall PercentageChance@<EAX>(int pC@<EAX>)

--- a/test/DETHRACE/test_utility.c
+++ b/test/DETHRACE/test_utility.c
@@ -96,10 +96,36 @@ void test_utility_PathCat() {
 }
 
 void test_utility_IRandomBetween() {
-    tU32 source_y_delta;
+    int r;
+    int i;
+    int j;
+    int actual_min;
+    int actual_max;
+    struct {
+        int min;
+        int max;
+    } ranges[] = {
+        { -2, 1 },
+        { 1, -2 },
+        { 2, -1 },
+        { -1, 2 },
+        { 0, 3 },
+        { 3, 0 },
+        { 0, 10000 },
+        { 10000, 0 },
+    };
 
-    source_y_delta = ((66 << 16) / 67) - 0x10000;
-    printf("delta %x, %x\n", source_y_delta, source_y_delta >> 16);
+    for (i = 0; i < BR_ASIZE(ranges); i++) {
+        LOG_INFO("Testing min=%d max=%d", ranges[i].min, ranges[i].max);
+        actual_min = MIN(ranges[i].min, ranges[i].max);
+        actual_max = MAX(ranges[i].min, ranges[i].max);
+        for (j = 0; j < 1000; j++) {
+            r = IRandomBetween(ranges[i].min, ranges[i].max);
+
+            TEST_ASSERT_GREATER_OR_EQUAL(actual_min, r);
+            TEST_ASSERT_LESS_OR_EQUAL(actual_max, r);
+        }
+    }
 }
 
 void test_utility_suite() {


### PR DESCRIPTION
Fix `IRandomBetween` returning numbers outside of the requested range.

e.g.:
```python
>>> pA = -5
>>> pB = -1
>>> r = 30701
>>> (pB + 1 - pA) * (30701 / (0x7fff+1)) + pA
-0.315399169921875
>>> int(_)
0
```

This fixes a potential stack overflow:
```
S3GetDescriptorByID audio.c:1102
S3GetDescriptorByID audio.c:1102
S3GetDescriptorByID audio.c:1102
S3GetDescriptorByID audio.c:1102
S3GetDescriptorByID audio.c:1102
S3GetDescriptorByID audio.c:1102
S3GetDescriptorByID audio.c:1102
S3GetDescriptorByID audio.c:1102
S3GetDescriptorByID audio.c:1102
S3GetDescriptorByID audio.c:1102
S3GetDescriptorByID audio.c:1102
S3GetDescriptorByID audio.c:1102
S3StartSound3D 3d.c:408
DRS3StartSound3D sound.c:514
CrashNoise car.c:3059
CollCheck car.c:2817
CollideCarWithWall car.c:1328
MoveAndCollideNonCar car.c:1316
ApplyPhysicsToCars car.c:1184
MainGameLoop mainloop.c:556
DoRace mainloop.c:722
DoGame structur.c:538
DoProgram structur.c:645
GameMain main.c:105
original_main dossys.c:664
main main.c:32
```
Inside `CrashNoise`, `IRandomBetween` returned a number outside of the input range. Because of that, a buffer overflow happened while accessing a sounds array. The resulting wrong value (`0`) caused a stack overflow inside s3.