### PR TITLE
ReceivedStatusReport 100% match

### DIFF
--- a/src/DETHRACE/common/network.c
+++ b/src/DETHRACE/common/network.c
@@ -1537,15 +1537,13 @@ void ReceivedStatusReport(tNet_contents* pContents, tNet_message* pMessage) {
         if (gNet_players[i].ID == pMessage->sender) {
             gNet_players[i].player_status = pContents->data.report.status;
             gNet_players[i].last_heard_from_him = PDGetTotalTime();
-            if (gNet_players[i].player_status < ePlayer_status_racing || gNet_players[i].player_status == ePlayer_status_recovering) {
-                if (gNet_players[i].player_status < ePlayer_status_racing) {
-                    DisableCar(gNet_players[i].car);
-                }
-            } else {
+            if (gNet_players[i].player_status >= ePlayer_status_racing && gNet_players[i].player_status != ePlayer_status_recovering) {
                 if (gNet_players[i].car->disabled) {
                     SendCurrentPowerups();
                 }
                 EnableCar(gNet_players[i].car);
+            } else if (gNet_players[i].player_status < ePlayer_status_racing) {
+                DisableCar(gNet_players[i].car);
             }
             return;
         }


### PR DESCRIPTION
Summary:
- Matched ReceivedStatusReport at 0x00449b46 by adjusting status-report control flow to match original codegen.

reccmp output:
```text
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.6s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name $$$00001(1)

0x449b46: ReceivedStatusReport 100% match.

✨ OK! ✨
```
