### PR TITLE
input: use PDKeyDown3 in PDGetASCIIFromKey

### DIFF
--- a/src/DETHRACE/pc-win95/win95sys.c
+++ b/src/DETHRACE/pc-win95/win95sys.c
@@ -308,7 +308,7 @@ void Win32ReleaseInputDevice(void) {
 int PDGetASCIIFromKey(int pKey) {
     LOG_TRACE("(%d)", pKey);
 
-    if (PDKeyDown(KEY_SHIFT_ANY)) {
+    if (PDKeyDown3(KEY_SHIFT_ANY)) {
         return gASCII_shift_table[pKey];
     } else {
         return gASCII_table[pKey];

--- a/src/DETHRACE/pc-win95/win95sys.c
+++ b/src/DETHRACE/pc-win95/win95sys.c
@@ -308,6 +308,7 @@ void Win32ReleaseInputDevice(void) {
 int PDGetASCIIFromKey(int pKey) {
     LOG_TRACE("(%d)", pKey);
 
+    /* The Windows Carmageddon executable uses PDKeyDown here. The German DOS executable uses PDKeyDown3. */
     if (PDKeyDown3(KEY_SHIFT_ANY)) {
         return gASCII_shift_table[pKey];
     } else {


### PR DESCRIPTION
PDKeyDown3 does not modify last_key_down and last_key_down_time

`PDKeyDown3` is used in the german DOS Carmageddon executable,
but not in the GOG splatpack Windows executable.

So I'm unsure what the correct approach is here.

Fixes #321

