### PR TITLE
Fix headup hole lookup

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -618,7 +618,6 @@ int FindAHeadupHoleWoofBarkSoundsABitRude(int pSlot_index) {
         }
         if (the_headup->type == eHeadup_unused) {
             empty_one = i;
-            break;
         }
     }
     return empty_one;


### PR DESCRIPTION
When searching for a particular headup slot, don't return on the first empty hole, but rather try to find if the matching slot is in use.

This resolves a bug where two headups of the same type could end up displayed on top of each other: https://github.com/dethrace-labs/dethrace/issues/267

Fix confirmed with OG disassembly.