### PR TITLE
Add Arch Linux AUR link to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Once cmake has generated the build files for your platform, run the build. For e
 make
 ```
 
+### Arch Linux
+
+For Arch Linux users, Dethrace is available on the AUR: [https://aur.archlinux.org/packages/dethrace](https://aur.archlinux.org/packages/dethrace)
+
+
 ## Running the game
 
 Dethrace does not ship with any content. You'll need access to the data from the original game. If you don't have an original CD then you can [buy Carmageddon from GoG.com](https://www.gog.com/game/carmageddon_max_pack).


### PR DESCRIPTION
Add a note in `README.md` pointing Arch Linux users to the AUR package: https://aur.archlinux.org/packages/dethrace