### PR TITLE
ci: use SDL2 from head

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -48,7 +48,7 @@ jobs:
           cmake-arguments: ${{ matrix.platform.cmake-args }}
           cmake-generator: Ninja
           cmake-toolchain-file: ${{ matrix.platform.cmake-toolchain-file }}
-          version: 2-latest
+          version: 2-head
           add-to-environment: true
 
       - name: 'Prepare sources for release'


### PR DESCRIPTION
SDL2 from head includes a patch that does not fail CMake configuration when libX11 can be found, but no xext.h header.