### PR TITLE
Fix oil spill rendering

### DIFF
--- a/src/DETHRACE/common/oil.c
+++ b/src/DETHRACE/common/oil.c
@@ -41,6 +41,8 @@ void InitOilSpills() {
         the_material->flags |= BR_MATF_LIGHT;
         the_material->flags |= BR_MATF_PERSPECTIVE;
         the_material->flags |= BR_MATF_SMOOTH;
+	// TODO: added by dethrace, investigate why oil spills in OG do not need this flag set to render correctly
+        the_material->flags |= BR_MATF_TWO_SIDED;
         the_material->index_range = 0;
         the_material->colour_map = NULL;
         BrMatrix23Identity(&the_material->map_transform);

--- a/src/harness/renderers/gl/gl_renderer.c
+++ b/src/harness/renderers/gl/gl_renderer.c
@@ -500,6 +500,12 @@ void setActiveMaterial(tStored_material* material) {
         glUniform1i(uniforms_3d.light_value, -1);
     }
 
+    if (material->flags & (BR_MATF_TWO_SIDED | BR_MATF_ALWAYS_VISIBLE)) {
+        glDisable(GL_CULL_FACE);
+    } else {
+        glEnable(GL_CULL_FACE);
+    }
+
     if (material->pixelmap) {
         tStored_pixelmap* stored_px = material->pixelmap->stored;
         if (stored_px != NULL) {


### PR DESCRIPTION
Due to the wrong order of vertices in the model, oil spill object is subject to back face culling, preventing it from being rendered. Make the oil spill front faced w/ regards to the floor.

Note: Setting `BR_MATF_TWO_SIDED` for the material flags does not solve this problem - the oil spill is still invisible. Has the original order of vertices been taken from OG disassembly?