### PR TITLE
Fix 399: Game does not obey sound effects volume level set in sound settings.

### DIFF
--- a/src/S3/s3sound.c
+++ b/src/S3/s3sound.c
@@ -350,9 +350,7 @@ int S3SyncSampleVolumeAndPan(tS3_channel* chan) {
     float pan_ratio; // [esp+38h] [ebp-8h]
     float total_vol; // [esp+3Ch] [ebp-4h]
 
-    int volume_db;
     int pan;
-    float linear_volume;
 
     if (chan->type != eS3_ST_sample) {
         return 1;
@@ -362,12 +360,8 @@ int S3SyncSampleVolumeAndPan(tS3_channel* chan) {
         total_vol = 1.0f;
     }
     if (chan->descriptor && chan->descriptor->type == chan->type) {
-        volume_db = 510.0f / total_vol * -5.0f - 350.0f;
-        if (volume_db >= 0) {
-            volume_db = 0;
-        }
 
-        if (AudioBackend_SetVolume(chan->type_struct_sample, volume_db) == eAB_success && chan->spatial_sound) {
+        if (AudioBackend_SetVolume(chan->type_struct_sample, total_vol) == eAB_success && chan->spatial_sound) {
 
             if (chan->left_volume != 0 && chan->right_volume > chan->left_volume) {
                 pan_ratio = chan->right_volume / (float)chan->left_volume;


### PR DESCRIPTION
Incorporated the following changes:

1. Moved calls to `S3SyncSampleVolumeAndPan()` and `S3SyncSampleRate()` to follow call to `AudioBackend_PlaySample()`. This is required because the later one initializes the object on which `S3Sync...()` functions operate.
2. Removed a call to `ma_volume_db_to_linear()` as it expects input volume to be in exponential scale where `volume_db` is in linear scale. The call has been replaced with explicit transformation using reverse formula of the one found in `S3SyncSampleVolumeAndPan()` function.

Fixes #399 