### PR TITLE
Fix some Address Sanitizer errors

### DIFF
--- a/src/DETHRACE/CMakeLists.txt
+++ b/src/DETHRACE/CMakeLists.txt
@@ -10,11 +10,12 @@ target_include_directories(dethrace_obj
         pd
 )
 
-# add_compile_options(-fsanitize=address)
-# add_link_options(-fsanitize=address)
+if (DETHRACE_ASAN)
+    target_compile_options(dethrace_obj PUBLIC -fsanitize=address)
+    target_link_options(dethrace_obj PUBLIC -fsanitize=address)
+endif()
 
 target_link_libraries(dethrace_obj PUBLIC SDL2::SDL2 smackw32 harness BRender::Full BRender::DDI s3)
-
 
 if(MSVC)
     target_compile_definitions(dethrace_obj PRIVATE -D_CRT_SECURE_NO_WARNINGS)

--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -2491,6 +2491,13 @@ void MungeSplash(tU32 pTime) {
     if (!gAction_replay_mode || GetReplayRate() == 0.0) {
         if (!gAction_replay_mode) {
             for (i = 0; i < gNum_cars_and_non_cars; i++) {
+#if defined(DETHRACE_FIX_BUGS)
+                // CreateSpash assumes a `tCar_spec*` argument. In the case a non-car is pushed into the water, a `tNon_car_spec*` is passed,
+                // causing invalid memory accesses
+                if (gActive_car_list[i]->driver < eDriver_oppo) {
+                    continue;
+                }
+#endif
                 if (gActive_car_list[i]->water_d != 10000.0 && gActive_car_list[i]->driver != eDriver_local_human) {
                     CreateSplash(gActive_car_list[i], pTime);
                 }
@@ -2516,7 +2523,7 @@ void MungeSplash(tU32 pTime) {
             }
         }
         if (gProgram_state.current_car.water_d != 10000.0) {
-            CreateSplash(&gProgram_state.current_car, 0x64u);
+            CreateSplash(&gProgram_state.current_car, 100);
         }
     }
     if (!gSplash_flags) {


### PR DESCRIPTION
Running with address sanitizer raised a couple of errors:

- `CollCheck` made some assumptions that the colliding object is a `tCar_spec`, when it could be a `tNon_car_spec`. 
- `CreateSplash` makes similar assumptions. 

A fairly reliable repro is to collide with the wrecked car next to the water in Maim Street and knock it into the water
