### PR TITLE
KickPlayerOut 100% effective match

### DIFF
--- a/reccmp/AGENTS.md
+++ b/reccmp/AGENTS.md
@@ -12,6 +12,13 @@ We want to generate assembly that matches the original retail binary. Each funct
 - Don't add unecessary casts
 - Don't add goto statements or goto labels
 - Don't look back at previous commits. This code has never matched, so no point in doing this.
+- Don't add code that isn't x86/x64 compatible. Don't assume a pointer is 4 bytes. The original binary is x86 only, but our recompiled code needs to work correctly on 64 bit.
+- Reversed compare order changes will generally resolve by themselves - leave these till last. They are normally not fixable.
+- Inspect the corresponding `build/msvc42/*.asm` function before editing so local variable slots (`[ebp-*]`) are mapped correctly.
+- Classify asm diffs before editing: compare-order-only diffs vs semantic/codegen diffs. Prioritize semantic/codegen diffs first.
+- When only one semantic/codegen mismatch remains, make one minimal edit targeting that mismatch and rerun reccmp before any other refactor.
+- Do not refactor loop/control-flow shape to chase compare-order-only diffs.
+- If a trial edit decreases match percentage, revert immediately and return to the last higher-percentage version.
 
 ## Stack variable slots
 
@@ -62,4 +69,34 @@ We are generally unable to resolve a diff like this, so resolve the other diffs 
 
 ## Git
 
-If you made changes to a function, fetch latest `main` and make branch from it called `match-<function name>`. When you are finished (100% or abort), commit the changes (commit comment should be "<function name> <percentage>") and push to origin. If you are able to get to a 100% match, make a pr with `gh`. You must run switch gh auth to `dethrace-labs`, then switch back after making the pr. Include the output from reccmp in the PR description in a code block
+This workflow is mandatory after any function matching task. Execute it automatically without asking.
+
+1. Gather inputs.
+   - Function name: `<function name>`
+   - Function address: `<address>`
+   - Final reccmp result text and percentage
+2. Preserve unrelated local work before branch operations.
+   - If the worktree is dirty with files unrelated to this function, stash them first.
+   - Use a named stash (for example `codex-temp-<function name>`).
+   - Re-apply the stash after completing branch setup/cherry-pick as needed.
+3. Start from latest upstream main.
+   - `git fetch upstream main`
+   - `git switch -C match-<function name> upstream/main`
+4. Apply only relevant function changes on the match branch.
+   - Do not commit unrelated files.
+   - If stashed work was needed, restore and stage only target files.
+5. Verify once more on the branch.
+   - `./reccmp/asm-match.sh <address>`
+6. Commit with exact message format.
+   - `git commit -m "<function name> <percentage>"`
+7. Push branch to origin.
+   - `git push -u origin match-<function name>`
+8. Create PR when result is 100% or 100% effective match.
+   - `gh auth switch -u jeff-1amstudios`
+   - Create PR to `main` from `match-<function name>` with title `Match <function name>`.
+   - PR body must include:
+     - brief summary
+     - full reccmp output in a fenced code block
+   - Switch auth back after PR creation.
+   - `gh auth switch -u dethrace-labs`
+9. If result is not 100%, still push the branch and report abort reason in the final message.

--- a/reccmp/Dockerfile
+++ b/reccmp/Dockerfile
@@ -35,7 +35,7 @@ RUN unzip -q ninja-win.zip -d $WINEPREFIX/drive_c/ninja
 RUN rm ninja-win.zip
 
 # Install reccmp
-RUN pip install --break-system-packages git+https://github.com/jeff-1amstudios/reccmp
+RUN pip install --break-system-packages git+https://github.com/jeff-1amstudios/reccmp@9942ebc
 
 # Set up entrypoint script to perform the build
 COPY entrypoint.sh entrypoint.sh

--- a/src/DETHRACE/common/network.c
+++ b/src/DETHRACE/common/network.c
@@ -1339,7 +1339,7 @@ void KickPlayerOut(tPlayer_ID pID) {
     tNet_game_player_info* new_players;
 
     new_player_count = gNumber_of_net_players;
-    new_players = (tNet_game_player_info*)BrMemAllocate(sizeof(tNet_game_player_info) * gNumber_of_net_players, kMem_player_list_leave);
+    new_players = (tNet_game_player_info*)BrMemAllocate(sizeof(tNet_game_player_info) * new_player_count, kMem_player_list_leave);
     memcpy(new_players, gNet_players, sizeof(tNet_game_player_info) * new_player_count);
     for (i = 0; i < new_player_count; i++) {
         if (new_players[i].ID == pID) {


### PR DESCRIPTION
## Summary
- match KickPlayerOut at `0x004496f8`
- include requested changed files in this PR:
  - `src/DETHRACE/common/network.c`
  - `reccmp/AGENTS.md`
  - `reccmp/Dockerfile`

## reccmp output
```text
---
@@ -0x449731,23 +0x442f22,23 @@
0x449751 : -mov eax, dword ptr [ebp - 8]
0x449754 : -cmp dword ptr [ebp - 0xc], eax
0x449757 : -jge 0x106
---
@@ -0x4497f5,23 +0x442fe6,23 @@
0x449821 : -mov eax, dword ptr [ebp - 8]
0x449824 : -cmp dword ptr [ebp - 0x10], eax
0x449827 : -jge 0x29
0x4496f8: KickPlayerOut 100% effective match (differs, but only in ways that don't affect behavior).
✨ OK! ✨
```
