### PR TITLE
ci: retry cpack a few times

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -118,7 +118,6 @@ jobs:
            echo "Package creation failed after $max_tries attempts."
            exit 1
           fi
-          cpack .
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
DMG creation on macOS occasionally fails, so retry a few times