### PR TITLE
Provide an argument to GLRenderer_FlushBuffer

### DIFF
--- a/src/harness/platforms/sdl_opengl.c
+++ b/src/harness/platforms/sdl_opengl.c
@@ -219,6 +219,10 @@ void set_palette(PALETTEENTRY_* pal) {
     GLRenderer_SetPalette((uint8_t*)pal);
 }
 
+void flush_buffers() {
+    GLRenderer_FlushBuffers(eFlush_all);
+}
+
 void Harness_Platform_Init(tHarness_platform* platform) {
     platform->ProcessWindowMessages = get_and_handle_message;
     platform->Sleep = SDL_Delay;
@@ -240,7 +244,7 @@ void Harness_Platform_Init(tHarness_platform* platform) {
     platform->Renderer_FullScreenQuad = GLRenderer_FullScreenQuad;
     platform->Renderer_Model = GLRenderer_Model;
     platform->Renderer_ClearBuffers = GLRenderer_ClearBuffers;
-    platform->Renderer_FlushBuffers = GLRenderer_FlushBuffers;
+    platform->Renderer_FlushBuffers = flush_buffers;
     platform->Renderer_BeginScene = GLRenderer_BeginScene;
     platform->Renderer_EndScene = GLRenderer_EndScene;
     platform->Renderer_SetViewport = GLRenderer_SetViewport;

--- a/src/harness/platforms/sdl_opengl.c
+++ b/src/harness/platforms/sdl_opengl.c
@@ -219,10 +219,6 @@ void set_palette(PALETTEENTRY_* pal) {
     GLRenderer_SetPalette((uint8_t*)pal);
 }
 
-void flush_buffers() {
-    GLRenderer_FlushBuffers(eFlush_all);
-}
-
 void Harness_Platform_Init(tHarness_platform* platform) {
     platform->ProcessWindowMessages = get_and_handle_message;
     platform->Sleep = SDL_Delay;
@@ -244,7 +240,7 @@ void Harness_Platform_Init(tHarness_platform* platform) {
     platform->Renderer_FullScreenQuad = GLRenderer_FullScreenQuad;
     platform->Renderer_Model = GLRenderer_Model;
     platform->Renderer_ClearBuffers = GLRenderer_ClearBuffers;
-    platform->Renderer_FlushBuffers = flush_buffers;
+    platform->Renderer_FlushBuffers = GLRenderer_FlushBuffers;
     platform->Renderer_BeginScene = GLRenderer_BeginScene;
     platform->Renderer_EndScene = GLRenderer_EndScene;
     platform->Renderer_SetViewport = GLRenderer_SetViewport;

--- a/src/harness/renderers/gl/gl_renderer.c
+++ b/src/harness/renderers/gl/gl_renderer.c
@@ -326,7 +326,7 @@ void GLRenderer_SetShadeTable(br_pixelmap* table) {
 void GLRenderer_SetBlendTable(br_pixelmap* table) {
 
     if (flush_counter != colourbuffer_upload_counter) {
-        GLRenderer_FlushBuffers(eFlush_color_buffer);
+        GLRenderer_FlushBuffer(eFlush_color_buffer);
         glActiveTexture(GL_TEXTURE4);
         glBindTexture(GL_TEXTURE_2D, current_colourbuffer_texture);
         glTexImage2D(GL_TEXTURE_2D, 0, GL_R8UI, render_width, render_height, 0, GL_RED_INTEGER, GL_UNSIGNED_BYTE, last_colour_buffer->pixels);
@@ -690,7 +690,7 @@ void GLRenderer_BufferTexture(br_pixelmap* pm) {
     CHECK_GL_ERROR("GLRenderer_BufferTexture");
 }
 
-void GLRenderer_FlushBuffers(tRenderer_flush_type flush_type) {
+void GLRenderer_FlushBuffer(tRenderer_flush_type flush_type) {
 
     if (!dirty_buffers) {
         return;
@@ -736,6 +736,10 @@ void GLRenderer_FlushBuffers(tRenderer_flush_type flush_type) {
     glClear(GL_COLOR_BUFFER_BIT);
     flush_counter++;
     dirty_buffers = 0;
+}
+
+void GLRenderer_FlushBuffers() {
+    GLRenderer_FlushBuffer(eFlush_all);
 }
 
 void GLRenderer_SetViewport(int x, int y, int width, int height) {

--- a/src/harness/renderers/gl/gl_renderer.h
+++ b/src/harness/renderers/gl/gl_renderer.h
@@ -52,7 +52,8 @@ void GLRenderer_BufferTexture(br_pixelmap* pm);
 void GLRenderer_BufferMaterial(br_material* mat);
 void GLRenderer_BufferModel(br_model* model);
 void GLRenderer_ClearBuffers();
-void GLRenderer_FlushBuffers(tRenderer_flush_type flush_type);
+void GLRenderer_FlushBuffer(tRenderer_flush_type flush_type);
+void GLRenderer_FlushBuffers();
 void GLRenderer_SetViewport(int x, int y, int width, int height);
 
 #endif


### PR DESCRIPTION
Part of the `tHarness_platform` set of function pointers is `void (*Renderer_FlushBuffers)();`. It does not take any arguments. We were assigning `GLRenderer_FlushBuffers` to that, which took a `tRenderer_flush_type` argument.

Because we were not providing the argument, its value was undefined and sometimes would appear to work and sometimes not.

fixes #310 