### PR TITLE
Fix windows chdir behavior

### DIFF
--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -181,7 +181,8 @@ void Harness_Init(int* argc, char* argv[]) {
     } else {
         root_dir = OS_Dirname(argv[0]);
     }
-    if (root_dir != NULL && strlen(root_dir) > 1) {
+    // if root_dir is empty or ".", no need to chdir
+    if (root_dir != NULL && root_dir != '\0' && root_dir != '.') {
         printf("Using root directory: %s\n", root_dir);
         result = chdir(root_dir);
         if (result != 0) {

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -181,10 +181,12 @@ void Harness_Init(int* argc, char* argv[]) {
     } else {
         root_dir = OS_Dirname(argv[0]);
     }
-    printf("Using root directory: %s\n", root_dir);
-    result = chdir(root_dir);
-    if (result != 0) {
-        LOG_PANIC("Failed to chdir. Error is %s", strerror(errno));
+    if (root_dir != NULL && strlen(root_dir) > 1) {
+        printf("Using root directory: %s\n", root_dir);
+        result = chdir(root_dir);
+        if (result != 0) {
+            LOG_PANIC("Failed to chdir. Error is %s", strerror(errno));
+        }
     }
 
     if (harness_game_info.mode == eGame_none) {

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -181,7 +181,7 @@ void Harness_Init(int* argc, char* argv[]) {
     } else {
         root_dir = OS_Dirname(argv[0]);
     }
-    // if root_dir is empty or ".", no need to chdir
+    // if root_dir is null or empty, no need to chdir
     if (root_dir != NULL && root_dir[0] != '\0') {
         printf("Using root directory: %s\n", root_dir);
         result = chdir(root_dir);

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -182,7 +182,7 @@ void Harness_Init(int* argc, char* argv[]) {
         root_dir = OS_Dirname(argv[0]);
     }
     // if root_dir is empty or ".", no need to chdir
-    if (root_dir != NULL && root_dir != '\0' && root_dir != '.') {
+    if (root_dir != NULL && root_dir[0] != '\0' && root_dir[0] != '.') {
         printf("Using root directory: %s\n", root_dir);
         result = chdir(root_dir);
         if (result != 0) {

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -182,7 +182,7 @@ void Harness_Init(int* argc, char* argv[]) {
         root_dir = OS_Dirname(argv[0]);
     }
     // if root_dir is empty or ".", no need to chdir
-    if (root_dir != NULL && root_dir[0] != '\0' && root_dir[0] != '.') {
+    if (root_dir != NULL && root_dir[0] != '\0') {
         printf("Using root directory: %s\n", root_dir);
         result = chdir(root_dir);
         if (result != 0) {

--- a/src/harness/harness_trace.c
+++ b/src/harness/harness_trace.c
@@ -19,6 +19,30 @@ void debug_printf(const char* fmt, const char* fn, const char* fmt2, ...) {
     puts("\033[0m");
 }
 
+void panic_printf(const char* fmt, const char* fn, const char* fmt2, ...) {
+    va_list ap;
+
+    FILE* fp = fopen("dethrace.log", "w");
+
+    puts("\033[0;31m");
+    printf(fmt, fn);
+
+    if (fp != NULL) {
+        fprintf(fp, fmt, fn);
+    }
+
+    va_start(ap, fmt2);
+    vprintf(fmt2, ap);
+    if (fp != NULL) {
+        vfprintf(fp, fmt2, ap);
+    }
+    va_end(ap);
+    if (fp != NULL) {
+        fclose(fp);
+    }
+    puts("\033[0m");
+}
+
 void debug_print_vector3(const char* fmt, const char* fn, char* msg, br_vector3* v) {
     printf(fmt, fn);
     printf("%s %f, %f, %f\n", msg, v->v[0], v->v[1], v->v[2]);

--- a/src/harness/include/harness/trace.h
+++ b/src/harness/include/harness/trace.h
@@ -5,9 +5,9 @@
 #include <stdlib.h>
 
 extern int harness_debug_level;
-extern int OS_IsDebuggerPresent(void);
 
-void debug_printf(const char* fmt, const char* fn, const char* fmt2, ...);
+void debug_printf(const char* fmt, const char* fn, const char* fmt2, ...);  
+void panic_printf(const char* fmt, const char* fn, const char* fmt2, ...);
 void debug_print_vector3(const char* fmt, const char* fn, char* msg, br_vector3* v);
 void debug_print_matrix34(const char* fmt, const char* fn, char* name, br_matrix34* m);
 void debug_print_matrix4(const char* fmt, const char* fn, char* name, br_matrix4* m);
@@ -41,7 +41,7 @@ void debug_print_matrix4(const char* fmt, const char* fn, char* name, br_matrix4
 #define LOG_WARN(...) debug_printf("\033[0;33m[WARN] %s ", __FUNCTION__, __VA_ARGS__)
 #define LOG_PANIC(...)                                                    \
     do {                                                                  \
-        debug_printf("\033[0;31m[PANIC] %s ", __FUNCTION__, __VA_ARGS__); \
+        panic_printf("[PANIC] %s ", __FUNCTION__, __VA_ARGS__); \
         abort();                                                          \
     } while (0)
 

--- a/src/harness/renderers/gl/gl_renderer.c
+++ b/src/harness/renderers/gl/gl_renderer.c
@@ -220,6 +220,10 @@ void GLRenderer_Init(int pRender_width, int pRender_height) {
     LOG_INFO("OpenGL version string: %s", glGetString(GL_VERSION));
     LOG_INFO("OpenGL shading language version string: %s", glGetString(GL_SHADING_LANGUAGE_VERSION));
 
+    if (glGetString(GL_SHADING_LANGUAGE_VERSION) == NULL) {
+        LOG_PANIC("GL_SHADING_LANGUAGE_VERSION is null");
+    }
+
     LoadShaders();
     SetupFullScreenRectGeometry();
 


### PR DESCRIPTION
`argv[0]` was expected to include the full path to the dethrace executable. On windows, this is not true, and only includes the filename. 

As a fix, we should only try to `chdir` if `root_dir` is not empty or a single character. 