### PR TITLE
Ini file and fallback directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/VERSION")
 else()
     include(GetGitRevisionDescription)
     git_describe(DETHRACE_VERSION)
+
     if(NOT DETHRACE_VERSION)
         set(DETHRACE_VERSION "unknown")
     endif()
@@ -42,12 +43,15 @@ option(DETHRACE_3DFX_PATCH "Include changes from VOODOO2C.EXE" ON)
 
 function(add_compile_flag_if_supported TARGET FLAG)
     cmake_parse_arguments(ARGS "" "" "LANGUAGES" ${ARGN})
+
     if(NOT ARGS_LANGUAGES)
         set(ARGS_LANGUAGES C CXX)
     endif()
+
     string(MAKE_C_IDENTIFIER "${FLAG}" FLAG_TO_IDENTIFIER)
     set(HAVE_FLAG_VARIABLE_NAME "HAVE_${FLAG_TO_IDENTIFIER}")
     check_c_compiler_flag("${FLAG}" "${HAVE_FLAG_VARIABLE_NAME}")
+
     if(${HAVE_FLAG_VARIABLE_NAME})
         string(REPLACE ";" "," ARGS_LANGUAGES "${ARGS_LANGUAGES}")
         target_compile_options("${TARGET}" PRIVATE "$<$<COMPILE_LANGUAGE:${ARGS_LANGUAGES}>:${FLAG}>")
@@ -63,20 +67,24 @@ endfunction()
 test_big_endian(IS_BIGENDIAN)
 
 option(DETHRACE_PLATFORM_SDL1 "Support SDL 1.2 platform driver" OFF)
-option(DETHRACE_PLATFORM_SDL2 "Support SDL 2 platform driver"   ON)
+option(DETHRACE_PLATFORM_SDL2 "Support SDL 2 platform driver" ON)
 set(count_sdl_platforms 0)
 
-set(DETHRACE_PLATFORMS )
+set(DETHRACE_PLATFORMS)
+
 if(DETHRACE_PLATFORM_SDL1)
     find_package(SDL REQUIRED)
     list(APPEND DETHRACE_PLATFORMS SDL1)
     math(EXPR count_sdl_platforms "${count_sdl_platforms} + 1")
 endif()
+
 if(DETHRACE_PLATFORM_SDL2)
     find_package(SDL2 CONFIG)
+
     if(NOT SDL2_FOUND)
         find_package(SDL2 MODULE REQUIRED)
     endif()
+
     list(APPEND DETHRACE_PLATFORMS SDL2)
     math(EXPR count_sdl_platforms "${count_sdl_platforms} + 1")
 endif()
@@ -100,6 +108,7 @@ add_subdirectory(lib/BRender-v1.3.2)
 add_subdirectory(lib/libsmacker)
 add_subdirectory(lib/miniaudio)
 add_subdirectory(lib/stb)
+add_subdirectory(lib/inih)
 
 add_library(compile_with_werror INTERFACE)
 
@@ -140,6 +149,7 @@ if(DETHRACE_INSTALL)
     set(CPACK_SYSTEM_NAME "${DETHRACE_PACKAGE_PLATFORM}")
 
     set(CPACK_PACKAGE_FILE_NAME "dethrace-${DETHRACE_VERSION}-${DETHRACE_PACKAGE_PLATFORM}")
+
     if(DETHRACE_PACKAGE_ARCH)
         string(APPEND CPACK_PACKAGE_FILE_NAME "-${DETHRACE_PACKAGE_ARCH}")
     endif()

