### PR TITLE
NetWaitForGuaranteeReplies 100% match

### DIFF
--- a/src/DETHRACE/common/network.c
+++ b/src/DETHRACE/common/network.c
@@ -2272,10 +2272,7 @@ void NetWaitForGuaranteeReplies(void) {
     tU32 start_time;
 
     start_time = PDGetTotalTime();
-    while (gNext_guarantee != 0) {
-        if (PDGetTotalTime() - start_time >= 5000) {
-            break;
-        }
+    while (gNext_guarantee != 0 && PDGetTotalTime() - start_time < 5000) {
         NetService(0);
     }
 }


### PR DESCRIPTION
## Summary
- match `NetWaitForGuaranteeReplies` at `0x44ad2f`
- adjusted loop condition/control-flow to match the original branch shape

## reccmp output
```text
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
[1/3] Building C object src\DETHRACE\CMakeFiles\dethrace_obj.dir\common\world.c.obj
[2/3] Building C object src\DETHRACE\CMakeFiles\dethrace_obj.dir\common\network.c.obj
[3/3] Linking C executable CARM95.exe
LINK : warning LNK4044: unrecognized option "pdbtype:sept"; ignored
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44ad2f: NetWaitForGuaranteeReplies 100% match.

✨ OK! ✨
```
