### PR TITLE
Fix ambient sample mixing (#281)

### DIFF
--- a/src/S3/audio.c
+++ b/src/S3/audio.c
@@ -748,8 +748,9 @@ void S3ServiceOutlets() {
 
 int S3ServiceChannel(tS3_channel* chan) {
     if (chan->type == eS3_ST_sample) {
-        if (chan->descriptor && chan->descriptor->type == chan->type) {
-            if (ma_sound_is_playing(chan->descriptor->sound_buffer)) {
+        if (chan->descriptor && chan->descriptor->type == chan->type &&
+            DR_SOUND_BUFFER != NULL) {
+            if (ma_sound_is_playing(DR_SOUND_BUFFER)) {
                 return 1;
             }
         }

--- a/src/S3/s3_defs.h
+++ b/src/S3/s3_defs.h
@@ -9,6 +9,12 @@
 #define MIN(a, b) ((a) < (b) ? a : b)
 #define MAX(a, b) ((a) > (b) ? a : b)
 
+#if defined(DETHRACE_FIX_BUGS)
+#define DR_SOUND_BUFFER (chan->sound_buffer)
+#else
+#define DR_SOUND_BUFFER (chan->descriptor->sound_buffer)
+#endif
+
 // Internal typedefs
 
 typedef float tF32;
@@ -104,6 +110,10 @@ typedef struct tS3_channel {
     char* type_struct_midi;
     char* type_struct_cda;
     tS3_sound_source* sound_source_ptr;
+#if defined(DETHRACE_FIX_BUGS)
+    void *sound_buffer;
+    tS3_sound_id id;
+#endif
 } tS3_channel;
 
 typedef struct tS3_outlet {


### PR DESCRIPTION
The sound engine used in Dethrace is unable to play the same sample more than once at a time. If two or more sound sources request to play the same sound id, the one to use it last will overwrite any previous effects on the sample. This is most prominent for car engine noises and cop sirens.
This issue also occurs in Windows builds of OG, but not in DOS ones.

Fix this issue by duplicating sound samples. Note that the game does not clean up ambient sounds, so extra care is taken to reuse the already allocated descriptors.

Note:
This patch depends on https://github.com/dethrace-labs/dethrace/pull/285.