### PR TITLE
DoNextJoinPoll 100% match

### DIFF
--- a/src/DETHRACE/common/network.c
+++ b/src/DETHRACE/common/network.c
@@ -320,14 +320,14 @@ void DoNextJoinPoll(void) {
         gCurrent_join_poll_game = NetAllocatePIDGameDetails();
         if (gCurrent_join_poll_game != NULL) {
             if (PDNetGetNextJoinGame(gCurrent_join_poll_game, gJoin_poll_index)) {
-                if (NetJoinGameLowLevel(gCurrent_join_poll_game, "!TEMP!")) {
-                    DisposeCurrentJoinPollGame();
-                } else {
+                if (!NetJoinGameLowLevel(gCurrent_join_poll_game, "!TEMP!")) {
                     gTime_for_next_one = 0;
                     the_message = NetBuildMessage(NETMSGID_SENDMEDETAILS, 0);
                     NetSendMessageToAddress(gCurrent_join_poll_game, the_message, gCurrent_join_poll_game);
                     gBastard_has_answered = 0;
                     gAsk_time = PDGetTotalTime();
+                } else {
+                    DisposeCurrentJoinPollGame();
                 }
                 gJoin_poll_index++;
             } else {


### PR DESCRIPTION
## Summary
- Match `DoNextJoinPoll` at `0x0044a179` to 100%.
- Adjust branch layout around `NetJoinGameLowLevel` so MSVC42 emits retail-identical control flow.

## reccmp output
```text
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
[1/2] Building C object src\DETHRACE\CMakeFiles\dethrace_obj.dir\common\network.c.obj
network.c
[2/2] Linking C executable CARM95.exe
LINK : warning LNK4044: unrecognized option "pdbtype:sept"; ignored
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44a179: DoNextJoinPoll 100% match.

✨ OK! ✨
```
