### PR TITLE
chdir to exe path

### DIFF
--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -9,7 +9,6 @@
 #include "version.h"
 
 #include <errno.h>
-#include <libgen.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -178,7 +178,7 @@ void Harness_Init(int* argc, char* argv[]) {
     if (root_dir != NULL) {
         LOG_INFO("DETHRACE_ROOT_DIR is set to '%s'", root_dir);
     } else {
-        root_dir = dirname(argv[0]);
+        root_dir = OS_Dirname(argv[0]);
     }
     printf("Using root directory: %s\n", root_dir);
     result = chdir(root_dir);

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -9,6 +9,7 @@
 #include "version.h"
 
 #include <errno.h>
+#include <libgen.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -174,15 +175,17 @@ void Harness_Init(int* argc, char* argv[]) {
     }
 
     char* root_dir = getenv("DETHRACE_ROOT_DIR");
-    if (root_dir == NULL) {
-        LOG_INFO("DETHRACE_ROOT_DIR is not set, assuming '.'");
+    if (root_dir != NULL) {
+        LOG_INFO("DETHRACE_ROOT_DIR is set to '%s'", root_dir);
     } else {
-        printf("Data directory: %s\n", root_dir);
-        result = chdir(root_dir);
-        if (result != 0) {
-            LOG_PANIC("Failed to chdir. Error is %s", strerror(errno));
-        }
+        root_dir = dirname(argv[0]);
     }
+    printf("Using root directory: %s\n", root_dir);
+    result = chdir(root_dir);
+    if (result != 0) {
+        LOG_PANIC("Failed to chdir. Error is %s", strerror(errno));
+    }
+
     if (harness_game_info.mode == eGame_none) {
         Harness_DetectGameMode();
     }

--- a/src/harness/include/harness/os.h
+++ b/src/harness/include/harness/os.h
@@ -30,8 +30,8 @@ FILE* OS_fopen(const char* pathname, const char* mode);
 
 size_t OS_ConsoleReadPassword(char* pBuffer, size_t pBufferLen);
 
-char* OS_Dirname(char* path);
+char* OS_Dirname(const char* path);
 
-char* OS_Basename(char* path);
+char* OS_Basename(const char* path);
 
 #endif

--- a/src/harness/include/harness/os.h
+++ b/src/harness/include/harness/os.h
@@ -30,4 +30,8 @@ FILE* OS_fopen(const char* pathname, const char* mode);
 
 size_t OS_ConsoleReadPassword(char* pBuffer, size_t pBufferLen);
 
+char* OS_Dirname(char* path);
+
+char* OS_Basename(char* path);
+
 #endif

--- a/src/harness/os/linux.c
+++ b/src/harness/os/linux.c
@@ -25,12 +25,14 @@
 #include <unistd.h>
 
 #define ARRAY_SIZE(A) (sizeof(A) / sizeof(A[0]))
+#define MAX_STACK_FRAMES 64
+#define TRACER_PID_STRING "TracerPid:"
 
 static int stack_nbr = 0;
 static char _program_name[1024];
-#define MAX_STACK_FRAMES 64
+
 static void* stack_traces[MAX_STACK_FRAMES];
-#define TRACER_PID_STRING "TracerPid:"
+static char name_buf[MAXPATHLEN];
 
 struct dl_iterate_callback_data {
     int initialized;
@@ -302,10 +304,12 @@ size_t OS_ConsoleReadPassword(char* pBuffer, size_t pBufferLen) {
     return len;
 }
 
-char* OS_Dirname(char* path) {
-    return dirname(path);
+char* OS_Dirname(const char* path) {
+    strcpy(name_buf, path);
+    return dirname(name_buf);
 }
 
-char* OS_Basename(char* path) {
-    return basename(path);
+char* OS_Basename(const char* path) {
+    strcpy(name_buf, path);
+    return dirname(name_buf);
 }

--- a/src/harness/os/linux.c
+++ b/src/harness/os/linux.c
@@ -176,7 +176,7 @@ static void signal_handler(int sig, siginfo_t* siginfo, void* context) {
 void resolve_full_path(char* path, const char* argv0) {
     if (argv0[0] == '/') { // run with absolute path
         strcpy(path, argv0);
-    } else { // run with relative path
+    } else {               // run with relative path
         if (NULL == getcwd(path, PATH_MAX)) {
             perror("getcwd error");
             return;
@@ -300,4 +300,12 @@ size_t OS_ConsoleReadPassword(char* pBuffer, size_t pBufferLen) {
 
     tcsetattr(STDIN_FILENO, TCSANOW, &old);
     return len;
+}
+
+char* OS_Dirname(char* path) {
+    return dirname(path);
+}
+
+char* OS_Basename(char* path) {
+    return basename(path);
 }

--- a/src/harness/os/linux.c
+++ b/src/harness/os/linux.c
@@ -32,7 +32,7 @@ static int stack_nbr = 0;
 static char _program_name[1024];
 
 static void* stack_traces[MAX_STACK_FRAMES];
-static char name_buf[MAXPATHLEN];
+static char name_buf[PATH_MAX];
 
 struct dl_iterate_callback_data {
     int initialized;

--- a/src/harness/os/linux.c
+++ b/src/harness/os/linux.c
@@ -311,5 +311,5 @@ char* OS_Dirname(const char* path) {
 
 char* OS_Basename(const char* path) {
     strcpy(name_buf, path);
-    return dirname(name_buf);
+    return basename(name_buf);
 }

--- a/src/harness/os/linux.c
+++ b/src/harness/os/linux.c
@@ -32,7 +32,7 @@ static int stack_nbr = 0;
 static char _program_name[1024];
 
 static void* stack_traces[MAX_STACK_FRAMES];
-static char name_buf[PATH_MAX];
+static char name_buf[4096];
 
 struct dl_iterate_callback_data {
     int initialized;

--- a/src/harness/os/macos.c
+++ b/src/harness/os/macos.c
@@ -25,7 +25,7 @@ static int stack_nbr = 0;
 static char _program_name[1024];
 #define MAX_STACK_FRAMES 64
 static void* stack_traces[MAX_STACK_FRAMES];
-static char name_buf[MAXPATHLEN];
+static char name_buf[PATH_MAX];
 
 // Resolve symbol name and source location given the path to the executable and an address
 int addr2line(char const* const program_name, void const* const addr) {

--- a/src/harness/os/macos.c
+++ b/src/harness/os/macos.c
@@ -25,7 +25,7 @@ static int stack_nbr = 0;
 static char _program_name[1024];
 #define MAX_STACK_FRAMES 64
 static void* stack_traces[MAX_STACK_FRAMES];
-static char name_buf[PATH_MAX];
+static char name_buf[4096];
 
 // Resolve symbol name and source location given the path to the executable and an address
 int addr2line(char const* const program_name, void const* const addr) {

--- a/src/harness/os/macos.c
+++ b/src/harness/os/macos.c
@@ -150,7 +150,7 @@ static uint8_t alternate_stack[SIGSTKSZ];
 void resolve_full_path(char* path, const char* argv0) {
     if (argv0[0] == '/') { // run with absolute path
         strcpy(path, argv0);
-    } else { // run with relative path
+    } else {               // run with relative path
         if (NULL == getcwd(path, PATH_MAX)) {
             perror("getcwd error");
             return;
@@ -216,4 +216,12 @@ size_t OS_ConsoleReadPassword(char* pBuffer, size_t pBufferLen) {
     pBuffer[0] = '\0';
     fgets(pBuffer, pBufferLen, stdin);
     return strlen(pBuffer);
+}
+
+char* OS_Dirname(char* path) {
+    return dirname(path);
+}
+
+char* OS_Basename(char* path) {
+    return basename(path);
 }

--- a/src/harness/os/macos.c
+++ b/src/harness/os/macos.c
@@ -25,6 +25,7 @@ static int stack_nbr = 0;
 static char _program_name[1024];
 #define MAX_STACK_FRAMES 64
 static void* stack_traces[MAX_STACK_FRAMES];
+static char name_buf[MAXPATHLEN];
 
 // Resolve symbol name and source location given the path to the executable and an address
 int addr2line(char const* const program_name, void const* const addr) {
@@ -218,10 +219,12 @@ size_t OS_ConsoleReadPassword(char* pBuffer, size_t pBufferLen) {
     return strlen(pBuffer);
 }
 
-char* OS_Dirname(char* path) {
-    return dirname(path);
+char* OS_Dirname(const char* path) {
+    strcpy(name_buf, path);
+    return dirname(name_buf);
 }
 
-char* OS_Basename(char* path) {
-    return basename(path);
+char* OS_Basename(const char* path) {
+    strcpy(name_buf, path);
+    return dirname(name_buf);
 }

--- a/src/harness/os/macos.c
+++ b/src/harness/os/macos.c
@@ -226,5 +226,5 @@ char* OS_Dirname(const char* path) {
 
 char* OS_Basename(const char* path) {
     strcpy(name_buf, path);
-    return dirname(name_buf);
+    return basename(name_buf);
 }

--- a/src/harness/os/windows.c
+++ b/src/harness/os/windows.c
@@ -29,6 +29,9 @@ void dr_dprintf(char* fmt_string, ...);
 static int stack_nbr = 0;
 static char _program_name[1024];
 
+static char dirnane_buf[_MAX_DIR];
+static char basename_buf[_MAX_FNAME];
+
 int addr2line(char const* const program_name, void const* const addr) {
     char addr2line_cmd[512] = { 0 };
 
@@ -170,14 +173,12 @@ size_t OS_ConsoleReadPassword(char* pBuffer, size_t pBufferLen) {
     return strlen(pBuffer);
 }
 
-char* dir[_MAX_DIR];
-char* fname[_MAX_FNAME];
-char* OS_Dirname(char* path) {
-    _splitpath(path, NULL, dir, NULL, NULL);
-    return dir;
+char* OS_Dirname(const char* path) {
+    _splitpath(path, NULL, dirname_buf, NULL, NULL);
+    return dirname_buf;
 }
 
-char* OS_Basename(char* path) {
-    _splitpath(path, NULL, NULL, fname, NULL);
-    return fname;
+char* OS_Basename(const char* path) {
+    _splitpath(path, NULL, NULL, basename_buf, NULL);
+    return basename_buf;
 }

--- a/src/harness/os/windows.c
+++ b/src/harness/os/windows.c
@@ -169,3 +169,15 @@ size_t OS_ConsoleReadPassword(char* pBuffer, size_t pBufferLen) {
     fgets(pBuffer, pBufferLen, stdin);
     return strlen(pBuffer);
 }
+
+char* dir[_MAX_DIR];
+char* fname[_MAX_FNAME];
+char* OS_Dirname(char* path) {
+    _splitpath(path, NULL, dir, NULL, NULL);
+    return dir;
+}
+
+char* OS_Basename(char* path) {
+    _splitpath(path, NULL, NULL, fname, NULL);
+    return fname;
+}

--- a/src/harness/os/windows.c
+++ b/src/harness/os/windows.c
@@ -29,8 +29,8 @@ void dr_dprintf(char* fmt_string, ...);
 static int stack_nbr = 0;
 static char _program_name[1024];
 
-static char dirnane_buf[_MAX_DIR];
-static char basename_buf[_MAX_FNAME];
+static char dirname_buf[_MAX_DIR];
+static char fname_buf[_MAX_FNAME];
 
 int addr2line(char const* const program_name, void const* const addr) {
     char addr2line_cmd[512] = { 0 };
@@ -179,6 +179,6 @@ char* OS_Dirname(const char* path) {
 }
 
 char* OS_Basename(const char* path) {
-    _splitpath(path, NULL, NULL, basename_buf, NULL);
-    return basename_buf;
+    _splitpath(path, NULL, NULL, fname_buf, NULL);
+    return fname_buf;
 }

--- a/src/harness/renderers/gl/gl_renderer.c
+++ b/src/harness/renderers/gl/gl_renderer.c
@@ -220,12 +220,6 @@ void GLRenderer_Init(int pRender_width, int pRender_height) {
     LOG_INFO("OpenGL version string: %s", glGetString(GL_VERSION));
     LOG_INFO("OpenGL shading language version string: %s", glGetString(GL_SHADING_LANGUAGE_VERSION));
 
-    int maxTextureImageUnits;
-    glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &maxTextureImageUnits);
-    if (maxTextureImageUnits < 3) {
-        LOG_PANIC("GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS is %d. Need at least 3", maxTextureImageUnits);
-    }
-
     LoadShaders();
     SetupFullScreenRectGeometry();
 

--- a/src/harness/win95/polyfill.c
+++ b/src/harness/win95/polyfill.c
@@ -1,5 +1,6 @@
 
 #include "harness/hooks.h"
+#include "harness/os.h"
 #include "harness/win95_polyfill.h"
 
 #include <assert.h>
@@ -237,12 +238,11 @@ void DirectDrawDevice_SetPaletteEntries(PALETTEENTRY_* palette, int pFirst_colou
 }
 
 void _splitpath_(char* path, char* drive, char* dir, char* fname, char* ext) {
-#ifdef _WIN32
-    _splitpath(path, NULL, NULL, fname, NULL);
-#else
-    char* base = basename(path);
-    strcpy(fname, base);
-#endif
+    assert(dir == NULL);
+    assert(fname != NULL);
+
+    char* result = OS_Basename(path);
+    strcpy(fname, result);
 }
 
 int _CrtDbgReport_(int reportType, const char* filename, int linenumber, const char* moduleName, const char* format, ...) {


### PR DESCRIPTION
This patch uses `DETHRACE_ROOT_DIR` if defined, otherwise, uses the executable path to set the root directory

Fixes #308 