### PR TITLE
Implement -noreplay from Carmageddon DOS version

### DIFF
--- a/src/DETHRACE/pc-win95/win95sys.c
+++ b/src/DETHRACE/pc-win95/win95sys.c
@@ -864,6 +864,11 @@ void Win32AllocateActionReplayBuffer(void) {
 void PDAllocateActionReplayBuffer(char** pBuffer, tU32* pBuffer_size) {
     LOG_TRACE("(%p, %p)", pBuffer, pBuffer_size);
 
+    if (gReplay_override) {
+        *pBuffer = NULL;
+        *pBuffer_size = 0;
+        return;
+    }
     Win32AllocateActionReplayBuffer();
     *pBuffer = gWin32_action_replay_buffer;
     *pBuffer_size = gWin32_action_replay_buffer_size;


### PR DESCRIPTION
The DOS version has a `-noreplay` option that disables replay.