### PR TITLE
Re-enables back face culling

### DIFF
--- a/src/harness/renderers/gl/gl_renderer.c
+++ b/src/harness/renderers/gl/gl_renderer.c
@@ -215,13 +215,13 @@ void GLRenderer_Init(int width, int height, int pRender_width, int pRender_heigh
     LoadShaders();
     SetupFullScreenRectGeometry();
 
-    // opengl config
+    // config
     glDisable(GL_BLEND);
-    // glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glDepthFunc(GL_LESS);
     glClearColor(0, 0, 0, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT);
-    glDisable(GL_CULL_FACE);
+    glEnable(GL_CULL_FACE);
+    glCullFace(GL_BACK);
 
     // textures
     glGenTextures(1, &screen_texture);


### PR DESCRIPTION
The cause of #187 is weird track geometry where two back-facing triangles with no texture are laid on top of two front-facing textured triangles. The OG game culls the back-facing triangle, so it is not visible in game. (Ref: https://twitter.com/toshiba_3/status/1584152161386389504?s=20&t=g1bQ8KAAtKvn2zy1Qw6PUw)

![image](https://user-images.githubusercontent.com/78985374/198009405-c8839f03-5b34-4693-9286-eaee00781231.png)


As we are not culling, we render the back facing triangles, which causes the appearance of a missing texture in that part of the track!

We originally removed culling because it caused sides of streetlight poles to be invisible when viewed from the rear. Since then, we fixed/implemented `RemoveDoubleSided` which causes every face with a `BR_MATF_TWO_SIDED` material to be duplicated and faced backwards. We can now cull back faces without any apparent graphical issues.

Fixes: #187 