### PR TITLE
Improve `RenderSmoke`

### DIFF
--- a/src/library_msvc.h
+++ b/src/library_msvc.h
@@ -18,6 +18,9 @@
 // LIBRARY: CARM95 0x004ead80
 // qsort
 
+// LIBRARY: CARM95 0x004eb3c0
+// srand
+
 // LIBRARY: CARM95 0x004eb3e0
 // rand
 


### PR DESCRIPTION
The only diff remaining is here:
```cpp
gSmoke[i].radius = pTime / 1000.0f * gSmoke[i].strength * 0.5 + gSmoke[i].radius;
```
```diff
-fmul qword ptr [0.5000000000000001 (FLOAT)]
+fmul qword ptr [0.5 (FLOAT)]
```
Since we're dealing with radius, maybe a trig function would fit here and could produce _almost_ one half?