### PR TITLE
NetGuaranteedSendMessageToAllPlayers 100% match

### DIFF
--- a/src/DETHRACE/common/network.c
+++ b/src/DETHRACE/common/network.c
@@ -2133,12 +2133,11 @@ int NetGuaranteedSendMessageToAllPlayers(tNet_game_details* pDetails, tNet_messa
     err = 0;
     if (gNumber_of_net_players == 1) {
         NetDisposeMessage(pDetails, pMessage);
-        err = 0;
-    } else {
-        for (i = 0; i < gNumber_of_net_players; i++) {
-            if (gThis_net_player_index != i) {
-                err |= NetGuaranteedSendMessageToAddress(pDetails, pMessage, &gNet_players[i], pNotifyFail);
-            }
+        return err;
+    }
+    for (i = 0; i < gNumber_of_net_players; i++) {
+        if (gThis_net_player_index != i) {
+            err |= NetGuaranteedSendMessageToAddress(pDetails, pMessage, &gNet_players[i], pNotifyFail);
         }
     }
     return err;


### PR DESCRIPTION
## Summary
- Match `NetGuaranteedSendMessageToAllPlayers` at `0x0044a5ef` to 100%.
- Preserve retail branch codegen by using an explicit early return in the single-player path.

## reccmp output
```text
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
[1/2] Building C object src\DETHRACE\CMakeFiles\dethrace_obj.dir\common\network.c.obj
network.c
[2/2] Linking C executable CARM95.exe
LINK : warning LNK4044: unrecognized option "pdbtype:sept"; ignored
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44a5ef: NetGuaranteedSendMessageToAllPlayers 100% match.

✨ OK! ✨
```
