### PR TITLE
Fixes #245

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -18,7 +18,7 @@
 
 int gSound_detail_level;
 int gVirgin_pass = 1;
-int gOld_sound_detail_level;
+int gOld_sound_detail_level = -1;
 int gLast_tune;
 int gRandom_MIDI_tunes[3];
 int gRandom_Rockin_MIDI_tunes[3];


### PR DESCRIPTION
The initial value of `gOld_sound_detail_level` wasn't correctly copied from OG, so some of the code in `InitSound` was skipped if `SoundDetailLevel = 0`