### PR TITLE
ReinitialiseCar 100% match

### DIFF
--- a/src/DETHRACE/common/netgame.c
+++ b/src/DETHRACE/common/netgame.c
@@ -596,7 +596,7 @@ void ReinitialiseCar(tCar_spec* pCar) {
     InitialiseCar(pCar);
     TotallyRepairACar(pCar);
     if (pCar->driver == eDriver_local_human) {
-        gLast_it_change = PDGetTotalTime() + 2000;
+        gTime_for_punishment = PDGetTotalTime() + 2000;
     }
 }
 


### PR DESCRIPTION
## Summary
- Match `ReinitialiseCar` at `0x430f14` by correcting the local-human punishment timestamp global assignment.

## reccmp output
```text
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x430f14: ReinitialiseCar 100% match.

✨ OK! ✨
```
