### PR TITLE
Fix ci warnings

### DIFF
--- a/.github/scripts/build-linux.sh
+++ b/.github/scripts/build-linux.sh
@@ -30,5 +30,5 @@ rm -rf "$releasename"
 mkdir "$releasename"
 cp build/dethrace "$releasename/dethrace"
 tar -czvf "$releasename.tar.gz" "$releasename"
-echo "::set-output name=filename::$releasename.tar.gz"
+echo "filename=$releasename.tar.gz" >>$GITHUB_OUTPUT
 

--- a/.github/scripts/build-macos.sh
+++ b/.github/scripts/build-macos.sh
@@ -20,4 +20,4 @@ rm -rf "$releasename"
 mkdir "$releasename"
 cp build/dethrace "$releasename/dethrace"
 tar -czvf "$releasename.tar.gz" "$releasename"
-echo "::set-output name=filename::$releasename.tar.gz"
+echo "filename=$releasename.tar.gz">>$GITHUB_OUTPUT

--- a/.github/scripts/build-msvc.ps1
+++ b/.github/scripts/build-msvc.ps1
@@ -32,4 +32,4 @@ cp build/SDL2.dll "$releasename/SDL2.dll"
 
 7z a -tzip "$releasename.zip" "$releasename"
 
-echo "::set-output name=filename::$releasename.zip"
+echo "filename=$releasename.zip">>$Env:GITHUB_OUTPUT

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Calculate Variables
         id: vars
         run: |
-          echo "::set-output name=ref_name_without_v::$(echo ${GITHUB_REF_NAME} | cut -c2-)"
+          echo "ref_name_without_v=$(echo ${GITHUB_REF_NAME} | cut -c2-)" >>$GITHUB_OUTPUT
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v0.1.14

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -5172,7 +5172,7 @@ int CollideCamera2(br_vector3* car_pos, br_vector3* cam_pos, br_vector3* old_cam
                 l = BrVector3Dot(&tv2, &tv);
                 alpha = BrVector3LengthSquared(&tv) - gMin_camera_car_distance * gMin_camera_car_distance;
                 ts2 = l * l - alpha * d * 4.0;
-                if (alpha >= 0.f && d != 0.f) {
+                if (ts2 >= 0.f && d != 0.f) {
                     sa = (sqrtf(ts2) - l) / (d * 2.0f);
                     BrVector3Scale(&tv2, &tv2, sa);
                     FindFace(cam_pos, &tv2, &a, &ts, &material);

--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -1290,8 +1290,8 @@ void CheckHorns() {
     int i;
     LOG_TRACE("()");
 
-    if (gNet_mode) {
-        for (i = 0; i < gNumber_of_net_players; ++i) {
+    if (gNet_mode != eNet_mode_none) {
+        for (i = 0; i < gNumber_of_net_players; i++) {
             CheckHorn3D(gNet_players[i].car);
         }
     } else {

--- a/src/DETHRACE/common/opponent.c
+++ b/src/DETHRACE/common/opponent.c
@@ -3665,7 +3665,7 @@ void RebuildOppoPathModel() {
                 edge_mat_finish_lt = gMat_lt_turq;
                 edge_mat_finish_dk = gMat_dk_turq;
             }
-            if (gAlready_elasticating != 0 && gMobile_section == i) {
+            if (gAlready_elasticating && gMobile_section == i) {
                 BrVector3Copy(&gProgram_state.AI_vehicles.path_nodes[gProgram_state.AI_vehicles.path_sections[i].node_indices[1]].p,
                     &gSelf->t.t.translate.t);
             }
@@ -4393,7 +4393,7 @@ void DeleteOppoPathNodeAndSections() {
     tS16 node_no;
     LOG_TRACE("()");
 
-    if (!gOppo_paths_shown == 0) {
+    if (!gOppo_paths_shown) {
         NewTextHeadupSlot(4, 0, 2000, -1, "Show paths first (F5)");
     }
     else if (gAlready_elasticating) {

--- a/src/DETHRACE/common/opponent.c
+++ b/src/DETHRACE/common/opponent.c
@@ -1873,9 +1873,9 @@ int RematerialiseOpponentOnThisSection(tOpponent_spec* pOpponent_spec, br_scalar
         } else if (t > 1.f) {
             BrVector3Copy(&p, finish);
         } else {
-            p.v[0] = start->v[0] + t * car_to_end.v[0];
-            p.v[1] = start->v[1] + t * car_to_end.v[1];
-            p.v[2] = start->v[2] + t * car_to_end.v[2];
+            p.v[0] = start->v[0] + t * section_v.v[0];
+            p.v[1] = start->v[1] + t * section_v.v[1];
+            p.v[2] = start->v[2] + t * section_v.v[2];
         }
         BrVector3Copy(&pOpponent_spec->car_spec->car_master_actor->t.t.translate.t, &p);
         BrVector3Sub(&a, finish, start);

--- a/src/DETHRACE/common/world.c
+++ b/src/DETHRACE/common/world.c
@@ -3149,7 +3149,7 @@ void FunkThoseTronics() {
                             if (the_funk->texture_animation_data.frames_info.current_frame >= the_funk->texture_animation_data.frames_info.texture_count) {
                                 the_funk->texture_animation_data.frames_info.current_frame = 0;
                             }
-                            the_material->colour_map = the_funk->texture_animation_data.frames_info.textures[(int)rot_amount];
+                            the_material->colour_map = the_funk->texture_animation_data.frames_info.textures[the_funk->texture_animation_data.frames_info.current_frame];
                         }
                     }
                     if (the_material->colour_map != old_colour_map) {


### PR DESCRIPTION
Fixes a few ci warnings (which were bugs) + other bugs + use brender macros for br_vector3 manipulation


About the ::set-output deprecation,
see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/