### PR TITLE
Reccmp batch 2

### DIFF
--- a/src/DETHRACE/common/brucetrk.c
+++ b/src/DETHRACE/common/brucetrk.c
@@ -26,7 +26,7 @@ void AllocateActorMatrix(tTrack_spec* pTrack_spec, br_actor**** pDst) {
     tU16 z;
 
     *pDst = BrMemAllocate(sizeof(br_actor***) * pTrack_spec->ncolumns_z, kMem_columns_z);
-    for (z = 0; z < pTrack_spec->ncolumns_z; z++) {
+    for (z = 0; z != pTrack_spec->ncolumns_z; z++) {
         (*pDst)[z] = BrMemAllocate(sizeof(br_actor**) * pTrack_spec->ncolumns_x, kMem_columns_x);
         memset((*pDst)[z], 0, sizeof(br_actor**) * pTrack_spec->ncolumns_x);
     }

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -4846,7 +4846,7 @@ void FreezeMechanics(void) {
 void PutOpponentsInNeutral(void) {
 
     gStop_opponents_moving = !gStop_opponents_moving;
-    if (gStop_opponents_moving == 0) {
+    if (gStop_opponents_moving) {
         NewTextHeadupSlot(eHeadupSlot_misc, 0, 3000, -4, "Opponents in neutral");
     } else {
         NewTextHeadupSlot(eHeadupSlot_misc, 0, 3000, -4, "Back in gear");
@@ -7164,9 +7164,9 @@ br_scalar TwoPointCollB(br_scalar* f, br_matrix4* m, br_scalar* d, br_vector3* t
     br_scalar ts;
 
     ts = m->m[1][1] * m->m[0][0] - m->m[0][1] * m->m[1][0];
-    if (fabs(ts) > 0.000001f) {
+    if (fabs(ts) > 0.000001) {
         f[0] = (m->m[1][1] * d[0] - m->m[0][1] * d[1]) / ts;
-        f[1] = (m->m[1][0] * d[0] - m->m[0][0] * d[1]) / -ts;
+        f[1] = (m->m[1][0] * d[0] - m->m[0][0] * d[1]) / (-ts);
     }
     if (f[1] < 0.0f) {
         ts = SinglePointColl(f, m, d);
@@ -7269,7 +7269,7 @@ br_scalar FourPointCollB(br_scalar* f, br_matrix4* m, br_scalar* d, br_vector3* 
 int TestForNan(float* f) {
     tU32 i;
     // i = *f;
-    //return isnan(*f);
+    // return isnan(*f);
     // return (~i & 0x7F800000) == 0;
 
     i = *(unsigned long*)f;

--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -2417,7 +2417,7 @@ void CycleSoundDetailLevel(void) {
     new_level = (gSound_detail_level + 1) % 3;
     ReallySetSoundDetailLevel(new_level);
     SetSoundDetailLevel(new_level);
-    switch (new_level) {
+    switch (gSound_detail_level) {
     case 0:
         NewTextHeadupSlot(eHeadupSlot_misc, 0, 2000, -4, GetMiscString(kMiscString_FewestSounds));
         break;

--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -445,7 +445,12 @@ void InitDepthEffects(void) {
     PathCat(the_path, the_path, "HORIZON.MAT");
     gHorizon_material = BrMaterialLoad(the_path);
     if (gHorizon_material == NULL) {
-        FatalError(kFatalError_FindSkyMaterial_S, "HORIZON.MAT"); // 2nd argument added
+        FatalError(kFatalError_FindSkyMaterial_S
+#ifdef DETHRACE_FIX_BUGS
+            ,
+            "HORIZON.MAT"
+#endif
+        );
     }
 #ifdef DETHRACE_3DFX_PATCH
     if (gScreen->type == BR_PMT_INDEX_8 && !gMaterial_fogging)

--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -865,7 +865,7 @@ void LessDepthFactor(void) {
 void MoreDepthFactor(void) {
     char s[256];
 
-    if (gProgram_state.current_depth_effect.start < 14) {
+    if (gProgram_state.current_depth_effect.start < 13) {
         gProgram_state.current_depth_effect.start++;
     }
     sprintf(s, "Depth start increased to %d", gProgram_state.current_depth_effect.start);
@@ -878,7 +878,7 @@ void MoreDepthFactor(void) {
 void LessDepthFactor2(void) {
     char s[256];
 
-    if (gProgram_state.current_depth_effect.end < 14) {
+    if (gProgram_state.current_depth_effect.end < 13) {
         gProgram_state.current_depth_effect.end++;
     }
     sprintf(s, "Depth end reduced to %d", gProgram_state.current_depth_effect.end);

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -835,10 +835,10 @@ void AdjustRenderScreenSize(void) {
         gRender_screen->height = gProgram_state.current_render_bottom - gProgram_state.current_render_top;
         gRender_screen->width = gProgram_state.current_render_right - gProgram_state.current_render_left;
     }
-    if (gRender_screen->row_bytes == gRender_screen->width) {
-        gRender_screen->flags |= BR_PMF_ROW_WHOLEPIXELS;
-    } else {
+    if (gRender_screen->row_bytes != gRender_screen->width) {
         gRender_screen->flags &= ~BR_PMF_ROW_WHOLEPIXELS;
+    } else {
+        gRender_screen->flags |= BR_PMF_ROW_WHOLEPIXELS;
     }
     gRender_screen->origin_x = gRender_screen->width / 2;
     gRender_screen->origin_y = gRender_screen->height / 2;

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -2465,7 +2465,7 @@ br_uint_32 AmbientificateMaterial(br_material* pMat, void* pArg) {
     a = pMat->ka + *(br_scalar*)pArg;
     if (a < 0.f) {
         a = 0.f;
-    } else if (a > 0.99f) {
+    } else if (a > 0.99) {
         a = 0.99f;
     }
     pMat->ka = a;

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -943,6 +943,7 @@ void DRSetPalette(br_pixelmap* pThe_palette) {
 // IDA: void __cdecl InitializePalettes()
 // FUNCTION: CARM95 0x004b3bd3
 void InitializePalettes(void) {
+    int i;
     int j;
     gCurrent_palette_pixels = BrMemAllocate(0x400u, kMem_cur_pal_pixels);
 #ifdef DETHRACE_3DFX_PATCH

--- a/src/DETHRACE/common/loading.c
+++ b/src/DETHRACE/common/loading.c
@@ -3485,15 +3485,15 @@ FILE* DRfopen(char* pFilename, char* pMode) {
     result = OldDRfopen(pFilename, pMode);
 
     if (result == NULL && !gAllow_open_to_fail) {
-        if (GetCDPathFromPathsTxtFile(CD_dir) && !PDCheckDriveExists(CD_dir)) {
+        if (GetCDPathFromPathsTxtFile(CD_dir) && PDCheckDriveExists(CD_dir) == 0) {
             if (gMisc_strings[0]) {
                 PDFatalError(GetMiscString(kMiscString_CouldNotFindTheCarmageddonCD));
             } else {
                 PDFatalError("Could not find the Carmageddon CD");
             }
-            sprintf(msg, "DRfopen( \"%s\", \"%s\" ) failed", pFilename, pMode);
-            PDFatalError(msg);
         }
+        sprintf(msg, "DRfopen( \"%s\", \"%s\" ) failed", pFilename, pMode);
+        PDFatalError(msg);
     }
     return result;
 }

--- a/src/DETHRACE/common/loading.c
+++ b/src/DETHRACE/common/loading.c
@@ -2646,6 +2646,7 @@ void UnlockOpponentMugshot(int pIndex) {
 }
 
 // IDA: void __usercall LoadOpponentMugShot(int pIndex@<EAX>)
+// FUNCTION: CARM95 0x004244B0
 void LoadOpponentMugShot(int pIndex) {
 
     PossibleService();
@@ -2661,6 +2662,7 @@ void LoadOpponentMugShot(int pIndex) {
 }
 
 // IDA: void __usercall DisposeOpponentGridIcon(tRace_info *pRace_info@<EAX>, int pIndex@<EDX>)
+// FUNCTION: CARM95 0x00424557
 void DisposeOpponentGridIcon(tRace_info* pRace_info, int pIndex) {
 
     if (pRace_info->opponent_list[pIndex].index >= 0) {

--- a/src/DETHRACE/common/loading.c
+++ b/src/DETHRACE/common/loading.c
@@ -419,10 +419,11 @@ void LoadGeneralParameters(void) {
     if (f == NULL) {
         FatalError(kFatalError_SettingsFile);
     }
-    gCamera_hither = GetAFloat(f) * HITHER_MULTIPLIER;
-    gCamera_yon = GetAFloat(f);
-    gCamera_angle = GetAFloat(f);
-    gAmbient_adjustment = GetAFloat(f) * AMBIENT_MULTIPLIER;
+    gCamera_hither = GetAScalar(f);
+    gCamera_hither *= HITHER_MULTIPLIER;
+    gCamera_yon = GetAScalar(f);
+    gCamera_angle = GetAScalar(f);
+    gAmbient_adjustment = GetAScalar(f) / 100.0f;
     gDim_amount = GetAnInt(f);
     gInitial_rank = GetAnInt(f);
     GetThreeInts(f, &gInitial_credits[0], &gInitial_credits[1], &gInitial_credits[2]);
@@ -523,10 +524,10 @@ void LoadGeneralParameters(void) {
     }
 
     gDefault_gravity = GetAFloat(f);
-    gCut_delay_1 = GetAFloat(f);
-    gCut_delay_2 = GetAFloat(f);
-    gCut_delay_3 = GetAFloat(f);
-    gCut_delay_4 = GetAFloat(f);
+    gCut_delay_1 = GetAScalar(f);
+    gCut_delay_2 = GetAScalar(f);
+    gCut_delay_3 = GetAScalar(f);
+    gCut_delay_4 = GetAScalar(f);
     gZombie_factor = 1.0f;
     fclose(f);
 }
@@ -759,19 +760,18 @@ void LoadInFiles(char* pThe_base_path, char* pThe_dir_name, void (*pLoad_routine
 // FUNCTION: CARM95 0x0041d5fd
 void LoadInRegisteeDir(char* pThe_dir_path) {
     tPath_name the_path;
-    tPath_name reg_path;
 
-    PathCat(reg_path, pThe_dir_path, "REG");
-    LoadInFiles(reg_path, "PALETTES", DRLoadPalette);
-    LoadInFiles(reg_path, "SHADETAB", DRLoadShadeTable);
+    PathCat(the_path, pThe_dir_path, "REG");
+    LoadInFiles(the_path, "PALETTES", DRLoadPalette);
+    LoadInFiles(the_path, "SHADETAB", DRLoadShadeTable);
 #ifdef DETHRACE_3DFX_PATCH
     InitializePalettes();
 #endif
-    LoadInFiles(reg_path, "PIXELMAP", DRLoadPixelmaps);
-    LoadInFiles(reg_path, "MATERIAL", DRLoadMaterials);
-    LoadInFiles(reg_path, "MODELS", DRLoadModels);
-    LoadInFiles(reg_path, "ACTORS", DRLoadActors);
-    LoadInFiles(reg_path, "LIGHTS", DRLoadLights);
+    LoadInFiles(the_path, "PIXELMAP", DRLoadPixelmaps);
+    LoadInFiles(the_path, "MATERIAL", DRLoadMaterials);
+    LoadInFiles(the_path, "MODELS", DRLoadModels);
+    LoadInFiles(the_path, "ACTORS", DRLoadActors);
+    LoadInFiles(the_path, "LIGHTS", DRLoadLights);
 }
 
 // IDA: void __cdecl LoadInRegistees()
@@ -1065,92 +1065,92 @@ void DisposeCar(tCar_spec* pCar_spec, int pOwner) {
     int i;
     int j;
 
-    if (pCar_spec->driver_name[0] == '\0') {
-        return;
-    }
-    gFunk_groove_flags[pCar_spec->fg_index] = 0;
-    pCar_spec->driver_name[0] = '\0';
-    if (pCar_spec->driver == eDriver_local_human) {
-        for (i = 0; i < COUNT_OF(pCar_spec->cockpit_images); i++) {
-            if (pCar_spec->cockpit_images[i] != NULL) {
-                BrMemFree(pCar_spec->cockpit_images[i]);
-            }
-        }
-        if (pCar_spec->speedo_image[0] != NULL) {
-            BrPixelmapFree(pCar_spec->speedo_image[0]);
-        }
-        if (pCar_spec->speedo_image[1] != NULL) {
-            BrPixelmapFree(pCar_spec->speedo_image[1]);
-        }
-        if (pCar_spec->tacho_image[0] != NULL) {
-            BrPixelmapFree(pCar_spec->tacho_image[0]);
-        }
-        if (pCar_spec->tacho_image[1] != NULL) {
-            BrPixelmapFree(pCar_spec->tacho_image[1]);
-        }
-        for (i = 0; i < pCar_spec->number_of_hands_images; i++) {
-            if (pCar_spec->lhands_images[i] != NULL) {
-                BrPixelmapFree(pCar_spec->lhands_images[i]);
-            }
-            if (pCar_spec->rhands_images[i] != NULL) {
-                BrPixelmapFree(pCar_spec->rhands_images[i]);
-            }
-        }
-        if (pCar_spec->prat_cam_left != NULL) {
-            BrPixelmapFree(pCar_spec->prat_cam_left);
-        }
-        if (pCar_spec->prat_cam_top != NULL) {
-            BrPixelmapFree(pCar_spec->prat_cam_top);
-        }
-        if (pCar_spec->prat_cam_right != NULL) {
-            BrPixelmapFree(pCar_spec->prat_cam_right);
-        }
-        if (pCar_spec->prat_cam_bottom != NULL) {
-            BrPixelmapFree(pCar_spec->prat_cam_bottom);
-        }
-        for (i = 0; i < COUNT_OF(pCar_spec->damage_units); i++) {
-            if (pCar_spec->damage_units[i].images != NULL) {
-                BrPixelmapFree(pCar_spec->damage_units[i].images);
-            }
-        }
-        if (pCar_spec->damage_background != NULL) {
-            BrPixelmapFree(pCar_spec->damage_background);
-        }
-        for (i = 0; i < COUNT_OF(pCar_spec->power_ups); i++) {
-            for (j = 0; j < pCar_spec->power_ups[i].number_of_parts; j++) {
-                if (pCar_spec->power_ups[i].info[j].data_ptr != NULL) {
-                    BrMemFree(pCar_spec->power_ups[i].info[j].data_ptr);
+    if (pCar_spec->driver_name[0] != '\0') {
+
+        gFunk_groove_flags[pCar_spec->fg_index] = 0;
+        pCar_spec->driver_name[0] = '\0';
+        if (pCar_spec->driver == eDriver_local_human) {
+            for (i = 0; i < COUNT_OF(pCar_spec->cockpit_images); i++) {
+                if (pCar_spec->cockpit_images[i] != NULL) {
+                    BrMemFree(pCar_spec->cockpit_images[i]);
                 }
             }
+            if (pCar_spec->speedo_image[0] != NULL) {
+                BrPixelmapFree(pCar_spec->speedo_image[0]);
+            }
+            if (pCar_spec->speedo_image[1] != NULL) {
+                BrPixelmapFree(pCar_spec->speedo_image[1]);
+            }
+            if (pCar_spec->tacho_image[0] != NULL) {
+                BrPixelmapFree(pCar_spec->tacho_image[0]);
+            }
+            if (pCar_spec->tacho_image[1] != NULL) {
+                BrPixelmapFree(pCar_spec->tacho_image[1]);
+            }
+            for (i = 0; i < pCar_spec->number_of_hands_images; i++) {
+                if (pCar_spec->lhands_images[i] != NULL) {
+                    BrPixelmapFree(pCar_spec->lhands_images[i]);
+                }
+                if (pCar_spec->rhands_images[i] != NULL) {
+                    BrPixelmapFree(pCar_spec->rhands_images[i]);
+                }
+            }
+            if (pCar_spec->prat_cam_left != NULL) {
+                BrPixelmapFree(pCar_spec->prat_cam_left);
+            }
+            if (pCar_spec->prat_cam_top != NULL) {
+                BrPixelmapFree(pCar_spec->prat_cam_top);
+            }
+            if (pCar_spec->prat_cam_right != NULL) {
+                BrPixelmapFree(pCar_spec->prat_cam_right);
+            }
+            if (pCar_spec->prat_cam_bottom != NULL) {
+                BrPixelmapFree(pCar_spec->prat_cam_bottom);
+            }
+            for (i = 0; i < COUNT_OF(pCar_spec->damage_units); i++) {
+                if (pCar_spec->damage_units[i].images != NULL) {
+                    BrPixelmapFree(pCar_spec->damage_units[i].images);
+                }
+            }
+            if (pCar_spec->damage_background != NULL) {
+                BrPixelmapFree(pCar_spec->damage_background);
+            }
+            for (i = 0; i < COUNT_OF(pCar_spec->power_ups); i++) {
+                for (j = 0; j < pCar_spec->power_ups[i].number_of_parts; j++) {
+                    if (pCar_spec->power_ups[i].info[j].data_ptr != NULL) {
+                        BrMemFree(pCar_spec->power_ups[i].info[j].data_ptr);
+                    }
+                }
+            }
+            gProgram_state.car_name[0] = '\0';
         }
-        gProgram_state.car_name[0] = '\0';
-    }
-    if (pCar_spec->screen_material != NULL) {
-        KillWindscreen(pCar_spec->car_model_actors[pCar_spec->principal_car_actor].actor->model,
-            pCar_spec->screen_material);
-        BrMaterialRemove(pCar_spec->screen_material);
-        BrMaterialFree(pCar_spec->screen_material);
-    }
-    for (i = 0; i < COUNT_OF(pCar_spec->damage_programs); i++) {
-        BrMemFree(pCar_spec->damage_programs[i].clauses);
-    }
-    DropOffDyingPeds(pCar_spec);
-    for (i = 0; i < pCar_spec->car_actor_count; i++) {
-        BrActorRemove(pCar_spec->car_model_actors[i].actor);
-        BrActorFree(pCar_spec->car_model_actors[i].actor);
-    }
-    if (pCar_spec->driver != eDriver_local_human) {
-        BrActorRemove(pCar_spec->car_master_actor);
-        BrActorFree(pCar_spec->car_master_actor);
-    }
-    DisposeFunkotronics(pOwner);
-    DisposeGroovidelics(pOwner);
-    for (i = 0; i < pCar_spec->car_actor_count; i++) {
-        if (pCar_spec->car_model_actors[i].crush_data.crush_points != NULL) {
-            DisposeCrushData(&pCar_spec->car_model_actors[i].crush_data);
+        if (pCar_spec->screen_material != NULL) {
+            KillWindscreen(pCar_spec->car_model_actors[pCar_spec->principal_car_actor].actor->model,
+                pCar_spec->screen_material);
+            BrMaterialRemove(pCar_spec->screen_material);
+            BrMaterialFree(pCar_spec->screen_material);
         }
-        if (pCar_spec->car_model_actors[i].undamaged_vertices != NULL) {
-            BrMemFree(pCar_spec->car_model_actors[i].undamaged_vertices);
+        for (i = 0; i < COUNT_OF(pCar_spec->damage_programs); i++) {
+            BrMemFree(pCar_spec->damage_programs[i].clauses);
+        }
+        DropOffDyingPeds(pCar_spec);
+        for (i = 0; i < pCar_spec->car_actor_count; i++) {
+            BrActorRemove(pCar_spec->car_model_actors[i].actor);
+            BrActorFree(pCar_spec->car_model_actors[i].actor);
+        }
+        if (pCar_spec->driver != eDriver_local_human) {
+            BrActorRemove(pCar_spec->car_master_actor);
+            BrActorFree(pCar_spec->car_master_actor);
+        }
+        DisposeFunkotronics(pOwner);
+        DisposeGroovidelics(pOwner);
+        for (i = 0; i < pCar_spec->car_actor_count; i++) {
+            if (pCar_spec->car_model_actors[i].crush_data.crush_points != NULL) {
+                DisposeCrushData(&pCar_spec->car_model_actors[i].crush_data);
+            }
+            if (pCar_spec->car_model_actors[i].undamaged_vertices != NULL) {
+                BrMemFree(pCar_spec->car_model_actors[i].undamaged_vertices);
+            }
         }
     }
 }
@@ -3625,7 +3625,7 @@ void ReadNetworkSettings(FILE* pF, tNet_game_options* pOptions) {
 // FUNCTION: CARM95 0x00427269
 int PrintNetOptions(FILE* pF, int pIndex) {
 
-    fprintf(pF, "NETSETTINGS %d\n", pIndex);
+    fprintf(pF, "NETSETTINGS %d\n\n", pIndex);
     fprintf(pF, "%d // Allow the sending of Abuse-o-Matic(tm) text messages\n", gNet_settings[pIndex].enable_text_messages);
     fprintf(pF, "%d // Show cars on map\n", gNet_settings[pIndex].show_players_on_map);
     fprintf(pF, "%d // Show peds on map\n", gNet_settings[pIndex].show_peds_on_map);

--- a/src/DETHRACE/common/netgame.c
+++ b/src/DETHRACE/common/netgame.c
@@ -998,7 +998,7 @@ void DeclareWinner(int pWinner_index) {
         if (gCurrent_net_game->type != eNet_game_type_sudden_death && gCurrent_net_game->type != eNet_game_type_tag && gCurrent_net_game->type != eNet_game_type_fight_to_death) {
             best_score_index = gNet_players[i].last_score_index;
             for (j = 0; j < gNumber_of_net_players; j++) {
-                if (gNet_players[j].score == gNet_players[i].score && gNet_players[j].last_score_index < best_score_index) {
+                if (gNet_players[i].score == gNet_players[j].score && gNet_players[j].last_score_index < best_score_index) {
                     best_score_index = gNet_players[j].last_score_index;
                 }
             }
@@ -1057,7 +1057,7 @@ int FarEnoughAway(tNet_game_player_info* pPlayer_1, tNet_game_player_info* pPlay
     br_vector3 difference;
 
     BrVector3Sub(&difference, &pPlayer_1->car->pos, &pPlayer_2->car->pos);
-    return BrVector3LengthSquared(&difference) >= 4.0f;
+    return BrVector3LengthSquared(&difference) >= 4.0;
 }
 
 // IDA: void __usercall CarInContactWithItOrFox(tNet_game_player_info *pPlayer@<EAX>)

--- a/src/DETHRACE/common/network.c
+++ b/src/DETHRACE/common/network.c
@@ -248,14 +248,13 @@ void NetSendHeadupToAllPlayers(char* pMessage) {
 void NetSendHeadupToEverybody(char* pMessage) {
     tNet_contents* the_contents;
 
-    if (gNet_mode == eNet_mode_none) {
-        return;
+    if (gNet_mode != eNet_mode_none) {
+        if (gProgram_state.racing) {
+            NewTextHeadupSlot(eHeadupSlot_misc, 0, 3000, -4, pMessage);
+        }
+        the_contents = NetGetBroadcastContents(NETMSGID_HEADUP, 0);
+        strcpy(the_contents->data.headup.text, pMessage);
     }
-    if (gProgram_state.racing) {
-        NewTextHeadupSlot(eHeadupSlot_misc, 0, 3000, -4, pMessage);
-    }
-    the_contents = NetGetBroadcastContents(NETMSGID_HEADUP, 0);
-    strcpy(the_contents->data.headup.text, pMessage);
 }
 
 // IDA: void __usercall NetSendHeadupToPlayer(char *pMessage@<EAX>, tPlayer_ID pPlayer@<EDX>)

--- a/src/DETHRACE/common/network.c
+++ b/src/DETHRACE/common/network.c
@@ -263,17 +263,16 @@ void NetSendHeadupToEverybody(char* pMessage) {
 void NetSendHeadupToPlayer(char* pMessage, tPlayer_ID pPlayer) {
     tNet_message* message;
 
-    if (gNet_mode == eNet_mode_none) {
-        return;
-    }
-    if (gLocal_net_ID == pPlayer) {
-        if (gProgram_state.racing) {
-            NewTextHeadupSlot(eHeadupSlot_misc, 0, 3000, -4, pMessage);
+    if (gNet_mode != eNet_mode_none) {
+        if (gLocal_net_ID == pPlayer) {
+            if (gProgram_state.racing) {
+                NewTextHeadupSlot(eHeadupSlot_misc, 0, 3000, -4, pMessage);
+            }
+        } else {
+            message = NetBuildMessage(NETMSGID_HEADUP, 0);
+            strcpy(message->contents.data.headup.text, pMessage);
+            NetGuaranteedSendMessageToPlayer(gCurrent_net_game, message, pPlayer, 0);
         }
-    } else {
-        message = NetBuildMessage(NETMSGID_HEADUP, 0);
-        strcpy(message->contents.data.headup.text, pMessage);
-        NetGuaranteedSendMessageToPlayer(gCurrent_net_game, message, pPlayer, 0);
     }
 }
 
@@ -728,10 +727,10 @@ int NetJoinGameLowLevel(tNet_game_details* pDetails, char* pPlayer_name) {
 }
 
 DR_STATIC_ASSERT(offsetof(tNet_message_join, player_info) == 4);
-//DR_STATIC_ASSERT(offsetof(tNet_game_player_info, this_players_time_stamp) == 0x10);
-//DR_STATIC_ASSERT(offsetof(tNet_game_player_info, wasted) == 0x68);
-//DR_STATIC_ASSERT(offsetof(tNet_game_player_info, initial_position) == 0x8c);
-//DR_STATIC_ASSERT(offsetof(tNet_game_player_info, car) == 0xbc);
+// DR_STATIC_ASSERT(offsetof(tNet_game_player_info, this_players_time_stamp) == 0x10);
+// DR_STATIC_ASSERT(offsetof(tNet_game_player_info, wasted) == 0x68);
+// DR_STATIC_ASSERT(offsetof(tNet_game_player_info, initial_position) == 0x8c);
+// DR_STATIC_ASSERT(offsetof(tNet_game_player_info, car) == 0xbc);
 
 // IDA: int __usercall NetJoinGame@<EAX>(tNet_game_details *pDetails@<EAX>, char *pPlayer_name@<EDX>, int pCar_index@<EBX>)
 // FUNCTION: CARM95 0x004476d9
@@ -2038,8 +2037,6 @@ void NetFinishRace(tNet_game_details* pDetails, tRace_over_reason pReason) {
 // IDA: void __usercall NetPlayerStatusChanged(tPlayer_status pNew_status@<EAX>)
 // FUNCTION: CARM95 0x0044a525
 void NetPlayerStatusChanged(tPlayer_status pNew_status) {
-    tNet_message* the_message;
-
     if (gNet_mode != eNet_mode_none && pNew_status != gNet_players[gThis_net_player_index].player_status) {
         gNet_players[gThis_net_player_index].player_status = pNew_status;
         BroadcastStatus();

--- a/src/DETHRACE/common/newgame.c
+++ b/src/DETHRACE/common/newgame.c
@@ -1426,7 +1426,7 @@ void DrawNetChoose(int pCurrent_choice, int pCurrent_mode) {
     }
     if (pCurrent_mode != 0) {
         gLast_net_choose_box = pCurrent_choice;
-        DrawAGraphBox__newgame(pCurrent_choice);
+        DrawAGraphBox__newgame(gLast_net_choose_box);
     } else {
         gLast_net_choose_box = -1;
     }

--- a/src/DETHRACE/common/newgame.c
+++ b/src/DETHRACE/common/newgame.c
@@ -230,6 +230,8 @@ int FrankieOrAnnie(void) {
         { { 55, 110 }, { 132, 317 }, { 161, 322 }, { 154, 370 } },
         { { 178, 356 }, { 132, 317 }, { 295, 590 }, { 154, 370 } }
     };
+
+    // GLOBAL: CARM95 0x0051EC18
     static tInterface_spec interface_spec = {
         0,               // initial_imode
         80,              // first_opening_flic
@@ -1131,15 +1133,14 @@ void RevertToDefaults(void) {
 
     PathCat(the_path, gApplication_path, "NETDEFLT.TXT");
     f = DRfopen(the_path, "rt");
-    if (f == NULL) {
-        return;
+    if (f != NULL) {
+        for (i = 0; i < gCurrent_game_selection + 1; i++) {
+            ReadNetworkSettings(f, &net_options);
+        }
+        SetNetOptions(&net_options);
+        DrawNOptInitialRadios();
+        fclose(f);
     }
-    for (i = 0; i < gCurrent_game_selection + 1; i++) {
-        ReadNetworkSettings(f, &net_options);
-    }
-    SetNetOptions(&net_options);
-    DrawNOptInitialRadios();
-    fclose(f);
 }
 
 // IDA: void __cdecl DefaultNetSettings()
@@ -1550,6 +1551,8 @@ int NetGameChoices(tNet_game_type* pGame_type, tNet_game_options* pGame_options,
         { { 53, 98 }, { 121, 264 }, { 211, 568 }, { 129, 283 }, 9, 1, 0, NULL },
         { { 53, 98 }, { 131, 264 }, { 211, 568 }, { 139, 283 }, 10, 1, 0, NULL },
     };
+
+    // GLOBAL: CARM95 0x0051FE48
     static tInterface_spec interface_spec = {
         0, 122, 0, 0, 0, 0, -1,
         { 1, 0 }, { 4, -10 }, { 4, 0 }, { 4, 0 }, { NetChooseLR, NULL },

--- a/src/DETHRACE/common/oil.c
+++ b/src/DETHRACE/common/oil.c
@@ -406,7 +406,7 @@ int PointInSpill(br_vector3* pV, int pSpill) {
 
     return gOily_spills[pSpill].current_size * gOily_spills[pSpill].current_size * 0.8f > SQR(pV->v[0] / WORLD_SCALE - gOily_spills[pSpill].actor->t.t.translate.t.v[0])
         && gOily_spills[pSpill].current_size * gOily_spills[pSpill].current_size * 0.8f > SQR(pV->v[2] / WORLD_SCALE - gOily_spills[pSpill].actor->t.t.translate.t.v[2])
-        && fabs(pV->v[1] / WORLD_SCALE - gOily_spills[pSpill].actor->t.t.translate.t.v[1]) < 0.1f;
+        && (float)fabs(pV->v[1] / WORLD_SCALE - gOily_spills[pSpill].actor->t.t.translate.t.v[1]) < 0.1f;
 }
 
 // IDA: void __usercall GetOilFrictionFactors(tCar_spec *pCar@<EAX>, br_scalar *pFl_factor@<EDX>, br_scalar *pFr_factor@<EBX>, br_scalar *pRl_factor@<ECX>, br_scalar *pRr_factor)

--- a/src/DETHRACE/common/oil.c
+++ b/src/DETHRACE/common/oil.c
@@ -44,14 +44,14 @@ void InitOilSpills(void) {
     for (i = 0; i < COUNT_OF(gOily_spills); i++) {
         the_material = BrMaterialAllocate(NULL);
         BrMaterialAdd(the_material);
+        the_material->flags |= BR_MATF_LIGHT;
+        the_material->flags |= BR_MATF_PERSPECTIVE;
+        the_material->flags |= BR_MATF_SMOOTH;
         the_material->ka = 0.99f;
         the_material->kd = 0.0f;
         the_material->ks = 0.0f;
         the_material->power = 0.0f;
         the_material->index_base = 0;
-        the_material->flags |= BR_MATF_LIGHT;
-        the_material->flags |= BR_MATF_PERSPECTIVE;
-        the_material->flags |= BR_MATF_SMOOTH;
         the_material->index_range = 0;
         the_material->colour_map = NULL;
         BrMatrix23Identity(&the_material->map_transform);

--- a/src/DETHRACE/common/opponent.c
+++ b/src/DETHRACE/common/opponent.c
@@ -326,7 +326,7 @@ int PointVisibleFromHere(br_vector3* pFrom, br_vector3* pTo) {
     from.v[1] += 0.15f;
     dir.v[1] += 0.15f;
     FindFace(&from, &dir, &norm, &t, &material);
-    return t > 1.0;
+    return t > 1.0f;
 }
 
 // IDA: tS16 __usercall FindNearestPathNode@<AX>(br_vector3 *pActor_coords@<EAX>, br_scalar *pDistance@<EDX>)
@@ -3191,7 +3191,7 @@ void ToggleOpponentProcessing(void) {
             gProgram_state.AI_vehicles.opponents[i].physics_me = 0;
         }
         for (i = 0; i < gProgram_state.AI_vehicles.number_of_cops; i++) {
-            gProgram_state.AI_vehicles.opponents[i].physics_me = 0;
+            gProgram_state.AI_vehicles.cops[i].physics_me = 0;
         }
         gActive_car_list_rebuild_required = 1;
         RebuildActiveCarList();
@@ -3211,7 +3211,7 @@ void ToggleMellowOpponents(void) {
             ObjectiveComplete(&gProgram_state.AI_vehicles.opponents[i]);
         }
     } else {
-        NewTextHeadupSlot(eHeadupSlot_misc, 0, 2000, -1, "Opponents hostile again");
+        NewTextHeadupSlot(eHeadupSlot_misc, 0, 3000, -1, "Opponents hostile again");
     }
 }
 
@@ -3345,7 +3345,7 @@ void DeleteNode(tS16 pNode_to_delete, int pAnd_sections) {
         if (pNode_to_delete < gProgram_state.AI_vehicles.path_sections[section_no].node_indices[0]) {
             gProgram_state.AI_vehicles.path_sections[section_no].node_indices[0]--;
         }
-        if (pNode_to_delete < gProgram_state.AI_vehicles.path_sections[section_no].node_indices[0]) {
+        if (pNode_to_delete < gProgram_state.AI_vehicles.path_sections[section_no].node_indices[1]) {
             gProgram_state.AI_vehicles.path_sections[section_no].node_indices[1]--;
         }
     }
@@ -3596,7 +3596,10 @@ void MakeCube(br_uint_16 pFirst_vertex, br_uint_16 pFirst_face, br_vector3* pPoi
     br_vector3 offset_v;
     br_vector3 point;
 
-    BrVector3Set(&point, pPoint->v[0], pPoint->v[1] + .15f, pPoint->v[2]);
+    point.v[0] = pPoint->v[0];
+    point.v[1] = pPoint->v[1];
+    point.v[1] += .15f;
+    point.v[2] = pPoint->v[2];
 
     BrVector3Set(&offset_v, .1f, .1f, .1f);
     MakeVertexAndOffsetIt(gOppo_path_model, pFirst_vertex + 0, point.v[0], point.v[1], point.v[2], &offset_v);

--- a/src/DETHRACE/common/options.c
+++ b/src/DETHRACE/common/options.c
@@ -1469,7 +1469,10 @@ void DrawDisabledOptions(void) {
 
     PrintMemoryDump(0, "INSIDE OPTIONS");
 
-    if (!harness_game_config.sound_options) {
+#ifdef DETHRACE_FIX_BUGS
+    if (!harness_game_config.sound_options)
+#endif
+    {
         // Disable sound options menu
         image = LoadPixelmap("NOSNDOPT.PIX");
         DisableChoice(0);

--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -738,7 +738,7 @@ void KillPedestrian(tPedestrian_data* pPedestrian) {
                 pPedestrian->current_frame,
                 pPedestrian->hit_points,
                 pPedestrian->done_initial,
-                (pPedestrian->actor->parent == gDont_render_actor) ? -1 : pPedestrian->killers_ID,
+                (pPedestrian->actor->parent == gDont_render_actor) ? (tU16)-1 : pPedestrian->killers_ID,
                 pPedestrian->spin_period,
                 pPedestrian->jump_magnitude,
                 &pPedestrian->offset);
@@ -2365,7 +2365,7 @@ void GroundPedestrian(tPedestrian_data* pPedestrian) {
             pPedestrian->current_frame,
             pPedestrian->hit_points,
             pPedestrian->done_initial,
-            pPedestrian->actor->parent == gDont_render_actor ? -1 : pPedestrian->killers_ID,
+            pPedestrian->actor->parent == gDont_render_actor ? (tU16)-1 : pPedestrian->killers_ID,
             pPedestrian->spin_period,
             pPedestrian->jump_magnitude,
             &pPedestrian->offset);

--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -1681,7 +1681,7 @@ int FancyATossOffMate(tPedestrian_data* pPedestrian, tCollision_info* pCar, floa
         && pPedestrian->ref_number < 100
         && (pCar->driver > 1 || ((tCar_spec*)pCar)->number_of_wheels_on_ground >= 4)
         && PercentageChance(50)
-        && pImpact_speed >= .0035f;
+        && pImpact_speed >= .0035;
 }
 
 // IDA: void __usercall CheckPedestrianDeathScenario(tPedestrian_data *pPedestrian@<EAX>)
@@ -2186,10 +2186,10 @@ void DoPedestrian(tPedestrian_data* pPedestrian, int pIndex) {
             pPedestrian->pos.v[X] - gCamera_to_world.m[3][X],
             pPedestrian->pos.v[Z] - gCamera_to_world.m[3][Z]);
         MungePedestrianSequence(pPedestrian, 0);
-        if (old_frame <= pPedestrian->sequences[pPedestrian->current_sequence].number_of_frames) {
-            pPedestrian->current_frame = old_frame;
-        } else {
+        if (pPedestrian->sequences[pPedestrian->current_sequence].number_of_frames < old_frame) {
             pPedestrian->current_frame = 0;
+        } else {
+            pPedestrian->current_frame = old_frame;
         }
         pPedestrian->colour_map = pPedestrian->sequences[MAX(pPedestrian->current_sequence, 0)].frames[MAX(pPedestrian->current_frame, 0)].pixelmap;
         gCurrent_lollipop_index = -1;
@@ -2231,7 +2231,7 @@ void DoPedestrian(tPedestrian_data* pPedestrian, int pIndex) {
                 pPedestrian->current_frame,
                 pPedestrian->hit_points,
                 pPedestrian->done_initial,
-                pPedestrian->actor->parent != gDont_render_actor ? pPedestrian->killers_ID : -1,
+                pPedestrian->actor->parent == gDont_render_actor ? (tU16)-1 : pPedestrian->killers_ID,
                 pPedestrian->spin_period,
                 pPedestrian->jump_magnitude,
                 &pPedestrian->offset);

--- a/src/DETHRACE/common/piping.c
+++ b/src/DETHRACE/common/piping.c
@@ -1041,7 +1041,7 @@ void InitLastDamageArrayEtc(void) {
                     car->frame_start_damage[j] = 0;
                 }
             }
-            car->car_ID = (cat << 8) | i;
+            car->car_ID = (cat << 8) + i;
         }
     }
 }

--- a/src/DETHRACE/common/powerup.c
+++ b/src/DETHRACE/common/powerup.c
@@ -1285,7 +1285,7 @@ void SendCurrentPowerups(void) {
     tNet_contents* the_contents;
     tPlayer_ID ID;
 
-    for (cat = eVehicle_self; cat < eVehicle_net_player; cat++) {
+    for (cat = eVehicle_self; cat <= eVehicle_net_player; cat++) {
         if (cat == eVehicle_self) {
             car_count = 1;
         } else {
@@ -1312,7 +1312,7 @@ void SendCurrentPowerups(void) {
                     the_contents->data.powerup.event = ePowerup_ongoing;
                     the_contents->data.powerup.player = ID;
                     the_contents->data.powerup.powerup_index = j;
-                    the_contents->data.powerup.time_left = car->powerups[i] - GetTotalTime();
+                    the_contents->data.powerup.time_left = car->powerups[j] - GetTotalTime();
                 }
             }
         }

--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -260,10 +260,12 @@ int UpRace(int* pCurrent_choice, int* pCurrent_mode) {
         gStart_interface_spec->pushed_flics[2].y[gGraf_data_index],
         1);
     DRS3StartSound(gEffects_outlet, 3000);
-    if (gCurrent_race_index != 0 && (gRace_list[gCurrent_race_index - 1].best_rank <= gProgram_state.rank || gProgram_state.game_completed || gChange_race_net_mode)) {
-        RemoveTransientBitmaps(1);
-        MoveRaceList(gCurrent_race_index, gCurrent_race_index - 1, 150);
-        gCurrent_race_index--;
+    if (gRace_list[gCurrent_race_index - 1].best_rank <= gProgram_state.rank || gProgram_state.game_completed || gChange_race_net_mode) {
+        if (gCurrent_race_index != 0) {
+            RemoveTransientBitmaps(1);
+            MoveRaceList(gCurrent_race_index, gCurrent_race_index - 1, 150);
+            gCurrent_race_index--;
+        }
     }
     return 0;
 }
@@ -579,6 +581,8 @@ int ChangeCar(int pNet_mode, int* pCar_index, tNet_game_details* pNet_game) {
         { { 30, 60 }, { 78, 187 }, { 45, 90 }, { 104, 250 }, -1, 0, 0, UpClickCar },
         { { 30, 60 }, { 118, 283 }, { 45, 90 }, { 145, 348 }, -1, 0, 0, DownClickCar },
     };
+
+    // GLOBAL: CARM95 0x0050F670
     static tInterface_spec interface_spec = {
         0,
         236,
@@ -682,9 +686,7 @@ int ChangeCar(int pNet_mode, int* pCar_index, tNet_game_details* pNet_game) {
         BrPixelmapFree(gTaken_image);
     }
     if (result == 0) {
-        if (pNet_mode) {
-            *pCar_index = gProgram_state.cars_available[gCurrent_car_index];
-        } else {
+        if (pNet_mode == eNet_mode_none) {
             AboutToLoadFirstCar();
             SwitchToRealResolution();
             for (i = 0; i < COUNT_OF(power_up_levels); i++) {
@@ -704,6 +706,8 @@ int ChangeCar(int pNet_mode, int* pCar_index, tNet_game_details* pNet_game) {
             DisposeRaceInfo(&gCurrent_race);
             SelectOpponents(&gCurrent_race);
             LoadRaceInfo(gProgram_state.current_race_index, &gCurrent_race);
+        } else {
+            *pCar_index = gProgram_state.cars_available[gCurrent_car_index];
         }
         return 1;
     } else {

--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -2644,10 +2644,18 @@ void NetSynchStartDraw(int pCurrent_choice, int pCurrent_mode) {
         DRPixelmapRectangleMaskedCopy(gBack_screen,
             gCurrent_graf_data->start_synch_x_0,
             gCurrent_graf_data->start_synch_top + 1 + gCurrent_graf_data->start_synch_y_pitch * i,
+#ifdef DETHRACE_FIX_BUGS
             gIcons_pix_low_res, /* DOS version uses low res, Windows version uses normal res */
+#else
+            gIcons_pix,
+#endif
             0,
             gNet_players[i].car_index * gCurrent_graf_data->net_head_icon_height,
+#ifdef DETHRACE_FIX_BUGS
             gIcons_pix_low_res->width, /* DOS version uses low res, Windows version uses normal res */
+#else
+            gIcons_pix->width,
+#endif
             gCurrent_graf_data->net_head_icon_height);
         TurnOnPaletteConversion();
         DrawAnItem__racestrt(

--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -1225,6 +1225,7 @@ tSO_result DoAutoPartsShop(void) {
         { { 84, 168 }, { 95, 228 }, { 147, 294 }, { 115, 276 }, 1, 0, 0, NULL },
         { { 84, 168 }, { 124, 298 }, { 147, 294 }, { 144, 346 }, 2, 0, 0, NULL },
     };
+    // GLOBAL: CARM95 0x0050FD20
     static tInterface_spec interface_spec = {
         0, 280, 0, 0, 0, 0, 6,
         { -1, 0 }, { 0, 0 }, { 0, 0 }, { 0, 0 }, { NULL, NULL },
@@ -2088,7 +2089,7 @@ void ChallengeStart(void) {
         gOpponents[gChallenger_index__racestrt].mug_shot_image_data,
         gOpponents[gChallenger_index__racestrt].mug_shot_image_data_length);
     if (gScreen->row_bytes < 0) {
-        BrFatal("C:\\Msdev\\Projects\\DethRace\\Racestrt.c", 2610, "Bruce bug at line %d, file C:\\Msdev\\Projects\\DethRace\\Racestrt.c", 50);
+        BrFatal("C:\\Msdev\\Projects\\DethRace\\Racestrt.c", 2610, "Bruce bug at line %d, file C:\\Msdev\\Projects\\DethRace\\Racestrt.c", 2610);
     }
     the_map = DRPixelmapAllocate(
 #ifdef DETHRACE_3DFX_PATCH

--- a/src/DETHRACE/common/racesumm.c
+++ b/src/DETHRACE/common/racesumm.c
@@ -256,7 +256,7 @@ void DrawSummaryItems(void) {
         gCurrent_graf_data->summ1_rank_inc_l,
         gCurrent_graf_data->summ1_rank_x_pitch,
         gCurrent_graf_data->summ1_rank_y,
-        (int)(gTemp_rank_increase + .5f));
+        (int)(gTemp_rank_increase + 0.5));
     DrawChromeNumber(
         gCurrent_graf_data->summ1_rank_total_c,
         gCurrent_graf_data->summ1_rank_total_l,

--- a/src/DETHRACE/common/racesumm.c
+++ b/src/DETHRACE/common/racesumm.c
@@ -826,18 +826,17 @@ int DamageScrnExit(int* pCurrent_choice, int* pCurrent_mode) {
 
     if (gProgram_state.prog_status == eProg_idling) {
         return 1;
-    } else {
-        if (gWreck_gallery_start == 0) {
-            gWreck_gallery_start = PDGetTotalTime();
-        } else if (!gDone_initial && gWreck_selected == 0) {
-            if (PDGetTotalTime() - gWreck_gallery_start > 1500) {
-                ZoomOutTo(gWreck_selected, pCurrent_choice, pCurrent_mode);
-                gDone_initial = 1;
-            }
-        }
-        CastSelectionRay(pCurrent_choice, pCurrent_mode);
-        return 0;
     }
+    if (gWreck_gallery_start == 0) {
+        gWreck_gallery_start = PDGetTotalTime();
+    } else if (!gDone_initial && gWreck_selected == 0) {
+        if (PDGetTotalTime() - gWreck_gallery_start > 1500) {
+            ZoomOutTo(gWreck_selected, pCurrent_choice, pCurrent_mode);
+            gDone_initial = 1;
+        }
+    }
+    CastSelectionRay(pCurrent_choice, pCurrent_mode);
+    return 0;
 }
 
 // IDA: void __usercall DamageScrnDraw(int pCurrent_choice@<EAX>, int pCurrent_mode@<EDX>)

--- a/src/DETHRACE/common/raycast.c
+++ b/src/DETHRACE/common/raycast.c
@@ -458,7 +458,7 @@ void FindBestY(br_vector3* pPosition, br_actor* gWorld, br_scalar pStarting_heig
 
     gLowest_y_above = 30000.0;
     gHighest_y_below = -30000.0;
-    gCurrent_y = pPosition->v[1] + 0.000011920929;
+    gCurrent_y = pPosition->v[1] + 0.000011920929f;
     gY_picking_camera->t.t.euler.t = *pPosition;
     gY_picking_camera->t.t.mat.m[3][1] = gY_picking_camera->t.t.mat.m[3][1] + pStarting_height;
     DRScenePick2D(gWorld, gY_picking_camera, FindHighestCallBack__raycast, 0);

--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -699,24 +699,21 @@ void MungeEngineNoise(void) {
 // IDA: void __cdecl SetSoundVolumes()
 // FUNCTION: CARM95 0x004655d8
 void SetSoundVolumes(void) {
-
-    if (!gSound_enabled) {
-        return;
+    if (gSound_enabled) {
+        if (gEffects_outlet != NULL) {
+            DRS3SetOutletVolume(gEffects_outlet, 42 * gProgram_state.effects_volume);
+        }
+        DRS3SetOutletVolume(gCar_outlet, 42 * gProgram_state.effects_volume);
+        DRS3SetOutletVolume(gEngine_outlet, 42 * gProgram_state.effects_volume);
+        DRS3SetOutletVolume(gDriver_outlet, 42 * gProgram_state.effects_volume);
+        DRS3SetOutletVolume(gPedestrians_outlet, 42 * gProgram_state.effects_volume);
+        DRS3SetOutletVolume(gMusic_outlet, 42 * gProgram_state.music_volume);
     }
-    if (gEffects_outlet != NULL) {
-        DRS3SetOutletVolume(gEffects_outlet, 42 * gProgram_state.effects_volume);
-    }
-    DRS3SetOutletVolume(gCar_outlet, 42 * gProgram_state.effects_volume);
-    DRS3SetOutletVolume(gEngine_outlet, 42 * gProgram_state.effects_volume);
-    DRS3SetOutletVolume(gDriver_outlet, 42 * gProgram_state.effects_volume);
-    DRS3SetOutletVolume(gPedestrians_outlet, 42 * gProgram_state.effects_volume);
-    DRS3SetOutletVolume(gMusic_outlet, 42 * gProgram_state.music_volume);
 }
 
 // IDA: tS3_outlet_ptr __usercall GetOutletFromIndex@<EAX>(int pIndex@<EAX>)
 // FUNCTION: CARM95 0x004656b1
 tS3_outlet_ptr GetOutletFromIndex(int pIndex) {
-
     return gIndexed_outlets[pIndex];
 }
 

--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -717,8 +717,8 @@ void AdjustSpark(int pSpark_num, br_vector3* pos, br_vector3* length) {
     if (gSparks[i].car != NULL) {
         mat = &gSparks[i].car->car_master_actor->t.t.mat;
         tv.v[0] = pos->v[0] - mat->m[3][0];
-        tv.v[1] = pos->v[0] - mat->m[3][1];
-        tv.v[2] = pos->v[0] - mat->m[3][2];
+        tv.v[1] = pos->v[1] - mat->m[3][1];
+        tv.v[2] = pos->v[2] - mat->m[3][2];
         BrMatrix34TApplyV(&gSparks[i].pos, &tv, mat);
     } else {
         gSparks[i].pos.v[0] = pos->v[0];
@@ -740,7 +740,7 @@ void AdjustShrapnel(int pShrapnel_num, br_vector3* pos, tU16 pAge, br_material* 
     if (!(gShrapnel_flags & (1u << i))) {
         BrActorAdd(gNon_track_actor, gShrapnel[i].actor);
     }
-    gShrapnel_flags |= 1u << i;
+    gShrapnel_flags = gShrapnel_flags | (1u << i);
     gShrapnel[i].actor->t.t.translate.t.v[0] = pos->v[0];
     gShrapnel[i].actor->t.t.translate.t.v[1] = pos->v[1];
     gShrapnel[i].actor->t.t.translate.t.v[2] = pos->v[2];
@@ -1315,7 +1315,7 @@ void ReplaySmoke(br_pixelmap* pRender_screen, br_pixelmap* pDepth_buffer, br_act
 
     for (i = 0; i < COUNT_OF(gSmoke_column); i++) {
         if (gSmoke_flags & (1 << i)) {
-            aspect = 1.f + (gSmoke[i].radius - .05f) / .25f * .5f;
+            aspect = 1.0 + (gSmoke[i].radius - .05f) / .25f * .5;
             if (gSmoke[i].type & 0x10) {
                 SmokeCircle3D(&gSmoke[i].pos, gSmoke[i].radius / aspect, gSmoke[i].strength, 1.f,
                     pRender_screen, pDepth_buffer, gShade_list[gSmoke[i].type & 0xf], pCamera);
@@ -2021,7 +2021,7 @@ void InitFlame(void) {
     if (num != COUNT_OF(gFlame_map)) {
         FatalError(kFatalError_LoadPixelmapFile_S, the_path);
     }
-    BrMapAddMany(gFlame_map, COUNT_OF(gFlame_map));
+    BrMapAddMany(gFlame_map, num);
     for (i = 0; i < MAX_SMOKE_COLUMNS; i++) {
         gSmoke_column[i].flame_actor = BrActorAllocate(BR_ACTOR_NONE, NULL);
         for (j = 0; j < COUNT_OF(gSmoke_column[0].frame_count); j++) {

--- a/src/DETHRACE/common/utility.c
+++ b/src/DETHRACE/common/utility.c
@@ -354,10 +354,14 @@ char* GetALineAndDontArgue(FILE* pF, char* pS) {
 // IDA: void __usercall PathCat(char *pDestn_str@<EAX>, char *pStr_1@<EDX>, char *pStr_2@<EBX>)
 // FUNCTION: CARM95 0x004c1d69
 void PathCat(char* pDestn_str, char* pStr_1, char* pStr_2) {
-
-    if (pDestn_str != pStr_1) { // Added to avoid strcpy overlap checks
+#ifdef DETHRACE_FIX_BUGS
+    // Added to avoid strcpy overlap checks
+    if (pDestn_str != pStr_1) {
         strcpy(pDestn_str, pStr_1);
     }
+#else
+    strcpy(pDestn_str, pStr_1);
+#endif
     if (strlen(pStr_2) != 0) {
         strcat(pDestn_str, gDir_separator);
         strcat(pDestn_str, pStr_2);

--- a/src/DETHRACE/common/world.c
+++ b/src/DETHRACE/common/world.c
@@ -2473,8 +2473,8 @@ void ParseSpecialVolume(FILE* pF, tSpecial_volume* pSpec, char* pScreen_name_str
     char s[256];
     pSpec->gravity_multiplier = GetAScalar(pF);
     pSpec->viscosity_multiplier = GetAScalar(pF);
-    pSpec->car_damage_per_ms = GetAScalar(pF);
-    pSpec->ped_damage_per_ms = GetAScalar(pF);
+    pSpec->car_damage_per_ms = GetAFloat(pF);
+    pSpec->ped_damage_per_ms = GetAFloat(pF);
     pSpec->camera_special_effect_index = GetAnInt(pF);
     pSpec->sky_col = GetAnInt(pF);
 
@@ -4544,30 +4544,31 @@ br_uint_32 SetIDAndDupModel(br_actor* pActor, void* pArg) {
     char s2[256];
     br_model* new_model;
 
-    if (pActor->identifier == NULL || pActor->identifier[0] == '@') {
-        return 0;
-    }
-    *(int*)(uintptr_t)pArg = *(int*)(uintptr_t)pArg + 1;
-    strcpy(s, pActor->identifier);
-    s[0] = '@';
-    strtok(s, ".");
-    strcat(s, "0000");
-    sprintf(&s[4], "%04d", *(int*)(uintptr_t)pArg);
-    strcpy(s2, s);
-    strcat(s, ".ACT");
-    BrResFree(pActor->identifier);
-    pActor->identifier = BrResStrDup(pActor, s);
-    if (pActor->model != NULL) {
-        strcat(s2, ".DAT");
-        new_model = BrModelAllocate(s2, pActor->model->nvertices, pActor->model->nfaces);
-        memcpy(new_model->vertices, pActor->model->vertices, pActor->model->nvertices * sizeof(br_vertex));
-        memcpy(new_model->faces, pActor->model->faces, pActor->model->nfaces * sizeof(br_face));
-        new_model->flags |= BR_MODF_UPDATEABLE;
-        BrModelAdd(new_model);
-        BrModelUpdate(new_model, BR_MODU_ALL);
-        pActor->model = new_model;
-        gAdditional_models[gNumber_of_additional_models] = new_model;
-        gNumber_of_additional_models++;
+    if (pActor->identifier) {
+        if (pActor->identifier[0] != '@') {
+            *(int*)(uintptr_t)pArg = *(int*)(uintptr_t)pArg + 1;
+            strcpy(s, pActor->identifier);
+            s[0] = '@';
+            strtok(s, ".");
+            strcat(s, "0000");
+            sprintf(&s[4], "%04d", *(int*)(uintptr_t)pArg);
+            strcpy(s2, s);
+            strcat(s, ".ACT");
+            BrResFree(pActor->identifier);
+            pActor->identifier = BrResStrDup(pActor, s);
+            if (pActor->model != NULL) {
+                strcat(s2, ".DAT");
+                new_model = BrModelAllocate(s2, pActor->model->nvertices, pActor->model->nfaces);
+                memcpy(new_model->vertices, pActor->model->vertices, pActor->model->nvertices * sizeof(br_vertex));
+                memcpy(new_model->faces, pActor->model->faces, pActor->model->nfaces * sizeof(br_face));
+                new_model->flags |= BR_MODF_UPDATEABLE;
+                BrModelAdd(new_model);
+                BrModelUpdate(new_model, BR_MODU_ALL);
+                pActor->model = new_model;
+                gAdditional_models[gNumber_of_additional_models] = new_model;
+                gNumber_of_additional_models++;
+            }
+        }
     }
     return 0;
 }
@@ -5342,10 +5343,10 @@ void BuildSpecVolModel(tSpecial_volume* pSpec, int pIndex, br_material* pInt_mat
     DrVertexSet(model->faces[11].vertices, 11, 10, 2);
 
     memcpy(&model->faces[12], model->faces, 12 * sizeof(br_face));
-    for (i = 12; i < 24; i++) {
-        temp = model->faces[i].vertices[0];
-        model->faces[i].vertices[0] = model->faces[i].vertices[1];
-        model->faces[i].vertices[1] = temp;
+    for (j = 12; j < 24; j++) {
+        temp = model->faces[j].vertices[0];
+        model->faces[j].vertices[0] = model->faces[j].vertices[1];
+        model->faces[j].vertices[1] = temp;
     }
     model->faces[5].material = model->faces[4].material = model->faces[1].material = model->faces[0].material = DRMaterialClone(pExt_mat);
     model->faces[11].material = model->faces[10].material = model->faces[9].material = model->faces[8].material = DRMaterialClone(pExt_mat);

--- a/src/DETHRACE/dr_types.h
+++ b/src/DETHRACE/dr_types.h
@@ -16,27 +16,9 @@
 #if _MSC_VER == 1020
 typedef unsigned int uintptr_t;
 typedef int intptr_t;
-
-#pragma intrinsic(memcpy, memset, memcmp, strlen, strcpy, strcmp, strcat)
-
-// required for platform-specific network structs
-// if needed for a different platform, make this conditional
-
-typedef struct tPD_net_player_info {
-    // cannot be a regular sockaddr_in because it is transmitted between OS's
-
-    int i;
-} tPD_net_player_info;
-
-// has to match `tPD_net_player_info` - see `PDNetGetNextJoinGame`
-typedef struct tPD_net_game_info {
-    // cannot be a regular sockaddr_in because it is transmitted between OS's
-    int i;
-
-} tPD_net_game_info;
-#else
-#include "pc-all/net_types.h"
 #endif
+
+#include "pc-all/net_types.h"
 
 typedef unsigned char tU8;
 typedef signed char tS8;

--- a/src/DETHRACE/pc-all/net_types.h
+++ b/src/DETHRACE/pc-all/net_types.h
@@ -3,15 +3,22 @@
 
 #include <dr_types.h>
 
+#if _MSC_VER == 1020
+typedef struct sockaddr_ipx {
+    short sa_family;          // AF_IPX = 6
+    char sa_netnum[4];        // network number
+    char sa_nodenum[6];       // node number (MAC addr)
+    unsigned short sa_socket; // socket number
+} SOCKADDR_IPX, *PSOCKADDR_IPX;
+#endif
+
 // This file added dethrace
 //  - have switched out IPX implementation for IP
 //  - cross-platform instead of per-platform implementation
-
 // cannot be a regular sockaddr_in because it is transmitted between OS's
 typedef struct tCopyable_sockaddr_in {
 #if _MSC_VER == 1020
-    long address;
-    long port;
+    SOCKADDR_IPX addr_ipx;
 #else
     uint64_t address;
     uint32_t port;
@@ -30,7 +37,7 @@ typedef struct tPD_net_game_info {
     // cannot be a regular sockaddr_in because it is transmitted between OS's
     tCopyable_sockaddr_in addr_in;
 
-    uint32_t last_response;
+    unsigned int last_response;
 } tPD_net_game_info;
 
 #endif

--- a/src/DETHRACE/pc-none/nonet.c
+++ b/src/DETHRACE/pc-none/nonet.c
@@ -82,6 +82,7 @@ int PDNetInitialise(void) {
 }
 
 // IDA: int __cdecl PDNetShutdown()
+// FUNCTION: CARM95 0x004549F2
 int PDNetShutdown(void) {
     return 0;
 }

--- a/src/S3/s3.c
+++ b/src/S3/s3.c
@@ -1091,6 +1091,7 @@ int S3GenerateTag(tS3_outlet* outlet) {
     return gS3_tag_seed | outlet->id;
 }
 
+// FUNCTION: CARM95 0x0049C829
 int S3SoundStillPlaying(tS3_sound_tag pTag) {
     tS3_channel* chan;
 

--- a/src/library_brender.h
+++ b/src/library_brender.h
@@ -411,3 +411,6 @@
 
 // LIBRARY: CARM95 0x004e6160
 // BrFileRead
+
+// LIBRARY: CARM95 0x004DF8B0
+// BrResStrDup

--- a/src/library_msvc.h
+++ b/src/library_msvc.h
@@ -200,3 +200,15 @@
 
 // LIBRARY: CARM95 0x004F0730
 // __cintrindisp2
+
+// LIBRARY: CARM95 0x004EA86A
+// __CIsqrt
+
+// LIBRARY: CARM95 0x0052D4B0
+// __OP_SQRTjmptab
+
+// LIBRARY: CARM95 0x004F7440
+// __loctotime_t
+
+// LIBRARY: CARM95 0x004EA9E0
+// __chkstk


### PR DESCRIPTION
- AllocateActorMatrix
- PutOpponentsInNeutral
- TwoPointCollB
- CycleSoundDetailLevel
- InitDepthEffects
- MoreDepthFactor
- LessDepthFactor2
- AdjustRenderScreenSize
- InitializePalettes
- AmbientificateMaterial
- LoadGeneralParameters
- LoadInRegisteeDir
- DisposeCar
- OldDRfopen
- ReadNetworkSettings
- DeclareWinner
- FarEnoughAway
- NetSendHeadupToEverybody
- NetSendHeadupToPlayer
- RevertToDefaults
- DrawNetChoose
- InitOilSpills
- PointInSpill
- CalcPlayerConspicuousness
- ToggleOpponentProcessing
- DeleteNode
- DoPedestrian
- InitLastDamageArrayEtc
- SendCurrentPowerups
- AdjustSpark
- BuildSpecVolModel

Total effective accuracy 88.44% across 2369 functions (88.43% actual accuracy)