### PR TITLE
Avoid fclose(NULL) and make [FI]ReturnBetween return in-range numbers

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -2146,11 +2146,11 @@ void LoadInterfaceStrings(void) {
         gTrans_fonts[10] = &gFonts[kFont_DRKPLAQ1];
         gTrans_fonts[11] = &gFonts[kFont_BUTTOUT1];
         gTrans_fonts[12] = &gFonts[kFont_BUTTIN1];
+#ifdef DETHRACE_FIX_BUGS
+        fclose(f);
+#endif
     }
 
-#ifdef DETHRACE_FIX_BUGS
-    fclose(f);
-#endif
 }
 
 // IDA: void __cdecl FlushInterfaceFonts()

--- a/src/DETHRACE/common/utility.c
+++ b/src/DETHRACE/common/utility.c
@@ -184,7 +184,7 @@ int IRandomBetween(int pA, int pB) {
     return num;
 #else
     //  If RAND_MAX != 0x7fff, then use floating numbers (alternative is using modulo)
-    return pA + (int)((pB + 1 - pA) * (rand() / ((float)RAND_MAX + 1)));
+    return pA + (int)((pB + 1 - pA) * (rand() / (float)RAND_MAX));
 #endif
 }
 
@@ -205,7 +205,11 @@ int IRandomPosNeg(int pN) {
 // IDA: float __cdecl FRandomBetween(float pA, float pB)
 // FUNCTION: CARM95 0x004c16bf
 float FRandomBetween(float pA, float pB) {
+#ifdef DETHRACE_FIX_BUGS
+    return (float)rand() * (pB - pA) / (float)RAND_MAX + pA;
+#else
     return (float)rand() * (pB - pA) / (RAND_MAX + 1) + pA;
+#endif
 }
 
 // IDA: float __cdecl FRandomPosNeg(float pN)


### PR DESCRIPTION
This fixes 2 issues:
- avoid calling `fclose` with a NULL file pointer
- fix `[FI]RandomBetween` returning out-of-range numbers

Fixes https://github.com/dethrace-labs/dethrace/issues/475