### PR TITLE
Prevent clicking on racer scroll buttons when hidden

### DIFF
--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -1282,6 +1282,11 @@ int TryToMoveToArrows(int* pCurrent_choice, int* pCurrent_mode) {
 int UpOpponent(int* pCurrent_choice, int* pCurrent_mode) {
     LOG_TRACE("(%p, %p)", pCurrent_choice, pCurrent_mode);
 
+#if defined(DETHRACE_FIX_BUGS)
+    if (gProgram_state.view_type != eVT_Opponents) {
+        return 0;
+    }
+#endif
     AddToFlicQueue(gStart_interface_spec->pushed_flics[5].flic_index,
         gStart_interface_spec->pushed_flics[5].x[gGraf_data_index],
         gStart_interface_spec->pushed_flics[5].y[gGraf_data_index],
@@ -1310,6 +1315,11 @@ int UpOpponent(int* pCurrent_choice, int* pCurrent_mode) {
 int DownOpponent(int* pCurrent_choice, int* pCurrent_mode) {
     LOG_TRACE("(%p, %p)", pCurrent_choice, pCurrent_mode);
 
+#if defined(DETHRACE_FIX_BUGS)
+    if (gProgram_state.view_type != eVT_Opponents) {
+        return 0;
+    }
+#endif
     AddToFlicQueue(gStart_interface_spec->pushed_flics[6].flic_index,
         gStart_interface_spec->pushed_flics[6].x[gGraf_data_index],
         gStart_interface_spec->pushed_flics[6].y[gGraf_data_index],

--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -1283,6 +1283,7 @@ int UpOpponent(int* pCurrent_choice, int* pCurrent_mode) {
     LOG_TRACE("(%p, %p)", pCurrent_choice, pCurrent_mode);
 
 #if defined(DETHRACE_FIX_BUGS)
+    // fixes bug where racers could be scrolled in other race menu modes
     if (gProgram_state.view_type != eVT_Opponents) {
         return 0;
     }
@@ -1316,6 +1317,7 @@ int DownOpponent(int* pCurrent_choice, int* pCurrent_mode) {
     LOG_TRACE("(%p, %p)", pCurrent_choice, pCurrent_mode);
 
 #if defined(DETHRACE_FIX_BUGS)
+    // fixes bug where racers could be scrolled in other race menu modes
     if (gProgram_state.view_type != eVT_Opponents) {
         return 0;
     }


### PR DESCRIPTION
Fix OG bug where racers could be scrolled in other view modes, messing up the screen.

This fixes https://github.com/dethrace-labs/dethrace/issues/262.