### PR TITLE
Original "high resolution" support

### DIFF
--- a/src/BRSRC13/CORE/DOSIO/dosio.c
+++ b/src/BRSRC13/CORE/DOSIO/dosio.c
@@ -7,6 +7,5 @@
 br_pixelmap* DOSGfxBegin(char* setup_string) {
     LOG_TRACE("(\"%s\")", setup_string);
 
-    Harness_Hook_DOSGfxBegin();
     return BrPixelmapAllocate(BR_PMT_INDEX_8, 320, 200, NULL, BR_PMAF_NORMAL);
 }

--- a/src/DETHRACE/common/globvars.c
+++ b/src/DETHRACE/common/globvars.c
@@ -3,7 +3,7 @@
 
 int gTyping;
 int gArrow_mode;
-int gInfo_on;
+int gInfo_on = 1;
 int gHost_abandon_game;
 int gRecover_car;
 int gDisallow_abandon_race;

--- a/src/DETHRACE/common/globvars.c
+++ b/src/DETHRACE/common/globvars.c
@@ -3,7 +3,7 @@
 
 int gTyping;
 int gArrow_mode;
-int gInfo_on = 1;
+int gInfo_on;
 int gHost_abandon_game;
 int gRecover_car;
 int gDisallow_abandon_race;

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -1504,7 +1504,6 @@ void RenderAFrame(int pDepth_mask_on) {
         gBack_screen->base_y = 0;
         if (gCurrent_race.map_image != NULL) {
             if (gReal_graf_data_index) {
-                LOG_DEBUG("DOUBLING");
                 BrPixelmapRectangleFill(gBack_screen, 0, 0, 640, 40, 0);
                 BrPixelmapRectangleFill(gBack_screen, 0, 440, 640, 40, 0);
                 DRPixelmapDoubledCopy(

--- a/src/DETHRACE/pc-dos/dossys.c
+++ b/src/DETHRACE/pc-dos/dossys.c
@@ -354,7 +354,19 @@ void PDAllocateScreenAndBack() {
     BrTableFindHook(PDMissingTable);
     BrModelFindHook(PDMissingModel);
     BrMapFindHook(PDMissingMap);
-    gScreen = DOSGfxBegin(gGraf_specs[gGraf_spec_index].gfx_init_string);
+
+    // This is a bit of a mix between the original DOS code and windows code...
+    // DOS:
+    // gScreen = DOSGfxBegin(gGraf_specs[gGraf_spec_index].gfx_init_string);
+    //
+    // Windows:
+    // SSDXInit(gGraf_specs[gGraf_spec_index].total_width, gGraf_specs[gGraf_spec_index].total_height)
+    // gScreen = BrPixelmapAllocate(BR_PMT_INDEX_8, ...)
+    //
+
+    Harness_Hook_GraphicsInit(gGraf_specs[gGraf_spec_index].total_width, gGraf_specs[gGraf_spec_index].total_height);
+    gScreen = BrPixelmapAllocate(BR_PMT_INDEX_8, gGraf_specs[gGraf_spec_index].total_width, gGraf_specs[gGraf_spec_index].total_height, NULL, BR_PMAF_NORMAL);
+
     gScreen->origin_x = 0;
     gDOSGfx_initialized = 1;
     gScreen->origin_y = 0;
@@ -518,13 +530,13 @@ void PDSetPaletteEntries(br_pixelmap* pPalette, int pFirst_colour, int pCount) {
 // IDA: void __cdecl PDSwitchToRealResolution()
 void PDSwitchToRealResolution() {
     LOG_TRACE("()");
-    NOT_IMPLEMENTED();
+    // NOT_IMPLEMENTED();
 }
 
 // IDA: void __cdecl PDSwitchToLoresMode()
 void PDSwitchToLoresMode() {
     LOG_TRACE("()");
-    NOT_IMPLEMENTED();
+    // NOT_IMPLEMENTED();
 }
 
 // IDA: void __usercall PDMouseButtons(int *pButton_1@<EAX>, int *pButton_2@<EDX>)

--- a/src/DETHRACE/pc-dos/dossys.c
+++ b/src/DETHRACE/pc-dos/dossys.c
@@ -530,13 +530,11 @@ void PDSetPaletteEntries(br_pixelmap* pPalette, int pFirst_colour, int pCount) {
 // IDA: void __cdecl PDSwitchToRealResolution()
 void PDSwitchToRealResolution() {
     LOG_TRACE("()");
-    // NOT_IMPLEMENTED();
 }
 
 // IDA: void __cdecl PDSwitchToLoresMode()
 void PDSwitchToLoresMode() {
     LOG_TRACE("()");
-    // NOT_IMPLEMENTED();
 }
 
 // IDA: void __usercall PDMouseButtons(int *pButton_1@<EAX>, int *pButton_2@<EDX>)

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -286,16 +286,24 @@ int Harness_ProcessCommandLine(int* argc, char* argv[]) {
     return 0;
 }
 
-void Harness_Hook_DOSGfxBegin() {
+void Harness_Hook_GraphicsInit(int render_width, int render_height) {
+    int window_width, window_height;
     if (force_nullrenderer) {
         return;
     }
-    renderer = Window_Create("Dethrace", 640, 400, 320, 200);
+    if (render_width == 320) {
+        window_width = render_width * 2;
+        window_height = render_height * 2;
+    } else {
+        window_width = render_width;
+        window_height = render_height;
+    }
+    renderer = Window_Create("Dethrace", window_width, window_height, render_width, render_height);
 }
 
 // Render 2d back buffer
 void Harness_RenderScreen(br_pixelmap* dst, br_pixelmap* src) {
-    renderer->FullScreenQuad((uint8_t*)src->pixels, 320, 200);
+    renderer->FullScreenQuad((uint8_t*)src->pixels);
 
     last_dst = dst;
     last_src = src;

--- a/src/harness/include/harness/hooks.h
+++ b/src/harness/include/harness/hooks.h
@@ -15,9 +15,9 @@ void Harness_Hook_PDServiceSystem();
 void Harness_Hook_PDSetKeyArray();
 // void Harness_Hook_MainGameLoop(); // limit FPS
 void Harness_Hook_FlushRenderer(); // synchronize in-memory framebuffer and depthbuffer
+void Harness_Hook_GraphicsInit(int render_width, int render_height);
 
 // BRender hooks
-void Harness_Hook_DOSGfxBegin();
 void Harness_Hook_BrDevPaletteSetOld(br_pixelmap* pm);
 void Harness_Hook_BrDevPaletteSetEntryOld(int i, br_colour colour);
 void Harness_Hook_BrPixelmapDoubleBuffer(br_pixelmap* dst, br_pixelmap* src);

--- a/src/harness/io_platforms/sdl_gl.c
+++ b/src/harness/io_platforms/sdl_gl.c
@@ -175,7 +175,7 @@ tRenderer* Window_Create(char* title, int width, int height, int pRender_width, 
     sdl_window_scale.x = ((float)pRender_width) / width;
     sdl_window_scale.y = ((float)pRender_height) / height;
 
-    // SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN);
+    SDL_ShowCursor(SDL_DISABLE);
 
     context = SDL_GL_CreateContext(window);
     if (!context) {

--- a/src/harness/renderers/gl/gl_renderer.c
+++ b/src/harness/renderers/gl/gl_renderer.c
@@ -360,7 +360,7 @@ void GLRenderer_EndScene() {
     CHECK_GL_ERROR("GLRenderer_RenderFullScreenQuad");
 }
 
-void GLRenderer_FullScreenQuad(uint8_t* screen_buffer, int width, int height) {
+void GLRenderer_FullScreenQuad(uint8_t* screen_buffer) {
     glViewport(vp_x, vp_y, vp_width, vp_height);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glDisable(GL_DEPTH_TEST);
@@ -370,7 +370,7 @@ void GLRenderer_FullScreenQuad(uint8_t* screen_buffer, int width, int height) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_R8UI, width, height, 0, GL_RED_INTEGER, GL_UNSIGNED_BYTE, screen_buffer);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_R8UI, render_width, render_height, 0, GL_RED_INTEGER, GL_UNSIGNED_BYTE, screen_buffer);
     glBindVertexArray(screen_buffer_vao);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, screen_buffer_ebo);
     glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);

--- a/src/harness/renderers/gl/gl_renderer.h
+++ b/src/harness/renderers/gl/gl_renderer.h
@@ -3,41 +3,49 @@
 
 #include "harness.h"
 
-
-#define CHECK_GL_ERROR(msg)                                         \
-    {                                                               \
-        GLenum e = glGetError();                                    \
-        if (e != GL_NO_ERROR) {                                     \
-            const char *err;                                        \
-            switch (e) {                                            \
-            case GL_NO_ERROR:                                       \
-                err = "GL_NO_ERROR"; break;                         \
-            case GL_INVALID_ENUM:                                   \
-                err = "GL_INVALID_ENUM"; break;                     \
-            case GL_INVALID_VALUE:                                  \
-                err = "GL_INVALID_VALUE"; break;                    \
-            case GL_INVALID_OPERATION:                              \
-                err = "GL_INVALID_OPERATION"; break;                \
-            case GL_INVALID_FRAMEBUFFER_OPERATION:                  \
-                err = "GL_INVALID_FRAMEBUFFER_OPERATION"; break;    \
-            case GL_OUT_OF_MEMORY:                                  \
-                err = "GL_OUT_OF_MEMORY"; break;                    \
-            case GL_STACK_UNDERFLOW:                                \
-                err = "GL_STACK_UNDERFLOW"; break;                  \
-            case GL_STACK_OVERFLOW:                                 \
-                err = "GL_STACK_OVERFLOW"; break;                   \
-            default:                                                \
-                err = "unknown"; break;                             \
-            }                                                       \
-            LOG_PANIC("glError %d (%s): %s", e, err, msg);          \
-        }                                                           \
+#define CHECK_GL_ERROR(msg)                                \
+    {                                                      \
+        GLenum e = glGetError();                           \
+        if (e != GL_NO_ERROR) {                            \
+            const char* err;                               \
+            switch (e) {                                   \
+            case GL_NO_ERROR:                              \
+                err = "GL_NO_ERROR";                       \
+                break;                                     \
+            case GL_INVALID_ENUM:                          \
+                err = "GL_INVALID_ENUM";                   \
+                break;                                     \
+            case GL_INVALID_VALUE:                         \
+                err = "GL_INVALID_VALUE";                  \
+                break;                                     \
+            case GL_INVALID_OPERATION:                     \
+                err = "GL_INVALID_OPERATION";              \
+                break;                                     \
+            case GL_INVALID_FRAMEBUFFER_OPERATION:         \
+                err = "GL_INVALID_FRAMEBUFFER_OPERATION";  \
+                break;                                     \
+            case GL_OUT_OF_MEMORY:                         \
+                err = "GL_OUT_OF_MEMORY";                  \
+                break;                                     \
+            case GL_STACK_UNDERFLOW:                       \
+                err = "GL_STACK_UNDERFLOW";                \
+                break;                                     \
+            case GL_STACK_OVERFLOW:                        \
+                err = "GL_STACK_OVERFLOW";                 \
+                break;                                     \
+            default:                                       \
+                err = "unknown";                           \
+                break;                                     \
+            }                                              \
+            LOG_PANIC("glError %d (%s): %s", e, err, msg); \
+        }                                                  \
     }
 
 void GLRenderer_Init(int width, int height, int render_width, int render_height);
 void GLRenderer_SetPalette(uint8_t* rgba_colors);
 void GLRenderer_BeginScene(br_actor* camera, br_pixelmap* colour_buffer);
 void GLRenderer_EndScene();
-void GLRenderer_FullScreenQuad(uint8_t* screen_buffer, int width, int height);
+void GLRenderer_FullScreenQuad(uint8_t* screen_buffer);
 void GLRenderer_Model(br_actor* actor, br_model* model, br_matrix34 model_matrix);
 void GLRenderer_BufferTexture(br_pixelmap* pm);
 void GLRenderer_BufferMaterial(br_material* mat);

--- a/src/harness/renderers/null.h
+++ b/src/harness/renderers/null.h
@@ -4,7 +4,7 @@ void Null_Init() {}
 void Null_BeginFrame(br_actor* camera, br_pixelmap* colour_buffer) {}
 void Null_EndFrame() {}
 void Null_SetPalette(uint8_t* palette) {}
-void Null_RenderFullScreenQuad(uint8_t* src, int width, int height) {}
+void Null_RenderFullScreenQuad(uint8_t* src) {}
 void Null_RenderModel(br_actor* actor, br_model* model, br_matrix34 model_matrix) {}
 void Null_RenderFrameBuffer() {}
 void Null_ClearBuffers() {}
@@ -12,10 +12,21 @@ void Null_BufferTexture(br_pixelmap* pm) {}
 void Null_BufferMaterial(br_material* mat) {}
 void Null_BufferModel(br_model* model) {}
 void Null_FlushBuffers(br_pixelmap* color_buffer, br_pixelmap* depth_buffer) {}
-void Null_GetRenderSize(int* width, int* height) { *width = 640; *height = 480; }
-void Null_GetWindowSize(int* width, int* height) { *width = 640; *height = 480; }
+void Null_GetRenderSize(int* width, int* height) {
+    *width = 640;
+    *height = 480;
+}
+void Null_GetWindowSize(int* width, int* height) {
+    *width = 640;
+    *height = 480;
+}
 void Null_SetWindowSize(int width, int height) {}
-void Null_GetViewportSize(int* x, int* y, int* width, int* height) { *x = 0; *y = 0; *width = 640; *height = 480; }
+void Null_GetViewportSize(int* x, int* y, int* width, int* height) {
+    *x = 0;
+    *y = 0;
+    *width = 640;
+    *height = 480;
+}
 
 tRenderer null_renderer = {
     Null_Init,

--- a/src/harness/renderers/renderer.h
+++ b/src/harness/renderers/renderer.h
@@ -8,7 +8,7 @@ typedef struct tRenderer {
     void (*BeginScene)(br_actor* camera, br_pixelmap* colour_buffer);
     void (*EndScene)();
     void (*SetPalette)(uint8_t* palette);
-    void (*FullScreenQuad)(uint8_t* src, int width, int height);
+    void (*FullScreenQuad)(uint8_t* src);
     void (*Model)(br_actor* actor, br_model* model, br_matrix34 model_matrix);
     void (*ClearBuffers)();
     void (*BufferTexture)(br_pixelmap* pm);


### PR DESCRIPTION
Implements support for `-hires` command line arg rendering at 640x480 and using more detailed pixmaps from the `64x48x8` directory.

Fixes #159 

<img width="752" alt="Screen Shot 2022-10-19 at 9 47 02 AM" src="https://user-images.githubusercontent.com/78985374/196545017-217f2cb1-439f-4853-b163-09cdd79ae698.png">
