### PR TITLE
Fix horizon rendering in OpenGL renderer

### DIFF
--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -260,9 +260,9 @@ br_scalar EdgeU(br_angle pSky, br_angle pView, br_angle pPerfect) {
     br_scalar b;
     br_scalar c;
 
-    a = cos(BrAngleToRadian(pPerfect)) * cos(BrAngleToRadian(pPerfect));
-    b = sin(BrAngleToRadian(pView));
-    c = cos(BrAngleToRadian(pView) + 1.0f) * BrAngleToRadian(pSky);
+    a = BR_COS(pPerfect) * BR_COS(pPerfect);
+    b = BR_SIN(pView);
+    c = (BR_COS(pView) + 1.0f) * BrAngleToRadian(pSky);
     return b * a / c;
 }
 


### PR DESCRIPTION
Fixes #489 

Caused by an incorrect assembly-level match caused by a strange `reccmp` bug

<img width="1674" height="1124" alt="image" src="https://github.com/user-attachments/assets/335771e9-dfca-4c87-87a7-d8a504f7394c" />
