### PR TITLE
Fix rendering of fancy headups

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -2148,6 +2148,7 @@ void DRPixelmapRectangleShearedCopy(br_pixelmap* pDest, br_int_16 pDest_x, br_in
     int last_shear_x;
     int current_shear_x;
     int shear_x_difference;
+    int pWidth_orig;
     tU8 the_byte;
     tU8* source_ptr;
     tU8* dest_ptr;
@@ -2186,13 +2187,27 @@ void DRPixelmapRectangleShearedCopy(br_pixelmap* pDest, br_int_16 pDest_x, br_in
             pDest_x = 0;
         }
         if (pDest->width > pDest_x) {
-            if (pDest_x + pWidth > pDest->width) {
-                shear_x_difference = pDest_x + pWidth - pDest->width;
-                pWidth = pDest->width - pDest_x;
-                source_row_wrap += shear_x_difference;
-                dest_row_wrap += shear_x_difference;
-            }
+            pWidth_orig = pWidth;
             for (y_count = 0; pHeight > y_count; ++y_count) {
+#if !defined(DETHRACE_FIX_BUGS)
+                /*
+                 * The OG compares against pWidth instead of pWidth_orig, which
+                 * ends up clipped to the dest pixelmap width. This effectively
+                 * clips the consecutive rows of pixels along the shear, leaving
+                 * a visible gap on the screen. Instead, when comparing against
+                 * pWidth_orig, the clip takes place vertically along the dest
+                 * pixelmap edge, allowing all pixels to be displayed.
+                 *
+                 * Simulate OG behavior by overwriting pWidth_orig with pWidth.
+                 */
+                pWidth_orig = pWidth;
+#endif
+                if (pDest_x + pWidth_orig > pDest->width) {
+                    shear_x_difference = pDest_x + pWidth - pDest->width;
+                    pWidth = pDest->width - pDest_x;
+                    source_row_wrap += shear_x_difference;
+                    dest_row_wrap += shear_x_difference;
+                }
                 for (x_count = 0; pWidth > x_count; ++x_count) {
                     the_byte = *source_ptr++;
                     if (the_byte) {
@@ -2216,12 +2231,6 @@ void DRPixelmapRectangleShearedCopy(br_pixelmap* pDest, br_int_16 pDest_x, br_in
                 }
                 if (pDest->width <= pDest_x) {
                     break;
-                }
-                if (pDest_x + pWidth > pDest->width) {
-                    shear_x_difference = pDest_x + pWidth - pDest->width;
-                    pWidth = pDest->width - pDest_x;
-                    source_row_wrap += shear_x_difference;
-                    dest_row_wrap += shear_x_difference;
                 }
             }
         }


### PR DESCRIPTION
Resolve a bug in `DRPixelmapRectangleShearedCopy`, where source pixelmap gets clipped along the shear, rather than vertically, at right-most edge of the destination pixelmap.

While at it, also eliminate duplicate code - this part introduces no logic changes.

This fixes https://github.com/dethrace-labs/dethrace/issues/251