### PR TITLE
Always use PDNetCopyToNative when working with tCopyable_sockaddr_in 

### DIFF
--- a/src/DETHRACE/pc-all/allnet.c
+++ b/src/DETHRACE/pc-all/allnet.c
@@ -144,7 +144,7 @@ int GetMessageTypeFromMessage(char* pMessage_str) {
 }
 
 int SameEthernetAddress(struct sockaddr_in* pAddr_1, struct sockaddr_in* pAddr_2) {
-    return memcmp(pAddr_1, pAddr_2, sizeof(struct sockaddr_in)) == 0;
+    return pAddr_1->sin_family == pAddr_2->sin_family && pAddr_1->sin_port == pAddr_2->sin_port && pAddr_1->sin_addr.s_addr == pAddr_2->sin_addr.s_addr;
 }
 
 // added by dethrace


### PR DESCRIPTION
Small portability fix to CopyableSockAddrToString. The address in tCopyable_sockaddr_in is 64-bit, but s_addr is 32-bit, so it's safer to first convert the address to sockaddr_in rather than passing it directly to inet_ntop. On big endian that latter would use the wrong half of the 64-bit address.