### PR TITLE
CMake: MinGW: fix build error with GCC 14+

### DIFF
--- a/src/DETHRACE/CMakeLists.txt
+++ b/src/DETHRACE/CMakeLists.txt
@@ -59,6 +59,10 @@ if(DETHRACE_REPLAY_DEBUG)
     target_compile_definitions(dethrace_obj PRIVATE DETHRACE_REPLAY_DEBUG)
 endif()
 
+if (MINGW)
+    target_compile_options(dethrace_obj PRIVATE -Wno-error=incompatible-pointer-types)
+endif()
+
 target_sources(dethrace_obj PRIVATE
     common/skidmark.c
     common/opponent.c


### PR DESCRIPTION
Compiling with recent MinGW compiler, an error will happen:

```
src/DETHRACE/pc-all/allnet.c: In function ‘PDNetInitialise’:
src/DETHRACE/pc-all/allnet.c:317:51: error: passing argument 4 of ‘setsockopt’ from incompatible pointer type [-Wincompatible-pointer-types]
  317 |     setsockopt(gSocket, SOL_SOCKET, SO_BROADCAST, &broadcast, sizeof(broadcast));
      |                                                   ^~~~~~~~~~
      |                                                   |
      |                                                   int *
In file included from src/DETHRACE/pc-all/allnet.c:21:
mingw/include/winsock2.h:1035:88: note: expected ‘const char *’ but argument is of type ‘int *’
 1035 |   WINSOCK_API_LINKAGE int WSAAPI setsockopt(SOCKET s,int level,int optname,const char *optval,int optlen);
      |                                                                            ~~~~~~~~~~~~^~~~~~
src/DETHRACE/pc-all/allnet.c:320:48: error: passing argument 4 of ‘setsockopt’ from incompatible pointer type [-Wincompatible-pointer-types]
  320 |     setsockopt(gSocket, SOL_SOCKET, SO_LINGER, &so_linger, sizeof(so_linger));
      |                                                ^~~~~~~~~~
      |                                                |
      |                                                struct linger *
mingw/include/winsock2.h:1035:88: note: expected ‘const char *’ but argument is of type ‘struct linger *’
 1035 |   WINSOCK_API_LINKAGE int WSAAPI setsockopt(SOCKET s,int level,int optname,const char *optval,int optlen);
      |                                                                            ~~~~~~~~~~~~^~~~~~
```

This error happens because Winsock declares some functions in a different manner.

POSIX standard declares setsockopt and recvfrom as:

```
int setsockopt(int socket, int level, int option_name, const void *option_value, socklen_t option_len);
ssize_t recvfrom(int socket, void *restrict buffer, size_t length, int flags, struct sockaddr *restrict address, socklen_t *restrict address_len);
```

Winsock declares them as:

```
int setsockopt(SOCKET s, int level, int optname, const char *optval, int optlen);
int recvfrom(SOCKET s, char *buf, int len, int flags, sockaddr *from, int *fromlen);
```

Actually, `option` is a `const void *` into POSIX while Winsock declares it as `const char *`.

In my opinion, this issue can be fixed by disabling this `incompatible-pointer-types` error into the CMakeLists.txt if MinGW is detected. This patch fixes this error.

See also #493.