### PR TITLE
Fix framebuffer effects

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -12,6 +12,7 @@
 #include "globvars.h"
 #include "globvrpb.h"
 #include "grafdata.h"
+#include "harness/hooks.h"
 #include "harness/os.h"
 #include "harness/trace.h"
 #include "init.h"
@@ -1615,6 +1616,7 @@ void RenderAFrame(int pDepth_mask_on) {
             ProcessTrack(gUniverse_actor, &gProgram_state.track_spec, gCamera, &gCamera_to_world, 1);
         }
         RenderSplashes();
+	Harness_Hook_FlushRenderer(); /* Dethrace. Flush buffers into memory. */
         RenderSmoke(gRender_screen, gDepth_buffer, gCamera, &gCamera_to_world, gFrame_period);
         RenderSparks(gRender_screen, gDepth_buffer, gCamera, &gCamera_to_world, gFrame_period);
         RenderProximityRays(gRender_screen, gDepth_buffer, gCamera, &gCamera_to_world, gFrame_period);


### PR DESCRIPTION
Screen effects such as smoke, sparks or electro-bastard ray need to be applied only after the 3D scene is rendered. Otherwise, they might end up rendered behind geometry on certain levels. Examples of such levels include "Fridge Racer" and "Drown in the Sumps", where said effects are rendered behind most geometry (except car shadows), and "Icing on the Quake", where they are obscured by translucent ice texture (see #214 for details).

Since my lack of access to symbolicated disassembly of the original game prevents me from checking whether the original game renders those effects before or after `BrZbSceneRenderEnd`, perhaps this is just a prelude to a bigger issue in the rendering pipeline.

With this change, smoke in "Drown in the Sumps" is now correctly rendered at the right Z position:
![sshot](https://user-images.githubusercontent.com/510643/205176851-5c551761-e9d7-443a-b9e8-f2e8ab7bb23d.png)

And it also doesn't get obscured by ice in "Icing on the Quake" anymore:
![sshot2](https://user-images.githubusercontent.com/510643/205177074-20984e6b-67b4-4be8-b2d4-0caa5994c26a.png)


