### PR TITLE
ReceivedCopInfo 100% match

### DIFF
--- a/src/DETHRACE/common/netgame.c
+++ b/src/DETHRACE/common/netgame.c
@@ -328,7 +328,7 @@ void ReceivedCopInfo(tNet_contents* pContents) {
     if (c == NULL) {
         return;
     }
-    if (pContents->data.cop_info.time > c->message.time) {
+    if (c->message.time > pContents->data.cop_info.time) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- Match `ReceivedCopInfo` at `0x4302c5` by correcting the stale-message time guard compare direction.

## reccmp output
```text
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x4302c5: ReceivedCopInfo 100% match.

✨ OK! ✨
```
