### PR TITLE
NET: fix type mismatch for sa_len parameter (it must be socklen_t)

### DIFF
--- a/src/DETHRACE/pc-all/allnet.c
+++ b/src/DETHRACE/pc-all/allnet.c
@@ -175,7 +175,7 @@ int ReceiveHostResponses(void) {
     int already_registered;
 
     char addr_string[32];
-    unsigned int sa_len;
+    socklen_t sa_len;
     int error;
 
     sa_len = sizeof(gRemote_addr);
@@ -519,7 +519,7 @@ tNet_message* PDNetGetNextMessage(tNet_game_details* pDetails, void** pSender_ad
     int msg_type;
 
     char addr_str[32];
-    unsigned int sa_len;
+    socklen_t sa_len;
     int res;
     tNet_message* msg;
 


### PR DESCRIPTION
`setsockopt()` and `recvfrom()` accept `socklen_t` and not an `unsigned int` as parameter.
See also PR #493 for additional details.