### PR TITLE
3dfx info mode

### DIFF
--- a/src/DETHRACE/common/opponent.c
+++ b/src/DETHRACE/common/opponent.c
@@ -2443,9 +2443,8 @@ void InitOpponents(tRace_info* pRace_info) {
     gHead_on_cos_value = cosf(.5235668f);
     gAcme_frame_count = 0;
     gProgram_state.current_car.no_of_processes_recording_my_trail = 0;
-    rank_dependent_difficulty = (101.f - (gCurrent_race.suggested_rank < 10 ? .5f : (float)gCurrent_race.suggested_rank));
-    // FIXME: unsure about gBig_bang
-    gBig_bang = 70.f - (float)(3 * rank_dependent_difficulty + 10 * gProgram_state.skill_level) * gOpponent_nastyness_frigger;
+    rank_dependent_difficulty = (101.f - (gCurrent_race.suggested_rank < 10 ? .5f : gCurrent_race.suggested_rank)) / 10.0f;
+    gBig_bang = 70.f - (3 * rank_dependent_difficulty + 10 * gProgram_state.skill_level) * gOpponent_nastyness_frigger;
     gIn_view_distance = gCamera_yon + 10.f;
     if (gCamera_yon + 10.f <= 45.f) {
         gIn_view_distance = 45.f;

--- a/src/DETHRACE/common/utility.c
+++ b/src/DETHRACE/common/utility.c
@@ -1735,8 +1735,7 @@ void GlorifyMaterial(br_material** pArray, int pCount) {
 
             if (gInterpolate_textures) {
                 // use linear texture filtering unless we have a "nobilinear" flag or the texture has transparent parts
-                if ((e == NULL || (e->flags & ExceptionFlag_NoBilinear) == 0)
-                    && !DRPixelmapHasZeros(pArray[i]->colour_map)) {
+                if ((e == NULL || (e->flags & ExceptionFlag_NoBilinear) == 0) && !DRPixelmapHasZeros(pArray[i]->colour_map)) {
                     pArray[i]->flags |= BR_MATF_MAP_INTERPOLATION;
                 }
             }

--- a/src/DETHRACE/common/world.c
+++ b/src/DETHRACE/common/world.c
@@ -1946,11 +1946,13 @@ int DRPixelmapHasZeros(br_pixelmap* pm) {
     if (pm->flags & BR_PMF_NO_ACCESS) {
         return 1;
     }
+
     row_ptr = (char*)pm->pixels + (pm->row_bytes * pm->base_y) + pm->base_x;
     for (y = 0; y < pm->height; y++) {
         pp = row_ptr;
         for (x = 0; x < pm->width; x++) {
-            if (!pp)
+            // found a zero (transparent) pixel?
+            if (*pp == 0)
                 return 1;
             pp++;
         }


### PR DESCRIPTION
- 3dfx patch introduces a third debug info mode, showing detail about the closest material.
- Fixes calculation of `gBig_bang`
- Fixes `DRPixelmapHasZeros` which fixes rendering of black borders around hanging vines in Mayan Mayhem track

<img width="752" alt="Screenshot 2025-04-01 at 12 08 09 am" src="https://github.com/user-attachments/assets/9ffe7b6e-d290-4b05-bfec-0bec4eb34cfe" />
