### PR TITLE
Fix for running with -robots + implement DOS gore password check

### DIFF
--- a/src/DETHRACE/common/init.c
+++ b/src/DETHRACE/common/init.c
@@ -327,7 +327,13 @@ void Init2DStuff() {
 // IDA: void __usercall InitialiseApplication(int pArgc@<EAX>, char **pArgv@<EDX>)
 void InitialiseApplication(int pArgc, char** pArgv) {
 
-    gProgram_state.sausage_eater_mode = gSausage_override;
+    if (harness_game_config.dos_mode) {
+        gProgram_state.sausage_eater_mode = gSausage_override ? 1 : (PDGetGorePassword() ? 0 : 1);
+        PDDisplayGoreworthiness(!gProgram_state.sausage_eater_mode);
+    } else {
+        gProgram_state.sausage_eater_mode = gSausage_override;
+    }
+
     MAMSInitMem();
     PrintMemoryDump(gSausage_override, *pArgv);
     if (gAustere_override || PDDoWeLeadAnAustereExistance() != 0) {

--- a/src/DETHRACE/common/skidmark.c
+++ b/src/DETHRACE/common/skidmark.c
@@ -110,22 +110,30 @@ void InitSkids() {
     int sl;
     br_model* square;
     char* str;
+#if defined(DETHRACE_FIX_BUGS)
+    char mat_name[32];
+#endif
     LOG_TRACE("()");
 
-    for (mat = 0; mat < 2; mat++) {
+    for (mat = 0; mat < COUNT_OF(gMaterial_names); mat++) {
         if (gProgram_state.sausage_eater_mode) {
             str = gBoring_material_names[mat];
         } else {
             str = gMaterial_names[mat];
         }
         gMaterial[mat] = BrMaterialFind(str);
-        if (!gMaterial[mat]) {
+        if (gMaterial[mat] == NULL) {
             if (gProgram_state.sausage_eater_mode) {
                 str = gBoring_material_names[mat];
             } else {
                 str = gMaterial_names[mat];
             }
 
+#if defined(DETHRACE_FIX_BUGS)
+            // Avoid modification of read-only data by strtok.
+            strcpy(mat_name, str);
+            str = mat_name;
+#endif
             sl = strlen(strtok(str, "."));
             strcpy(str + sl, ".PIX");
             BrMapAdd(LoadPixelmap(str));

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -197,6 +197,8 @@ void Harness_Init(int* argc, char* argv[]) {
     harness_game_config.start_full_screen = 0;
     // disable replay by default
     harness_game_config.enable_replay = 0;
+    // Emulate DOS behavior
+    harness_game_config.dos_mode = 0;
 
     // install signal handler by default
     harness_game_config.install_signalhandler = 1;
@@ -288,6 +290,9 @@ int Harness_ProcessCommandLine(int* argc, char* argv[]) {
             handled = 1;
         } else if (strcasecmp(argv[i], "--enable-replay") == 0) {
             harness_game_config.enable_replay = 1;
+            handled = 1;
+        } else if (strcasecmp(argv[i], "--dos-mode") == 0) {
+            harness_game_config.dos_mode = 1;
             handled = 1;
         }
 

--- a/src/harness/include/harness/config.h
+++ b/src/harness/include/harness/config.h
@@ -40,6 +40,7 @@ typedef struct tHarness_game_config {
     float volume_multiplier;
     int start_full_screen;
     int enable_replay;
+    int dos_mode;
 
     int install_signalhandler;
 } tHarness_game_config;

--- a/src/harness/include/harness/os.h
+++ b/src/harness/include/harness/os.h
@@ -49,4 +49,6 @@ FILE* OS_fopen(const char* pathname, const char* mode);
 // Required: return a buffer for action replay. Preferably 20MB. If that is not available, then allocate a buffer of 12MB, 6MB, 4MB, 500kB or 64kiB
 void OS_AllocateActionReplayBuffer(char** pBuffer, unsigned* pBuffer_size);
 
+size_t OS_ConsoleReadPassword(char* pBuffer, size_t pBufferLen);
+
 #endif

--- a/src/harness/os/macos.c
+++ b/src/harness/os/macos.c
@@ -324,3 +324,10 @@ void OS_AllocateActionReplayBuffer(char** pBuffer, unsigned* pBuffer_size) {
     *pBuffer = buffer;
     *pBuffer_size = buffer_size;
 }
+
+size_t OS_ConsoleReadPassword(char* pBuffer, size_t pBufferLen) {
+    // FIXME: unsafe implementation (echos the password)
+    pBuffer[0] = '\0';
+    fgets(pBuffer, pBufferLen, stdin);
+    return strlen(pBuffer);
+}

--- a/src/harness/os/windows.c
+++ b/src/harness/os/windows.c
@@ -308,3 +308,10 @@ void OS_AllocateActionReplayBuffer(char** pBuffer, unsigned* pBuffer_size) {
     *pBuffer = buffer;
     *pBuffer_size = buffer_size;
 }
+
+size_t OS_ConsoleReadPassword(char* pBuffer, size_t pBufferLen) {
+    // FIXME: unsafe implementation (echos the password)
+    pBuffer[0] = '\0';
+    fgets(pBuffer, pBufferLen, stdin);
+    return strlen(pBuffer);
+}


### PR DESCRIPTION
- Running DethRace with `-robots` segfaulted because `strtok` modifies read-only data. I found this error weird, because non-zombie mode also modifies read-only data. Fix this by copying the read-only data to the stack before modification.
- The Carmageddon DOS version asks for a password to allow running DethRace with gore. Re-implement this behavior when starting DethRace with `--dos-mode`