### PR TITLE
Fix damaged cars in action replay

### DIFF
--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -129,7 +129,7 @@ void InstantDepthChange(tDepth_effect_type pType, br_pixelmap* pSky_texture, int
 
     gProgram_state.current_depth_effect.sky_texture = pSky_texture;
     gHorizon_material->colour_map = pSky_texture;
-    BrMaterialUpdate(gHorizon_material, 0x7FFFu);
+    BrMaterialUpdate(gHorizon_material, BR_MATU_ALL);
     gProgram_state.current_depth_effect.type = pType;
     gProgram_state.current_depth_effect.start = pStart;
     gProgram_state.current_depth_effect.end = pEnd;

--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -995,7 +995,7 @@ void DoDamageScreen(tU32 pThe_time) {
     } else {
         the_wobble_x = gProgram_state.current_car.damage_x_offset;
         the_wobble_y = gProgram_state.current_car.damage_y_offset;
-        if (gProgram_state.current_car.damage_background) {
+        if (gProgram_state.current_car.damage_background != NULL) {
             DRPixelmapRectangleMaskedCopy(
                 gBack_screen,
                 gProgram_state.current_car.damage_background_x,
@@ -1019,7 +1019,7 @@ void DoDamageScreen(tU32 pThe_time) {
                 the_wobble_y + gProgram_state.current_car.damage_units[i].y_coord,
                 the_image,
                 0,
-                y_pitch * (2 * the_step + ((pThe_time / the_damage->periods[5 * the_damage->damage_level / 100]) & 1)),
+                y_pitch * (2 * the_step + ((pThe_time / the_damage->periods[the_step]) & 1)),
                 the_image->width,
                 y_pitch);
         }

--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -1101,7 +1101,11 @@ void DoInstruments(tU32 pThe_time) {
                 cos_angle = gCosine_array[(unsigned int)((TAU - the_angle2) / DR_PI * 128.0)];
             } else if (the_angle2 > DR_PI) {
                 cos_angle = -gCosine_array[(unsigned int)((the_angle2 - DR_PI) / DR_PI * 128.0)];
+#if defined(DETHRACE_FIX_BUGS)
+            } else if (the_angle2 >= DR_PI_OVER_2) {
+#else
             } else if (the_angle2 > DR_PI_OVER_2) {
+#endif
                 cos_angle = -gCosine_array[(unsigned int)((DR_PI - the_angle2) / DR_PI * 128.0)];
             } else {
                 cos_angle = gCosine_array[(unsigned int)(the_angle2 / DR_PI * 128.0)];
@@ -1110,7 +1114,11 @@ void DoInstruments(tU32 pThe_time) {
                 sin_angle = gCosine_array[(unsigned int)((TAU - the_angle) / DR_PI * 128.0)];
             } else if (the_angle > DR_PI) {
                 sin_angle = -gCosine_array[(unsigned int)((the_angle - DR_PI) / DR_PI * 128.0)];
+#if defined(DETHRACE_FIX_BUGS)
+            } else if (the_angle >= DR_PI_OVER_2) {
+#else
             } else if (the_angle > DR_PI_OVER_2) {
+#endif
                 sin_angle = -gCosine_array[(unsigned int)((DR_PI - the_angle) / DR_PI * 128.0)];
             } else {
                 sin_angle = gCosine_array[(unsigned int)(the_angle / DR_PI * 128.0)];

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -375,8 +375,8 @@ void BuildColourTable(br_pixelmap* pPalette) {
 
 #define SQR(i) i* i
 
-    for (i = 0; i < COUNT_OF(gRGB_colours); ++i) {
-        nearest_distance = 0x48400000;
+    for (i = 0; i < COUNT_OF(gRGB_colours); i++) {
+        nearest_distance = 196608.f;
         red = (gRGB_colours[i] >> 16) & 0xFF;
         green = (gRGB_colours[i] >> 8) & 0xFF;
         blue = gRGB_colours[i] & 0xFF;
@@ -1088,7 +1088,7 @@ br_scalar DistanceFromPlane(br_vector3* pPos, br_scalar pA, br_scalar pB, br_sca
     br_vector3 normal;
     LOG_TRACE("(%p, %f, %f, %f, %f)", pPos, pA, pB, pC, pD);
 
-    return fabs((pPos->v[1] * pB + pPos->v[0] * pA + pPos->v[2] * pC + pD) / (pA * pA + pC * pC + pB * pB));
+    return fabsf((pPos->v[1] * pB + pPos->v[0] * pA + pPos->v[2] * pC + pD) / (pA * pA + pC * pC + pB * pB));
 }
 
 // IDA: void __cdecl DisableLights()

--- a/src/DETHRACE/common/piping.c
+++ b/src/DETHRACE/common/piping.c
@@ -2024,7 +2024,7 @@ int UndoPipedSession(tU8** pPtr) {
     chunk_ptr = &((tPipe_session*)*pPtr)->chunks;
     chunk_type = ((tPipe_session*)*pPtr)->chunk_type;
     pushed_end_of_session = gEnd_of_session;
-    for (i = 0; i < ((tPipe_session*)pPtr)->number_of_chunks; i++) {
+    for (i = 0; i < ((tPipe_session*)*pPtr)->number_of_chunks; i++) {
         if (!(chunk_type == ePipe_chunk_model_geometry || chunk_type == ePipe_chunk_sound || chunk_type == ePipe_chunk_damage || chunk_type == ePipe_chunk_special || chunk_type == ePipe_chunk_incident || chunk_type == ePipe_chunk_prox_ray || chunk_type == ePipe_chunk_smudge)) {
             prev_chunk = FindPreviousChunk(*pPtr, ((tPipe_session*)*pPtr)->chunk_type, chunk_ptr->subject_index);
         }

--- a/src/DETHRACE/common/piping.c
+++ b/src/DETHRACE/common/piping.c
@@ -310,7 +310,7 @@ tU32 LengthOfSession(tPipe_session* pSession) {
     }
     running_total += offsetof(tPipe_session, chunks) + sizeof(tU16);
     if (running_total % 2 != 0) {
-        FatalError(98);
+        FatalError(kFatalError_PipingSystem);
     }
     return running_total;
 }

--- a/src/DETHRACE/common/replay.c
+++ b/src/DETHRACE/common/replay.c
@@ -306,11 +306,6 @@ void MoveToStartOfReplay(void) {
 void ToggleReplay(void) {
     LOG_TRACE("()");
 
-    if (!harness_game_config.enable_replay) {
-        NewTextHeadupSlot(4, 0, 1000, -4, "Action replay disabled (start dethrace with --enable-replay)");
-        return;
-    }
-
     if (!IsActionReplayAvailable()) {
         NewTextHeadupSlot(4, 0, 1000, -4, GetMiscString(37));
         return;

--- a/src/DETHRACE/common/world.c
+++ b/src/DETHRACE/common/world.c
@@ -2611,7 +2611,7 @@ void LoadTrack(char* pFile_name, tTrack_spec* pTrack_spec, tRace_info* pRace_inf
     strcat(str, ".ACT");
     PathCat(gAdditional_actor_path, gApplication_path, "ACTORS");
     PathCat(gAdditional_actor_path, gAdditional_actor_path, str);
-    gAdditional_actors = BrActorAllocate(0, 0);
+    gAdditional_actors = BrActorAllocate(BR_ACTOR_NONE, NULL);
     BrActorAdd(gUniverse_actor, gAdditional_actors);
     gLast_actor = NULL;
     SaveAdditionalStuff();

--- a/src/DETHRACE/dr_types.h
+++ b/src/DETHRACE/dr_types.h
@@ -2660,6 +2660,9 @@ typedef struct tPipe_skid_adjustment {
 
 typedef struct tPipe_chunk {                                 // size: 0x58
     tChunk_subject_index subject_index;                      // @0x0
+#if defined(DETHRACE_REPLAY_DEBUG)
+    int chunk_magic1;
+#endif
     union {                                                  // size: 0x54
         tPipe_actor_rstyle_data actor_rstyle_data;           // @0x0
         tPipe_actor_translate_data actor_translate_data;     // @0x0
@@ -2700,7 +2703,7 @@ typedef struct tPipe_session {
     tPipe_chunk_type chunk_type;
     tU8 number_of_chunks;
 #if defined(DETHRACE_REPLAY_DEBUG)
-    int magic1;
+    int pipe_magic1;
 #endif
     tPipe_chunk chunks;
 } tPipe_session;

--- a/src/S3/3d.c
+++ b/src/S3/3d.c
@@ -198,9 +198,9 @@ int S3BindAmbientSoundToOutlet(tS3_outlet* pOutlet, int pSound, tS3_sound_source
 
     source->ambient_repeats = pRepeats < 0 ? 0 : pRepeats;
     source->time_since_last_played = pPeriod;
-    source->channel = 0;
+    source->channel = NULL;
     source->tag = 0;
-    return 0;
+    return eS3_error_none;
 }
 
 void S3UpdateSoundSource(tS3_outlet* outlet, tS3_sound_tag tag, tS3_sound_source* src, float pMax_distance_squared, int pPeriod, tS3_repeats pAmbient_repeats, tS3_volume pVolume, int pPitch, tS3_speed pSpeed) {

--- a/src/S3/audio.c
+++ b/src/S3/audio.c
@@ -445,7 +445,7 @@ tS3_descriptor* S3CreateDescriptor(void) {
     d = S3MemAllocate(sizeof(tS3_descriptor), kMem_S3_descriptor);
     if (!d) {
         gS3_last_error = eS3_error_memory;
-        return 0;
+        return NULL;
     }
     memset(d, 0, sizeof(tS3_descriptor));
     root = gS3_root_descriptor;
@@ -561,12 +561,12 @@ void S3ReleaseOutlet(tS3_outlet* outlet) {
         S3UnbindChannels(outlet);
         prev = outlet->prev;
         next = outlet->next;
-        if (prev) {
+        if (prev != NULL) {
             prev->next = next;
         } else {
             gS3_outlets = outlet->next;
         }
-        if (next) {
+        if (next != NULL) {
             next->prev = prev;
         }
         if (gS3_noutlets) {
@@ -654,7 +654,7 @@ tS3_channel* S3AllocateChannel(tS3_outlet* outlet, int priority) {
         lowest_priority_chan->active = 1;
     }
 
-    return 0;
+    return NULL;
 }
 
 int S3StopChannel(tS3_channel* chan) {

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -159,8 +159,6 @@ void Harness_Init(int* argc, char* argv[]) {
     harness_game_config.volume_multiplier = 1.0f;
     // start window in windowed mode
     harness_game_config.start_full_screen = 0;
-    // disable replay by default
-    harness_game_config.enable_replay = 0;
     // Emulate DOS behavior
     harness_game_config.dos_mode = 0;
 
@@ -247,9 +245,6 @@ int Harness_ProcessCommandLine(int* argc, char* argv[]) {
             handled = 1;
         } else if (strcasecmp(argv[i], "--full-screen") == 0) {
             harness_game_config.start_full_screen = 1;
-            handled = 1;
-        } else if (strcasecmp(argv[i], "--enable-replay") == 0) {
-            harness_game_config.enable_replay = 1;
             handled = 1;
         } else if (strcasecmp(argv[i], "--dos-mode") == 0) {
             harness_game_config.dos_mode = 1;

--- a/src/harness/include/harness/config.h
+++ b/src/harness/include/harness/config.h
@@ -41,7 +41,6 @@ typedef struct tHarness_game_config {
     int enable_diagnostics;
     float volume_multiplier;
     int start_full_screen;
-    int enable_replay;
     int dos_mode;
 
     int install_signalhandler;


### PR DESCRIPTION
This fixes buffer a overflow in action replay, when the car has been damaged.
It also fixes a bonus overflow (catched with asan), + more debug checks for piping.
Because replay behaves more stable and much faster, the patch removes the `--enable-replay` option to enable replay. It is now always available.


The header of a session `{type; u8, count: u8}`. 
The number of chunks in a session was read wrong, most often it was 0xff on my system because heap pointers on my system (=Linux) look like `0x7ffff3aec800`.
Perhaps `malloc` behaves different on other platform because not everybody was seeing these crashes.
It fixes slow seeking in replay, and explains broken models.
This bug caused all deltas to be undone 255 times instead of 1 time.
It looks like only geometry and "hp" damage are stored as deltas in the pipe, so those were undone 254 times too often. 