### PR TITLE
Fix gear rendering for Suppressor

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -1160,15 +1160,26 @@ void DoInstruments(tU32 pThe_time) {
             } else {
                 gear = gCar_to_view->gear;
             }
+#if defined(DETHRACE_FIX_BUGS)
+/*
+ * The OG derives gear mask height of 28 by `gears_image->height / 8`, but
+ * this is only valid for HGEARS.PIX, which contains 8 gear images. Hardcoding
+ * this number fixes gear rendering for cars using HGEARS4.PIX, which consists
+ * of 11 gear images.
+ */
+#define GEAR_HEIGHT 28
+#else
+#define GEAR_HEIGHT ((int)gProgram_state.current_car.gears_image->height / 8)
+#endif
             DRPixelmapRectangleMaskedCopy(
                 gBack_screen,
                 the_wobble_x + gProgram_state.current_car.gear_x[gProgram_state.cockpit_on],
                 the_wobble_y + gProgram_state.current_car.gear_y[gProgram_state.cockpit_on],
                 gProgram_state.current_car.gears_image,
                 0,
-                (gear + 1) * ((int)gProgram_state.current_car.gears_image->height >> 3),
+                (gear + 1) * GEAR_HEIGHT,
                 gProgram_state.current_car.gears_image->width,
-                (int)gProgram_state.current_car.gears_image->height >> 3);
+                GEAR_HEIGHT);
         }
         speedo_image = gProgram_state.current_car.speedo_image[gProgram_state.cockpit_on];
         if (gProgram_state.current_car.speedo_radius_2[gProgram_state.cockpit_on] >= 0) {


### PR DESCRIPTION
Fix misaligned gear mask and a buffer overflow for cars which use more than 8 gears, and thus pixelmaps other than HGEARS.PIX.

This issue exists because the gear rendering code assumes that the pixelmap with gear images contains 8 individual gear images. However, this is only true for HGEARS.PIX. In case of the Suppressor, which uses HGEARS4.PIX, there are 11 gears and so the mask is applied at the wrong offset.
Since both of the pixelmaps in question have gears that should clip at the height of 28, hardcode this number instead of trying to calculate it.

Another solution would be to simply force HGEARS4.PIX for all the cars, as those graphics are identical for both files (just with more gears in the latter one). I guess they really wanted to save every byte of memory in the OG, huh?

This fixes https://github.com/dethrace-labs/dethrace/issues/256:
![gear2](https://user-images.githubusercontent.com/510643/205402090-23f6f8e9-2d31-4214-bfe1-79e36cf698b0.png)
