### PR TITLE
Fix signal handler for pie executables

### DIFF
--- a/.github/scripts/build-linux.sh
+++ b/.github/scripts/build-linux.sh
@@ -3,11 +3,16 @@ set -e
 
 if [ "${MATRIX_PLATFORM}" = "clang" ]
 then
-    CC=clang
-    CXX=clang++
+    export CC=clang
+    export CXX=clang++
 else
-    CC=gcc
-    CXX=g++
+    export CC=gcc
+    export CXX=g++
+
+    # Disable PIE such that addr2line is able to convert an address info file name and line number
+    export CFLAGS=-no-pie
+    export CXXFLAGS=-no-pie
+    export LDFLAGS=-no-pie
 fi
 
 # install deps

--- a/.github/scripts/build-linux.sh
+++ b/.github/scripts/build-linux.sh
@@ -8,11 +8,6 @@ then
 else
     export CC=gcc
     export CXX=g++
-
-    # Disable PIE such that addr2line is able to convert an address info file name and line number
-    export CFLAGS=-no-pie
-    export CXXFLAGS=-no-pie
-    export LDFLAGS=-no-pie
 fi
 
 # install deps


### PR DESCRIPTION
I noticed the stacktraces printed by our release only contained addresses and no file names + line numbers.
Running `file` on a released ELF and comparing with a locally built one gave the following:

**Release** -> "bad" stacktrace
```
dethrace: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=90bc4091d54dbbc6b6e890873a7988cf8d8172aa, for GNU/Linux 3.2.0, with debug_info, not stripped
```

**Local one** -> "good" stacktrace
```
dethrace: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=04916cbf9a5e87fb591ed2fe95a21262b2667566, for GNU/Linux 3.2.0, with debug_info, not stripped
```

Adding `-DCMAKE_C_FLAGS=-pie -DCMAKE_EXE_LINKER_FLAGS=-pie` to the cmake configuration then created an executable with "broken stacktrace".

~So this PR proposes to disable pie on CI.~

~An alternative could be to use a library, such as libbacktrace which has support for Windows.~

Using [`dl_iterate_phdr`](https://man7.org/linux/man-pages/man3/dl_iterate_phdr.3.html), it is possible to get the base address of the running process. By subtracting this base address from every address, it is possible to get an offset that `addr2line` can handle.

The function returns base address `0` for an executable with pie disabled.

