### PR TITLE
Fix NULL pointer dereference in S3StartSound (#284)

### DIFF
--- a/src/S3/CMakeLists.txt
+++ b/src/S3/CMakeLists.txt
@@ -18,6 +18,9 @@ else()
         /wd4996
     )
 endif()
+if(DETHRACE_FIX_BUGS)
+    target_compile_definitions(s3 PRIVATE DETHRACE_FIX_BUGS)
+endif()
 
 if(IS_BIGENDIAN)
     target_compile_definitions(s3 PRIVATE BR_ENDIAN_BIG=1)

--- a/src/S3/audio.c
+++ b/src/S3/audio.c
@@ -962,6 +962,13 @@ void S3CalculateRandomizedFields(tS3_channel* chan, tS3_descriptor* desc) {
     chan->left_volume = vol;
     chan->right_volume = vol;
     if (desc->type == eS3_ST_sample) {
+#if defined(DETHRACE_FIX_BUGS)
+    /* Avoid a possible NULL pointer dereference. */
+    if (desc->sound_data == NULL) {
+        chan->rate = desc->min_pitch;
+        return;
+    }
+#endif
         chan->rate = S3IRandomBetweenLog(desc->min_pitch, desc->max_pitch, ((tS3_sample*)desc->sound_data)->rate);
     }
 }


### PR DESCRIPTION
If the sound has been muted (!gS3_enabled) during game data loading, it is then possible to unmute it during gameplay and request a sound effect which doesn't have a sample loaded (most prominent for pratcam sfx). While the code accommodates for such a case, it does it too late, triggering a NULL pointer dereference on platforms which feature memory protection. This bug is most likely an overlook from the DOS era.

Fix this by moving the sample NULL pointer check before its first use.

Signed-off-by: Artur Rojek <contact@artur-rojek.eu>