### PR TITLE
utility: fix filename of generated shade table

### DIFF
--- a/src/DETHRACE/common/utility.c
+++ b/src/DETHRACE/common/utility.c
@@ -856,6 +856,7 @@ void BuildShadeTablePath(char* pThe_path, int pR, int pG, int pB) {
     s[6] = 'A' + ((pB & 0xf0) >> 4);
     s[7] = 'A' + ((pB & 0x0f) >> 0);
     s[8] = '\0';
+    strcat(s, ".TAB");
     PathCat(pThe_path, gApplication_path, "SHADETAB");
     PathCat(pThe_path, pThe_path, s);
 }


### PR DESCRIPTION
The generated shade tables in `DATA/SHADETAB` were missing a `.TAB` suffix.
Found while looking into #297.