### PR TITLE
Fix sounds

### DIFF
--- a/src/S3/3d.c
+++ b/src/S3/3d.c
@@ -517,12 +517,10 @@ int S3Calculate3D(tS3_channel* chan, int pIs_ambient) {
     }
     if (pIs_ambient) {
         v11 = 1.0f - ((chan->position.z - gS3_listener_position_now.z) * (chan->velocity.z - gS3_listener_vel_now.z) + (chan->velocity.y - gS3_listener_vel_now.y) * (chan->position.y - gS3_listener_position_now.y) + (chan->position.x - gS3_listener_position_now.x) * (chan->velocity.x - gS3_listener_vel_now.x)) / dist / flt_531D98;
-        if (v11 <= 2.0f) {
-            if (v11 < 0.5f) {
-                v11 = 0.5f;
-            }
-        } else {
+        if (v11 > 2.0f) {
             v11 = 2.0f;
+        } else if (v11 < 0.5f) {
+            v11 = 0.5;
         }
         chan->rate = chan->initial_pitch * v11;
     } else {

--- a/src/S3/audio.c
+++ b/src/S3/audio.c
@@ -710,11 +710,11 @@ void S3Service(int inside_cockpit, int unk1) {
             } else if (c->spatial_sound && c->active) {
                 if (S3UpdateSpatialSound(c)) {
                     if (c->sound_source_ptr && c->sound_source_ptr->ambient && !S3SoundStillPlaying(c->tag)) {
-                        // TODO: S3UpdateSound(0, -1, c->sound_source_ptr, -1.0, -1, -1, 0, -1, -1);
+                        S3UpdateSoundSource(NULL, -1, c->sound_source_ptr, -1.0f, -1, -1, 0, -1, -1);
                     }
                 } else if (c->sound_source_ptr) {
                     if (c->sound_source_ptr->ambient) {
-                        // TODO: S3UpdateSound(0, -1, c->sound_source_ptr, -1.0, -1, -1, 0, -1, -1);
+                        S3UpdateSoundSource(NULL, -1, c->sound_source_ptr, -1.0f, -1, -1, 0, -1, -1);
                     }
                 } else {
                     S3StopChannel(c);

--- a/src/S3/s3sound.c
+++ b/src/S3/s3sound.c
@@ -1,5 +1,6 @@
 #include "s3sound.h"
 #include "audio.h"
+#include "harness/config.h"
 #include "miniaudio/miniaudio.h"
 #include "resource.h"
 #include <stdio.h>
@@ -15,33 +16,20 @@ tS3_sample_filter* gS3_sample_filter_disable_func;
 ma_engine engine;
 
 int S3OpenSampleDevice() {
-
     ma_result result;
 
     ma_engine_config engineConfig;
     engineConfig = ma_engine_config_init();
-
     engineConfig.sampleRate = 22050;
+
     result = ma_engine_init(&engineConfig, &engine);
     if (result != MA_SUCCESS) {
         printf("Failed to initialize audio engine.");
         return 0;
     }
 
-    ma_engine_set_volume(&engine, 0.5f);
+    ma_engine_set_volume(&engine, harness_game_config.volume_multiplier);
 
-    // if (Mix_OpenAudio(22050, MIX_DEFAULT_FORMAT, 2, 1024) == -1) {
-    //     return 0;
-    // }
-
-    // Mix_AllocateChannels(20);
-
-    // if (DirectSoundCreate(0, &gS3_direct_sound_ptr, 0)) {
-    //     return 0;
-    // }
-    // if (gS3_direct_sound_ptr->lpVtbl->SetCooperativeLevel(gS3_direct_sound_ptr, hWnd, 3)) {
-    //     return 0;
-    // }
     S3Enable();
     return 1;
 }

--- a/src/S3/s3sound.c
+++ b/src/S3/s3sound.c
@@ -20,14 +20,15 @@ int S3OpenSampleDevice() {
 
     ma_engine_config engineConfig;
     engineConfig = ma_engine_config_init();
-    // engineConfig.sampleRate = 22050;
+
+    engineConfig.sampleRate = 22050;
     result = ma_engine_init(&engineConfig, &engine);
     if (result != MA_SUCCESS) {
         printf("Failed to initialize audio engine.");
         return 0;
     }
 
-    // ma_engine_set_volume(&engine, 0.5f);
+    ma_engine_set_volume(&engine, 0.5f);
 
     // if (Mix_OpenAudio(22050, MIX_DEFAULT_FORMAT, 2, 1024) == -1) {
     //     return 0;
@@ -311,6 +312,7 @@ int S3SyncSampleVolume(tS3_channel* chan) {
 
     int volume_db;
     int pan;
+    float linear_volume;
 
     if (chan->type != eS3_ST_sample) {
         return 1;
@@ -325,14 +327,10 @@ int S3SyncSampleVolume(tS3_channel* chan) {
             volume_db = 0;
         }
 
-        // if (!sound_buffer->lpVtbl->SetVolume(sound_buffer, v3) {
-        //     return 1;
-        // }
-
         // convert from directsound -10000-0 volume scale
-        float linear_vol = 1.0f - (volume_db / -10000.0f);
+        linear_volume = ma_volume_db_to_linear(volume_db / 100.0f);
+        ma_sound_set_volume(chan->descriptor->sound_buffer, linear_volume);
 
-        ma_sound_set_volume(chan->descriptor->sound_buffer, linear_vol);
         if (chan->spatial_sound) {
             if (chan->left_volume != 0 && chan->right_volume > chan->left_volume) {
                 pan_ratio = chan->right_volume / (float)chan->left_volume;

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -190,6 +190,8 @@ void Harness_Init(int* argc, char* argv[]) {
     harness_game_config.demo_timeout = 240000;
     // disable developer diagnostics by default
     harness_game_config.enable_diagnostics = 0;
+    // no volume multiplier
+    harness_game_config.volume_multiplier = 1.0f;
 
     // install signal handler by default
     harness_game_config.install_signalhandler = 1;
@@ -270,6 +272,11 @@ int Harness_ProcessCommandLine(int* argc, char* argv[]) {
             handled = 1;
         } else if (strcasecmp(argv[i], "--enable-diagnostics") == 0) {
             harness_game_config.enable_diagnostics = 1;
+            handled = 1;
+        } else if (strstr(argv[i], "--volume-multiplier=") != NULL) {
+            char* s = strstr(argv[i], "=");
+            harness_game_config.volume_multiplier = atof(s + 1);
+            LOG_INFO("Volume multiplier set to %f", harness_game_config.volume_multiplier);
             handled = 1;
         }
 

--- a/src/harness/include/harness/config.h
+++ b/src/harness/include/harness/config.h
@@ -36,6 +36,7 @@ typedef struct tHarness_game_config {
     int freeze_timer;
     unsigned demo_timeout;
     int enable_diagnostics;
+    float volume_multiplier;
 
     int install_signalhandler;
 } tHarness_game_config;


### PR DESCRIPTION
- Fixes sounds should be stopped when the emitter is too far way (weren't calling `S3UpdateSoundSource` inside `S3Service`)
- Fixes DirectSound decibels to linear conversion by using `ma_volume_db_to_linear` 
- Adds `--volume-multiplier` command line arg to set overall volume gain. (windows seems to match OG, on OSX the audio seems too loud at the default gain of 1.0