### PR TITLE
Polish localization support

### DIFF
--- a/src/DETHRACE/common/utility.c
+++ b/src/DETHRACE/common/utility.c
@@ -8,6 +8,7 @@
 #include "globvrpb.h"
 #include "graphics.h"
 #include "harness/config.h"
+#include "harness/hooks.h"
 #include "harness/trace.h"
 #include "input.h"
 #include "loading.h"
@@ -292,7 +293,7 @@ char* GetALineWithNoPossibleService(FILE* pF, unsigned char* pS) {
         if (ch != -1) {
             ungetc(ch, pF);
         }
-    } while (!isalnum(s[0])
+    } while (!Harness_Hook_isalnum(s[0])
         && s[0] != '-'
         && s[0] != '.'
         && s[0] != '!'

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -6,6 +6,7 @@
 #include "platforms/null.h"
 #include "version.h"
 
+#include <ctype.h>
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
@@ -95,6 +96,9 @@ static void Harness_DetectGameMode(void) {
         if (strstr(buffer, "NEUES SPIEL") != NULL) {
             harness_game_info.localization = eGameLocalization_german;
             LOG_INFO("Language: \"%s\"", "German");
+        } else if (strstr(buffer, "NOWA GRA") != NULL) {
+            harness_game_info.localization = eGameLocalization_polish;
+            LOG_INFO("Language: \"%s\"", "Polish");
         } else {
             LOG_INFO("Language: unrecognized");
         }
@@ -281,4 +285,20 @@ int Harness_ProcessCommandLine(int* argc, char* argv[]) {
 // Filesystem hooks
 FILE* Harness_Hook_fopen(const char* pathname, const char* mode) {
     return OS_fopen(pathname, mode);
+}
+
+// Localization
+int Harness_Hook_isalnum(int c)
+{
+    if (harness_game_info.localization == eGameLocalization_polish) {
+        // Polish diacritic letters in Windows-1250
+        unsigned char letters[] = { 140, 143, 156, 159, 163, 165, 175, 179, 185, 191, 198, 202, 209, 211, 230, 234, 241, 243 };
+        for (int i = 0; i < (int)sizeof(letters); i++) {
+            if ((unsigned char)c == letters[i]) {
+                return 1;
+            }
+        }
+    }
+
+    return isalnum(c);
 }

--- a/src/harness/include/harness/config.h
+++ b/src/harness/include/harness/config.h
@@ -13,6 +13,7 @@ typedef enum tHarness_game_type {
 typedef enum {
     eGameLocalization_none,
     eGameLocalization_german,
+    eGameLocalization_polish,
 } tHarness_game_localization;
 
 typedef struct tHarness_game_info {

--- a/src/harness/include/harness/hooks.h
+++ b/src/harness/include/harness/hooks.h
@@ -45,4 +45,7 @@ void Harness_Init(int* argc, char* argv[]);
 // Filesystem hooks
 FILE* Harness_Hook_fopen(const char* pathname, const char* mode);
 
+// Localization
+int Harness_Hook_isalnum(int c);
+
 #endif


### PR DESCRIPTION
This PR adds support for the Polish localized version of Carmageddon released in 2002 as a covermount disc for the Click! magazine. I added a wrapper to isalnum to deal with extended ASCII characters that can cause problems for the parser.