### PR TITLE
Add totally repair car

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -4450,7 +4450,15 @@ void ResetCarScreens() {
     int i;
     tCar_spec* the_car;
     LOG_TRACE("()");
-    STUB();
+
+    for (cat = eVehicle_self; cat < eVehicle_drone; cat++) {
+        car_count = (cat == eVehicle_self) ? 1 : GetCarCount(cat);
+        for (i = 0; i < car_count; i++) {
+            the_car = (cat == eVehicle_self) ? &gProgram_state.current_car : GetCarSpec(cat, i);
+            the_car->last_special_volume = NULL;
+        }
+    }
+    MungeCarGraphics(gFrame_period);
 }
 
 // IDA: tCar_spec* __cdecl GetRaceLeader()

--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -483,6 +483,7 @@ void TotallyRepairACar(tCar_spec* pCar) {
                 memcpy(the_car_actor->actor->model->vertices,
                     the_car_actor->undamaged_vertices,
                     the_car_actor->actor->model->nvertices * sizeof(br_vertex));
+                // FIXME: BrModelUpdate(..., BR_MODU_EDGES | BR_MODU_NORMALS) fails on TELL_ME_IF_WE_PASS_THIS_WAY
 //                BrModelUpdate(the_car_actor->actor->model, BR_MODU_EDGES | BR_MODU_NORMALS);
                 BrModelUpdate(the_car_actor->actor->model, BR_MODU_ALL);
                 if (pipe_vertex_count != 0 && IsActionReplayAvailable()) {

--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -949,5 +949,8 @@ void MungeForwardSky() {
 // IDA: void __cdecl MungeRearviewSky()
 void MungeRearviewSky() {
     LOG_TRACE("()");
-    STUB();
+
+    if (gSky_image_width != 0) {
+        MungeSkyModel(gRearview_camera, gRearview_sky_model);
+    }
 }


### PR DESCRIPTION
Car damage after a race was not repaired because `TotallyRepairCar` was not implemented.
This pr implements that function + 3 other functions of which a message was printed.

Fixes #184