### PR TITLE
Ensure initial volume for CD music is properly set.

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -699,6 +699,11 @@ int DRS3StartCDA(tS3_sound_id pCDA_id) {
                     }
                     gLast_tune = pCDA_id;
                     gCDA_is_playing = DRS3StartSoundNoPiping(gMusic_outlet, pCDA_id);
+#if defined(DETHRACE_FIX_BUGS)
+                    // Not a bug, but this is the less abusing place
+                    // where the initial music volume might be set with success.
+                    DRS3SetOutletVolume(gMusic_outlet, 42 * gProgram_state.music_volume);                    
+#endif
                     gCDA_tag = gCDA_is_playing;
                     if (!gCDA_is_playing) {
                         gCD_is_disabled = 1;

--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -700,8 +700,7 @@ int DRS3StartCDA(tS3_sound_id pCDA_id) {
                     gLast_tune = pCDA_id;
                     gCDA_is_playing = DRS3StartSoundNoPiping(gMusic_outlet, pCDA_id);
 #if defined(DETHRACE_FIX_BUGS)
-                    // Not a bug, but this is the less abusing place
-                    // where the initial music volume might be set with success.
+                    // Initial CD music volume was not set correctly
                     DRS3SetOutletVolume(gMusic_outlet, 42 * gProgram_state.music_volume);                    
 #endif
                     gCDA_tag = gCDA_is_playing;


### PR DESCRIPTION
First intention was to do a fix in a similar way like it has been fixed for effects volume. However, the "set-volume" request does not reach `S3SetCDAVolume()` function where caching of requested volume level could take place because it's stopped at `if (c->active)` [>>here<<](https://github.com/dethrace-labs/dethrace/blob/main/src/S3/s3.c#L1242).

As the fix enforced a change in original code, I decided to put it in a place where it's easier to understand. Other option was to do a fix in mentioned spot of S3.c file together with an implementation of deferred volume set in `S3SetCDAVolume()`, but that would change two files compared to one in proposed solution.