### PR TITLE
Annotate and match `interface_spec` static vars

### DIFF
--- a/src/DETHRACE/common/loadsave.c
+++ b/src/DETHRACE/common/loadsave.c
@@ -244,6 +244,7 @@ void LoadStart(void) {
 // IDA: int __usercall DoLoadGame@<EAX>(int pSave_allowed@<EAX>)
 // FUNCTION: CARM95 0x0044bf62
 int DoLoadGame(void) {
+    // GLOBAL: CARM95 0x0050dd98
     static tFlicette flicker_on[9] = {
         { 74, { 47, 94 }, { 23, 55 } },
         { 74, { 47, 94 }, { 44, 110 } },
@@ -255,6 +256,7 @@ int DoLoadGame(void) {
         { 74, { 47, 94 }, { 170, 408 } },
         { 57, { 255, 510 }, { 151, 362 } },
     };
+    // GLOBAL: CARM95 0x0050de50
     static tFlicette flicker_off[9] = {
         { 73, { 47, 94 }, { 23, 55 } },
         { 73, { 47, 94 }, { 44, 110 } },
@@ -266,6 +268,7 @@ int DoLoadGame(void) {
         { 73, { 47, 94 }, { 170, 408 } },
         { 56, { 255, 510 }, { 151, 362 } },
     };
+    // GLOBAL: CARM95 0x0050df08
     static tFlicette push[9] = {
         { 74, { 47, 94 }, { 23, 55 } },
         { 74, { 47, 94 }, { 44, 110 } },
@@ -277,6 +280,7 @@ int DoLoadGame(void) {
         { 74, { 47, 94 }, { 170, 408 } },
         { 59, { 255, 510 }, { 151, 362 } },
     };
+    // GLOBAL: CARM95 0x0050dfc0
     static tMouse_area mouse_areas[9] = {
         { { 48, 96 }, { 17, 41 }, { 250, 500 }, { 33, 79 }, 0, 0, 0, NULL },
         { { 48, 96 }, { 39, 94 }, { 250, 500 }, { 55, 132 }, 1, 0, 0, NULL },
@@ -288,6 +292,7 @@ int DoLoadGame(void) {
         { { 48, 96 }, { 164, 394 }, { 250, 500 }, { 180, 432 }, 7, 0, 0, NULL },
         { { 152, 304 }, { 151, 362 }, { 299, 598 }, { 171, 410 }, 8, 1, 0, NULL },
     };
+    // GLOBAL: CARM95 0x0050e170
     static tRectile recopy_areas[24] = {
         {
             { 53, 106 },
@@ -434,6 +439,8 @@ int DoLoadGame(void) {
             { 182, 437 },
         },
     };
+
+    // GLOBAL: CARM95 0x0050e470
     static tInterface_spec interface_spec = {
         0,
         71,
@@ -589,22 +596,27 @@ void SaveTheGame(int pSlot_number) {
 // IDA: int __cdecl ConfirmMidGameSave()
 // FUNCTION: CARM95 0x0044ceb9
 int ConfirmMidGameSave(void) {
+    // GLOBAL: CARM95 0x0050e5a0
     static tFlicette flicker_on[2] = {
         { 43, { 84, 168 }, { 124, 298 } },
         { 43, { 181, 362 }, { 124, 298 } },
     };
+    // GLOBAL: CARM95 0x0050e5c8
     static tFlicette flicker_off[2] = {
         { 42, { 84, 168 }, { 124, 298 } },
         { 42, { 181, 362 }, { 124, 298 } },
     };
+    // GLOBAL: CARM95 0x0050e5f0
     static tFlicette push[2] = {
         { 44, { 84, 168 }, { 124, 298 } },
         { 45, { 181, 362 }, { 124, 298 } },
     };
+    // GLOBAL: CARM95 0x0050e618
     static tMouse_area mouse_areas[2] = {
         { { 84, 168 }, { 124, 298 }, { 147, 294 }, { 144, 346 }, 0, 0, 0, NULL },
         { { 181, 362 }, { 124, 298 }, { 244, 488 }, { 144, 346 }, 1, 0, 0, NULL },
     };
+    // GLOBAL: CARM95 0x0050e678
     static tInterface_spec interface_spec = {
         0, 40, 0, 41, -1, -1, 0,
         { -1, 0 }, { -1, 0 }, { 0, 0 }, { 1, 0 }, { NULL, NULL },
@@ -762,6 +774,7 @@ int SaveEscape(int* pCurrent_choice, int* pCurrent_mode) {
 // IDA: int __usercall SaveGameInterface@<EAX>(int pDefault_choice@<EAX>)
 // FUNCTION: CARM95 0x0044ceee
 int SaveGameInterface(int pDefault_choice) {
+    // GLOBAL: CARM95 0x0050e7a8
     static tFlicette flicker_on[9] = {
         { 74, { 47, 94 }, { 23, 55 } },
         { 74, { 47, 94 }, { 44, 106 } },
@@ -773,6 +786,7 @@ int SaveGameInterface(int pDefault_choice) {
         { 74, { 47, 94 }, { 170, 408 } },
         { 57, { 255, 510 }, { 151, 362 } },
     };
+    // GLOBAL: CARM95 0x0050e860
     static tFlicette flicker_off[9] = {
         { 73, { 47, 94 }, { 23, 55 } },
         { 73, { 47, 94 }, { 44, 106 } },
@@ -784,6 +798,7 @@ int SaveGameInterface(int pDefault_choice) {
         { 73, { 47, 94 }, { 170, 408 } },
         { 56, { 255, 510 }, { 151, 362 } },
     };
+    // GLOBAL: CARM95 0x0050e918
     static tFlicette push[9] = {
         { 74, { 47, 94 }, { 23, 55 } },
         { 74, { 47, 94 }, { 44, 106 } },
@@ -795,6 +810,7 @@ int SaveGameInterface(int pDefault_choice) {
         { 74, { 47, 94 }, { 170, 408 } },
         { 59, { 255, 510 }, { 151, 362 } },
     };
+    // GLOBAL: CARM95 0x0050e9d0
     static tMouse_area mouse_areas[9] = {
         { { 48, 96 }, { 17, 41 }, { 250, 500 }, { 33, 79 }, 0, 0, 0, NULL },
         { { 48, 96 }, { 39, 94 }, { 250, 500 }, { 55, 132 }, 1, 0, 0, NULL },
@@ -806,6 +822,7 @@ int SaveGameInterface(int pDefault_choice) {
         { { 48, 96 }, { 164, 394 }, { 250, 500 }, { 180, 432 }, 7, 0, 0, NULL },
         { { 152, 304 }, { 151, 362 }, { 299, 598 }, { 171, 410 }, 8, 1, 0, NULL },
     };
+    // GLOBAL: CARM95 0x0050eb80
     static tRectile recopy_areas[24] = {
         {
             { 53, 106 },

--- a/src/DETHRACE/common/mainmenu.c
+++ b/src/DETHRACE/common/mainmenu.c
@@ -467,13 +467,18 @@ int QuitVerifyDone(int pCurrent_choice, int pCurrent_mode, int pGo_ahead, int pE
 // IDA: int __usercall DoVerifyQuit@<EAX>(int pReplace_background@<EAX>)
 // FUNCTION: CARM95 0x0044b25a
 int DoVerifyQuit(int pReplace_background) {
+    // GLOBAL: CARM95 0x0050db90
     static tFlicette flicker_on[2] = { { 43, { 181, 362 }, { 124, 298 } }, { 43, { 84, 168 }, { 124, 298 } } };
+    // GLOBAL: CARM95 0x0050dbb8
     static tFlicette flicker_off[2] = { { 42, { 181, 362 }, { 124, 298 } }, { 42, { 84, 168 }, { 124, 298 } } };
+    // GLOBAL: CARM95 0x0050dbe0
     static tFlicette push[2] = { { 135, { 181, 362 }, { 124, 298 } }, { 45, { 84, 168 }, { 124, 298 } } };
+    // GLOBAL: CARM95 0x0050dc08
     static tMouse_area mouse_areas[2] = {
         { { 181, 362 }, { 124, 298 }, { 244, 488 }, { 144, 346 }, 0, 0, 0, NULL },
         { { 84, 168 }, { 124, 298 }, { 147, 294 }, { 144, 346 }, 1, 0, 0, NULL }
     };
+    // GLOBAL: CARM95 0x0050dc68
     static tInterface_spec interface_spec = {
         0,                 // initial_imode
         0,                 // first_opening_flic

--- a/src/DETHRACE/common/newgame.c
+++ b/src/DETHRACE/common/newgame.c
@@ -206,26 +206,31 @@ void FrankAnneDraw(int pCurrent_choice, int pCurrent_mode) {
 // IDA: int __cdecl FrankieOrAnnie()
 // FUNCTION: CARM95 0x004b03cd
 int FrankieOrAnnie(void) {
+    // GLOBAL: CARM95 0x0051ea88
     static tFlicette flicker_on[3] = {
         { 83, { 61, 122 }, { 52, 125 } },
         { 83, { 184, 398 }, { 52, 125 } },
         { 43, { 215, 430 }, { 158, 379 } }
     };
+    // GLOBAL: CARM95 0x0051eac8
     static tFlicette flicker_off[3] = {
         { 82, { 61, 122 }, { 52, 125 } },
         { 82, { 184, 398 }, { 52, 125 } },
         { 42, { 215, 430 }, { 158, 379 } }
     };
+    // GLOBAL: CARM95 0x0051eb08
     static tFlicette push[3] = {
         { 83, { 61, 122 }, { 52, 125 } },
         { 83, { 184, 398 }, { 52, 125 } },
         { 45, { 215, 430 }, { 158, 379 } }
     };
+    // GLOBAL: CARM95 0x0051eb48
     static tMouse_area mouse_areas[3] = {
         { { 55, 110 }, { 52, 125 }, { 161, 322 }, { 154, 370 }, 0, 0, 0, NULL },
         { { 178, 356 }, { 52, 125 }, { 295, 596 }, { 154, 370 }, 1, 0, 0, NULL },
         { { 215, 430 }, { 158, 379 }, { 278, 556 }, { 179, 430 }, 2, 1, 1, NULL }
     };
+    // GLOBAL: CARM95 0x0051ebd8
     static tRectile recopy_areas[2] = {
         { { 55, 110 }, { 132, 317 }, { 161, 322 }, { 154, 370 } },
         { { 178, 356 }, { 132, 317 }, { 295, 590 }, { 154, 370 } }
@@ -298,6 +303,7 @@ int FrankieOrAnnie(void) {
 // IDA: int __cdecl SelectSkillLevel()
 // FUNCTION: CARM95 0x004b0436
 int SelectSkillLevel(void) {
+    // GLOBAL: CARM95 0x0051ed48
     static tFlicette flicker_on[4] = {
         { 116, { 38, 76 }, { 55, 132 } },
         { 119, { 36, 72 }, { 83, 199 } },
@@ -305,6 +311,7 @@ int SelectSkillLevel(void) {
         { 43, { 227, 454 }, { 158, 379 } }
     };
 
+    // GLOBAL: CARM95 0x0051ed98
     static tFlicette flicker_off[4] = {
         { 115, { 38, 76 }, { 55, 132 } },
         { 118, { 36, 72 }, { 83, 199 } },
@@ -312,12 +319,14 @@ int SelectSkillLevel(void) {
         { 42, { 227, 454 }, { 158, 379 } }
     };
 
+    // GLOBAL: CARM95 0x0051ede8
     static tFlicette push[4] = {
         { 117, { 38, 76 }, { 55, 132 } },
         { 117, { 36, 72 }, { 83, 199 } },
         { 117, { 38, 76 }, { 111, 266 } },
         { 45, { 227, 454 }, { 158, 379 } }
     };
+    // GLOBAL: CARM95 0x0051ee38
     static tMouse_area mouse_areas[4] = {
         { { 38, 76 }, { 55, 132 }, { 205, 410 }, { 69, 166 }, 0, 0, 0, NULL },
         { { 36, 72 }, { 83, 199 }, { 205, 410 }, { 98, 235 }, 1, 0, 0, NULL },
@@ -325,6 +334,7 @@ int SelectSkillLevel(void) {
         { { 227, 454 }, { 158, 379 }, { 290, 580 }, { 178, 427 }, 3, 0, 0, NULL }
     };
 
+    // GLOBAL: CARM95 0x0051eef8
     static tInterface_spec interface_spec = {
         0,              // initial_imode
         110,            // first_opening_flic
@@ -752,23 +762,28 @@ int NewNetGoAhead(int* pCurrent_choice, int* pCurrent_mode) {
 // IDA: tJoin_or_host_result __usercall JoinOrHostGame@<EAX>(tNet_game_details **pGame_to_join@<EAX>)
 // FUNCTION: CARM95 0x004b1113
 tJoin_or_host_result JoinOrHostGame(tNet_game_details** pGame_to_join) {
+    // GLOBAL: CARM95 0x0051f028
     static tFlicette flicker_on[2] = {
         { 43, { 41, 122 }, { 164, 370 } },
         { 43, { 230, 440 }, { 164, 370 } },
     };
+    // GLOBAL: CARM95 0x0051f050
     static tFlicette flicker_off[2] = {
         { 42, { 41, 122 }, { 164, 370 } },
         { 42, { 230, 440 }, { 164, 370 } },
     };
+    // GLOBAL: CARM95 0x0051f078
     static tFlicette push[2] = {
         { 90, { 41, 122 }, { 164, 370 } },
         { 45, { 230, 440 }, { 164, 370 } },
     };
+    // GLOBAL: CARM95 0x0051f0a0
     static tMouse_area mouse_areas[3] = {
         { { 41, 122 }, { 164, 370 }, { 104, 326 }, { 184, 422 }, 0, 0, 1, NULL },
         { { 230, 440 }, { 164, 370 }, { 293, 568 }, { 184, 422 }, 1, 0, 1, NULL },
         { { 42, 94 }, { 57, 137 }, { 290, 556 }, { 150, 341 }, 2, 1, 1, NULL },
     };
+    // GLOBAL: CARM95 0x0051f130
     static tRectile recopy_areas[1] = {
         {
             { 124, 110 },
@@ -777,6 +792,7 @@ tJoin_or_host_result JoinOrHostGame(tNet_game_details** pGame_to_join) {
             { 180, 370 },
         },
     };
+    // GLOBAL: CARM95 0x0051f150
     static tInterface_spec interface_spec = {
         0,
         100,
@@ -1222,6 +1238,7 @@ void DrawNetOptBox(int pCurrent_choice, int pCurrent_mode) {
 // IDA: void __usercall DoNetOptions(tNet_game_options *pGame_options@<EAX>)
 // FUNCTION: CARM95 0x004b2d37
 void DoNetOptions(tNet_game_options* pGame_options) {
+    // GLOBAL: CARM95 0x0051f280
     static tFlicette flicker_on[14] = {
         { 43, { 169, 90 }, { 156, 398 } },
         { 43, { 236, 440 }, { 156, 398 } },
@@ -1238,6 +1255,7 @@ void DoNetOptions(tNet_game_options* pGame_options) {
         { 139, { 81, 98 }, { 130, 310 } },
         { 143, { 81, 98 }, { 141, 331 } },
     };
+    // GLOBAL: CARM95 0x0051f398
     static tFlicette flicker_off[14] = {
         { 42, { 169, 90 }, { 156, 398 } },
         { 42, { 236, 440 }, { 156, 398 } },
@@ -1254,6 +1272,7 @@ void DoNetOptions(tNet_game_options* pGame_options) {
         { 142, { 81, 98 }, { 130, 310 } },
         { 148, { 81, 98 }, { 141, 331 } },
     };
+    // GLOBAL: CARM95 0x0051f4b0
     static tFlicette push[14] = {
         { 154, { 169, 90 }, { 156, 398 } },
         { 45, { 236, 440 }, { 156, 398 } },
@@ -1270,6 +1289,7 @@ void DoNetOptions(tNet_game_options* pGame_options) {
         { 139, { 81, 98 }, { 130, 310 } },
         { 143, { 81, 98 }, { 141, 331 } },
     };
+    // GLOBAL: CARM95 0x0051f5c8
     static tMouse_area mouse_areas[14] = {
         { { 169, 90 }, { 156, 396 }, { 232, 214 }, { 176, 444 }, 0, 0, 0, NULL },
         { { 236, 440 }, { 156, 396 }, { 299, 552 }, { 176, 444 }, 1, 0, 0, NULL },
@@ -1286,6 +1306,7 @@ void DoNetOptions(tNet_game_options* pGame_options) {
         { { 61, 98 }, { 128, 329 }, { 270, 322 }, { 138, 348 }, 12, 1, 0, NetRadioClick },
         { { 61, 98 }, { 139, 358 }, { 270, 322 }, { 149, 377 }, 13, 1, 0, NetRadioClick },
     };
+    // GLOBAL: CARM95 0x0051f868
     static tInterface_spec interface_spec = {
         0, 65, 0, 66, 66, 66, -1,
         { -1, 0 }, { -1, 0 }, { 0, 3 }, { 2, 13 }, { NULL, NetOptLeft },
@@ -1499,6 +1520,7 @@ void SetGameTarget(tNet_game_type* pGame_type, tNet_game_options* pGame_options)
 // IDA: int __usercall NetGameChoices@<EAX>(tNet_game_type *pGame_type@<EAX>, tNet_game_options *pGame_options@<EDX>, int *pRace_index@<EBX>)
 // FUNCTION: CARM95 0x004b2ba3
 int NetGameChoices(tNet_game_type* pGame_type, tNet_game_options* pGame_options, int* pRace_index) {
+    // GLOBAL: CARM95 0x0051f998
     static tFlicette flicker_on[11] = {
         { 43, { 226, 90 }, { 117, 398 } },
         { 43, { 226, 440 }, { 148, 398 } },
@@ -1512,6 +1534,7 @@ int NetGameChoices(tNet_game_type* pGame_type, tNet_game_options* pGame_options,
         { 167, { 74, 98 }, { 123, 266 } },
         { 168, { 74, 98 }, { 133, 288 } },
     };
+    // GLOBAL: CARM95 0x0051fa78
     static tFlicette flicker_off[11] = {
         { 42, { 226, 90 }, { 117, 398 } },
         { 42, { 226, 440 }, { 148, 398 } },
@@ -1525,6 +1548,7 @@ int NetGameChoices(tNet_game_type* pGame_type, tNet_game_options* pGame_options,
         { 187, { 74, 98 }, { 123, 266 } },
         { 188, { 74, 98 }, { 133, 288 } },
     };
+    // GLOBAL: CARM95 0x0051fb58
     static tFlicette push[11] = {
         { 88, { 227, 90 }, { 117, 398 } },
         { 45, { 226, 440 }, { 148, 398 } },
@@ -1538,6 +1562,7 @@ int NetGameChoices(tNet_game_type* pGame_type, tNet_game_options* pGame_options,
         { 167, { 74, 98 }, { 123, 266 } },
         { 168, { 74, 98 }, { 133, 288 } },
     };
+    // GLOBAL: CARM95 0x0051fc38
     static tMouse_area mouse_areas[11] = {
         { { 226, 90 }, { 117, 396 }, { 290, 214 }, { 137, 444 }, 0, 0, 0, NULL },
         { { 226, 440 }, { 148, 396 }, { 290, 552 }, { 168, 444 }, 1, 0, 0, NULL },
@@ -1556,7 +1581,7 @@ int NetGameChoices(tNet_game_type* pGame_type, tNet_game_options* pGame_options,
     static tInterface_spec interface_spec = {
         0, 122, 0, 0, 0, 0, -1,
         { 1, 0 }, { 4, -10 }, { 4, 0 }, { 4, 0 }, { NetChooseLR, NULL },
-        { 1, 0 }, { 3, -10 }, { 4, 0 }, { 4, 0 }, { NetChooseLR, NULL },
+        { 1, 0 }, { 4, -10 }, { 4, 0 }, { 4, 0 }, { NetChooseLR, NULL },
         { -1, -1 }, { -1, -1 }, { 0, 4 }, { 3, 10 }, { NULL, NULL },
         { -1, -1 }, { 1, 1 }, { 0, 4 }, { 3, 10 }, { NULL, NULL },
         { 1, 1 }, { NetChooseGoAhead, NetChooseGoAhead }, { 1, 1 }, { NULL, NULL },

--- a/src/DETHRACE/common/options.c
+++ b/src/DETHRACE/common/options.c
@@ -235,26 +235,31 @@ int SoundClick(int* pCurrent_choice, int* pCurrent_mode, int pX_offset, int pY_o
 // IDA: void __cdecl DoSoundOptions()
 // FUNCTION: CARM95 0x0049b7bf
 void DoSoundOptions(void) {
+    // GLOBAL: CARM95 0x00519cc0
     static tFlicette flicker_on[3] = {
         { 156, { 26, 52 }, { 21, 50 } },
         { 156, { 155, 310 }, { 88, 211 } },
         { 43, { 38, 76 }, { 153, 367 } },
     };
+    // GLOBAL: CARM95 0x00519d00
     static tFlicette flicker_off[3] = {
         { 155, { 26, 52 }, { 21, 50 } },
         { 155, { 155, 310 }, { 88, 211 } },
         { 42, { 38, 76 }, { 153, 367 } },
     };
+    // GLOBAL: CARM95 0x00519d40
     static tFlicette push[3] = {
         { 156, { 26, 52 }, { 21, 50 } },
         { 156, { 155, 310 }, { 88, 211 } },
         { 43, { 38, 76 }, { 153, 367 } },
     };
+    // GLOBAL: CARM95 0x00519d80
     static tMouse_area mouse_areas[3] = {
         { { 26, 52 }, { 21, 50 }, { 144, 288 }, { 97, 233 }, 0, 0, 0, SoundClick },
         { { 155, 310 }, { 88, 211 }, { 273, 546 }, { 164, 394 }, 1, 0, 0, SoundClick },
         { { 38, 76 }, { 153, 367 }, { 101, 202 }, { 173, 415 }, 2, 0, 0, NULL },
     };
+    // GLOBAL: CARM95 0x00519e10
     static tInterface_spec interface_spec = {
         0,
         150,
@@ -703,6 +708,7 @@ void DrawGraphBox(int pCurrent_choice, int pCurrent_mode) {
 // IDA: void __cdecl DoGraphicsOptions()
 // FUNCTION: CARM95 0x0049b805
 void DoGraphicsOptions(void) {
+    // GLOBAL: CARM95 0x00519f40
     static tFlicette flicker_on[14] = {
         { 43, { 45, 90 }, { 166, 398 } },
         { 43, { 220, 440 }, { 166, 398 } },
@@ -719,6 +725,7 @@ void DoGraphicsOptions(void) {
         { 248, { 49, 98 }, { 138, 331 } },
         { 249, { 49, 98 }, { 150, 360 } },
     };
+    // GLOBAL: CARM95 0x0051a058
     static tFlicette flicker_off[14] = {
         { 42, { 45, 90 }, { 166, 398 } },
         { 42, { 220, 440 }, { 166, 398 } },
@@ -735,6 +742,7 @@ void DoGraphicsOptions(void) {
         { 275, { 49, 98 }, { 138, 331 } },
         { 276, { 49, 98 }, { 150, 360 } },
     };
+    // GLOBAL: CARM95 0x0051a170
     static tFlicette push[14] = {
         { 154, { 45, 90 }, { 166, 398 } },
         { 45, { 220, 440 }, { 166, 398 } },
@@ -751,8 +759,9 @@ void DoGraphicsOptions(void) {
         { 45, { 210, 440 }, { 170, 408 } },
         { 45, { 210, 440 }, { 170, 408 } },
     };
+    // GLOBAL: CARM95 0x0051a288
     static tMouse_area mouse_areas[14] = {
-        { { 45, 90 }, { 165, 396 }, { 104, 214 }, { 185, 444 }, 0, 0, 0, NULL },
+        { { 45, 90 }, { 165, 396 }, { 107, 214 }, { 185, 444 }, 0, 0, 0, NULL },
         { { 220, 440 }, { 165, 396 }, { 276, 552 }, { 185, 444 }, 1, 0, 0, NULL },
         { { 49, 98 }, { 35, 84 }, { 284, 568 }, { 43, 103 }, 2, 1, 0, RadioClick },
         { { 49, 98 }, { 44, 106 }, { 284, 568 }, { 52, 125 }, 3, 1, 0, RadioClick },
@@ -767,6 +776,7 @@ void DoGraphicsOptions(void) {
         { { 49, 98 }, { 137, 329 }, { 284, 322 }, { 145, 348 }, 12, 1, 0, RadioClick },
         { { 49, 98 }, { 149, 358 }, { 284, 322 }, { 157, 377 }, 13, 1, 0, RadioClick },
     };
+    // GLOBAL: CARM95 0x0051a528
     static tInterface_spec interface_spec = {
         0,
         160,
@@ -778,7 +788,7 @@ void DoGraphicsOptions(void) {
         { -1, 0 },
         { -1, 0 },
         { 0, 2 },
-        { 1, 2 },
+        { 1, 13 },
         { NULL, GraphOptLeft },
         { -1, 0 },
         { 1, 0 },
@@ -1363,24 +1373,28 @@ void DrawInitialKMRadios(void) {
 // IDA: void __cdecl DoControlOptions()
 // FUNCTION: CARM95 0x0049be2c
 void DoControlOptions(void) {
+    // GLOBAL: CARM95 0x0051a658
     static tFlicette flicker_on[4] = {
         { 177, { 51, 102 }, { 166, 398 } },
         { 177, { 112, 224 }, { 166, 398 } },
         { 177, { 173, 346 }, { 166, 398 } },
         { 177, { 234, 468 }, { 166, 398 } },
     };
+    // GLOBAL: CARM95 0x0051a6a8
     static tFlicette flicker_off[4] = {
         { 176, { 51, 102 }, { 166, 398 } },
         { 176, { 112, 224 }, { 166, 398 } },
         { 176, { 173, 346 }, { 166, 398 } },
         { 176, { 234, 468 }, { 166, 398 } },
     };
+    // GLOBAL: CARM95 0x0051a6f8
     static tFlicette push[4] = {
         { 172, { 51, 102 }, { 166, 398 } },
         { 175, { 112, 224 }, { 166, 398 } },
         { 174, { 173, 346 }, { 166, 398 } },
         { 173, { 234, 468 }, { 166, 398 } },
     };
+    // GLOBAL: CARM95 0x0051a748
     static tMouse_area mouse_areas[5] = {
         { { 51, 102 }, { 166, 398 }, { 102, 204 }, { 187, 449 }, 0, 0, 0, NULL },
         { { 112, 224 }, { 166, 398 }, { 164, 328 }, { 187, 449 }, 1, 0, 0, NULL },
@@ -1388,6 +1402,7 @@ void DoControlOptions(void) {
         { { 234, 468 }, { 166, 398 }, { 286, 572 }, { 187, 449 }, 3, 0, 0, NULL },
         { { 45, 90 }, { 33, 79 }, { 285, 570 }, { 159, 382 }, 4, 1, 0, MouseyClickBastard },
     };
+    // GLOBAL: CARM95 0x0051a838
     static tInterface_spec interface_spec = {
         0, 170, 179, 0, 0, 0, 1,
         { -1, -1 }, { -1, 0 }, { 0, 4 }, { 3, 4 }, { NULL, KeyAssignLeft },
@@ -1497,30 +1512,35 @@ void DrawDisabledOptions(void) {
 // IDA: void __cdecl DoOptions()
 // FUNCTION: CARM95 0x0049b705
 void DoOptions(void) {
+    // GLOBAL: CARM95 0x0051a968
     static tFlicette flicker_on[4] = {
         { 43, { 57, 114 }, { 41, 98 } },
         { 43, { 57, 114 }, { 78, 187 } },
         { 43, { 57, 114 }, { 114, 274 } },
         { 43, { 57, 114 }, { 154, 370 } }
     };
+    // GLOBAL: CARM95 0x0051a9b8
     static tFlicette flicker_off[4] = {
         { 42, { 57, 114 }, { 41, 98 } },
         { 42, { 57, 114 }, { 78, 187 } },
         { 42, { 57, 114 }, { 114, 274 } },
         { 42, { 57, 114 }, { 154, 370 } },
     };
+    // GLOBAL: CARM95 0x0051aa08
     static tFlicette push[4] = {
         { 144, { 57, 114 }, { 41, 98 } },
         { 146, { 57, 114 }, { 78, 187 } },
         { 145, { 57, 114 }, { 114, 274 } },
         { 45, { 57, 114 }, { 154, 370 } },
     };
+    // GLOBAL: CARM95 0x0051aa58
     static tMouse_area mouse_areas[4] = {
         { { 57, 114 }, { 41, 98 }, { 123, 246 }, { 62, 149 }, 0, 0, 0, NULL },
         { { 57, 114 }, { 78, 187 }, { 123, 246 }, { 99, 238 }, 1, 0, 0, NULL },
         { { 57, 114 }, { 114, 274 }, { 123, 246 }, { 135, 324 }, 2, 0, 0, NULL },
         { { 57, 114 }, { 154, 370 }, { 123, 246 }, { 175, 420 }, 3, 0, 0, NULL },
     };
+    // GLOBAL: CARM95 0x0051ab18
     static tInterface_spec interface_spec = {
         0,
         140,

--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -336,24 +336,28 @@ void StartChangeRace(void) {
 // IDA: int __usercall ChangeRace@<EAX>(int *pRace_index@<EAX>, int pNet_mode@<EDX>, tNet_sequence_type pNet_race_sequence@<EBX>)
 // FUNCTION: CARM95 0x0044f131
 int ChangeRace(int* pRace_index, int pNet_mode, tNet_sequence_type pNet_race_sequence) {
+    // GLOBAL: CARM95 0x0050f1b0
     static tFlicette flicker_on[4] = {
         { 43, { 60, 120 }, { 154, 370 } },
         { 43, { 221, 442 }, { 154, 370 } },
         { 221, { 30, 60 }, { 78, 187 } },
         { 221, { 30, 60 }, { 78, 187 } },
     };
+    // GLOBAL: CARM95 0x0050f200
     static tFlicette flicker_off[4] = {
         { 42, { 60, 120 }, { 154, 370 } },
         { 42, { 221, 442 }, { 154, 370 } },
         { 220, { 30, 60 }, { 78, 187 } },
         { 220, { 30, 60 }, { 78, 187 } },
     };
+    // GLOBAL: CARM95 0x0050f250
     static tFlicette push[4] = {
         { 154, { 60, 120 }, { 154, 370 } },
         { 45, { 221, 442 }, { 154, 370 } },
         { 222, { 30, 60 }, { 78, 187 } },
         { 225, { 30, 60 }, { 118, 283 } },
     };
+    // GLOBAL: CARM95 0x0050f2a0
     static tMouse_area mouse_areas[5] = {
         { { 60, 120 }, { 154, 370 }, { 125, 250 }, { 174, 418 }, 0, 0, 0, NULL },
         { { 221, 442 }, { 154, 370 }, { 286, 572 }, { 174, 418 }, 1, 0, 0, NULL },
@@ -361,6 +365,7 @@ int ChangeRace(int* pRace_index, int pNet_mode, tNet_sequence_type pNet_race_seq
         { { 30, 60 }, { 118, 283 }, { 45, 90 }, { 145, 348 }, -1, 0, 0, DownClickRace },
         { { 66, 132 }, { 33, 79 }, { 278, 556 }, { 144, 346 }, -1, 0, 0, ClickOnRace },
     };
+    // GLOBAL: CARM95 0x0050f390
     static tInterface_spec interface_spec = {
         0, 230, 60, 231, 231, 231, 6,
         { -1, 0 }, { -1, 0 }, { 0, 0 }, { 1, 0 }, { NULL, NULL },
@@ -557,24 +562,28 @@ int ChangeCarGoAhead(int* pCurrent_choice, int* pCurrent_mode) {
 // IDA: int __usercall ChangeCar@<EAX>(int pNet_mode@<EAX>, int *pCar_index@<EDX>, tNet_game_details *pNet_game@<EBX>)
 // FUNCTION: CARM95 0x0044f7e6
 int ChangeCar(int pNet_mode, int* pCar_index, tNet_game_details* pNet_game) {
+    // GLOBAL: CARM95 0x0050f4c0
     static tFlicette flicker_on[4] = {
         { 43, { 60, 120 }, { 154, 370 } },
         { 43, { 221, 442 }, { 154, 370 } },
         { 221, { 30, 60 }, { 78, 187 } },
         { 221, { 30, 60 }, { 78, 187 } },
     };
+    // GLOBAL: CARM95 0x0050f510
     static tFlicette flicker_off[4] = {
         { 42, { 60, 120 }, { 154, 370 } },
         { 42, { 221, 442 }, { 154, 370 } },
         { 220, { 30, 60 }, { 78, 187 } },
         { 220, { 30, 60 }, { 78, 187 } },
     };
+    // GLOBAL: CARM95 0x0050f560
     static tFlicette push[4] = {
         { 154, { 60, 120 }, { 154, 370 } },
         { 45, { 221, 442 }, { 154, 370 } },
         { 222, { 30, 60 }, { 78, 187 } },
         { 225, { 30, 60 }, { 118, 283 } },
     };
+    // GLOBAL: CARM95 0x0050f5b0
     static tMouse_area mouse_areas[4] = {
         { { 60, 120 }, { 154, 370 }, { 125, 250 }, { 174, 418 }, 0, 0, 0, NULL },
         { { 221, 442 }, { 154, 370 }, { 286, 572 }, { 174, 418 }, 1, 0, 0, NULL },
@@ -1121,6 +1130,7 @@ void DrawPartsShop(int pCurrent_choice, int pCurrent_mode) {
 // IDA: void __usercall DoPartsShop(int pFade_away@<EAX>)
 // FUNCTION: CARM95 0x00450e06
 void DoPartsShop(int pFade_away) {
+    // GLOBAL: CARM95 0x0050f7a0
     static tFlicette flicker_on[7] = {
         { 43, { 225, 450 }, { 30, 72 } },
         { 43, { 225, 450 }, { 60, 144 } },
@@ -1130,6 +1140,7 @@ void DoPartsShop(int pFade_away) {
         { 221, { 30, 60 }, { 79, 190 } },
         { 221, { 30, 60 }, { 79, 190 } },
     };
+    // GLOBAL: CARM95 0x0050f830
     static tFlicette flicker_off[7] = {
         { 42, { 225, 450 }, { 30, 72 } },
         { 42, { 225, 450 }, { 60, 144 } },
@@ -1139,6 +1150,7 @@ void DoPartsShop(int pFade_away) {
         { 220, { 30, 60 }, { 79, 190 } },
         { 220, { 30, 60 }, { 79, 190 } },
     };
+    // GLOBAL: CARM95 0x0050f8c0
     static tFlicette push[7] = {
         { 254, { 225, 450 }, { 30, 72 } },
         { 255, { 225, 450 }, { 60, 144 } },
@@ -1148,6 +1160,7 @@ void DoPartsShop(int pFade_away) {
         { 222, { 30, 60 }, { 79, 190 } },
         { 225, { 30, 60 }, { 120, 288 } },
     };
+    // GLOBAL: CARM95 0x0050f950
     static tMouse_area mouse_areas[7] = {
         { { 225, 450 }, { 30, 72 }, { 288, 576 }, { 50, 120 }, 0, 0, 0, NULL },
         { { 225, 450 }, { 60, 144 }, { 288, 576 }, { 80, 192 }, 1, 0, 0, NULL },
@@ -1157,6 +1170,7 @@ void DoPartsShop(int pFade_away) {
         { { 30, 60 }, { 79, 190 }, { 45, 90 }, { 106, 254 }, -1, 1, 0, UpClickPart },
         { { 30, 60 }, { 120, 288 }, { 45, 90 }, { 147, 353 }, -1, 1, 0, DownClickPart },
     };
+    // GLOBAL: CARM95 0x0050faa0
     static tInterface_spec interface_spec = {
         0, 250, 190, 0, 0, 0, 6,
         { 1, 0 }, { 4, -1 }, { 4, 0 }, { 4, 3 }, { PartsArrowsOn, PartsArrowsOff },
@@ -1209,21 +1223,25 @@ int AutoPartsDone(int pCurrent_choice, int pCurrent_mode, int pGo_ahead, int pEs
 // IDA: tSO_result __cdecl DoAutoPartsShop()
 // FUNCTION: CARM95 0x00450b05
 tSO_result DoAutoPartsShop(void) {
+    // GLOBAL: CARM95 0x0050fbd0
     static tFlicette flicker_on[3] = {
         { 43, { 84, 168 }, { 67, 161 } },
         { 43, { 84, 168 }, { 95, 228 } },
         { 43, { 84, 168 }, { 124, 298 } },
     };
+    // GLOBAL: CARM95 0x0050fc10
     static tFlicette flicker_off[3] = {
         { 42, { 84, 168 }, { 67, 161 } },
         { 42, { 84, 168 }, { 95, 228 } },
         { 42, { 84, 168 }, { 124, 298 } },
     };
+    // GLOBAL: CARM95 0x0050fc50
     static tFlicette push[3] = {
         { 284, { 84, 168 }, { 67, 161 } },
         { 284, { 84, 168 }, { 95, 228 } },
         { 284, { 84, 168 }, { 124, 298 } },
     };
+    // GLOBAL: CARM95 0x0050fc90
     static tMouse_area mouse_areas[3] = {
         { { 84, 168 }, { 32, 77 }, { 147, 294 }, { 87, 209 }, 0, 0, 0, NULL },
         { { 84, 168 }, { 95, 228 }, { 147, 294 }, { 115, 276 }, 1, 0, 0, NULL },
@@ -1627,6 +1645,7 @@ void SelectRaceDraw(int pCurrent_choice, int pCurrent_mode) {
 // IDA: tSO_result __usercall DoSelectRace@<EAX>(int *pSecond_time_around@<EAX>)
 // FUNCTION: CARM95 0x00451c8e
 tSO_result DoSelectRace(int* pSecond_time_around) {
+    // GLOBAL: CARM95 0x0050fe50
     static tFlicette flicker_on[7] = {
         { 43, { 224, 448 }, { 28, 67 } },
         { 43, { 224, 448 }, { 56, 134 } },
@@ -1637,6 +1656,7 @@ tSO_result DoSelectRace(int* pSecond_time_around) {
         { 221, { 30, 60 }, { 79, 190 } }
     };
 
+    // GLOBAL: CARM95 0x0050fee0
     static tFlicette flicker_off[7] = {
         { 42, { 224, 448 }, { 28, 67 } },
         { 42, { 224, 448 }, { 56, 134 } },
@@ -1647,6 +1667,7 @@ tSO_result DoSelectRace(int* pSecond_time_around) {
         { 220, { 30, 60 }, { 79, 190 } }
     };
 
+    // GLOBAL: CARM95 0x0050ff70
     static tFlicette push[7] = {
         { 195, { 224, 448 }, { 28, 67 } },
         { -1, { 224, 448 }, { 56, 134 } },
@@ -1657,6 +1678,7 @@ tSO_result DoSelectRace(int* pSecond_time_around) {
         { 225, { 30, 60 }, { 119, 286 } }
     };
 
+    // GLOBAL: CARM95 0x00510000
     static tMouse_area mouse_areas[7] = {
         { { 224, 448 }, { 28, 67 }, { 287, 574 }, { 48, 115 }, 0, 0, 0, NULL },
         { { 224, 448 }, { 56, 134 }, { 287, 574 }, { 76, 182 }, 1, 0, 0, NULL },
@@ -1681,6 +1703,7 @@ tSO_result DoSelectRace(int* pSecond_time_around) {
             &DownClickOpp }
     };
 
+    // GLOBAL: CARM95 0x00510150
     static tInterface_spec interface_spec = {
         0,                            // initial_imode
         191,                          // first_opening_flic
@@ -2200,13 +2223,18 @@ int ChallengeDone(int pCurrent_choice, int pCurrent_mode, int pGo_ahead, int pEs
 // IDA: void __cdecl DoChallengeScreen()
 // FUNCTION: CARM95 0x00453952
 void DoChallengeScreen(void) {
+    // GLOBAL: CARM95 0x00510280
     static tFlicette flicker_on[2] = { { 43, { 54, 108 }, { 157, 377 } }, { 43, { 218, 436 }, { 157, 377 } } };
+    // GLOBAL: CARM95 0x005102a8
     static tFlicette flicker_off[2] = { { 42, { 54, 108 }, { 157, 377 } }, { 42, { 218, 436 }, { 157, 377 } } };
+    // GLOBAL: CARM95 0x005102d0
     static tFlicette push[2] = { { 304, { 54, 108 }, { 157, 377 } }, { 305, { 218, 436 }, { 157, 377 } } };
+    // GLOBAL: CARM95 0x005102f8
     static tMouse_area mouse_areas[2] = {
         { { 54, 108 }, { 157, 377 }, { 117, 234 }, { 178, 427 }, 0, 0, 0, NULL },
         { { 218, 436 }, { 157, 377 }, { 281, 562 }, { 178, 427 }, 1, 0, 0, NULL }
     };
+    // GLOBAL: CARM95 0x00510358
     static tInterface_spec interface_spec = {
         0,               // initial_imode
         301,             // first_opening_flic
@@ -2444,23 +2472,27 @@ void SortOpponents(void) {
 // IDA: tSO_result __cdecl DoGridPosition()
 // FUNCTION: CARM95 0x004537ee
 tSO_result DoGridPosition(void) {
+    // GLOBAL: CARM95 0x00510488
     static tFlicette flicker_on[3] = {
         { 43, { 240, 480 }, { 158, 379 } },
         { 293, { 56, 112 }, { 151, 362 } },
         { 296, { 136, 272 }, { 151, 362 } }
     };
 
+    // GLOBAL: CARM95 0x005104c8
     static tFlicette flicker_off[3] = {
         { 42, { 240, 480 }, { 158, 379 } },
         { 292, { 56, 112 }, { 151, 362 } },
         { 295, { 136, 272 }, { 151, 362 } }
     };
 
+    // GLOBAL: CARM95 0x00510508
     static tFlicette push[3] = {
         { 154, { 240, 480 }, { 158, 379 } },
         { 294, { 56, 112 }, { 151, 362 } },
         { 297, { 136, 272 }, { 151, 362 } }
     };
+    // GLOBAL: CARM95 0x00510548
     static tMouse_area mouse_areas[5] = {
         { { 240, 480 }, { 158, 379 }, { 305, 610 }, { 178, 427 }, 0, 0, 0, NULL },
         { { 56, 112 },
@@ -2497,6 +2529,7 @@ tSO_result DoGridPosition(void) {
             GridClickNumbers }
     };
 
+    // GLOBAL: CARM95 0x00510638
     static tInterface_spec interface_spec = {
         0,                       // initial_imode
         290,                     // first_opening_flic

--- a/src/DETHRACE/common/racesumm.c
+++ b/src/DETHRACE/common/racesumm.c
@@ -436,15 +436,19 @@ int SummCheckGameOver(int* pCurrent_choice, int* pCurrent_mode) {
 // IDA: tSO_result __cdecl DoEndRaceSummary1()
 // FUNCTION: CARM95 0x004161dd
 tSO_result DoEndRaceSummary1(void) {
+    // GLOBAL: CARM95 0x00509bc0
     static tFlicette flicker_on[1] = {
         { 43, { 218, 436 }, { 147, 353 } },
     };
+    // GLOBAL: CARM95 0x00509bd8
     static tFlicette flicker_off[1] = {
         { 42, { 218, 436 }, { 147, 353 } },
     };
+    // GLOBAL: CARM95 0x00509bf0
     static tFlicette push[1] = {
         { 154, { 218, 436 }, { 147, 353 } },
     };
+    // GLOBAL: CARM95 0x00509c08
     static tMouse_area mouse_areas[1] = {
         { { 218, 436 }, { 147, 353 }, { 281, 562 }, { 167, 401 }, 0, 0, 0, NULL },
     };
@@ -1239,16 +1243,19 @@ int DamageScrnDone(int pCurrent_choice, int pCurrent_mode, int pGo_ahead, int pE
 // IDA: tSO_result __cdecl DoEndRaceSummary2()
 // FUNCTION: CARM95 0x0041797b
 tSO_result DoEndRaceSummary2(void) {
+    // GLOBAL: CARM95 0x00509d68
     static tFlicette flicker_on[3] = {
         { -1, { 0, 0 }, { 0, 0 } },
         { 321, { 9, 18 }, { 174, 418 } },
         { 321, { 247, 494 }, { 174, 418 } },
     };
+    // GLOBAL: CARM95 0x00509da8
     static tFlicette flicker_off[3] = {
         { -1, { 0, 0 }, { 0, 0 } },
         { 322, { 9, 18 }, { 174, 418 } },
         { 322, { 247, 494 }, { 174, 418 } },
     };
+    // GLOBAL: CARM95 0x00509de8
     static tFlicette push[3] = {
         { -1, { 0, 0 }, { 0, 0 } },
         { 324, { 9, 18 }, { 174, 418 } },
@@ -1417,9 +1424,13 @@ void NetSumDraw(int pCurrent_choice, int pCurrent_mode) {
 // IDA: void __cdecl DoNetRaceSummary()
 // FUNCTION: CARM95 0x00418452
 void DoNetRaceSummary(void) {
+    // GLOBAL: CARM95 0x00509fe8
     static tFlicette flicker_on[1] = { { 321, { 219, 112 }, { 172, 362 } } };
+    // GLOBAL: CARM95 0x0050a000
     static tFlicette flicker_off[1] = { { 322, { 219, 112 }, { 172, 362 } } };
+    // GLOBAL: CARM95 0x0050a018
     static tFlicette push[1] = { { 323, { 219, 112 }, { 172, 362 } } };
+    // GLOBAL: CARM95 0x0050a030
     static tMouse_area mouse_areas[1] = { { { 219, 112 }, { 172, 362 }, { 282, 182 }, { 192, 379 }, 0, 0, 0, NULL } };
 
     // GLOBAL: CARM95 0x0050A060


### PR DESCRIPTION
Many of the apparent diffs in `datacmp` were due to not annotating the static structs referenced by various members of `interface_spec`. (e.g. `flicker_on_flics`).

Fixed two real diffs in `NetGameChoices` and `DoGraphicsOptions`.

This all resulted in this accuracy improvement for functions:
```
Increased (15):
0x44b25a - DoVerifyQuit (90.24% -> 95.12%)
0x44bf62 - DoLoadGame (75.62% -> 76.62%)
0x44ceb9 - ConfirmMidGameSave (95.24% -> 100.00%)
0x44f131 - ChangeRace (90.57% -> 94.34%)
0x450e06 - DoPartsShop (90.91% -> 95.45%)
0x451c8e - DoSelectRace (66.67% -> 67.73%)
0x4537ee - DoGridPosition (85.53% -> 88.16%)
0x453952 - DoChallengeScreen (90.11% -> 92.31%)
0x49b705 - DoOptions (88.66% -> 90.72%)
0x49b7bf - DoSoundOptions (72.73% -> 77.27%)
0x49b805 - DoGraphicsOptions (94.12% -> 100.00%)
0x49be2c - DoControlOptions (68.42% -> 71.05%)
0x4b0436 - SelectSkillLevel (79.17% -> 83.33%)
0x4b1113 - JoinOrHostGame (91.30% -> 92.39%)
0x4b2d37 - DoNetOptions (93.94% -> 100.00%)
```