### PR TITLE
NetCarFromPlayerID 100% match

### DIFF
--- a/src/DETHRACE/common/network.c
+++ b/src/DETHRACE/common/network.c
@@ -2302,8 +2302,9 @@ tCar_spec* NetCarFromPlayerID(tPlayer_ID pPlayer) {
     player = NetPlayerFromID(pPlayer);
     if (player) {
         return player->car;
+    } else {
+        return NULL;
     }
-    return NULL;
 }
 
 // IDA: tNet_game_player_info* __usercall NetPlayerFromCar@<EAX>(tCar_spec *pCar@<EAX>)


### PR DESCRIPTION
Summary:
- Match `NetCarFromPlayerID` at `0x44add4` by adjusting the null-return control flow shape to match MSVC4.2 codegen.

Reccmp output:
```text
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
[1/2] Building C object src\DETHRACE\CMakeFiles\dethrace_obj.dir\common\network.c.obj
network.c
[2/2] Linking C executable CARM95.exe
LINK : warning LNK4044: unrecognized option "pdbtype:sept"; ignored
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44add4: NetCarFromPlayerID 100% match.

✨ OK! ✨
```
