### PR TITLE
Fixes crash when not calling ma_audio_unint correctly

### DIFF
--- a/src/S3/s3music.c
+++ b/src/S3/s3music.c
@@ -9,7 +9,6 @@ void S3DisableMIDI(void) {
 }
 
 void S3StopMIDIOutlets(void) {
-    STUB();
 }
 
 void S3ReleaseMIDI(tS3_sound_tag tag) {

--- a/src/harness/audio/miniaudio.c
+++ b/src/harness/audio/miniaudio.c
@@ -42,6 +42,7 @@ typedef struct tMiniaudio_stream {
 
 ma_engine engine;
 ma_sound cda_sound;
+int cda_sound_initialized;
 
 tAudioBackend_error_code AudioBackend_Init(void) {
     ma_result result;
@@ -75,10 +76,14 @@ void AudioBackend_UnInitCDA(void) {
 }
 
 tAudioBackend_error_code AudioBackend_StopCDA(void) {
+    if (!cda_sound_initialized) {
+        return eAB_success;
+    }
     if (ma_sound_is_playing(&cda_sound)) {
         ma_sound_stop(&cda_sound);
-        ma_sound_uninit(&cda_sound);
     }
+    ma_sound_uninit(&cda_sound);
+    cda_sound_initialized = 0;
     return eAB_success;
 }
 
@@ -95,6 +100,7 @@ tAudioBackend_error_code AudioBackend_PlayCDA(int track) {
     if (result != MA_SUCCESS) {
         return eAB_error;
     }
+    cda_sound_initialized = 1;
     result = ma_sound_start(&cda_sound);
     if (result != MA_SUCCESS) {
         return eAB_error;
@@ -103,10 +109,16 @@ tAudioBackend_error_code AudioBackend_PlayCDA(int track) {
 }
 
 int AudioBackend_CDAIsPlaying(void) {
+    if (!cda_sound_initialized) {
+        return 0;
+    }
     return ma_sound_is_playing(&cda_sound);
 }
 
 tAudioBackend_error_code AudioBackend_SetCDAVolume(int volume) {
+    if (!cda_sound_initialized) {
+        return eAB_error;
+    }
     ma_sound_set_volume(&cda_sound, volume / 255.0f);
     return eAB_success;
 }

--- a/src/harness/audio/miniaudio.c
+++ b/src/harness/audio/miniaudio.c
@@ -96,6 +96,10 @@ tAudioBackend_error_code AudioBackend_PlayCDA(int track) {
     if (access(path, F_OK) == -1) {
         return eAB_error;
     }
+
+    // ensure we are not still playing a track
+    AudioBackend_StopCDA();
+
     result = ma_sound_init_from_file(&engine, path, 0, NULL, NULL, &cda_sound);
     if (result != MA_SUCCESS) {
         return eAB_error;


### PR DESCRIPTION
`AudioBackend_StopCDA` doesn't call `ma_audio_unint` if the track has already finished playing. 

- Adds call to `ma_audio_unint` if necessary
- Adds call to `AudioBackend_StopCDA` inside `AudioBackend_PlayCDA` to ensure we are not still playing the previous track

Fixes #396 