### PR TITLE
Fix of 3 little issues found with the undefined behavior sanitizer

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -991,11 +991,11 @@ void DoDamageScreen(tU32 pThe_time) {
         if (gProgram_state.which_view != eView_forward) {
             return;
         }
-        the_wobble_y = gScreen_wobble_x;
-        the_wobble_x = gScreen_wobble_y;
+        the_wobble_x = gScreen_wobble_x;
+        the_wobble_y = gScreen_wobble_y;
     } else {
-        the_wobble_y = gProgram_state.current_car.damage_x_offset;
-        the_wobble_x = gProgram_state.current_car.damage_y_offset;
+        the_wobble_x = gProgram_state.current_car.damage_x_offset;
+        the_wobble_y = gProgram_state.current_car.damage_y_offset;
         if (gProgram_state.current_car.damage_background) {
             DRPixelmapRectangleMaskedCopy(
                 gBack_screen,
@@ -1010,17 +1010,17 @@ void DoDamageScreen(tU32 pThe_time) {
     }
     for (i = 0; i < COUNT_OF(gProgram_state.current_car.damage_units); i++) {
         the_damage = &gProgram_state.current_car.damage_units[i];
-        if (i != 2) {
+        if (i != eDamage_driver) {
             the_image = the_damage->images;
             the_step = 5 * the_damage->damage_level / 100;
             y_pitch = (the_image->height / 2) / 5;
             DRPixelmapRectangleMaskedCopy(
                 gBack_screen,
-                the_wobble_y + gProgram_state.current_car.damage_units[i].x_coord,
-                the_wobble_x + gProgram_state.current_car.damage_units[i].y_coord,
+                the_wobble_x + gProgram_state.current_car.damage_units[i].x_coord,
+                the_wobble_y + gProgram_state.current_car.damage_units[i].y_coord,
                 the_image,
                 0,
-                y_pitch * (2 * (5 * the_damage->damage_level / 100) + ((pThe_time / the_damage->periods[5 * the_damage->damage_level / 100]) & 1)),
+                y_pitch * (2 * the_step + ((pThe_time / the_damage->periods[5 * the_damage->damage_level / 100]) & 1)),
                 the_image->width,
                 y_pitch);
         }

--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -498,6 +498,9 @@ void DoHeadups(tU32 pThe_time) {
                                     (((1500 - time_factor) * the_headup->data.fancy_info.shear_amount / 500) << 16)
                                         / the_headup->data.image_info.image->height);
                             } else {
+#if DETHRACE_FIX_BUGS
+                                time_factor = MAX(time_factor, 0);
+#endif
                                 DRPixelmapRectangleShearedCopy(
                                     gBack_screen,
                                     the_headup->x - the_headup->data.fancy_info.shear_amount * (time_factor - 500) / 500,

--- a/src/DETHRACE/common/opponent.c
+++ b/src/DETHRACE/common/opponent.c
@@ -2336,7 +2336,7 @@ void MungeOpponents(tU32 pFrame_period) {
             }
         }
         for (i = 0; i < gNumber_of_cops_before_faffage; i++) {
-            if (!gProgram_state.AI_vehicles.opponents[i].finished_for_this_race) {
+            if (!gProgram_state.AI_vehicles.cops[i].finished_for_this_race) {
                 if (un_stun_flag) {
                     UnStunTheBugger(&gProgram_state.AI_vehicles.cops[i]);
                 }

--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -1818,16 +1818,14 @@ void DrawGrid(int pOffset, int pDraw_it) {
                     45);
             }
         }
-        if (gCurrent_race.opponent_list[i].index >= 0) {
-            if (gCurrent_race.opponent_list[i].ranking >= gProgram_state.rank) {
-                if (str_index >= 2) {
-                    str_index = 3;
-                } else {
-                    str_index = 1;
-                }
-            }
-        } else {
+        if (gCurrent_race.opponent_list[i].index < 0) {
             str_index = 2;
+        } else if (gProgram_state.rank <= gCurrent_race.opponent_list[i].ranking) {
+            if (str_index >= 2) {
+                str_index = 3;
+            } else {
+                str_index = 1;
+            }
         }
         if (gCurrent_race.opponent_list[i].index >= 0) {
             if (gOpponents[gCurrent_race.opponent_list[i].index].car_number <= 0
@@ -1842,7 +1840,7 @@ void DrawGrid(int pOffset, int pDraw_it) {
                     gOpponents[gCurrent_race.opponent_list[i].index].car_number);
             }
         } else {
-            if (gProgram_state.frank_or_anniness) {
+            if (gProgram_state.frank_or_anniness == eAnnie) {
                 sprintf(&numbers_str[str_index][strlen(numbers_str[str_index])], "%c ", '<');
             } else {
                 sprintf(&numbers_str[str_index][strlen(numbers_str[str_index])], "%c ", ';');
@@ -1861,12 +1859,12 @@ void DrawGrid(int pOffset, int pDraw_it) {
     }
     if (gDraw_grid_status == eGrid_draw_all) {
         if (strlen(numbers_str[3])) {
-            numbers_str[2][strlen(numbers_str[3]) + 99] = 0;
+            numbers_str[3][strlen(numbers_str[3]) - 1] = '\0';
         } else {
-            numbers_str[1][strlen(numbers_str[2]) + 99] = 0;
+            numbers_str[2][strlen(numbers_str[2]) - 1] = '\0';
         }
-        strcpy(total_str, (const char*)numbers_str);
-        for (i = 1; i <= 3; i++) {
+        strcpy(total_str, numbers_str[0]);
+        for (i = 1; i < COUNT_OF(numbers_str); i++) {
             strcat(total_str, numbers_str[i]);
         }
         str_x = (gCurrent_graf_data->grid_numbers_left + gCurrent_graf_data->grid_numbers_right) / 2
@@ -1894,7 +1892,7 @@ void DrawGrid(int pOffset, int pDraw_it) {
         for (i = gCurrent_race.number_of_racers - 1; i > 0; i--) {
             for (j = strlen(total_str) - 2; j >= 0; j--) {
                 if (total_str[j] == ' ') {
-                    total_str[j + 1] = 0;
+                    total_str[j + 1] = '\0';
                     break;
                 }
             }


### PR DESCRIPTION
- Avoid negative arguments to `DRPixelmapRectangleShearedCopy` in `DoHeadups`
- Wrong end of loop condition in `MungeOpponents`
- Avoid writing out of bounds in `DrawGrid`