--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ Dethrace is an attempt to learn how the 1997 driving/mayhem game [Carmageddon](h
 
 ### Dependencies
 
-Dethrace has a dependency on SDL2. The easiest way to install SDL is via your favorite package manager.
+Dethrace using CMake to build, and SDL2 at runtime. The easiest way to install them is via your favorite package manager.
 
 OSX:
 ```sh
-brew install SDL2
+brew install SDL2 cmake
 ```
 
 Linux:
 ```sh
-apt-get install libsdl2-dev
+apt-get install libsdl2-dev cmake
 ```
 
 ### Clone
@@ -41,9 +41,10 @@ cd dethrace
 git submodule update --init --recursive
 ```
 
-Dethrace uses [cmake](https://cmake.org/) for generating build files.
+### Build
+Dethrace uses [cmake](https://cmake.org/)
 
-To generate the build files (generally only required once):
+To generate the build files:
 ```sh
 mkdir build
 cd build
@@ -64,16 +65,12 @@ Dethrace does not ship with any content. You'll need access to the data from the
 - [Splat Pack demo](https://rr2000.cwaboard.co.uk/R4/PC/splatdem.zip)
 - [Splat Pack Xmas demo](https://rr2000.cwaboard.co.uk/R4/PC/Splatpack_christmas_demo.zip)
 
-## Configuration
-
 Dethrace generally expects to be placed into the top level Carmageddon folder. You know you have the right folder when you see the original `CARMA.EXE` there. If you are on Windows, you must also place `SDL2.dll` in the same folder.
 
-<img width="638" alt="Screenshot 2024-09-20 at 12 25 05 PM" src="https://github.com/user-attachments/assets/fda77818-9007-44fa-9d8d-c311396fd435">
-
-Alternatively, you may configure a different directory by providing a [dethrace.ini file](docs/CONFIGURATION.md).
+### Configuration INI file
+Alternatively, you may configure a different Carmageddon directory and settings by providing a [dethrace.ini file](docs/CONFIGURATION.md).
 
 ### CD audio
-
 Dethrace supports the GOG cd audio convention. If there is a `MUSIC` folder in the Carmageddon folder containing files `Track02.ogg`, `Track03.ogg` etc, then Dethrace will use those files in place of the original CD audio functions.
 
 <img width="571" alt="Screenshot 2024-09-30 at 8 31 59 AM" src="https://github.com/user-attachments/assets/cec72203-9156-4c2a-a15a-328609e65c68">

--- a/README.md
+++ b/README.md
@@ -16,30 +16,6 @@ Dethrace is an attempt to learn how the 1997 driving/mayhem game [Carmageddon](h
 <img width="752" alt="Screenshot 2024-05-27 at 8 44 10 AM" src="https://github.com/dethrace-labs/dethrace/assets/1063652/10b3b579-1eb1-4242-8b56-ff062cfff810">
 
 
-## Background
-Watcom debug symbols for an earlier internal build [were discovered](http://1amstudios.com/2014/12/02/carma1-symbols-dumped) named `DETHRSC.SYM` on the [Carmageddon Splat Pack](http://carmageddon.wikia.com/wiki/Carmageddon_Splat_Pack) expansion CD release. The symbols unfortunately did not match any known released executable, meaning they were interesting but not immediately usable to reverse engineer the game.
-
-This is what it looked like from the Watcom debugger - the names of all the methods were present but the code location they were pointing to was junk:
-
-![watcom-debugger](http://1amstudios.com/img/watcom-debugger.jpg)
-
-_CrayzKirk_ from the Carmageddon community picked it up and did a lot of painstaking work manually matching up many functions and data structures in the DOS executable to the debugging symbols.
-
-We are slowly replacing the original assembly code with equivalent C code, function by function.
-
-### Is "dethrace" a typo?
-No, well, I don't think so at least. The original files according to the symbol dump were stored in `c:\DETHRACE`, and the symbol file is called `DETHSRC.SYM`. Maybe they removed the "a" to be compatible with [8.3 filenames](https://en.wikipedia.org/wiki/8.3_filename)?
-
-## Game content
-
-Dethrace does not ship with any content. You'll need access to the data from the original game. If you don't have an original CD then you can [buy Carmageddon from GoG.com](https://www.gog.com/game/carmageddon_max_pack).
-
-`dethrace` also supports the various freeware demos:
-- [Original Carmageddon demo](https://rr2000.cwaboard.co.uk/R4/PC/carmdemo.zip)
-- [Splat Pack demo](https://rr2000.cwaboard.co.uk/R4/PC/splatdem.zip)
-- [Splat Pack Xmas demo](https://rr2000.cwaboard.co.uk/R4/PC/Splatpack_christmas_demo.zip)
-
-
 ## Building
 
 ### Dependencies
@@ -54,12 +30,6 @@ brew install SDL2
 Linux:
 ```sh
 apt-get install libsdl2-dev
-```
-
-
-Point Dethrace at the Carmageddon install directory:
-```sh
-export DETHRACE_ROOT_DIR=/path/to/carmageddon
 ```
 
 ### Clone
@@ -87,11 +57,20 @@ make
 
 ## Running the game
 
-Firstly, you need a copy of the [Carmageddon game content](https://github.com/dethrace-labs/dethrace?tab=readme-ov-file#game-content). Extract the zip file if necessary.
+Dethrace does not ship with any content. You'll need access to the data from the original game. If you don't have an original CD then you can [buy Carmageddon from GoG.com](https://www.gog.com/game/carmageddon_max_pack).
 
-Dethrace expects to be placed into the top level Carmageddon folder. You know you have the right folder when you see the original `CARMA.EXE` there. If you are on Windows, you must also place `SDL2.dll` in the same folder.
+`dethrace` also supports the various freeware demos:
+- [Original Carmageddon demo](https://rr2000.cwaboard.co.uk/R4/PC/carmdemo.zip)
+- [Splat Pack demo](https://rr2000.cwaboard.co.uk/R4/PC/splatdem.zip)
+- [Splat Pack Xmas demo](https://rr2000.cwaboard.co.uk/R4/PC/Splatpack_christmas_demo.zip)
+
+## Configuration
+
+Dethrace generally expects to be placed into the top level Carmageddon folder. You know you have the right folder when you see the original `CARMA.EXE` there. If you are on Windows, you must also place `SDL2.dll` in the same folder.
 
 <img width="638" alt="Screenshot 2024-09-20 at 12 25 05 PM" src="https://github.com/user-attachments/assets/fda77818-9007-44fa-9d8d-c311396fd435">
+
+Alternatively, you may configure a different directory by providing a [dethrace.ini file](docs/CONFIGURATION.md).
 
 ### CD audio
 
@@ -99,13 +78,23 @@ Dethrace supports the GOG cd audio convention. If there is a `MUSIC` folder in t
 
 <img width="571" alt="Screenshot 2024-09-30 at 8 31 59 AM" src="https://github.com/user-attachments/assets/cec72203-9156-4c2a-a15a-328609e65c68">
 
+## Background
+Watcom debug symbols for an earlier internal build [were discovered](http://1amstudios.com/2014/12/02/carma1-symbols-dumped) named `DETHRSC.SYM` on the [Carmageddon Splat Pack](http://carmageddon.wikia.com/wiki/Carmageddon_Splat_Pack) expansion CD release. The symbols unfortunately did not match any known released executable, meaning they were interesting but not immediately usable to reverse engineer the game.
 
+This is what it looked like from the Watcom debugger - the names of all the methods were present but the code location they were pointing to was junk:
+
+![watcom-debugger](http://1amstudios.com/img/watcom-debugger.jpg)
+
+We are slowly replacing the original assembly code with equivalent C code, function by function.
+
+### Is "dethrace" a typo?
+No, well, I don't think so at least. The original files according to the symbol dump were stored in `c:\DETHRACE`, and the symbol file is called `DETHSRC.SYM`. Maybe they removed the "a" to be compatible with [8.3 filenames](https://en.wikipedia.org/wiki/8.3_filename)?
 
 ## Changelog
 [From the beginning until release](docs/CHANGELOG.md)
 
 ## Credits
-- CrayzKirk (manually matching up functions and data structures in the executable to the debugging symbols)
+- CrayzKirk (did the first manual matching up functions and data structures in the DOS executable to the debugging symbols and proved it was possible!)
 - The developer at Stainless Software who left an old debugging .SYM file on the Splat Pack CD ;)
 
 ## Legal

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,70 @@
+# Configuration
+
+Dethrace looks for a `dethrace.ini` file in the [system preferences directory](https://wiki.libsdl.org/SDL2/SDL_GetPrefPath):
+| Platform | Example Path                                                                 |
+|----------|----------------------------------------------------------------------|
+| Windows  | `C:\Users\bob\AppData\Roaming\dethrace\dethrace.ini`                |
+| macOS    | `/Users/bob/Library/Application Support/dethrace/dethrace.ini`      |
+| Linux    | `/home/bob/.local/share/dethrace/dethrace.ini`                      |
+
+
+If this file is not present, dethrace will run with default configuration and attempt to discover the correct Carmageddon directory to use (see below).
+
+## Example dethrace.ini file
+```ini
+[General]
+; Enable original CD check
+CdCheck = 0
+
+; Enable original censorship check
+GoreCheck = 0
+
+; set to 0 to disable
+FPSLimit = 60
+
+; Full screen or window
+Windowed = 1
+
+; 3dfx mode (via OpenGL)
+Emulate3DFX = 0
+
+; Censored zombie/robots mode
+BoringMode = 0
+
+; Play cut scenes on startup and between races
+Cutscenes = 0
+
+; "hires" mode is 640x480, otherwise default 320x200
+Hires = 1
+
+; Only used in 'demo' mode. Default demo time out is 240s (5 mins)
+DemoTimeout = 240
+
+; Which directory in the [Games] section to run
+DefaultGame = c1
+
+[Games]
+c1 = /opt/carma/c1
+c1demo = /opt/carma/c1demo
+sp = /opt/carma/splatpack
+
+[Cheats]
+EditMode = 0
+FreezeTimer = 0
+GameCompleted = 0
+
+[Sound]
+Enabled = 1
+SoundOptionsScreen = 1
+VolumeMultiplier = 1
+
+[Network]
+AdapterName = ""
+```
+
+## Order of precedence for game directory detection:
+1. Directory pointed to by DefaultGame
+2. First game in the list if at least 1 game dir is specified
+3. `DETHRACE_ROOT_DIR` environment variable
+4. Current working directory (if `DATA/GENERAL.TXT` exists)
+5. `SDL_GetPrefPath` directory

--- a/lib/inih/CMakeLists.txt
+++ b/lib/inih/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.10)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
+
+if(NOT DEFINED CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo" FORCE)
+endif()
+
+project(inih C)
+
+add_library(inih STATIC)
+
+target_include_directories(inih
+    SYSTEM PUBLIC
+    .
+)
+
+target_sources(inih PRIVATE
+    ini.c
+)

--- a/lib/inih/LICENSE.TXT
+++ b/lib/inih/LICENSE.TXT
@@ -1,0 +1,28 @@
+// Taken from https://github.com/benhoyt/inih/blob/master/LICENSE.txt
+
+The "inih" library is distributed under the New BSD license:
+
+Copyright (c) 2009, Ben Hoyt
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Ben Hoyt nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY BEN HOYT ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL BEN HOYT BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/lib/inih/ini.c
+++ b/lib/inih/ini.c
@@ -1,0 +1,315 @@
+/* inih -- simple .INI file parser
+
+SPDX-License-Identifier: BSD-3-Clause
+
+Copyright (C) 2009-2020, Ben Hoyt
+
+inih is released under the New BSD license (see LICENSE.txt). Go to the project
+home page for more info:
+
+https://github.com/benhoyt/inih
+
+*/
+
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "ini.h"
+
+#if !INI_USE_STACK
+#if INI_CUSTOM_ALLOCATOR
+#include <stddef.h>
+void* ini_malloc(size_t size);
+void ini_free(void* ptr);
+void* ini_realloc(void* ptr, size_t size);
+#else
+#include <stdlib.h>
+#define ini_malloc malloc
+#define ini_free free
+#define ini_realloc realloc
+#endif
+#endif
+
+#define MAX_SECTION 50
+#define MAX_NAME 50
+
+/* Used by ini_parse_string() to keep track of string parsing state. */
+typedef struct {
+    const char* ptr;
+    size_t num_left;
+} ini_parse_string_ctx;
+
+/* Strip whitespace chars off end of given string, in place. Return s. */
+static char* ini_rstrip(char* s) {
+    char* p = s + strlen(s);
+    while (p > s && isspace((unsigned char)(*--p)))
+        *p = '\0';
+    return s;
+}
+
+/* Return pointer to first non-whitespace char in given string. */
+static char* ini_lskip(const char* s) {
+    while (*s && isspace((unsigned char)(*s)))
+        s++;
+    return (char*)s;
+}
+
+/* Return pointer to first char (of chars) or inline comment in given string,
+   or pointer to NUL at end of string if neither found. Inline comment must
+   be prefixed by a whitespace character to register as a comment. */
+static char* ini_find_chars_or_comment(const char* s, const char* chars) {
+#if INI_ALLOW_INLINE_COMMENTS
+    int was_space = 0;
+    while (*s && (!chars || !strchr(chars, *s)) && !(was_space && strchr(INI_INLINE_COMMENT_PREFIXES, *s))) {
+        was_space = isspace((unsigned char)(*s));
+        s++;
+    }
+#else
+    while (*s && (!chars || !strchr(chars, *s))) {
+        s++;
+    }
+#endif
+    return (char*)s;
+}
+
+/* Similar to strncpy, but ensures dest (size bytes) is
+   NUL-terminated, and doesn't pad with NULs. */
+static char* ini_strncpy0(char* dest, const char* src, size_t size) {
+    /* Could use strncpy internally, but it causes gcc warnings (see issue #91) */
+    size_t i;
+    for (i = 0; i < size - 1 && src[i]; i++)
+        dest[i] = src[i];
+    dest[i] = '\0';
+    return dest;
+}
+
+/* See documentation in header file. */
+int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+    void* user) {
+    /* Uses a fair bit of stack (use heap instead if you need to) */
+#if INI_USE_STACK
+    char line[INI_MAX_LINE];
+    size_t max_line = INI_MAX_LINE;
+#else
+    char* line;
+    size_t max_line = INI_INITIAL_ALLOC;
+#endif
+#if INI_ALLOW_REALLOC && !INI_USE_STACK
+    char* new_line;
+#endif
+    char section[MAX_SECTION] = "";
+#if INI_ALLOW_MULTILINE
+    char prev_name[MAX_NAME] = "";
+#endif
+
+    size_t offset;
+    char* start;
+    char* end;
+    char* name;
+    char* value;
+    int lineno = 0;
+    int error = 0;
+    char abyss[16]; /* Used to consume input when a line is too long. */
+
+#if !INI_USE_STACK
+    line = (char*)ini_malloc(INI_INITIAL_ALLOC);
+    if (!line) {
+        return -2;
+    }
+#endif
+
+#if INI_HANDLER_LINENO
+#define HANDLER(u, s, n, v) handler(u, s, n, v, lineno)
+#else
+#define HANDLER(u, s, n, v) handler(u, s, n, v)
+#endif
+
+    /* Scan through stream line by line */
+    while (reader(line, (int)max_line, stream) != NULL) {
+        offset = strlen(line);
+
+#if INI_ALLOW_REALLOC && !INI_USE_STACK
+        while (offset == max_line - 1 && line[offset - 1] != '\n') {
+            max_line *= 2;
+            if (max_line > INI_MAX_LINE)
+                max_line = INI_MAX_LINE;
+            new_line = ini_realloc(line, max_line);
+            if (!new_line) {
+                ini_free(line);
+                return -2;
+            }
+            line = new_line;
+            if (reader(line + offset, (int)(max_line - offset), stream) == NULL)
+                break;
+            offset += strlen(line + offset);
+            if (max_line >= INI_MAX_LINE)
+                break;
+        }
+#endif
+
+        lineno++;
+
+        /* If line exceeded INI_MAX_LINE bytes, discard till end of line. */
+        if (offset == max_line - 1 && line[offset - 1] != '\n') {
+            while (reader(abyss, sizeof(abyss), stream) != NULL) {
+                if (!error)
+                    error = lineno;
+                if (abyss[strlen(abyss) - 1] == '\n')
+                    break;
+            }
+        }
+
+        start = line;
+#if INI_ALLOW_BOM
+        if (lineno == 1 && (unsigned char)start[0] == 0xEF && (unsigned char)start[1] == 0xBB && (unsigned char)start[2] == 0xBF) {
+            start += 3;
+        }
+#endif
+        start = ini_rstrip(ini_lskip(start));
+
+        if (strchr(INI_START_COMMENT_PREFIXES, *start)) {
+            /* Start-of-line comment */
+        }
+#if INI_ALLOW_MULTILINE
+        else if (*prev_name && *start && start > line) {
+#if INI_ALLOW_INLINE_COMMENTS
+            end = ini_find_chars_or_comment(start, NULL);
+            if (*end)
+                *end = '\0';
+            ini_rstrip(start);
+#endif
+            /* Non-blank line with leading whitespace, treat as continuation
+               of previous name's value (as per Python configparser). */
+            if (!HANDLER(user, section, prev_name, start) && !error)
+                error = lineno;
+        }
+#endif
+        else if (*start == '[') {
+            /* A "[section]" line */
+            end = ini_find_chars_or_comment(start + 1, "]");
+            if (*end == ']') {
+                *end = '\0';
+                ini_strncpy0(section, start + 1, sizeof(section));
+#if INI_ALLOW_MULTILINE
+                *prev_name = '\0';
+#endif
+#if INI_CALL_HANDLER_ON_NEW_SECTION
+                if (!HANDLER(user, section, NULL, NULL) && !error)
+                    error = lineno;
+#endif
+            } else if (!error) {
+                /* No ']' found on section line */
+                error = lineno;
+            }
+        } else if (*start) {
+            /* Not a comment, must be a name[=:]value pair */
+            end = ini_find_chars_or_comment(start, "=:");
+            if (*end == '=' || *end == ':') {
+                *end = '\0';
+                name = ini_rstrip(start);
+                value = end + 1;
+#if INI_ALLOW_INLINE_COMMENTS
+                end = ini_find_chars_or_comment(value, NULL);
+                if (*end)
+                    *end = '\0';
+#endif
+                value = ini_lskip(value);
+                ini_rstrip(value);
+
+#if INI_ALLOW_MULTILINE
+                ini_strncpy0(prev_name, name, sizeof(prev_name));
+#endif
+                /* Valid name[=:]value pair found, call handler */
+                if (!HANDLER(user, section, name, value) && !error)
+                    error = lineno;
+            } else if (!error) {
+                /* No '=' or ':' found on name[=:]value line */
+#if INI_ALLOW_NO_VALUE
+                *end = '\0';
+                name = ini_rstrip(start);
+                if (!HANDLER(user, section, name, NULL) && !error)
+                    error = lineno;
+#else
+                error = lineno;
+#endif
+            }
+        }
+
+#if INI_STOP_ON_FIRST_ERROR
+        if (error)
+            break;
+#endif
+    }
+
+#if !INI_USE_STACK
+    ini_free(line);
+#endif
+
+    return error;
+}
+
+/* See documentation in header file. */
+int ini_parse_file(FILE* file, ini_handler handler, void* user) {
+    return ini_parse_stream((ini_reader)fgets, file, handler, user);
+}
+
+/* See documentation in header file. */
+int ini_parse(const char* filename, ini_handler handler, void* user) {
+    FILE* file;
+    int error;
+
+    file = fopen(filename, "r");
+    if (!file)
+        return -1;
+    error = ini_parse_file(file, handler, user);
+    fclose(file);
+    return error;
+}
+
+/* An ini_reader function to read the next line from a string buffer. This
+   is the fgets() equivalent used by ini_parse_string(). */
+static char* ini_reader_string(char* str, int num, void* stream) {
+    ini_parse_string_ctx* ctx = (ini_parse_string_ctx*)stream;
+    const char* ctx_ptr = ctx->ptr;
+    size_t ctx_num_left = ctx->num_left;
+    char* strp = str;
+    char c;
+
+    if (ctx_num_left == 0 || num < 2)
+        return NULL;
+
+    while (num > 1 && ctx_num_left != 0) {
+        c = *ctx_ptr++;
+        ctx_num_left--;
+        *strp++ = c;
+        if (c == '\n')
+            break;
+        num--;
+    }
+
+    *strp = '\0';
+    ctx->ptr = ctx_ptr;
+    ctx->num_left = ctx_num_left;
+    return str;
+}
+
+/* See documentation in header file. */
+int ini_parse_string(const char* string, ini_handler handler, void* user) {
+    return ini_parse_string_length(string, strlen(string), handler, user);
+}
+
+/* See documentation in header file. */
+int ini_parse_string_length(const char* string, size_t length,
+    ini_handler handler, void* user) {
+    ini_parse_string_ctx ctx;
+
+    ctx.ptr = string;
+    ctx.num_left = length;
+    return ini_parse_stream((ini_reader)ini_reader_string, &ctx, handler,
+        user);
+}

--- a/lib/inih/ini.h
+++ b/lib/inih/ini.h
@@ -1,0 +1,188 @@
+/* inih -- simple .INI file parser
+
+SPDX-License-Identifier: BSD-3-Clause
+
+Copyright (C) 2009-2020, Ben Hoyt
+
+inih is released under the New BSD license (see LICENSE.txt). Go to the project
+home page for more info:
+
+https://github.com/benhoyt/inih
+
+*/
+
+#ifndef INI_H
+#define INI_H
+
+/* Make this header file easier to include in C++ code */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+
+/* Nonzero if ini_handler callback should accept lineno parameter. */
+#ifndef INI_HANDLER_LINENO
+#define INI_HANDLER_LINENO 0
+#endif
+
+/* Visibility symbols, required for Windows DLLs */
+#ifndef INI_API
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef INI_SHARED_LIB
+#ifdef INI_SHARED_LIB_BUILDING
+#define INI_API __declspec(dllexport)
+#else
+#define INI_API __declspec(dllimport)
+#endif
+#else
+#define INI_API
+#endif
+#else
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define INI_API __attribute__((visibility("default")))
+#else
+#define INI_API
+#endif
+#endif
+#endif
+
+/* Typedef for prototype of handler function.
+
+   Note that even though the value parameter has type "const char*", the user
+   may cast to "char*" and modify its content, as the value is not used again
+   after the call to ini_handler. This is not true of section and name --
+   those must not be modified.
+*/
+#if INI_HANDLER_LINENO
+typedef int (*ini_handler)(void* user, const char* section,
+    const char* name, const char* value,
+    int lineno);
+#else
+typedef int (*ini_handler)(void* user, const char* section,
+    const char* name, const char* value);
+#endif
+
+/* Typedef for prototype of fgets-style reader function. */
+typedef char* (*ini_reader)(char* str, int num, void* stream);
+
+/* Parse given INI-style file. May have [section]s, name=value pairs
+   (whitespace stripped), and comments starting with ';' (semicolon). Section
+   is "" if name=value pair parsed before any section heading. name:value
+   pairs are also supported as a concession to Python's configparser.
+
+   For each name=value pair parsed, call handler function with given user
+   pointer as well as section, name, and value (data only valid for duration
+   of handler call). Handler should return nonzero on success, zero on error.
+
+   Returns 0 on success, line number of first error on parse error (doesn't
+   stop on first error), -1 on file open error, or -2 on memory allocation
+   error (only when INI_USE_STACK is zero).
+*/
+INI_API int ini_parse(const char* filename, ini_handler handler, void* user);
+
+/* Same as ini_parse(), but takes a FILE* instead of filename. This doesn't
+   close the file when it's finished -- the caller must do that. */
+INI_API int ini_parse_file(FILE* file, ini_handler handler, void* user);
+
+/* Same as ini_parse(), but takes an ini_reader function pointer instead of
+   filename. Used for implementing custom or string-based I/O (see also
+   ini_parse_string). */
+INI_API int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+    void* user);
+
+/* Same as ini_parse(), but takes a zero-terminated string with the INI data
+   instead of a file. Useful for parsing INI data from a network socket or
+   which is already in memory. */
+INI_API int ini_parse_string(const char* string, ini_handler handler, void* user);
+
+/* Same as ini_parse_string(), but takes a string and its length, avoiding
+   strlen(). Useful for parsing INI data from a network socket or which is
+   already in memory, or interfacing with C++ std::string_view. */
+INI_API int ini_parse_string_length(const char* string, size_t length, ini_handler handler, void* user);
+
+/* Nonzero to allow multi-line value parsing, in the style of Python's
+   configparser. If allowed, ini_parse() will call the handler with the same
+   name for each subsequent line parsed. */
+#ifndef INI_ALLOW_MULTILINE
+#define INI_ALLOW_MULTILINE 1
+#endif
+
+/* Nonzero to allow a UTF-8 BOM sequence (0xEF 0xBB 0xBF) at the start of
+   the file. See https://github.com/benhoyt/inih/issues/21 */
+#ifndef INI_ALLOW_BOM
+#define INI_ALLOW_BOM 1
+#endif
+
+/* Chars that begin a start-of-line comment. Per Python configparser, allow
+   both ; and # comments at the start of a line by default. */
+#ifndef INI_START_COMMENT_PREFIXES
+#define INI_START_COMMENT_PREFIXES ";#"
+#endif
+
+/* Nonzero to allow inline comments (with valid inline comment characters
+   specified by INI_INLINE_COMMENT_PREFIXES). Set to 0 to turn off and match
+   Python 3.2+ configparser behaviour. */
+#ifndef INI_ALLOW_INLINE_COMMENTS
+#define INI_ALLOW_INLINE_COMMENTS 1
+#endif
+#ifndef INI_INLINE_COMMENT_PREFIXES
+#define INI_INLINE_COMMENT_PREFIXES ";"
+#endif
+
+/* Nonzero to use stack for line buffer, zero to use heap (malloc/free). */
+#ifndef INI_USE_STACK
+#define INI_USE_STACK 1
+#endif
+
+/* Maximum line length for any line in INI file (stack or heap). Note that
+   this must be 3 more than the longest line (due to '\r', '\n', and '\0'). */
+#ifndef INI_MAX_LINE
+#define INI_MAX_LINE 200
+#endif
+
+/* Nonzero to allow heap line buffer to grow via realloc(), zero for a
+   fixed-size buffer of INI_MAX_LINE bytes. Only applies if INI_USE_STACK is
+   zero. */
+#ifndef INI_ALLOW_REALLOC
+#define INI_ALLOW_REALLOC 0
+#endif
+
+/* Initial size in bytes for heap line buffer. Only applies if INI_USE_STACK
+   is zero. */
+#ifndef INI_INITIAL_ALLOC
+#define INI_INITIAL_ALLOC 200
+#endif
+
+/* Stop parsing on first error (default is to keep parsing). */
+#ifndef INI_STOP_ON_FIRST_ERROR
+#define INI_STOP_ON_FIRST_ERROR 0
+#endif
+
+/* Nonzero to call the handler at the start of each new section (with
+   name and value NULL). Default is to only call the handler on
+   each name=value pair. */
+#ifndef INI_CALL_HANDLER_ON_NEW_SECTION
+#define INI_CALL_HANDLER_ON_NEW_SECTION 0
+#endif
+
+/* Nonzero to allow a name without a value (no '=' or ':' on the line) and
+   call the handler with value NULL in this case. Default is to treat
+   no-value lines as an error. */
+#ifndef INI_ALLOW_NO_VALUE
+#define INI_ALLOW_NO_VALUE 0
+#endif
+
+/* Nonzero to use custom ini_malloc, ini_free, and ini_realloc memory
+   allocation functions (INI_USE_STACK must also be 0). These functions must
+   have the same signatures as malloc/free/realloc and behave in a similar
+   way. ini_realloc is only needed if INI_ALLOW_REALLOC is set. */
+#ifndef INI_CUSTOM_ALLOCATOR
+#define INI_CUSTOM_ALLOCATOR 0
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INI_H */

--- a/src/DETHRACE/common/structur.c
+++ b/src/DETHRACE/common/structur.c
@@ -311,9 +311,7 @@ void DoLogos(void) {
 #ifdef DETHRACE_FIX_BUGS
     /* StartMusic is only called in PlaySmackerFile when sound and cutscenes are enabled */
     if (!gSound_override && gCut_scene_override) {
-        if (!harness_game_config.no_music) {
-            StartMusic();
-        }
+        StartMusic();
     }
 #endif
     gProgram_state.prog_status = eProg_opening;

--- a/src/harness/CMakeLists.txt
+++ b/src/harness/CMakeLists.txt
@@ -4,18 +4,18 @@ add_library(harness STATIC)
 
 target_include_directories(harness
     PRIVATE
-        .
-        ${CMAKE_SOURCE_DIR}
-        "${CMAKE_CURRENT_BINARY_DIR}"
+    .
+    ${CMAKE_SOURCE_DIR}
+    "${CMAKE_CURRENT_BINARY_DIR}"
     PUBLIC
-        include
+    include
 )
 
 if(DETHRACE_FIX_BUGS)
     target_compile_definitions(harness PRIVATE DETHRACE_FIX_BUGS)
 endif()
 
-target_link_libraries(harness PRIVATE brender miniaudio stb compile_with_werror)
+target_link_libraries(harness PRIVATE brender miniaudio stb inih compile_with_werror)
 
 if(NOT MSVC)
     target_compile_options(harness PRIVATE
@@ -41,6 +41,7 @@ target_sources(harness PRIVATE
     include/harness/config.h
     include/harness/os.h
     include/harness/audio.h
+
     # cameras/debug_camera.c
     # cameras/debug_camera.h
     ascii_tables.h
@@ -61,6 +62,7 @@ if(DETHRACE_PLATFORM_SDL1)
         platforms/sdl1_syms.h
     )
     target_compile_definitions(harness PRIVATE DETHRACE_PLATFORM_SDL1)
+
     if(DETHRACE_PLATFORM_SDL_DYNAMIC)
         set_property(SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/platforms/sdl1.c" APPEND PROPERTY INCLUDE_DIRECTORIES "$<TARGET_PROPERTY:SDL::SDL,INTERFACE_INCLUDE_DIRECTORIES>")
         get_filename_component(sdl_library_directory "${SDL_LIBRARY}" DIRECTORY)
@@ -78,6 +80,7 @@ if(DETHRACE_PLATFORM_SDL2)
         platforms/sdl2_syms.h
     )
     target_compile_definitions(harness PRIVATE DETHRACE_PLATFORM_SDL2)
+
     if(DETHRACE_PLATFORM_SDL_DYNAMIC)
         set_property(SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/platforms/sdl2.c" APPEND PROPERTY INCLUDE_DIRECTORIES "$<TARGET_PROPERTY:SDL2::SDL2,INTERFACE_INCLUDE_DIRECTORIES>")
         set_property(GLOBAL APPEND PROPERTY DETHRACE_BUILD_RPATHS "$<TARGET_FILE_DIR:SDL2::SDL2>")

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -432,7 +432,7 @@ static int Harness_Ini_Callback(void* user, const char* section, const char* nam
         harness_game_config.fps = i;
     } else if (MATCH("General", "DemoTimeout")) {
         i = atoi(value);
-        harness_game_config.demo_timeout = i;
+        harness_game_config.demo_timeout = i * 1000;
     } else if (MATCH("General", "Windowed")) {
         harness_game_config.start_full_screen = (value[0] == '0');
     } else if (MATCH("General", "Emulate3DFX")) {

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -224,7 +224,7 @@ void Harness_DetectAndSetWorkingDirectory(char* argv0) {
         if (access("DATA/GENERAL.TXT", F_OK) == 0) {
             // good, found
         } else {
-            gHarness_platform.GetPrefPath("dethrace", pref_path);
+            gHarness_platform.GetPrefPath(pref_path, "dethrace");
             path = pref_path;
         }
     }
@@ -481,7 +481,7 @@ static int Harness_Ini_Callback(void* user, const char* section, const char* nam
 int Harness_ProcessIniFile(void) {
     int i;
     char path[1024];
-    gHarness_platform.GetPrefPath("dethrace", path);
+    gHarness_platform.GetPrefPath(path, "dethrace");
 
     strcat(path, "dethrace.ini");
 

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -3,6 +3,7 @@
 #include "include/harness/config.h"
 #include "include/harness/hooks.h"
 #include "include/harness/os.h"
+#include "ini.h"
 #include "platforms/null.h"
 #include "version.h"
 
@@ -13,13 +14,14 @@
 #include <sys/stat.h>
 
 extern uint32_t gI_am_cheating;
+extern int gSound_override;
 
 extern void Harness_Platform_Init(tHarness_platform* platform);
 
 extern const tPlatform_bootstrap SDL1_bootstrap;
 extern const tPlatform_bootstrap SDL2_bootstrap;
 
-static const tPlatform_bootstrap *platform_bootstraps[] = {
+static const tPlatform_bootstrap* platform_bootstraps[] = {
 #ifdef DETHRACE_PLATFORM_SDL2
     &SDL2_bootstrap,
 #endif
@@ -40,12 +42,67 @@ tHarness_platform gHarness_platform;
 static int force_null_platform = 0;
 
 typedef struct {
-    const char *platform_name;
+    const char* platform_name;
     uint32_t platform_capabilityies;
-    int install_signalhandler;
 } tArgument_config;
 
 static int Harness_ProcessCommandLine(tArgument_config* argument_config, int* argc, char* argv[]);
+static int Harness_ProcessIniFile(void);
+
+static int Harness_InitPlatform(tArgument_config* argument_config) {
+    if (force_null_platform) {
+        Null_Platform_Init(&gHarness_platform);
+    } else {
+        const tPlatform_bootstrap* selected_bootstrap = NULL;
+
+        if (argument_config->platform_name != NULL) {
+            size_t i;
+            for (i = 0; i < BR_ASIZE(platform_bootstraps); i++) {
+                if (strcasecmp(platform_bootstraps[i]->name, argument_config->platform_name) == 0) {
+                    if ((platform_bootstraps[i]->capabilities & argument_config->platform_capabilityies) != argument_config->platform_capabilityies) {
+                        fprintf(stderr, "Platform \"%s\" does not support requested capabilities. Try another video driver and/or add/remove --opengl\n", selected_bootstrap->name);
+                        return 1;
+                    }
+                    selected_bootstrap = platform_bootstraps[i];
+                    break;
+                }
+            }
+            if (selected_bootstrap == NULL) {
+                fprintf(stderr, "Could not find a platform named \"%s\"\n", argument_config->platform_name);
+                return 1;
+            }
+            if (selected_bootstrap->init(&gHarness_platform) != 0) {
+                fprintf(stderr, "%s initialization failed\n", selected_bootstrap->name);
+                return 1;
+            }
+        } else {
+            size_t i;
+            for (i = 0; i < BR_ASIZE(platform_bootstraps); i++) {
+                LOG_TRACE10("Attempting video driver \"%s\"", platform_bootstraps[i]->name);
+                if ((platform_bootstraps[i]->capabilities & argument_config->platform_capabilityies) != argument_config->platform_capabilityies) {
+                    fprintf(stderr, "Skipping platform \"%s\". Does not support required capabilities.\n", platform_bootstraps[i]->name);
+                    continue;
+                }
+                LOG_TRACE10("Try platform \"%s\"...");
+                if (platform_bootstraps[i]->init(&gHarness_platform) == 0) {
+                    selected_bootstrap = platform_bootstraps[i];
+                    break;
+                }
+            }
+            if (selected_bootstrap == NULL) {
+                fprintf(stderr, "Could not find a supported platform\n");
+                return 1;
+            }
+        }
+        if (selected_bootstrap == NULL) {
+            fprintf(stderr, "Could not find a supported platform\n");
+            return 1;
+        }
+        LOG_INFO("Platform: %s (%s)", selected_bootstrap->name, selected_bootstrap->description);
+    }
+
+    return 0;
+}
 
 static void Harness_DetectGameMode(void) {
     if (access("DATA/RACES/CASTLE.TXT", F_OK) != -1) {
@@ -150,10 +207,46 @@ static void Harness_DetectGameMode(void) {
     }
 }
 
+void Harness_DetectAndSetWorkingDirectory(char* argv0) {
+    char* path;
+    char* env_var;
+    char pref_path[MAX_PATH];
+
+    env_var = getenv("DETHRACE_ROOT_DIR");
+
+    if (harness_game_config.selected_dir != NULL) {
+        path = harness_game_config.selected_dir->directory;
+    } else if (env_var != NULL) {
+        LOG_INFO("DETHRACE_ROOT_DIR is set to '%s'", env_var);
+        path = env_var;
+    } else {
+        path = OS_GetWorkingDirectory(argv0);
+        if (access("DATA/GENERAL.TXT", F_OK) == 0) {
+            // good, found
+        } else {
+            gHarness_platform.GetPrefPath("dethrace", pref_path);
+            path = pref_path;
+        }
+    }
+
+    // if root_dir is null or empty, no need to chdir
+    if (path != NULL && path[0] != '\0') {
+        printf("Using game directory: %s\n", path);
+        if (chdir(path) != 0) {
+            LOG_PANIC("Failed to chdir. Error is %s", strerror(errno));
+        }
+    }
+}
+
 int Harness_Init(int* argc, char* argv[]) {
-    int result;
 
     printf("Dethrace version: %s\n", DETHRACE_VERSION);
+
+    tArgument_config argument_config;
+    // don't require a particular platform
+    argument_config.platform_name = NULL;
+    // request software renderer capability
+    argument_config.platform_capabilityies = ePlatform_cap_software;
 
     memset(&harness_game_info, 0, sizeof(harness_game_info));
 
@@ -182,37 +275,25 @@ int Harness_Init(int* argc, char* argv[]) {
     // Disable verbose logging
     harness_game_config.verbose = 0;
 
-    tArgument_config argument_config;
-    // don't require a particular platform
-    argument_config.platform_name = NULL;
-    // request software renderer capability
-    argument_config.platform_capabilityies = ePlatform_cap_software;
     // install signal handler
-    argument_config.install_signalhandler = 1;
+    harness_game_config.install_signalhandler = 1;
 
     if (Harness_ProcessCommandLine(&argument_config, argc, argv) != 0) {
         fprintf(stderr, "Failed to parse harness command line\n");
         return 1;
     }
 
-    if (argument_config.install_signalhandler) {
+    if (Harness_InitPlatform(&argument_config) != 0) {
+        return 1;
+    }
+
+    Harness_ProcessIniFile();
+
+    if (harness_game_config.install_signalhandler) {
         OS_InstallSignalHandler(argv[0]);
     }
 
-    char* root_dir = getenv("DETHRACE_ROOT_DIR");
-    if (root_dir != NULL) {
-        LOG_INFO("DETHRACE_ROOT_DIR is set to '%s'", root_dir);
-    } else {
-        root_dir = OS_GetWorkingDirectory(argv[0]);
-    }
-    // if root_dir is null or empty, no need to chdir
-    if (root_dir != NULL && root_dir[0] != '\0') {
-        printf("Using root directory: %s\n", root_dir);
-        result = chdir(root_dir);
-        if (result != 0) {
-            LOG_PANIC("Failed to chdir. Error is %s", strerror(errno));
-        }
-    }
+    Harness_DetectAndSetWorkingDirectory(argv[0]);
 
     if (harness_game_info.mode == eGame_none) {
         Harness_DetectGameMode();
@@ -223,56 +304,6 @@ int Harness_Init(int* argc, char* argv[]) {
         exit(1);
     }
 
-    if (force_null_platform) {
-        Null_Platform_Init(&gHarness_platform);
-    } else {
-        const tPlatform_bootstrap* selected_bootstrap = NULL;
-
-        if (argument_config.platform_name != NULL) {
-            size_t i;
-            for (i = 0; i < BR_ASIZE(platform_bootstraps); i++) {
-                if (strcasecmp(platform_bootstraps[i]->name, argument_config.platform_name) == 0) {
-                    if ((platform_bootstraps[i]->capabilities & argument_config.platform_capabilityies) != argument_config.platform_capabilityies) {
-                        fprintf(stderr, "Platform \"%s\" does not support requested capabilities. Try another video driver and/or add/remove --opengl\n", selected_bootstrap->name);
-                        return 1;
-                    }
-                    selected_bootstrap = platform_bootstraps[i];
-                    break;
-                }
-            }
-            if (selected_bootstrap == NULL) {
-                fprintf(stderr, "Could not find a platform named \"%s\"\n", argument_config.platform_name);
-                return 1;
-            }
-            if (selected_bootstrap->init(&gHarness_platform) != 0) {
-                fprintf(stderr, "%s initialization failed\n", selected_bootstrap->name);
-                return 1;
-            }
-        } else {
-            size_t i;
-            for (i = 0; i < BR_ASIZE(platform_bootstraps); i++) {
-                LOG_TRACE10("Attempting video driver \"%s\"", platform_bootstraps[i]->name);
-                if ((platform_bootstraps[i]->capabilities & argument_config.platform_capabilityies) != argument_config.platform_capabilityies) {
-                    fprintf(stderr, "Skipping platform \"%s\". Does not support required capabilities.\n", platform_bootstraps[i]->name);
-                    continue;
-                }
-                LOG_TRACE10("Try platform \"%s\"...");
-                if (platform_bootstraps[i]->init(&gHarness_platform) == 0) {
-                    selected_bootstrap = platform_bootstraps[i];
-                    break;
-                }
-            }
-            if (selected_bootstrap == NULL) {
-                fprintf(stderr, "Could not find a supported platform\n");
-                return 1;
-            }
-        }
-        if (selected_bootstrap == NULL) {
-            fprintf(stderr, "Could not find a supported platform\n");
-            return 1;
-        }
-        LOG_INFO("Platform: %s (%s)", selected_bootstrap->name, selected_bootstrap->description);
-    }
     return 0;
 }
 
@@ -309,7 +340,7 @@ int Harness_ProcessCommandLine(tArgument_config* config, int* argc, char* argv[]
             consumed = 1;
         } else if (strcasecmp(argv[i], "--no-signal-handler") == 0) {
             LOG_INFO("Don't install the signal handler");
-            config->install_signalhandler = 0;
+            harness_game_config.install_signalhandler = 0;
             consumed = 1;
         } else if (strstr(argv[i], "--demo-timeout=") != NULL) {
             char* s = strstr(argv[i], "=");
@@ -345,9 +376,6 @@ int Harness_ProcessCommandLine(tArgument_config* config, int* argc, char* argv[]
             config->platform_capabilityies |= ePlatform_cap_opengl;
             harness_game_config.opengl_3dfx_mode = 1;
             consumed = 1;
-        } else if (strcasecmp(argv[i], "--no-music") == 0) {
-            harness_game_config.no_music = 1;
-            consumed = 1;
         } else if (strcasecmp(argv[i], "--game-completed") == 0) {
             harness_game_config.game_completed = 1;
             consumed = 1;
@@ -374,6 +402,107 @@ int Harness_ProcessCommandLine(tArgument_config* config, int* argc, char* argv[]
         } else {
             i += 1;
         }
+    }
+
+    return 0;
+}
+
+static int Harness_Ini_Callback(void* user, const char* section, const char* name, const char* value) {
+    int i;
+    float f;
+
+#define MATCH(s, n) strcmp(section, s) == 0 && strcmp(name, n) == 0
+#define MATCH_NAME(s, n) strcmp(name, s) == 0
+
+    if (strcmp(section, "Games") == 0) {
+        strcpy(harness_game_config.game_dirs[harness_game_config.game_dirs_count].name, name);
+        strcpy(harness_game_config.game_dirs[harness_game_config.game_dirs_count].directory, value);
+        harness_game_config.game_dirs_count++;
+    }
+
+    else if (MATCH("General", "CdCheck")) {
+        harness_game_config.enable_cd_check = (value[0] == '1');
+    } else if (MATCH("General", "GoreCheck")) {
+        harness_game_config.gore_check = (value[0] == '1');
+    } else if (MATCH("General", "FPSLimit")) {
+        i = atoi(value);
+        harness_game_config.fps = i;
+    } else if (MATCH("General", "DemoTimeout")) {
+        i = atoi(value);
+        harness_game_config.demo_timeout = i;
+    } else if (MATCH("General", "Windowed")) {
+        harness_game_config.start_full_screen = (value[0] == '0');
+    } else if (MATCH("General", "Emulate3DFX")) {
+        harness_game_config.opengl_3dfx_mode = (value[0] == '1');
+    } else if (MATCH("General", "DefaultGame")) {
+        strcpy(harness_game_config.default_game, value);
+    }
+
+    else if (MATCH("Cheats", "EditMode")) {
+        if (value[0] == '1') {
+            gI_am_cheating = 0xa11ee75d;
+        }
+    } else if (MATCH("Cheats", "FreezeTimer")) {
+        harness_game_config.freeze_timer = (value[0] == '1');
+    } else if (MATCH("Cheats", "GameCompleted")) {
+        harness_game_config.game_completed = (value[0] == '1');
+    }
+
+    else if (MATCH("Sound", "Enabled")) {
+        // gSound_override=1 means sound is disabled
+        gSound_override = (value[0] == '0');
+    } else if (MATCH("Sound", "SoundOptionsScreen")) {
+        harness_game_config.sound_options = (value[0] == '1');
+    } else if (MATCH("Sound", "VolumeMultiplier")) {
+        f = atof(value);
+        harness_game_config.volume_multiplier = f;
+    }
+
+    else if (MATCH("Network", "AdapterName")) {
+        strcpy(harness_game_config.network_adapter_name, value);
+    }
+
+    else if (MATCH("Developers", "Diagnostics")) {
+        harness_game_config.enable_diagnostics = (value[0] == '1');
+    } else if (MATCH("Developers", "PhysicsStepTime")) {
+        i = atoi(value);
+        harness_game_config.physics_step_time = i;
+    } else if (MATCH("Developers", "InstallSignalHandler")) {
+        harness_game_config.install_signalhandler = (value[0] == '1');
+    }
+
+    else {
+        // unknown section/name
+    }
+
+    return 1;
+}
+
+int Harness_ProcessIniFile(void) {
+    int i;
+    char path[1024];
+    gHarness_platform.GetPrefPath("dethrace", path);
+
+    strcat(path, "dethrace.ini");
+
+    if (ini_parse(path, Harness_Ini_Callback, NULL) < 0) {
+        LOG_DEBUG("Failed to load config file %s", path);
+        return 1;
+    }
+
+    // if there is a default specified
+    if (strlen(harness_game_config.default_game) > 0) {
+        for (i = 0; i < harness_game_config.game_dirs_count; i++) {
+            if (strcmp(harness_game_config.game_dirs[i].name, harness_game_config.default_game) == 0) {
+                harness_game_config.selected_dir = &harness_game_config.game_dirs[i];
+                break;
+            }
+        }
+    }
+
+    // if no default found, and we have some game dirs, default to first one
+    if (harness_game_config.selected_dir == NULL && harness_game_config.game_dirs_count > 0) {
+        harness_game_config.selected_dir = &harness_game_config.game_dirs[0];
     }
 
     return 0;

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -13,8 +13,11 @@
 #include <string.h>
 #include <sys/stat.h>
 
+// todo tidy this up...
 extern uint32_t gI_am_cheating;
 extern int gSound_override;
+extern int gSausage_override;
+extern int gGraf_spec_index;
 
 extern void Harness_Platform_Init(tHarness_platform* platform);
 
@@ -436,6 +439,10 @@ static int Harness_Ini_Callback(void* user, const char* section, const char* nam
         harness_game_config.opengl_3dfx_mode = (value[0] == '1');
     } else if (MATCH("General", "DefaultGame")) {
         strcpy(harness_game_config.default_game, value);
+    } else if (MATCH("General", "BoringMode")) {
+        gSausage_override = (value[0] == '1');
+    } else if (MATCH("General", "Hires")) {
+        gGraf_spec_index = (value[0] == '1');
     }
 
     else if (MATCH("Cheats", "EditMode")) {

--- a/src/harness/include/harness/config.h
+++ b/src/harness/include/harness/config.h
@@ -1,6 +1,8 @@
 #ifndef HARNESS_CONFIG_H
 #define HARNESS_CONFIG_H
 
+#define MAX_PATH 1024
+
 typedef enum tHarness_game_type {
     eGame_none,
     eGame_carmageddon,
@@ -34,6 +36,11 @@ typedef struct tHarness_game_info {
     int data_dir_has_3dfx_assets;
 } tHarness_game_info;
 
+typedef struct tHarness_game_dir {
+    char name[256];
+    char directory[MAX_PATH];
+} tHarness_game_dir;
+
 typedef struct tHarness_game_config {
     int enable_cd_check;
     int physics_step_time;
@@ -46,7 +53,6 @@ typedef struct tHarness_game_config {
     int gore_check;
     int sound_options;
 
-    int no_music;
     int verbose;
     int opengl_3dfx_mode;
     int game_completed;
@@ -54,6 +60,11 @@ typedef struct tHarness_game_config {
     int install_signalhandler;
     int no_bind;
     char network_adapter_name[256];
+
+    tHarness_game_dir* selected_dir;
+    int game_dirs_count;
+    tHarness_game_dir game_dirs[10];
+    char default_game[256];
 } tHarness_game_config;
 
 extern tHarness_game_info harness_game_info;

--- a/src/harness/include/harness/hooks.h
+++ b/src/harness/include/harness/hooks.h
@@ -47,7 +47,7 @@ typedef struct tHarness_platform {
     void* (*GL_GetProcAddress)(const char* name);
     void (*GetViewport)(int* x, int* y, float* width_multiplier, float* height_multiplier);
 
-    void (*GetPrefPath)(char* app_name, char* path);
+    void (*GetPrefPath)(char* path, char* app_name);
 
 } tHarness_platform;
 

--- a/src/harness/include/harness/hooks.h
+++ b/src/harness/include/harness/hooks.h
@@ -47,6 +47,8 @@ typedef struct tHarness_platform {
     void* (*GL_GetProcAddress)(const char* name);
     void (*GetViewport)(int* x, int* y, float* width_multiplier, float* height_multiplier);
 
+    void (*GetPrefPath)(char* app_name, char* path);
+
 } tHarness_platform;
 
 enum {

--- a/src/harness/platforms/null.c
+++ b/src/harness/platforms/null.c
@@ -1,4 +1,5 @@
 #include "null.h"
+#include <string.h>
 
 static uint32_t null_time;
 
@@ -53,6 +54,10 @@ static uint32_t null_getticks(void) {
     return null_time;
 }
 
+static void null_get_pref_path(char* path, char* app_name) {
+    strcpy(path, ".");
+}
+
 void Null_Platform_Init(tHarness_platform* platform) {
     null_time = 0;
     platform->ProcessWindowMessages = null_get_and_handle_message;
@@ -68,4 +73,5 @@ void Null_Platform_Init(tHarness_platform* platform) {
     platform->ShowErrorMessage = null_show_error_message;
 
     platform->Renderer_SetPalette = null_set_palette;
+    platform->GetPrefPath = null_get_pref_path;
 }

--- a/src/harness/platforms/sdl1.c
+++ b/src/harness/platforms/sdl1.c
@@ -286,6 +286,12 @@ static void SDL1_Harness_GetViewport(int* x, int* y, float* width_multipler, flo
     *height_multiplier = viewport.scale_y;
 }
 
+static void SDL1_Harness_GetPrefPath(char* app_name, char* path) {
+    // SDL_GetPrefPath not in SDL1. We could implement it if we really needed to.
+    // for now, just return the current path
+    strcpy(path, ".");
+}
+
 static int SDL1_Harness_Platform_Init(tHarness_platform* platform) {
     if (SDL1_LoadSymbols() != 0) {
         return 1;
@@ -307,6 +313,7 @@ static int SDL1_Harness_Platform_Init(tHarness_platform* platform) {
     platform->PaletteChanged = SDL1_Harness_PaletteChanged;
     platform->GL_GetProcAddress = SDL1_GL_GetProcAddress;
     platform->GetViewport = SDL1_Harness_GetViewport;
+    platform->GetPrefPath = SDL1_Harness_GetPrefPath;
     return 0;
 }
 

--- a/src/harness/platforms/sdl1.c
+++ b/src/harness/platforms/sdl1.c
@@ -286,7 +286,7 @@ static void SDL1_Harness_GetViewport(int* x, int* y, float* width_multipler, flo
     *height_multiplier = viewport.scale_y;
 }
 
-static void SDL1_Harness_GetPrefPath(char* app_name, char* path) {
+static void SDL1_Harness_GetPrefPath(char* path, char* app_name) {
     // SDL_GetPrefPath not in SDL1. We could implement it if we really needed to.
     // for now, just return the current path
     strcpy(path, ".");

--- a/src/harness/platforms/sdl2.c
+++ b/src/harness/platforms/sdl2.c
@@ -370,7 +370,7 @@ static void SDL2_Harness_GetViewport(int* x, int* y, float* width_multipler, flo
 static void SDL2_Harness_GetPrefPath(char* app_name, char* path) {
     char* sdl_path = SDL2_GetPrefPath(NULL, app_name);
     strcpy(path, sdl_path);
-    SDL_free(sdl_path);
+    SDL2_free(sdl_path);
 }
 
 static int SDL2_Harness_Platform_Init(tHarness_platform* platform) {

--- a/src/harness/platforms/sdl2.c
+++ b/src/harness/platforms/sdl2.c
@@ -368,7 +368,7 @@ static void SDL2_Harness_GetViewport(int* x, int* y, float* width_multipler, flo
 }
 
 static void SDL2_Harness_GetPrefPath(char* app_name, char* path) {
-    char* sdl_path = SDL_GetPrefPath(NULL, app_name);
+    char* sdl_path = SDL2_GetPrefPath(NULL, app_name);
     strcpy(path, sdl_path);
     SDL_free(sdl_path);
 }

--- a/src/harness/platforms/sdl2.c
+++ b/src/harness/platforms/sdl2.c
@@ -367,7 +367,7 @@ static void SDL2_Harness_GetViewport(int* x, int* y, float* width_multipler, flo
     *height_multiplier = viewport.scale_y;
 }
 
-static void SDL2_Harness_GetPrefPath(char* app_name, char* path) {
+static void SDL2_Harness_GetPrefPath(char* path, char* app_name) {
     char* sdl_path = SDL2_GetPrefPath(NULL, app_name);
     strcpy(path, sdl_path);
     SDL2_free(sdl_path);

--- a/src/harness/platforms/sdl2.c
+++ b/src/harness/platforms/sdl2.c
@@ -367,6 +367,12 @@ static void SDL2_Harness_GetViewport(int* x, int* y, float* width_multipler, flo
     *height_multiplier = viewport.scale_y;
 }
 
+static void SDL2_Harness_GetPrefPath(char* app_name, char* path) {
+    char* sdl_path = SDL_GetPrefPath(NULL, app_name);
+    strcpy(path, sdl_path);
+    SDL_free(sdl_path);
+}
+
 static int SDL2_Harness_Platform_Init(tHarness_platform* platform) {
     if (SDL2_LoadSymbols() != 0) {
         return 1;
@@ -388,6 +394,7 @@ static int SDL2_Harness_Platform_Init(tHarness_platform* platform) {
     platform->PaletteChanged = SDL2_Harness_PaletteChanged;
     platform->GL_GetProcAddress = SDL2_GL_GetProcAddress;
     platform->GetViewport = SDL2_Harness_GetViewport;
+    platform->GetPrefPath = SDL2_Harness_GetPrefPath;
     return 0;
 };
 

--- a/src/harness/platforms/sdl2_syms.h
+++ b/src/harness/platforms/sdl2_syms.h
@@ -10,7 +10,7 @@
     X(GetTicks, Uint32, (void))                                                         \
     X(GetError, const char*, (void))                                                    \
     X(PollEvent, int, (SDL_Event*))                                                     \
-    X(ShowSimpleMessageBox, int, (Uint32, const char*, const char *, SDL_Window*))      \
+    X(ShowSimpleMessageBox, int, (Uint32, const char*, const char*, SDL_Window*))       \
     X(CreateWindow, SDL_Window*, (const char*, int, int, int, int, Uint32))             \
     X(DestroyWindow, void, (SDL_Window*))                                               \
     X(GetWindowFlags, Uint32, (SDL_Window*))                                            \
@@ -20,7 +20,7 @@
     X(SetWindowSize, void, (SDL_Window*, int, int))                                     \
     X(CreateRenderer, SDL_Renderer*, (SDL_Window*, int, Uint32))                        \
     X(RenderClear, int, (SDL_Renderer*))                                                \
-    X(RenderCopy, int, (SDL_Renderer*,SDL_Texture*, const SDL_Rect*, const SDL_Rect*))  \
+    X(RenderCopy, int, (SDL_Renderer*, SDL_Texture*, const SDL_Rect*, const SDL_Rect*)) \
     X(RenderPresent, void, (SDL_Renderer*))                                             \
     X(RenderWindowToLogical, void, (SDL_Renderer*, int, int, float*, float*))           \
     X(GetRendererInfo, int, (SDL_Renderer*, SDL_RendererInfo*))                         \
@@ -33,12 +33,13 @@
     X(GetMouseState, Uint32, (int*, int*))                                              \
     X(ShowCursor, int, (int))                                                           \
     X(GetPixelFormatName, const char*, (Uint32))                                        \
-    X(GetScancodeName, const char *, (SDL_Scancode))                                    \
+    X(GetScancodeName, const char*, (SDL_Scancode))                                     \
     X(GL_CreateContext, SDL_GLContext, (SDL_Window*))                                   \
     X(GL_GetProcAddress, void*, (const char*))                                          \
     X(GL_SetAttribute, int, (SDL_GLattr, int))                                          \
     X(GL_SetSwapInterval, int, (int))                                                   \
-    X(GL_SwapWindow, void, (SDL_Window*))
+    X(GL_SwapWindow, void, (SDL_Window*))                                               \
+    X(GetPrefPath, char*, (const char* org, const char* app))
 
 #undef SDL2_SYM
 

--- a/src/harness/platforms/sdl2_syms.h
+++ b/src/harness/platforms/sdl2_syms.h
@@ -39,7 +39,8 @@
     X(GL_SetAttribute, int, (SDL_GLattr, int))                                          \
     X(GL_SetSwapInterval, int, (int))                                                   \
     X(GL_SwapWindow, void, (SDL_Window*))                                               \
-    X(GetPrefPath, char*, (const char* org, const char* app))
+    X(GetPrefPath, char*, (const char* org, const char* app))                           \
+    X(free, void, (void*))
 
 #undef SDL2_SYM
 


### PR DESCRIPTION
- Looks for `dethrace.ini` in `SDL_GetPrefPath` location, and uses it. 
- Can specify a list of directories and nominate a default one.

### Order of precedence for game directory detection:
1) Directory pointed to by DefaultGame
2) First game in the list if at least 1 game dir is specified
3) `DETHRACE_ROOT_DIR` environment variable
4) Current working directory (if `DATA/GENERAL.TXT` exists)
5) `SDL_GetPrefPath` directory

```
[General]
CdCheck = 0
GoreCheck = 0

FPSLimit = 60

; default demo time out is 240s (5 mins)
DemoTimeout = 240000

Windowed = 0
Emulate3DFX = 1

DefaultGame = c1demo

[Games]
sp = /opt/carma/c1sp
c1 = /opt/carma/c1
c1demo = /opt/carma/c1demo

[Cheats]
EditMode = 1
FreezeTimer = 0
GameCompleted = 0

[Sound]
Enabled = 1
SoundOptionsScreen = 1
VolumeMultiplier = 1

[Network]
NoBind = 0
AdapterName = ""

[Developers]
Diagnostics = 0
PhysicsStepTime = 40
InstallSignalHandler = 1
```