### PR TITLE
Implements BRender environment mapping

### DIFF
--- a/src/BRSRC13/include/brender/brender.h
+++ b/src/BRSRC13/include/brender/brender.h
@@ -110,6 +110,7 @@ void BrMatrix4ApplyP(br_vector4* A, br_vector3* B, br_matrix4* C);
 void BrMatrix4Perspective(br_matrix4* mat, br_angle field_of_view, br_scalar aspect, br_scalar hither, br_scalar yon);
 void BrMatrix4Scale(br_matrix4* mat, br_scalar sx, br_scalar sy, br_scalar sz);
 void BrMatrix4Mul(br_matrix4* A, br_matrix4* B, br_matrix4* C);
+void BrMatrix4Copy34(br_matrix4* A, br_matrix34* B);
 
 // BrMem
 void BrMemFree(void* block);

--- a/src/harness/resources/3d_vert.glsl
+++ b/src/harness/resources/3d_vert.glsl
@@ -1,5 +1,6 @@
 #version 140
 #extension GL_ARB_explicit_attrib_location : require
+
 layout (location = 0) in vec3 a_pos;
 layout (location = 1) in vec3 a_normal;
 layout (location = 2) in vec2 a_uv;
@@ -13,6 +14,22 @@ out float v_color;
 uniform mat4 u_model;
 uniform mat4 u_view;
 uniform mat4 u_projection;
+uniform uint u_material_flags;
+uniform mat4 u_normal_matrix;
+
+// material_flags values
+const uint BR_MATF_ENVIRONMENT_L = 0x10u;
+
+// https://rr2000.cwaboard.co.uk/R4/BRENDER/TEBK_43.HTM#HEADING331
+// https://www.clicktorelease.com/blog/creating-spherical-environment-mapping-shader/
+void do_spherical_environment_map() {
+    mat4 view_model = u_view * u_model;
+    vec3 e = normalize( vec3( view_model * vec4( a_pos, 1.0 ) ) );
+    vec3 n = normalize( mat3(u_normal_matrix) * a_normal );
+    vec3 r = reflect( e, n );
+    float m = 2. * sqrt( pow( r.x, 2. ) + pow( r.y, 2. ) + pow( r.z + 1., 2. ) );
+    v_tex_coord = r.xy / m + .5;
+}
 
 void main() {
     v_frag_pos = vec3(u_model * vec4(a_pos, 1.0));
@@ -20,4 +37,8 @@ void main() {
     v_tex_coord = a_uv;
     v_color = a_color;
     gl_Position = u_projection * u_view * vec4(v_frag_pos, 1.0);
+
+    if ((u_material_flags & BR_MATF_ENVIRONMENT_L) != 0u) {
+        do_spherical_environment_map();
+    }
 }


### PR DESCRIPTION
Some windscreen materials (for example, Eagle 1, Grimm, Harry) have a `BR_MATF_ENVIRONMENT_L` flag, and are somehow reflective.

According to BRender docs, this flag describes a spherical environment map. https://rr2000.cwaboard.co.uk/R4/BRENDER/TEBK_43.HTM#HEADING331

<img width="752" alt="Screenshot 2023-04-25 at 5 59 40 am" src="https://user-images.githubusercontent.com/78985374/234078558-61df78ac-b0ab-401f-bd5d-c7f680285b57.png">


Fixes: #307 