### PR TITLE
Fix NetReceive functions using the wrong content data union members

### DIFF
--- a/src/DETHRACE/common/netgame.c
+++ b/src/DETHRACE/common/netgame.c
@@ -194,10 +194,10 @@ void SendCarData(tU32 pNext_frame_time) {
 void ReceivedRecover(tNet_contents* pContents) {
     int i;
 
-    if (gNet_players[gThis_net_player_index].ID != pContents->data.player_list.number_of_players) {
+    if (gNet_players[gThis_net_player_index].ID != pContents->data.recover.ID) {
         for (i = 0; i < gNumber_of_net_players; i++) {
-            if (gNet_players[i].ID == pContents->data.player_list.number_of_players) {
-                gNet_players[i].car->time_to_recover = pContents->data.mech.time;
+            if (gNet_players[i].ID == pContents->data.recover.ID) {
+                gNet_players[i].car->time_to_recover = pContents->data.recover.time_to_recover;
             }
         }
     }
@@ -437,7 +437,7 @@ void ReceivedNonCar(tNet_contents* pContents) {
             c->doing_nothing_flag = 0;
         }
     } else {
-        GetExpandedMatrix(&actor->t.t.mat, &pContents->data.mech.mat);
+        GetExpandedMatrix(&actor->t.t.mat, &pContents->data.non_car.mat);
         BrVector3InvScale(&actor->t.t.translate.t, &actor->t.t.translate.t, WORLD_SCALE);
         XZToColumnXZ(&cx, &cz, actor->t.t.translate.t.v[0], actor->t.t.translate.t.v[2], track_spec);
         if (track_spec->columns[cz][cx] != actor->parent) {

--- a/src/DETHRACE/common/network.c
+++ b/src/DETHRACE/common/network.c
@@ -1490,7 +1490,7 @@ void ReceivedStartRace(tNet_contents* pContents) {
     int i;
     int index;
 
-    if (pContents->data.player_list.number_of_players == -1) {
+    if (pContents->data.start_race.car_count == -1) {
         if (gProgram_state.racing) {
             index = pContents->data.start_race.car_list[0].index;
             BrMatrix34Copy(&gNet_players[index].car->car_master_actor->t.t.mat, &pContents->data.start_race.car_list[0].mat);
@@ -1512,7 +1512,7 @@ void ReceivedStartRace(tNet_contents* pContents) {
             gNet_players[pContents->data.start_race.car_list[i].index].next_car_index = pContents->data.start_race.car_list[i].next_car_index;
         }
     } else {
-        for (i = 0; i < pContents->data.player_list.number_of_players; i++) {
+        for (i = 0; i < pContents->data.start_race.car_count; i++) {
             gCurrent_race.number_of_racers = i + 1;
             gCurrent_race.opponent_list[i].index = -1;
             gCurrent_race.opponent_list[i].ranking = -1;
@@ -1526,10 +1526,10 @@ void ReceivedStartRace(tNet_contents* pContents) {
             }
             gNet_players[pContents->data.start_race.car_list[i].index].next_car_index = pContents->data.start_race.car_list[i].next_car_index;
         }
-        gPending_race = pContents->data.player_list.batch_number;
-        gCurrent_race.number_of_racers = pContents->data.player_list.number_of_players;
+        gPending_race = pContents->data.start_race.next_race;
+        gCurrent_race.number_of_racers = pContents->data.start_race.car_count;
         gSynch_race_start = 1;
-        if (!pContents->data.player_list.this_index || gProgram_state.racing) {
+        if (!pContents->data.start_race.racing || gProgram_state.racing) {
             gWait_for_it = 0;
         }
     }


### PR DESCRIPTION
This was harmless because all of these union members were at the same memory offset and type, but it made the code harder to read. 