### PR TITLE
Fix hires cockpit image display

### DIFF
--- a/src/DETHRACE/common/loading.c
+++ b/src/DETHRACE/common/loading.c
@@ -842,7 +842,7 @@ tS8* ConvertPixToStripMap(br_pixelmap* pThe_br_map) {
     temp_strip_image = BrMemAllocate(pThe_br_map->row_bytes * pThe_br_map->height, kMem_strip_image);
     current_size = 2;
 
-    *temp_strip_image = pThe_br_map->height;
+    *(br_uint_16 *)temp_strip_image = pThe_br_map->height;
     current_strip_pointer = temp_strip_image;
 
     for (i = 0; i < pThe_br_map->height; i++) {


### PR DESCRIPTION
Strip map height is a 16 bit value. Cast to `uint16_t *`, so that the upper 8 bits don't get lost.

This fixes cockpit image rendering for -hires mode, where said images have heights exceeding 255px.

This patch resolves part 2 of https://github.com/dethrace-labs/dethrace/issues/271.