### PR TITLE
NetReceiveAndProcessMessages 100% match

### DIFF
--- a/src/DETHRACE/common/network.c
+++ b/src/DETHRACE/common/network.c
@@ -1983,21 +1983,24 @@ void NetReceiveAndProcessMessages(void) {
     tU32 receive_time;
     int old_net_service;
 
-    old_net_service = gIn_net_service;
     if (gNet_mode != eNet_mode_none || gJoin_list_mode) {
+        old_net_service = gIn_net_service;
         gIn_net_service = 1;
-        while ((message = NetGetNextMessage(gCurrent_net_game, &sender_address)) != NULL) {
-            receive_time = GetRaceTime();
-            if (message->magic_number == 0x763a5058) {
-                CheckCheckSum(message);
-                ReceivedMessage(message, sender_address, receive_time);
-            } else {
-                message->guarantee_number = 0;
+        do {
+            message = NetGetNextMessage(gCurrent_net_game, &sender_address);
+            if (message != NULL) {
+                receive_time = GetRaceTime();
+                if (message->magic_number == 0x763a5058) {
+                    CheckCheckSum(message);
+                    ReceivedMessage(message, sender_address, receive_time);
+                } else {
+                    message->guarantee_number = 0;
+                }
+                NetDisposeMessage(gCurrent_net_game, message);
             }
-            NetDisposeMessage(gCurrent_net_game, message);
-        }
+        } while (message != NULL);
+        gIn_net_service = old_net_service;
     }
-    gIn_net_service = old_net_service;
 }
 
 // IDA: void __cdecl BroadcastStatus()


### PR DESCRIPTION
## Summary
- Match `NetReceiveAndProcessMessages` at `0x00449f82` to the retail binary.
- Adjust control-flow/state-restore shape to produce matching codegen.

## reccmp output
```text
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
[1/2] Building C object src\DETHRACE\CMakeFiles\dethrace_obj.dir\common\network.c.obj
network.c
[2/2] Linking C executable CARM95.exe
LINK : warning LNK4044: unrecognized option "pdbtype:sept"; ignored
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x449f82: NetReceiveAndProcessMessages 100% match.

✨ OK! ✨
```
