### PR TITLE
Add AudioBackend_SetVolumeSeparate to the harness audio interface

### DIFF
--- a/src/S3/s3sound.c
+++ b/src/S3/s3sound.c
@@ -362,6 +362,11 @@ int S3SyncSampleVolumeAndPan(tS3_channel* chan) {
     if (chan->type != eS3_ST_sample) {
         return 1;
     }
+
+    if (AudioBackend_SetVolumeSeparate(chan->type_struct_sample, chan->left_volume, chan->right_volume) == eAB_success) {
+        return 1;
+    }
+
     total_vol = chan->left_volume + chan->right_volume;
     if (total_vol == 0.0f) {
         total_vol = 1.0f;

--- a/src/harness/audio/miniaudio.c
+++ b/src/harness/audio/miniaudio.c
@@ -233,6 +233,10 @@ tAudioBackend_error_code AudioBackend_SetFrequency(void* type_struct_sample, int
     return eAB_success;
 }
 
+tAudioBackend_error_code AudioBackend_SetVolumeSeparate(void* type_struct_sample, int left_volume, int right_volume) {
+    return eAB_error;
+}
+
 tAudioBackend_error_code AudioBackend_StopSample(void* type_struct_sample) {
     tMiniaudio_sample* miniaudio;
 

--- a/src/harness/include/harness/audio.h
+++ b/src/harness/include/harness/audio.h
@@ -21,6 +21,7 @@ tAudioBackend_error_code AudioBackend_StopSample(void* type_struct_sample);
 tAudioBackend_error_code AudioBackend_SetVolume(void* type_struct_sample, int volume);
 tAudioBackend_error_code AudioBackend_SetPan(void* type_struct_sample, int pan);
 tAudioBackend_error_code AudioBackend_SetFrequency(void* type_struct_sample, int original_rate, int new_rate);
+tAudioBackend_error_code AudioBackend_SetVolumeSeparate(void* type_struct_sample, int left_volume, int right_volume);
 
 tAudioBackend_error_code AudioBackend_PlayCDA(int track);
 tAudioBackend_error_code AudioBackend_StopCDA(void);


### PR DESCRIPTION
I added a function to the harness audio interface to set the left/right volume separately as an alternative to volume/panning. It's not necessary for miniaudio, but it simplified implementing my custom audio backend, so I thought it might come in handy for other alternative platforms.