### PR TITLE
Fixes Toshiba's blend test map

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -1612,8 +1612,6 @@ void RenderAFrame(int pDepth_mask_on) {
         DepthEffectSky(gRender_screen, gDepth_buffer, gCamera, &gCamera_to_world);
         DepthEffect(gRender_screen, gDepth_buffer, gCamera, &gCamera_to_world);
         if (!gAusterity_mode) {
-            // dethrace: must flush gpu buffer before rendering blended materials
-            Harness_Hook_FlushRenderer();
             ProcessTrack(gUniverse_actor, &gProgram_state.track_spec, gCamera, &gCamera_to_world, 1);
         }
         RenderSplashes();

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -377,7 +377,7 @@ void Harness_Hook_renderActor(br_actor* actor, br_model* model, br_material* mat
 }
 
 void Harness_Hook_BrZbSceneRenderEnd() {
-    renderer->FlushBuffers();
+    renderer->FlushBuffers(eFlush_all);
     renderer->EndScene();
 }
 
@@ -408,7 +408,7 @@ void Harness_Hook_PDSetKeyArray() {
 }
 
 void Harness_Hook_FlushRenderer() {
-    renderer->FlushBuffers();
+    renderer->FlushBuffers(eFlush_all);
 }
 
 void Harness_Hook_BrMaterialUpdate(br_material* mat, br_uint_16 flags) {

--- a/src/harness/renderers/gl/gl_renderer.h
+++ b/src/harness/renderers/gl/gl_renderer.h
@@ -2,6 +2,7 @@
 #define HARNESS_GL_RENDERER
 
 #include "harness.h"
+#include "renderers/renderer.h"
 
 #define CHECK_GL_ERROR(msg)                                \
     {                                                      \
@@ -51,7 +52,7 @@ void GLRenderer_BufferTexture(br_pixelmap* pm);
 void GLRenderer_BufferMaterial(br_material* mat);
 void GLRenderer_BufferModel(br_model* model);
 void GLRenderer_ClearBuffers();
-void GLRenderer_FlushBuffers();
+void GLRenderer_FlushBuffers(tRenderer_flush_type flush_type);
 void GLRenderer_GetRenderSize(int* width, int* height);
 void GLRenderer_GetWindowSize(int* width, int* height);
 void GLRenderer_SetWindowSize(int width, int height);

--- a/src/harness/renderers/renderer.h
+++ b/src/harness/renderers/renderer.h
@@ -3,6 +3,11 @@
 
 #include "brender/br_types.h"
 
+typedef enum {
+    eFlush_all,
+    eFlush_color_buffer
+} tRenderer_flush_type;
+
 typedef struct tRenderer {
     void (*Init)(int width, int height, int pRender_width, int pRender_height);
     void (*BeginScene)(br_actor* camera, br_pixelmap* colour_buffer, br_pixelmap* depth_buffer);
@@ -14,7 +19,7 @@ typedef struct tRenderer {
     void (*BufferTexture)(br_pixelmap* pm);
     void (*BufferMaterial)(br_material* mat);
     void (*BufferModel)(br_model* model);
-    void (*FlushBuffers)();
+    void (*FlushBuffers)(tRenderer_flush_type);
     void (*GetRenderSize)(int* width, int* height);
     void (*GetWindowSize)(int* width, int* height);
     void (*SetWindowSize)(int width, int height);


### PR DESCRIPTION
- Blend Test map available here: https://rr2000.cwaboard.co.uk/carmageddon-1
- Fix is to ensure we have the latest framebuffer while processing an `index_blend` material.

The reason it wasn't fully working already is because dethrace made the assumption that blendable materials will only be seen in the separate explicit blending rendering pass. This particular track fails to detect columns (in `ExtractColumns`), so blended materials are rendered in the first pass. The framebuffer hadn't yet been uploaded back to the GPU, so nothing was blended.

<img width="750" alt="Screenshot 2023-02-20 at 12 42 21 pm" src="https://user-images.githubusercontent.com/78985374/219982558-f074fdd8-289b-4029-8ee9-9eb14d51e447.png">
<img width="750" alt="Screenshot 2023-02-20 at 12 42 43 pm" src="https://user-images.githubusercontent.com/78985374/219982574-5528f683-d7b3-48af-9aee-ad162bec657b.png">
<img width="750" alt="Screenshot 2023-02-20 at 12 42 57 pm" src="https://user-images.githubusercontent.com/78985374/219982585-821260c9-a6de-4407-a997-1c99bf2b37d7.png">