### PR TITLE
Remove signal handler before exiting

### DIFF
--- a/src/DETHRACE/main.c
+++ b/src/DETHRACE/main.c
@@ -10,6 +10,7 @@
 #include "brender.h"
 
 extern int Harness_Init(int* argc, char* argv[]);
+extern int Harness_Quit(void);
 extern int original_main(int pArgc, char* pArgv[]);
 
 void BR_CALLBACK _BrBeginHook(void) {
@@ -57,5 +58,9 @@ int main(int argc, char* argv[]) {
         return result;
     }
 
-    return original_main(argc, argv);
+    result = original_main(argc, argv);
+
+    Harness_Quit();
+
+    return result;
 }

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -328,6 +328,13 @@ int Harness_Init(int* argc, char* argv[]) {
     return 0;
 }
 
+void Harness_Quit(void) {
+
+    if (harness_game_config.install_signalhandler) {
+        OS_RemoveSignalHandler();
+    }
+}
+
 // used by unit tests
 void Harness_ForceNullPlatform(void) {
     force_null_platform = 1;

--- a/src/harness/include/harness/hooks.h
+++ b/src/harness/include/harness/hooks.h
@@ -66,7 +66,9 @@ typedef struct tPlatform_bootstrap {
 
 extern tHarness_platform gHarness_platform;
 
-int Harness_Init(int* argc, char* argv[]);
+extern int Harness_Init(int* argc, char* argv[]);
+
+extern void Harness_Quit(void);
 
 // Hooks are called from original game code.
 

--- a/src/harness/include/harness/os.h
+++ b/src/harness/include/harness/os.h
@@ -23,7 +23,9 @@
 #endif
 
 // Optional: install a handler to print stack trace during a crash
-void OS_InstallSignalHandler(char* program_name);
+extern void OS_InstallSignalHandler(char* program_name);
+
+extern void OS_RemoveSignalHandler(void);
 
 char* OS_GetFirstFileInDirectory(char* path);
 

--- a/src/harness/os/macos.c
+++ b/src/harness/os/macos.c
@@ -229,6 +229,45 @@ void OS_InstallSignalHandler(char* program_name) {
     }
 }
 
+void OS_RemoveSignalHandler(void) {
+
+    /* Unregister our signal handlers */
+    {
+        struct sigaction sig_action = {};
+        sig_action.sa_handler = SIG_DFL;
+        sigemptyset(&sig_action.sa_mask);
+
+        if (sigaction(SIGSEGV, &sig_action, NULL) != 0) {
+            err(1, "sigaction");
+        }
+        if (sigaction(SIGFPE, &sig_action, NULL) != 0) {
+            err(1, "sigaction");
+        }
+        if (sigaction(SIGINT, &sig_action, NULL) != 0) {
+            err(1, "sigaction");
+        }
+        if (sigaction(SIGILL, &sig_action, NULL) != 0) {
+            err(1, "sigaction");
+        }
+        if (sigaction(SIGTERM, &sig_action, NULL) != 0) {
+            err(1, "sigaction");
+        }
+        if (sigaction(SIGABRT, &sig_action, NULL) != 0) {
+            err(1, "sigaction");
+        }
+    }
+
+    /* remove alternate stack */
+    {
+        stack_t ss = {};
+        ss.ss_flags = SS_DISABLE;
+
+        if (sigaltstack(&ss, NULL) != 0) {
+            err(1, "sigaltstack");
+        }
+    }
+}
+
 char* OS_GetFirstFileInDirectory(char* path) {
     directory_iterator = opendir(path);
     if (directory_iterator == NULL) {

--- a/src/harness/os/null.c
+++ b/src/harness/os/null.c
@@ -4,6 +4,9 @@
 void OS_InstallSignalHandler(char* program_name) {
 }
 
+void OS_RemoveSignalHandler(void) {
+}
+
 char* OS_GetFirstFileInDirectory(char* path) {
     return NULL;
 }

--- a/src/harness/os/windows.c
+++ b/src/harness/os/windows.c
@@ -44,6 +44,8 @@ static char path_addr2line[1024];
 static char dirname_buf[_MAX_DIR];
 static char fname_buf[_MAX_FNAME];
 
+static LPTOP_LEVEL_EXCEPTION_FILTER prevUnhandledExceptionFilter;
+
 HANDLE directory_handle = NULL;
 char last_found_file[260];
 
@@ -338,7 +340,12 @@ void OS_InstallSignalHandler(char* program_name) {
         }
     }
     strcpy(windows_program_name, program_name);
-    SetUnhandledExceptionFilter(windows_exception_handler);
+    prevUnhandledExceptionFilter = SetUnhandledExceptionFilter(windows_exception_handler);
+}
+
+void OS_RemoveSignalHandler(void) {
+    SetUnhandledExceptionFilter(prevUnhandledExceptionFilter);
+    prevUnhandledExceptionFilter = NULL;
 }
 
 char* OS_GetFirstFileInDirectory(char* path) {


### PR DESCRIPTION
On Linux and macOS, this avoids a leak.