### PR TITLE
Fix skidmark orientation

### DIFF
--- a/src/DETHRACE/common/skidmark.c
+++ b/src/DETHRACE/common/skidmark.c
@@ -231,9 +231,6 @@ void SkidSection(tCar_spec* pCar, int pWheel_num, br_vector3* pPos, int pMateria
         gSkids[skid].actor->render_style = BR_RSTYLE_DEFAULT;
         gSkids[skid].actor->material = material;
         gSkids[skid].normal = pCar->nor[pWheel_num];
-        gSkids[skid].normal.v[0] = 0;
-        gSkids[skid].normal.v[1] = 1;
-        gSkids[skid].normal.v[2] = 0;
         StretchMark(&gSkids[skid], &pCar->prev_skid_pos[pWheel_num], pPos, pCar->total_length[pWheel_num]);
         PipeSingleSkidAdjustment(skid, &gSkids[skid].actor->t.t.mat, pMaterial_index);
         pCar->old_skid[pWheel_num] = skid;


### PR DESCRIPTION
Don't reset skidmark normal to the horizontal plane, but rather use the one received from the wheel.

This fixes incorrect rendering of skidmarks on sloped surfaces (#220).

Before:

https://user-images.githubusercontent.com/510643/200192096-4ade21ad-a683-42af-9394-59016e16c75f.mp4

After:

https://user-images.githubusercontent.com/510643/200192095-d70e2e9b-5793-4a08-96d4-caac67d1d604.mp4