### PR TITLE
MainMenuDone2 100% match

### DIFF
--- a/src/DETHRACE/common/mainmenu.c
+++ b/src/DETHRACE/common/mainmenu.c
@@ -86,6 +86,7 @@ int MainMenuDone1(int pCurrent_choice, int pCurrent_mode, int pGo_ahead, int pEs
 // FUNCTION: CARM95 0x0044af61
 int MainMenuDone2(int pCurrent_choice, int pCurrent_mode, int pGo_ahead, int pEscaped, int pTimed_out) {
 
+#ifdef DETHRACE_FIX_BUGS
     if (harness_game_info.mode == eGame_carmageddon_demo || harness_game_info.mode == eGame_splatpack_demo || harness_game_info.mode == eGame_splatpack_xmas_demo) {
         if (pCurrent_mode == 0) {
             if (pCurrent_choice == 4) {
@@ -96,28 +97,32 @@ int MainMenuDone2(int pCurrent_choice, int pCurrent_mode, int pGo_ahead, int pEs
         }
         return pCurrent_choice;
     }
+#endif
 
     if (pTimed_out) {
         return -1;
+    } else {
+        switch (pCurrent_choice) {
+        case 0:
+            PreloadBunchOfFlics(4);
+            break;
+        case 1:
+            PreloadBunchOfFlics(5);
+            break;
+        case 2:
+            PreloadBunchOfFlics(1);
+            break;
+        case 3:
+            PreloadBunchOfFlics(3);
+            break;
+        case 4:
+            PreloadBunchOfFlics(7);
+            break;
+        default:
+            break;
+        }
+        return pCurrent_choice;
     }
-    switch (pCurrent_choice) {
-    case 0:
-        PreloadBunchOfFlics(4);
-        break;
-    case 1:
-        PreloadBunchOfFlics(5);
-        break;
-    case 2:
-        PreloadBunchOfFlics(1);
-        break;
-    case 3:
-        PreloadBunchOfFlics(3);
-        break;
-    case 4:
-        PreloadBunchOfFlics(7);
-        break;
-    }
-    return pCurrent_choice;
 }
 
 // IDA: void __cdecl StartMainMenu()


### PR DESCRIPTION
## Summary
- Match `MainMenuDone2` at `0x0044af61`.
- Guarded the demo/harness block with `#ifdef DETHRACE_FIX_BUGS` for non-fix matching builds.
- Adjusted timeout/switch control-flow shape to align codegen, including explicit `default: break;`.

## reccmp output
```text
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
[1/2] Building C object src\DETHRACE\CMakeFiles\dethrace_obj.dir\common\mainmenu.c.obj
mainmenu.c
[2/2] Linking C executable CARM95.exe
LINK : warning LNK4044: unrecognized option "pdbtype:sept"; ignored
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44af61: MainMenuDone2 100% match.

✨ OK! ✨
```
