### PR TITLE
Match `MungeSplash`

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -2709,7 +2709,7 @@ void MungeSplash(tU32 pTime) {
     if (gNum_splash_types == 0) {
         return;
     }
-    if (gAction_replay_mode && GetReplayRate() != 0.0f) {
+    if (gAction_replay_mode != eNet_mode_none && GetReplayRate() != 0.0f) {
         for (type = eVehicle_net_player; type <= eVehicle_rozzer; type++) {
             for (i = 0; i < (type == eVehicle_self ? 1 : GetCarCount(type)); i++) {
                 if (type == eVehicle_self) {


### PR DESCRIPTION
100%. In this section, `BrVector3Scale` matched the scaling on `m[0]`. Using it for `m[1]` and `m[2]` did not match.
```cpp
ts = gSplash[i].size * gSplash[i].scale_x;
BrVector3Scale((br_vector3*)gSplash[i].actor->t.t.mat.m[0], (br_vector3*)gCamera_to_world.m[0], ts);
gSplash[i].actor->t.t.mat.m[1][0] = gSplash[i].size * gCamera_to_world.m[1][0];
gSplash[i].actor->t.t.mat.m[1][1] = gSplash[i].size * gCamera_to_world.m[1][1];
gSplash[i].actor->t.t.mat.m[1][2] = gSplash[i].size * gCamera_to_world.m[1][2];
gSplash[i].actor->t.t.mat.m[2][0] = gSplash[i].size * gCamera_to_world.m[2][0];
gSplash[i].actor->t.t.mat.m[2][1] = gSplash[i].size * gCamera_to_world.m[2][1];
gSplash[i].actor->t.t.mat.m[2][2] = gSplash[i].size * gCamera_to_world.m[2][2];
```
I'm not familiar with all the BRender macros, so if there's a better way we should use it. This pattern of casting one matrix dimension as a `br_vector3*` is used in a few other spots so it seemed okay here.