### PR TITLE
Remove references to `u_material_index_range`

### DIFF
--- a/src/harness/renderers/gl/gl_renderer.c
+++ b/src/harness/renderers/gl/gl_renderer.c
@@ -161,6 +161,8 @@ void LoadShaders() {
     uniforms_3d.material_blend_enabled = GetValidatedUniformLocation(shader_program_3d, "u_material_blend_enabled");
     uniforms_3d.material_blend_table = GetValidatedUniformLocation(shader_program_3d, "u_material_blend_table");
     uniforms_3d.material_index_base = GetValidatedUniformLocation(shader_program_3d, "u_material_index_base");
+    // TODO: re-add when we support untextured lighting
+    // uniforms_3d.material_index_range = GetValidatedUniformLocation(shader_program_3d, "u_material_index_range");
 
     // bind the uniform samplers to texture units
     glUniform1i(uniforms_3d.material_texture_pixelmap, 0);

--- a/src/harness/renderers/gl/gl_renderer.c
+++ b/src/harness/renderers/gl/gl_renderer.c
@@ -65,7 +65,7 @@ struct {
     GLuint material_blend_enabled;
     GLuint material_blend_table;
     GLuint material_index_base;
-    GLuint material_index_range;
+    // GLuint material_index_range;  TODO: re-add when we add untextured lighting
     GLuint material_shade_table_height;
 
 } uniforms_3d;
@@ -161,7 +161,6 @@ void LoadShaders() {
     uniforms_3d.material_blend_enabled = GetValidatedUniformLocation(shader_program_3d, "u_material_blend_enabled");
     uniforms_3d.material_blend_table = GetValidatedUniformLocation(shader_program_3d, "u_material_blend_table");
     uniforms_3d.material_index_base = GetValidatedUniformLocation(shader_program_3d, "u_material_index_base");
-    uniforms_3d.material_index_range = GetValidatedUniformLocation(shader_program_3d, "u_material_index_range");
 
     // bind the uniform samplers to texture units
     glUniform1i(uniforms_3d.material_texture_pixelmap, 0);
@@ -544,7 +543,7 @@ void setActiveMaterial(tStored_material* material) {
 
         // index_base and index_range are only used for untextured materials
         glUniform1ui(uniforms_3d.material_index_base, material->index_base);
-        glUniform1ui(uniforms_3d.material_index_range, material->index_range);
+        // glUniform1ui(uniforms_3d.material_index_range, material->index_range);  TODO: re-add when we support untextured lighting
     }
 
     if (material->shade_table) {

--- a/src/harness/resources/3d_frag.glsl
+++ b/src/harness/resources/3d_frag.glsl
@@ -66,7 +66,6 @@ void main() {
 
         if ((u_material_flags & BR_MATF_LIGHT) != 0u) {
             // TODO: lighting calculations based on https://rr2000.cwaboard.co.uk/R4/BRENDER/TEBK_43.HTM#0
-            uint range = u_material_index_range;
         }
     }
     else {


### PR DESCRIPTION
Removes unused reference to `u_material_index_range` uniform since it can be optimized away and cause `glGetUniformLocation` to fail.

Fixes #304