### PR TITLE
Do not look for null special volume actor

### DIFF
--- a/src/DETHRACE/common/world.c
+++ b/src/DETHRACE/common/world.c
@@ -1848,6 +1848,12 @@ int FindSpecVolIndex(br_actor* pActor) {
     int i;
     tSpecial_volume* v;
 
+#ifdef DETHRACE_FIX_BUGS
+    if (pActor == NULL) {
+        return -1;
+    }
+#endif
+
     for (i = 0; i < gProgram_state.special_volume_count; i++) {
         if (gSpec_vol_actors[i] == pActor) {
             return i;


### PR DESCRIPTION
This fixes segmentation faults in the special volume edit mode when no volumes are available.

Reproducer:
- enter special volume edit mode
- spam F8 (to remove special volumes)