### PR TITLE
Fix time credit headup

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -1439,9 +1439,9 @@ void AwardTime(tU32 pTime) {
     }
     gOld_times[0] = pTime;
     if (gLast_time_credit_headup >= 0 && (the_time - gLast_time_earn_time) < 2000) {
-        pTime += gLast_time_credit_headup;
+        pTime += gLast_time_credit_amount;
     }
-    gLast_time_credit_headup = pTime;
+    gLast_time_credit_amount = pTime;
     gTimer += original_amount * 1000;
     s[0] = '+';
     TimerString(1000 * pTime, &s[1], 0, 0);


### PR DESCRIPTION
Store the previous time credit in `gLast_time_credit_amount` instead of `gLast_time_credit_headup`. The latter is supposed to hold the headup slot number and gets overwritten with `NewTextHeadupSlot` index, effectively capping the time credits at the value of `+13`.

This fixes https://github.com/dethrace-labs/dethrace/issues/182.