### PR TITLE
PaletteFuckedUpByDrugs matching properly

### DIFF
--- a/src/DETHRACE/common/powerup.c
+++ b/src/DETHRACE/common/powerup.c
@@ -895,7 +895,7 @@ void PaletteFuckedUpByDrugs(br_pixelmap* pPixelmap, int pOffset) {
     ((tU32*)gRender_palette->pixels)[0] = gReal_render_palette[0];
 
     for (i = 224; i < 256; i++) {
-        ((tU32*)gRender_palette->pixels)[i] = gReal_render_palette[i] & 0xff;
+        ((tU32*)gRender_palette->pixels)[i] = gReal_render_palette[i & 0xff];
     }
 }
 


### PR DESCRIPTION
Fixes #558

reccmp output, meaning the previously "effective" match is now a full match
```
0x42e30a - PaletteFuckedUpByDrugs (100.00%* -> 100.00%)
```