### PR TITLE
Fix fd memory leak on Linux

### DIFF
--- a/src/harness/os/linux.c
+++ b/src/harness/os/linux.c
@@ -332,10 +332,12 @@ FILE* OS_fopen(const char* pathname, const char* mode) {
         if (strcasecmp(pBaseName, pDirent->d_name) == 0) {
             strcat(pDirName, "/");
             strcat(pDirName, pDirent->d_name);
-            return fopen(pDirName, mode);
+            f = fopen(pDirName, mode);
+            break;
         }
     }
-    return NULL;
+    closedir(pDir);
+    return f;
 }
 
 void OS_AllocateActionReplayBuffer(char** pBuffer, unsigned* pBuffer_size) {


### PR DESCRIPTION
The Linux implementation of `OS_fopen` fails to close directories after use, leaking the underlying file descriptors. Eventually, the limit of allowed file descriptors per process is reached, causing subsequent `opendir` failures, and leading to random game crashes.

Fix this issue by calling `closedir` once the directory can be disposed.

This fixes https://github.com/dethrace-labs/dethrace/issues/264.