### PR TITLE
ReceivedStartRace 100% effective match

### DIFF
--- a/src/DETHRACE/common/network.c
+++ b/src/DETHRACE/common/network.c
@@ -1575,30 +1575,32 @@ void ReceivedStartRace(tNet_contents* pContents) {
             gNet_players[index].last_waste_message = 0;
             gNet_players[index].wasteage_attributed = 0;
         }
-    } else if (gSynch_race_start) {
-        for (i = 0; i < pContents->data.start_race.car_count; i++) {
-            gNet_players[pContents->data.start_race.car_list[i].index].next_car_index = pContents->data.start_race.car_list[i].next_car_index;
-        }
     } else {
-        for (i = 0; i < pContents->data.start_race.car_count; i++) {
-            gCurrent_race.number_of_racers = i + 1;
-            gCurrent_race.opponent_list[i].index = -1;
-            gCurrent_race.opponent_list[i].ranking = -1;
-            gCurrent_race.opponent_list[i].car_spec = gNet_players[pContents->data.start_race.car_list[i].index].car;
-            gCurrent_race.opponent_list[i].net_player_index = pContents->data.start_race.car_list[i].index;
-            gNet_players[gCurrent_race.opponent_list[i].net_player_index].last_waste_message = 0;
-            gNet_players[gCurrent_race.opponent_list[i].net_player_index].wasteage_attributed = 0;
-            if (!gProgram_state.racing || gCurrent_race.opponent_list[i].car_spec->driver != eDriver_local_human) {
-                BrMatrix34Copy(&gCurrent_race.opponent_list[i].car_spec->car_master_actor->t.t.mat, &pContents->data.start_race.car_list[i].mat);
-                InitialiseCar(gCurrent_race.opponent_list[i].car_spec);
+        if (!gSynch_race_start) {
+            for (i = 0; i < pContents->data.start_race.car_count; i++) {
+                gCurrent_race.number_of_racers = i + 1;
+                gCurrent_race.opponent_list[i].index = -1;
+                gCurrent_race.opponent_list[i].ranking = -1;
+                gCurrent_race.opponent_list[i].car_spec = gNet_players[pContents->data.start_race.car_list[i].index].car;
+                gCurrent_race.opponent_list[i].net_player_index = pContents->data.start_race.car_list[i].index;
+                gNet_players[gCurrent_race.opponent_list[i].net_player_index].last_waste_message = 0;
+                gNet_players[gCurrent_race.opponent_list[i].net_player_index].wasteage_attributed = 0;
+                if (!gProgram_state.racing || gCurrent_race.opponent_list[i].car_spec->driver != eDriver_local_human) {
+                    BrMatrix34Copy(&gCurrent_race.opponent_list[i].car_spec->car_master_actor->t.t.mat, &pContents->data.start_race.car_list[i].mat);
+                    InitialiseCar(gCurrent_race.opponent_list[i].car_spec);
+                }
+                gNet_players[pContents->data.start_race.car_list[i].index].next_car_index = pContents->data.start_race.car_list[i].next_car_index;
             }
-            gNet_players[pContents->data.start_race.car_list[i].index].next_car_index = pContents->data.start_race.car_list[i].next_car_index;
-        }
-        gPending_race = pContents->data.start_race.next_race;
-        gCurrent_race.number_of_racers = pContents->data.start_race.car_count;
-        gSynch_race_start = 1;
-        if (!pContents->data.start_race.racing || gProgram_state.racing) {
-            gWait_for_it = 0;
+            gPending_race = pContents->data.start_race.next_race;
+            gCurrent_race.number_of_racers = pContents->data.start_race.car_count;
+            gSynch_race_start = 1;
+            if (!pContents->data.start_race.racing || gProgram_state.racing) {
+                gWait_for_it = 0;
+            }
+        } else {
+            for (i = 0; i < pContents->data.start_race.car_count; i++) {
+                gNet_players[pContents->data.start_race.car_list[i].index].next_car_index = pContents->data.start_race.car_list[i].next_car_index;
+            }
         }
     }
 }


### PR DESCRIPTION
Summary
- Reworked control-flow shape in ReceivedStartRace to achieve a 100% effective match at 0x00449c42.
- Kept all edits scoped to src/DETHRACE/common/network.c.

Reccmp output
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
[1/2] Building C object src\DETHRACE\CMakeFiles\dethrace_obj.dir\common\network.c.obj
network.c
[2/2] Linking C executable CARM95.exe
LINK : warning LNK4044: unrecognized option "pdbtype:sept"; ignored
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

---
+++
@@ -0x449c42,43 +0x443660,43 @@
0x449c42 : push ebp 	(network.c:1557)
...
@@ -0x449efb,10 +0x443918,11 @@
0x449f16 : leave
+ret

0x449c42: ReceivedStartRace 100% effective match (differs, but only in ways that don't affect behavior).

✨ OK! ✨
```
