### PR TITLE
When respawning pedestrians, only animate nearby pedestrians

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -1682,7 +1682,7 @@ void RenderAFrame(int pDepth_mask_on) {
         } else {
             FlashyMapCheckpoint(gCheckpoint - 1, the_time);
         }
-        if (gShow_peds_on_map || (gNet_mode && gCurrent_net_game->options.show_powerups_on_map)) {
+        if (gShow_peds_on_map || (gNet_mode != eNet_mode_none && gCurrent_net_game->options.show_powerups_on_map)) {
             for (i = 0; i < GetPedCount(); i++) {
                 ped_type = GetPedPosition(i, &pos);
                 if (ped_type > 0 && gShow_peds_on_map) {

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -971,16 +971,12 @@ void MungeClipPlane(br_vector3* pLight, tCar_spec* pCar, br_vector3* p1, br_vect
 
     BrMatrix34ApplyP(&v1, p1, &pCar->car_master_actor->t.t.mat);
     BrMatrix34ApplyP(&v2, p2, &pCar->car_master_actor->t.t.mat);
-    v3.v[0] = p2->v[0] - p1->v[0];
-    v3.v[1] = p2->v[1] - p1->v[1];
-    v3.v[2] = p2->v[2] - p1->v[2];
-    v4.v[0] = pLight->v[2] * v3.v[1] - pLight->v[1] * v3.v[2];
-    v4.v[1] = pLight->v[0] * v3.v[2] - pLight->v[2] * v3.v[0];
-    v4.v[2] = pLight->v[1] * v3.v[0] - v3.v[1] * pLight->v[0];
-    if (fabs(v4.v[0]) >= 0.01 || fabs(v4.v[1]) >= 0.01 || fabs(v4.v[2]) >= 0.01) {
-        v3 = *p1;
-        v3.v[1] = v3.v[1] - pY_offset;
-        if (v3.v[1] * v4.v[1] + v4.v[2] * v3.v[2] + v4.v[0] * v3.v[0] > 0.0) {
+    BrVector3Sub(&v3, p2, p1);
+    BrVector3Cross(&v4, &v3, pLight);
+    if (fabsf(v4.v[0]) >= 0.01f || fabsf(v4.v[1]) >= 0.01f || fabsf(v4.v[2]) >= 0.01f) {
+        BrVector3Copy(&v3, p1);
+        v3.v[1] -= pY_offset;
+        if (BrVector3Dot(&v3, &v4) > 0.f) {
             BrVector3Negate(&v4, &v4);
         }
         BrVector3Normalise(&v3, &v4);
@@ -991,7 +987,7 @@ void MungeClipPlane(br_vector3* pLight, tCar_spec* pCar, br_vector3* p1, br_vect
         ((br_vector4*)new_clip->type_data)->v[0] = v4.v[0];
         ((br_vector4*)new_clip->type_data)->v[1] = v4.v[1];
         ((br_vector4*)new_clip->type_data)->v[2] = v4.v[2];
-        ((br_vector4*)new_clip->type_data)->v[3] = -(v4.v[1] * v1.v[1] + v4.v[2] * v1.v[2] + v1.v[0] * v4.v[0]);
+        ((br_vector4*)new_clip->type_data)->v[3] = -BrVector3Dot(&v1, &v4);
         gShadow_clip_planes[gShadow_clip_plane_count].length = length;
         gShadow_clip_plane_count++;
     }

--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -2402,11 +2402,24 @@ void RespawnPedestrians() {
     for (i = 0; i < gPed_count; i++) {
         the_pedestrian = &gPedestrian_array[i];
         if (the_pedestrian->ref_number < 100) {
+#if defined(DETHRACE_FIX_BUGS)
+            // Only animate the respawn when we are in viewing distance.
+            // This is done such that the "Peds visible on map" powerup draws far away items.
+            // (far away animated pedestrians would otherwise remain invisible on the map)
+            br_scalar x_delta;
+            br_scalar z_delta;
+            int ped_respawn_animate;
+            x_delta = fabsf(the_pedestrian->pos.v[V_X] - gCamera_to_world.m[3][V_X]);
+            z_delta = fabsf(the_pedestrian->pos.v[V_Z] - gCamera_to_world.m[3][V_Z]);
+            ped_respawn_animate = x_delta <= ACTIVE_PED_DXDZ && z_delta <= ACTIVE_PED_DXDZ;
+#else
+#define ped_respawn_animate 1
+#endif
             if (the_pedestrian->hit_points == -100) {
-                RevivePedestrian(the_pedestrian, 1);
+                RevivePedestrian(the_pedestrian, ped_respawn_animate);
             } else if ((the_pedestrian->current_action == the_pedestrian->fatal_car_impact_action || the_pedestrian->current_action == the_pedestrian->fatal_ground_impact_action || the_pedestrian->current_action == the_pedestrian->giblets_action)
                 && the_pedestrian->actor->parent == gDont_render_actor) {
-                RevivePedestrian(the_pedestrian, 1);
+                RevivePedestrian(the_pedestrian, ped_respawn_animate);
             }
         }
     }

--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -29,6 +29,7 @@
 #include <time.h>
 
 #define FLAG_WAVING_BASTARD_REF 99
+#define ACTIVE_PED_DXDZ 11.f
 
 #define FOURCC(A, B, C, D) (((A & 0xff) << 24) | ((B & 0xff) << 16) | ((C & 0xff) << 8) | ((D & 0xff) << 0))
 #define PEDESTRIAN_MAGIC FOURCC('P', 'e', 'd', '!')
@@ -2336,7 +2337,7 @@ void MungePedestrians(tU32 pFrame_period) {
             the_pedestrian = &gPedestrian_array[i];
             x_delta = fabsf(the_pedestrian->pos.v[V_X] - gCamera_to_world.m[3][V_X]);
             z_delta = fabsf(the_pedestrian->pos.v[V_Z] - gCamera_to_world.m[3][V_Z]);
-            if ((the_pedestrian->actor->parent != gDont_render_actor || (x_delta <= 11.f && z_delta <= 11.f))
+            if ((the_pedestrian->actor->parent != gDont_render_actor || (x_delta <= ACTIVE_PED_DXDZ && z_delta <= ACTIVE_PED_DXDZ))
                 && (gPedestrians_on || the_pedestrian->ref_number >= 100)
                 && the_pedestrian->hit_points != -100) {
                 gCurrent_lollipop_index = -1;
@@ -2349,7 +2350,7 @@ void MungePedestrians(tU32 pFrame_period) {
             x_delta = fabsf(the_pedestrian->pos.v[V_X] - gCamera_to_world.m[3][V_X]);
             z_delta = fabsf(the_pedestrian->pos.v[V_Z] - gCamera_to_world.m[3][V_Z]);
             if (the_pedestrian->actor->parent == gDont_render_actor
-                && (x_delta > 11.f || z_delta > 11.f)) {
+                && (x_delta > ACTIVE_PED_DXDZ || z_delta > ACTIVE_PED_DXDZ)) {
                 the_pedestrian->active = 0;
             } else if (the_pedestrian->hit_points == -100) {
                 if (the_pedestrian->respawn_time == 0) {


### PR DESCRIPTION
Only animate the respawn when we are in viewing distance.
This is done such that the "Peds visible on map" powerup draws far away items.
Far away animated pedestrians would otherwise remain invisible on the map until we get close to them.

Fixes #206