### PR TITLE
Fixed random rotation in Wrecks Gallery on first click

### DIFF
--- a/src/DETHRACE/common/racesumm.c
+++ b/src/DETHRACE/common/racesumm.c
@@ -1045,7 +1045,7 @@ int ClickDamage(int* pCurrent_choice, int* pCurrent_mode, int pX_offset, int pY_
     old_mouse_x = 0; // Fixes warning caused by -Wsometimes-uninitialized
     old_mouse_y = 0; // Fixes warning caused by -Wsometimes-uninitialized
 #endif
-    GetMousePosition(&old_mouse_y, &old_mouse_y);
+    GetMousePosition(&old_mouse_x, &old_mouse_y);
     if (gWreck_zoomed_in < 0) {
         if (CastSelectionRay(pCurrent_choice, pCurrent_mode)) {
             gUser_interacted = 1;


### PR DESCRIPTION
When player wants to look closer for a certain car in post race gallery (Wrecks Gallery) its model rotates by random angle when LMB is clicked. This change fixes the issue which is certainly a typo done during reverse engineering of code.