### PR TITLE
Tidy up debug logging

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Calculate Variables
         id: vars
         run: |
-          echo "::set-output name=ref_name_without_v::$(echo ${GITHUB_REF_NAME} | cut -c2-20)"
+          echo "::set-output name=ref_name_without_v::$(echo ${GITHUB_REF_NAME} | cut -c2-)"
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v0.1.14

--- a/src/DETHRACE/common/errors.c
+++ b/src/DETHRACE/common/errors.c
@@ -241,12 +241,6 @@ void dr_dprintf(char* fmt_string, ...) {
     va_end(args);
     fputs("\n", gDiagnostic_file);
     fflush(gDiagnostic_file);
-
-    va_start(args, fmt_string);
-    printf("dr_dprintf: ");
-    vfprintf(stdout, fmt_string, args);
-    printf("\n");
-    va_end(args);
 }
 
 // IDA: int __usercall DoErrorInterface@<EAX>(int pMisc_text_index@<EAX>)

--- a/src/DETHRACE/common/errors.c
+++ b/src/DETHRACE/common/errors.c
@@ -2,6 +2,7 @@
 #include "cutscene.h"
 #include "globvars.h"
 #include "graphics.h"
+#include "harness/config.h"
 #include "harness/trace.h"
 #include "network.h"
 #include "pd/sys.h"
