### PR TITLE
Improve `DamageUnit2`

### DIFF
--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -573,16 +573,16 @@ void DamageUnit2(tCar_spec* pCar, int pUnit_type, int pDamage_amount) {
     tDamage_unit* the_damage;
     int last_level;
 
-    the_damage = &pCar->damage_units[pUnit_type];
-    if ((pCar->driver < eDriver_net_human || pUnit_type != eDamage_driver) && pDamage_amount >= 5 && !pCar->invulnerable) {
+    if (pCar->driver >= eDriver_net_human && pUnit_type == eDamage_driver) {
+        return;
+    }
+
+    if (pDamage_amount >= 5 && !pCar->invulnerable) {
+        the_damage = &pCar->damage_units[pUnit_type];
         last_level = the_damage->damage_level;
-        the_damage->damage_level = pDamage_amount + last_level;
+        the_damage->damage_level += pDamage_amount;
         if (the_damage->damage_level >= 99) {
-            if (pDamage_amount >= 10) {
-                the_damage->damage_level = 99;
-            } else {
-                the_damage->damage_level = last_level;
-            }
+            the_damage->damage_level = (pDamage_amount < 10) ? last_level : 99;
         }
         if (pCar->driver == eDriver_oppo || gNet_mode != eNet_mode_none) {
             SetKnackeredFlag(pCar);


### PR DESCRIPTION
Should be 100% but I couldn't find a way to influence the ordering here:
```diff
@@ 0x4be7ad @@
cmp dword ptr [ebp + 0x10], 0xa      (crush.c:585)
-jge 0xe
+jl 0xf
+mov eax, dword ptr [ebp - 8]
+mov dword ptr [eax + 8], 0x63
+jmp 0x9
mov eax, dword ptr [ebp - 4]
mov ecx, dword ptr [ebp - 8]
mov dword ptr [ecx + 8], eax
-jmp 0xa
-mov eax, dword ptr [ebp - 8]
-mov dword ptr [eax + 8], 0x63
mov eax, dword ptr [ebp + 8]         (crush.c:587)
```
