### PR TITLE
NetGuaranteedSendMessageToPlayer 100% match

### DIFF
--- a/src/DETHRACE/common/network.c
+++ b/src/DETHRACE/common/network.c
@@ -2168,24 +2168,22 @@ int NetGuaranteedSendMessageToHost(tNet_game_details* pDetails, tNet_message* pM
 int NetGuaranteedSendMessageToPlayer(tNet_game_details* pDetails, tNet_message* pMessage, tPlayer_ID pPlayer, int (*pNotifyFail)(tU32, tNet_message*)) {
     int i;
 
-    for (i = 0; i <= gNumber_of_net_players; i++) {
+    for (i = 0; gNumber_of_net_players > i; i++) {
         if (pPlayer == gNet_players[i].ID) {
-            break;
+            if (gLocal_net_ID == pPlayer) {
+                pMessage->sender = gLocal_net_ID;
+                pMessage->senders_time_stamp = PDGetTotalTime();
+                pMessage->num_contents = 1;
+                pMessage->guarantee_number = 0;
+                ReceivedMessage(pMessage, &gNet_players[i], GetRaceTime());
+                NetDisposeMessage(pDetails, pMessage);
+                return 0;
+            } else {
+                return NetGuaranteedSendMessageToAddress(pDetails, pMessage, &gNet_players[i].pd_net_info, pNotifyFail);
+            }
         }
     }
-    if (i == gNumber_of_net_players) {
-        return -1;
-    }
-    if (gLocal_net_ID != pPlayer) {
-        return NetGuaranteedSendMessageToAddress(pDetails, pMessage, &gNet_players[i].pd_net_info, pNotifyFail);
-    }
-    pMessage->sender = gLocal_net_ID;
-    pMessage->senders_time_stamp = PDGetTotalTime();
-    pMessage->num_contents = 1;
-    pMessage->guarantee_number = 0;
-    ReceivedMessage(pMessage, &gNet_players[i], GetRaceTime());
-    NetDisposeMessage(pDetails, pMessage);
-    return 0;
+    return -1;
 }
 
 // IDA: int __usercall NetGuaranteedSendMessageToAddress@<EAX>(tNet_game_details *pDetails@<EAX>, tNet_message *pMessage@<EDX>, void *pAddress@<EBX>, int (*pNotifyFail)(tU32, tNet_message*)@<ECX>)


### PR DESCRIPTION
Summary:
- Match `NetGuaranteedSendMessageToPlayer` at `0x0044a721` to 100%.
- Adjusted loop/control-flow shape to match original codegen while preserving behavior.

Reccmp output:
```text
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
[1/2] Building C object src\DETHRACE\CMakeFiles\dethrace_obj.dir\common\network.c.obj
network.c
[2/2] Linking C executable CARM95.exe
LINK : warning LNK4044: unrecognized option "pdbtype:sept"; ignored
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44a721: NetGuaranteedSendMessageToPlayer 100% match.

✨ OK! ✨
```
