### PR TITLE
Splatpack x-mas demo executes ToggleArrow when the race finished

### DIFF
--- a/src/DETHRACE/common/mainloop.c
+++ b/src/DETHRACE/common/mainloop.c
@@ -664,6 +664,10 @@ tRace_result MainGameLoop() {
     if (gAction_replay_mode) {
         ToggleReplay();
     }
+    // From splatpack x-mas demo
+    if (gArrow_mode) {
+        ToggleArrow();
+    }
 
     if (gHost_abandon_game) {
         result = eRace_game_abandonned;


### PR DESCRIPTION
Disable the arrow at the end of the race.