### PR TITLE
WIN32: replace LOG_DEBUG() with LOG_DEBUG2()

### DIFF
--- a/src/harness/os/windows.c
+++ b/src/harness/os/windows.c
@@ -437,7 +437,7 @@ int OS_GetAdapterAddress(char* name, void* pSockaddr_in) {
     }
 
     for (IP_ADAPTER_ADDRESSES* aa = adapter_addrs; aa != NULL; aa = aa->Next) {
-        LOG_DEBUG("name: %s", aa->FriendlyName); // Skip if name is provided and doesn't match FriendlyName
+        LOG_DEBUG2("name: %s", aa->FriendlyName); // Skip if name is provided and doesn't match FriendlyName
         if (wcslen(wideName) > 0 && wcscmp(aa->FriendlyName, wideName) != 0)
             continue;
 


### PR DESCRIPTION
Compiling dethrace rises this error when it is compiled with MinGW:

```
dethrace/src/harness/os/windows.c: In function 'OS_GetAdapterAddress':
dethrace/src/harness/os/windows.c:440:47: error: macro 'LOG_DEBUG' passed 2 arguments, but takes just 1
  440 |         LOG_DEBUG("name: %s", aa->FriendlyName); // Skip if name is provided and doesn't match FriendlyName
      |                                               ^
```

According to the content of `dethrace/src/harness/include/harness/trace.h`, I replaced with `LOG_DEBUG2()` macro and the problem has been solved.