### PR TITLE
DisposeOpponents 100% match

### DIFF
--- a/src/DETHRACE/common/opponent.c
+++ b/src/DETHRACE/common/opponent.c
@@ -2755,7 +2755,7 @@ void DisposeOpponents(void) {
     int i;
     if (gProgram_state.AI_vehicles.number_of_cops != 0) {
         for (i = 0; i < gProgram_state.AI_vehicles.number_of_cops; i++) {
-            DisposeCar(gProgram_state.AI_vehicles.cops[i].car_spec, (i == gBIG_APC_index) ? 4 : 3);
+            DisposeCar(gProgram_state.AI_vehicles.cops[i].car_spec, (i - gBIG_APC_index != 0) ? 3 : 4);
             BrMemFree(gProgram_state.AI_vehicles.cops[i].car_spec);
         }
     }


### PR DESCRIPTION
Summary:
- Match `DisposeOpponents` at `0x40b186` to 100% by adjusting the ternary condition shape to match original codegen.

Reccmp output:
```text
0x40b186: DisposeOpponents 100% match.

✨ OK! ✨
```