@@ -228,6 +229,10 @@ void dr_dprintf(char* fmt_string, ...) {
     static tU32 first_time = 0;
     va_list args;
     tU32 the_time;
+
+    if (harness_game_config.enable_diagnostics == 0) {
+        return;
+    }
 
     if (first_time == 0) {
         first_time = GetTotalTime();

--- a/src/DETHRACE/common/errors.c
+++ b/src/DETHRACE/common/errors.c
@@ -208,6 +208,10 @@ void NonFatalError(int pStr_index, ...) {
 void CloseDiagnostics() {
     LOG_TRACE("()");
 
+    if (harness_game_config.enable_diagnostics == 0) {
+        return;
+    }
+
     fclose(gDiagnostic_file);
 }
 
@@ -215,6 +219,10 @@ void CloseDiagnostics() {
 // This function is stripped from the retail binary, we've guessed at the implementation
 void OpenDiagnostics() {
     LOG_TRACE("()");
+
+    if (harness_game_config.enable_diagnostics == 0) {
+        return;
+    }
 
     gDiagnostic_file = fopen("DIAGNOST.TXT", "w");
 

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -585,13 +585,11 @@ void AdjustRenderScreenSize() {
         gRender_screen->base_y = gProgram_state.current_render_top;
         gRender_screen->height = gProgram_state.current_render_bottom - gProgram_state.current_render_top;
         gRender_screen->width = gProgram_state.current_render_right - gProgram_state.current_render_left;
-        LOG_DEBUG("renderscreen is %d %d, %d x %d", gRender_screen->base_x, gRender_screen->base_y, gRender_screen->width, gRender_screen->height);
     }
     if (gRender_screen->row_bytes == gRender_screen->width) {
         gRender_screen->flags |= BR_PMF_ROW_WHOLEPIXELS;
     } else {
         gRender_screen->flags &= ~BR_PMF_ROW_WHOLEPIXELS;
-        // TELL_ME_IF_WE_PASS_THIS_WAY();
     }
     gRender_screen->origin_x = gRender_screen->width / 2;
     gRender_screen->origin_y = gRender_screen->height / 2;

--- a/src/DETHRACE/common/intrface.c
+++ b/src/DETHRACE/common/intrface.c
@@ -58,7 +58,6 @@ void ResetInterfaceTimeout() {
 void ChangeSelection(tInterface_spec* pSpec, int* pOld_selection, int* pNew_selection, int pMode, int pSkip_disabled) {
     int i;
     LOG_TRACE("(%p, %p, %p, %d, %d)", pSpec, *pOld_selection, *pNew_selection, pMode, pSkip_disabled);
-    //    LOG_DEBUG("on entry: old: %p, new %p", pOld_selection, pNew_selection);
 
     if (ChoiceDisabled(*pNew_selection)) {
         if (!pSkip_disabled) {
@@ -103,7 +102,6 @@ void ChangeSelection(tInterface_spec* pSpec, int* pOld_selection, int* pNew_sele
         }
         *pOld_selection = *pNew_selection;
     }
-    LOG_DEBUG("new: %d, old %d, new mode %d", *pNew_selection, *pOld_selection, pMode);
 }
 
 // IDA: void __usercall RecopyAreas(tInterface_spec *pSpec@<EAX>, br_pixelmap **pCopy_areas@<EDX>)
@@ -481,7 +479,6 @@ int DoInterfaceScreen(tInterface_spec* pSpec, int pOptions, int pCurrent_choice)
         }
     } while ((pSpec->exit_proc == NULL || !(pSpec->exit_proc)(&gCurrent_choice, &gCurrent_mode)) && !go_ahead && !timed_out && !escaped);
 
-    LOG_WARN("OUT OF LOOP %d %d %d", go_ahead, timed_out, escaped);
     gTyping = 0;
     if (pSpec->font_needed) {
         EndRollingLetters();

--- a/src/DETHRACE/common/loading.c
+++ b/src/DETHRACE/common/loading.c
@@ -3293,8 +3293,6 @@ int GetCDPathFromPathsTxtFile(char* pPath_name) {
 
 // IDA: int __cdecl TestForOriginalCarmaCDinDrive()
 int TestForOriginalCarmaCDinDrive() {
-    LOG_TRACE("()");
-
     // The symbol dump didn't include any local variable information.
     // These names are not necessarily the original names.
     tPath_name cd_pathname;
@@ -3303,6 +3301,7 @@ int TestForOriginalCarmaCDinDrive() {
     FILE* paths_txt_fp;
     tPath_name paths_txt;
     int paths_txt_first_char;
+    LOG_TRACE("()");
 
     if (harness_game_config.enable_cd_check == 0) {
         return 1;

--- a/src/DETHRACE/common/loading.c
+++ b/src/DETHRACE/common/loading.c
@@ -3295,7 +3295,7 @@ int GetCDPathFromPathsTxtFile(char* pPath_name) {
 int TestForOriginalCarmaCDinDrive() {
     LOG_TRACE("()");
 
-    // Jeff: the symbol dump didn't include any local variable information.
+    // The symbol dump didn't include any local variable information.
     // These names are not necessarily the original names.
     tPath_name cd_pathname;
     tPath_name cd_data_pathname;
@@ -3304,8 +3304,7 @@ int TestForOriginalCarmaCDinDrive() {
     tPath_name paths_txt;
     int paths_txt_first_char;
 
-    // Jeff: Added to optionally bypass this check
-    if (harness_game_config.disable_cd_check) {
+    if (harness_game_config.enable_cd_check == 0) {
         return 1;
     }
 

--- a/src/DETHRACE/common/opponent.c
+++ b/src/DETHRACE/common/opponent.c
@@ -568,7 +568,6 @@ int SearchForSection(tRoute_section* pTemp_store, tRoute_section* pPerm_store, i
                 memcpy(pPerm_store, pTemp_store, sizeof(tRoute_section) * *pNum_of_perm_store_sections);
                 // dword_530DD4 = ++routes_found
                 routes_found++;
-                LOG_DEBUG("found route");
                 if (routes_found >= 2) {
                     return 1;
                 }

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -179,7 +179,7 @@ void Harness_Init(int* argc, char* argv[]) {
     LOG_INFO("version: " DETHRACE_VERSION);
 
     // disable the original CD check code
-    harness_game_config.disable_cd_check = 1;
+    harness_game_config.enable_cd_check = 0;
     // original physics time step. Lower values seem to work better at 30+ fps
     harness_game_config.physics_step_time = 40;
     // do not limit fps by default
@@ -188,6 +188,8 @@ void Harness_Init(int* argc, char* argv[]) {
     harness_game_config.freeze_timer = 0;
     // default demo time out is 240s
     harness_game_config.demo_timeout = 240000;
+    // disable developer diagnostics by default
+    harness_game_config.enable_diagnostics = 0;
 
     // install signal handler by default
     harness_game_config.install_signalhandler = 1;
@@ -233,7 +235,7 @@ int Harness_ProcessCommandLine(int* argc, char* argv[]) {
         int handled = 0;
 
         if (strcasecmp(argv[i], "--cdcheck") == 0) {
-            harness_game_config.disable_cd_check = 0;
+            harness_game_config.enable_cd_check = 1;
             handled = 1;
         } else if (strstr(argv[i], "--debug=") != NULL) {
             char* s = strstr(argv[i], "=");
@@ -265,6 +267,9 @@ int Harness_ProcessCommandLine(int* argc, char* argv[]) {
             handled = 1;
         } else if (strcasecmp(argv[i], "--i-am-cheating") == 0) {
             gI_am_cheating = 0xa11ee75d;
+            handled = 1;
+        } else if (strcasecmp(argv[i], "--enable-diagnostics") == 0) {
+            harness_game_config.enable_diagnostics = 1;
             handled = 1;
         }
 

--- a/src/harness/include/harness/config.h
+++ b/src/harness/include/harness/config.h
@@ -23,18 +23,19 @@ typedef struct tHarness_game_info {
         // different between demo and full game
         char* GERMAN_LOADSCRN;
         // built-in keyboard look-up table for certain localized Carmageddon releases
-        int *ascii_table;
+        int* ascii_table;
         // built-in shifted keyboard look-up table for certain localized Carmageddon releases
-        int *ascii_shift_table;
+        int* ascii_shift_table;
     } defines;
 } tHarness_game_info;
 
 typedef struct tHarness_game_config {
-    int disable_cd_check;
+    int enable_cd_check;
     float physics_step_time;
     float fps;
     int freeze_timer;
     unsigned demo_timeout;
+    int enable_diagnostics;
 
     int install_signalhandler;
 } tHarness_game_config;

--- a/src/harness/include/harness/trace.h
+++ b/src/harness/include/harness/trace.h
@@ -37,7 +37,7 @@ void debug_print_matrix4(const char* fmt, const char* fn, char* name, br_matrix4
 #define LOG_VEC(msg, v) debug_print_vector3("\033[0;34m[DEBUG] %s ", __FUNCTION__, msg, v)
 #define LOG_MATRIX(msg, m) debug_print_matrix34("\033[0;34m[DEBUG] %s ", __FUNCTION__, msg, m)
 #define LOG_MATRIX4(msg, m) debug_print_matrix4("\033[0;34m[DEBUG] %s ", __FUNCTION__, msg, m)
-#define LOG_INFO(...) debug_printf("\033[0;34m[INFO] %s ", __FUNCTION__, __VA_ARGS__)
+#define LOG_INFO(...) debug_printf("[INFO] %s ", __FUNCTION__, __VA_ARGS__)
 #define LOG_WARN(...) debug_printf("\033[0;33m[WARN] %s ", __FUNCTION__, __VA_ARGS__)
 #define LOG_PANIC(...)                                                    \
     do {                                                                  \

--- a/src/harness/renderers/gl/gl_renderer.c
+++ b/src/harness/renderers/gl/gl_renderer.c
@@ -201,6 +201,11 @@ void GLRenderer_Init(int width, int height, int pRender_width, int pRender_heigh
     render_height = pRender_height;
     update_viewport();
 
+    LOG_INFO("OpenGL vendor string: %s", glGetString(GL_VENDOR));
+    LOG_INFO("OpenGL renderer string: %s", glGetString(GL_RENDERER));
+    LOG_INFO("OpenGL version string: %s", glGetString(GL_VERSION));
+    LOG_INFO("OpenGL shading language version string: %s", glGetString(GL_SHADING_LANGUAGE_VERSION));
+
     int maxTextureImageUnits;
     glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &maxTextureImageUnits);
     if (maxTextureImageUnits < 3) {
@@ -671,7 +676,7 @@ void GLRenderer_SetWindowSize(int width, int height) {
     update_viewport();
 }
 
-void GLRenderer_GetViewport(int* x, int* y, int* width, int* height)  {
+void GLRenderer_GetViewport(int* x, int* y, int* width, int* height) {
     *x = vp_x;
     *y = vp_y;
     *width = vp_width;


### PR DESCRIPTION
- disable diagnostics by default (`--enable-diagnostics` command line parameter to enable)
- print OpenGL information strings 
- remove random debug log lines that are not longer useful