### PR TITLE
CheckForDisappearees 100% match

### DIFF
--- a/src/DETHRACE/common/network.c
+++ b/src/DETHRACE/common/network.c
@@ -2024,7 +2024,8 @@ void CheckForDisappearees(void) {
         for (i = 0; i < gNumber_of_net_players; i++) {
             if (!gNet_players[i].host && gNet_players[i].last_heard_from_him != 0 && the_time - gNet_players[i].last_heard_from_him >= 20000) {
                 strcpy(s, gNet_players[i].player_name);
-                strcat(s, (s2 = GetMiscString(kMiscString_IS_NO_LONGER_RESPONDING), " "));
+                s2 = GetMiscString(kMiscString_IS_NO_LONGER_RESPONDING);
+                strcat(s, " ");
                 strcat(s, s2);
                 NetSendHeadupToAllPlayers(s);
                 KickPlayerOut(gNet_players[i].ID);

--- a/src/DETHRACE/common/network.c
+++ b/src/DETHRACE/common/network.c
@@ -2024,8 +2024,8 @@ void CheckForDisappearees(void) {
         for (i = 0; i < gNumber_of_net_players; i++) {
             if (!gNet_players[i].host && gNet_players[i].last_heard_from_him != 0 && the_time - gNet_players[i].last_heard_from_him >= 20000) {
                 strcpy(s, gNet_players[i].player_name);
-                strcat(s, " ");
-                strcat(s, GetMiscString(kMiscString_IS_NO_LONGER_RESPONDING));
+                strcat(s, (s2 = GetMiscString(kMiscString_IS_NO_LONGER_RESPONDING), " "));
+                strcat(s, s2);
                 NetSendHeadupToAllPlayers(s);
                 KickPlayerOut(gNet_players[i].ID);
                 if (gProgram_state.racing) {


### PR DESCRIPTION
## Summary
- Match `CheckForDisappearees` at `0x0044a2a3` to 100%.
- Adjust message concatenation expression ordering to produce retail-identical codegen.

## reccmp output
```text
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
[1/2] Building C object src\DETHRACE\CMakeFiles\dethrace_obj.dir\common\network.c.obj
network.c
[2/2] Linking C executable CARM95.exe
LINK : warning LNK4044: unrecognized option "pdbtype:sept"; ignored
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44a2a3: CheckForDisappearees 100% match.

✨ OK! ✨
```
