### PR TITLE
Fixing CD music that randomly dies due to invalid track id

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -763,7 +763,7 @@ int DRS3StartCDA(tS3_sound_id pCDA_id) {
                     gCDA_tag = DRS3StartSoundNoPiping(gMusic_outlet, pCDA_id);
 #if defined(DETHRACE_FIX_BUGS)
                     // Fix issue where attempting to play the last cd track (9607) causes the CD audio playback to stop and not play any other tracks until sound is disabled then re-enabled.
-                    if (gCDA_tag == 0 && gS3_last_error == eS3_error_bad_id && random_track && retries_remaining > 0) {
+                    if (gCDA_tag == 0 && gS3_last_error != 0 && random_track && retries_remaining > 0) {
                         retries_remaining--;
                         // Retry with a random tune if the CD track is missing, instead of disabling music completely
                         pCDA_id = 9999;


### PR DESCRIPTION
Hello,
ever since I have been playing carmageddon, I had noticed this very weird glitch where sometimes the music would just stop playing after finishing a track. Abusing the "s" key triggered the same glitch eventually, so now that carmageddon is more or less open source, I took the liberty of looking at the code to figure this out.

Turns out the game seems to look for an 8th audio track, even though the game only has 7 and the splat pack has 3. I considered removing id 9607, but I guess it was put there for a reason, and technically the game *could* play an 8th track given the right CD/.ogg (although I also tried adding an 8th .ogg file, and that didn't work ...).
Haven't played the splat pack much yet, but I'm assuming it would need 5 out of the 8 ids removed ?

Instead I decided to make the game a little bit smarter, thus if some track can't be played, which causes the entire CD audio backend to turn off and it's impossible to turn on again without a complete game reset, because gCD_is_disabled is set and S3DisableCDA() is called.
Instead it now knows if the track it picked is wrong and it will just find another one.

It may not be the cleanest fix, feel free to tell me how to improve it if it's not good enough