### PR TITLE
Fix APC/BIGAPC wheels when player wasted equivalent cop car in previous race

### DIFF
--- a/src/DETHRACE/common/loading.c
+++ b/src/DETHRACE/common/loading.c
@@ -1745,8 +1745,16 @@ void LoadCar(char* pCar_name, tDriver pDriver, tCar_spec* pCar_spec, int pOwner,
     LOG_TRACE("(\"%s\", %d, %p, %d, \"%s\", %p)", pCar_name, pDriver, pCar_spec, pOwner, pDriver_name, pStorage_space);
 
     if (pDriver == eDriver_local_human) {
+#if defined(DETHRACE_FIX_BUGS)
+        // Player's APC/BIGAPC wheels got stuck if the equivalent cop car was wasted in previous race
+        if (strcmp(gProgram_state.car_name, pCar_name) == 0 &&
+            strcmp(gProgram_state.car_name, "APC.TXT") != 0 &&
+            strcmp(gProgram_state.car_name, "BIGAPC.TXT") != 0)
+            return;
+#else
         if (strcmp(gProgram_state.car_name, pCar_name) == 0)
             return;
+#endif
         if (gProgram_state.car_name[0] != '\0') {
             DisposeCar(&gProgram_state.current_car, gProgram_state.current_car.index);
             ClearOutStorageSpace(&gOur_car_storage_space);

--- a/src/DETHRACE/common/structur.c
+++ b/src/DETHRACE/common/structur.c
@@ -480,6 +480,10 @@ void DoGame(void) {
     int second_select_race;
     int first_summary_done;
     int i;
+#if defined(DETHRACE_FIX_BUGS)
+    // Player's APC/BIGAPC wheels got stuck if the equivalent cop car was wasted in previous race
+    int power_up_levels[3];
+#endif
     LOG_TRACE("()");
 
     gAbandon_game = 0;
@@ -523,6 +527,28 @@ void DoGame(void) {
                     SwapNetCarsLoad();
                 }
             } else {
+#if defined(DETHRACE_FIX_BUGS)
+                // Player's APC/BIGAPC wheels got stuck if the equivalent cop car was wasted in previous race
+                if(strcmp(gProgram_state.car_name, "APC.TXT") == 0 ||
+                   strcmp(gProgram_state.car_name, "BIGAPC.TXT") == 0) {
+                    AboutToLoadFirstCar();
+                    SwitchToRealResolution();
+                    for (i = 0; i < COUNT_OF(power_up_levels); i++) {
+                        power_up_levels[i] = gProgram_state.current_car.power_up_levels[i];
+                    }
+                    LoadCar(gOpponents[gProgram_state.cars_available[gCurrent_car_index]].car_file_name,
+                        eDriver_local_human,
+                        &gProgram_state.current_car,
+                        gProgram_state.cars_available[gCurrent_car_index],
+                        gProgram_state.player_name[gProgram_state.frank_or_anniness],
+                        &gOur_car_storage_space);
+                    for (i = 0; i < COUNT_OF(power_up_levels); i++) {
+                        gProgram_state.current_car.power_up_levels[i] = power_up_levels[i];
+                    }
+                    SwitchToLoresMode();
+                    SetCarStorageTexturingLevel(&gOur_car_storage_space, GetCarTexturingLevel(), eCTL_full);
+                }
+#endif                    
                 LoadOpponentsCars(&gCurrent_race);
             }
             PrintMemoryDump(0, "AFTER LOADING OPPONENTS IN");


### PR DESCRIPTION
This is a fix to a bug which existed in original game. If player wasted a cop car driving a cop car then in next race player's APC wheels do not rotate nor turn in any direction. The same applies in case Suppressor is wasted by Suppressor.