### PR TITLE
Adds missing 3dfx patch for skid material cleanup

### DIFF
--- a/src/DETHRACE/common/skidmark.c
+++ b/src/DETHRACE/common/skidmark.c
@@ -369,5 +369,8 @@ void SkidsPerFrame(void) {
 // IDA: void __cdecl RemoveMaterialsFromSkidmarks()
 void RemoveMaterialsFromSkidmarks(void) {
     int skid;
-    NOT_IMPLEMENTED();
+
+    for (skid = 0; skid < COUNT_OF(gSkids); skid++) {
+        gSkids[skid].actor->material = NULL;
+    }
 }

--- a/src/DETHRACE/common/world.c
+++ b/src/DETHRACE/common/world.c
@@ -23,6 +23,7 @@
 #include "pedestrn.h"
 #include "piping.h"
 #include "replay.h"
+#include "skidmark.h"
 #include "spark.h"
 #include "trig.h"
 #include "utility.h"
@@ -1964,7 +1965,6 @@ void SaveAdditionalStuff(void) {
 
 // IDA: br_uint_32 __cdecl ProcessMaterials(br_actor *pActor, tPMFM2CB pCallback)
 br_uint_32 ProcessMaterials(br_actor* pActor, tPMFM2CB pCallback) {
-
     if (pActor->material) {
         pCallback(pActor->material);
     }
@@ -3186,6 +3186,9 @@ void FreeTrack(tTrack_spec* pTrack_spec) {
     PossibleService();
     ClearOutStorageSpace(&gTrack_storage_space);
     PossibleService();
+#ifdef DETHRACE_3DFX_PATCH
+    RemoveMaterialsFromSkidmarks();
+#endif
     DisposeGroovidelics(-2);
     PossibleService();
     DisposeOpponentPaths();


### PR DESCRIPTION
When a skid is active, its material is set to the current skidmark material.

When a track is unloaded, all materials are free'd.

In 3dfx mode, when a new track is loaded all active materials have fog properties set. In the 3dfx case, active skid marks still had a reference to the (now freed) material, which was then used to set fog properties, which caused a crash.

We had missed another piece of 3dfx patch change which was `RemoveMaterialsFromSkidmarks` which clears out the current skid materials.