### PR TITLE
Replace leftover magic numbers with NETMSGID_* enums

### DIFF
--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -1177,7 +1177,7 @@ int DoCrashEarnings(tCar_spec* pCar1, tCar_spec* pCar2) {
                 credits_squared = sqr(0.7f / victim->car_model_actors[victim->principal_car_actor].crush_data.softness_factor) * gWasted_creds[gProgram_state.skill_level] + 50.0f;
                 credits = 100 * (int)(credits_squared / 100.0f);
                 if (gNet_mode) {
-                    message = NetBuildMessage(0x18u, 0);
+                    message = NetBuildMessage(NETMSGID_WASTED, 0);
                     message->contents.data.wasted.victim = NetPlayerFromCar(victim)->ID;
                     if (NetPlayerFromCar(culprit)) {
                         message->contents.data.wasted.culprit = NetPlayerFromCar(culprit)->ID;

--- a/src/DETHRACE/common/oil.c
+++ b/src/DETHRACE/common/oil.c
@@ -324,7 +324,7 @@ void ProcessOilSpills(tU32 pFrame_period) {
                         gOily_spills[i].stop_time = 0;
                         SetInitialOilStuff(&gOily_spills[i], the_model);
                         if (gNet_mode != eNet_mode_none) {
-                            message = NetBuildMessage(30, 0);
+                            message = NetBuildMessage(NETMSGID_OILSPILL, 0);
                             message->contents.data.oil_spill.player = NetPlayerFromCar(gOily_spills[i].car)->ID;
                             message->contents.data.oil_spill.full_size = gOily_spills[i].full_size;
                             message->contents.data.oil_spill.grow_rate = gOily_spills[i].grow_rate;

--- a/src/DETHRACE/common/powerup.c
+++ b/src/DETHRACE/common/powerup.c
@@ -179,7 +179,7 @@ void LosePowerupX(tPowerup* pThe_powerup, int pTell_net_players) {
         pThe_powerup->lose_proc(pThe_powerup, pThe_powerup->car);
     }
     if (gNet_mode != eNet_mode_none) {
-        the_message = NetBuildMessage(21, 0);
+        the_message = NetBuildMessage(NETMSGID_POWERUP, 0);
         the_message->contents.data.powerup.event = ePowerup_lost;
         the_message->contents.data.powerup.player = gLocal_net_ID;
         the_message->contents.data.powerup.event = GET_POWERUP_INDEX(pThe_powerup);
@@ -287,7 +287,7 @@ int GotPowerupX(tCar_spec* pCar, int pIndex, int pTell_net_players, int pDisplay
         PratcamEvent(the_powerup->prat_cam_event);
     }
     if (gNet_mode != eNet_mode_none && pTell_net_players && pIndex == original_index && !ps_power) {
-        the_message = NetBuildMessage(21, 0);
+        the_message = NetBuildMessage(NETMSGID_POWERUP, 0);
         the_message->contents.data.powerup.event = ePowerup_gained;
         the_message->contents.data.powerup.player = gLocal_net_ID;
         the_message->contents.data.powerup.powerup_index = pIndex;


### PR DESCRIPTION
I noticed a few instances of NetBuildMessage that didn't use the NETMSG enums. Let me know if I missed any of them!