### PR TITLE
Use `GNUInstallDirs` in `CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ if(MSVC)
     set(CMAKE_INSTALL_DOCDIR "." CACHE PATH "Documentation root")
 endif()
 
+include(GNUInstallDirs)
 include(CheckCCompilerFlag)
 include(CMakeDependentOption)
 include(TestBigEndian)
@@ -152,7 +153,7 @@ endif()
 
 if(DETHRACE_INSTALL)
     install(FILES LICENSE
-        DESTINATION "."
+        DESTINATION "${CMAKE_INSTALL_DOCDIR}"
     )
 
     set(DETHRACE_PACKAGE_PLATFORM "" CACHE STRING "Dethrace binary package platform")

--- a/src/DETHRACE/CMakeLists.txt
+++ b/src/DETHRACE/CMakeLists.txt
@@ -237,7 +237,7 @@ endif()
 if(DETHRACE_INSTALL)
     install(TARGETS dethrace
         BUNDLE DESTINATION . COMPONENT Runtime
-        RUNTIME DESTINATION . COMPONENT Runtime
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT Runtime
     )
 
     if(APPLE)


### PR DESCRIPTION
I'm maintaining an Arch PKGBUILD for Dethrace in the [AUR](https://aur.archlinux.org/packages/dethrace).

The current build process required a small patch, which I've applied here: [fix_install_dirs.patch](https://aur.archlinux.org/cgit/aur.git/tree/fix_install_dirs.patch?h=dethrace&id=520c003050bdd783009b58acdc9df7c8081bf400). This patch adopts `GNUInstallDirs` for install paths, making the project more compliant with CMake conventions and easier for distro packaging.

For developers who want the original "install everything in ." behavior, CMake can still be invoked like:

```sh
$ cmake -B build -S . \
  -DCMAKE_INSTALL_PREFIX=. \
  -DCMAKE_INSTALL_BINDIR=. \
  -DCMAKE_INSTALL_DOCDIR=.
```