### PR TITLE
DoVerifyQuit 100% match

### DIFF
--- a/src/DETHRACE/common/mainmenu.c
+++ b/src/DETHRACE/common/mainmenu.c
@@ -535,6 +535,7 @@ int DoVerifyQuit(int pReplace_background) {
     int switched_res;
     int woz_in_race;
 
+    switched_res = 0;
     woz_in_race = 0;
     if (gAusterity_mode) {
         return 1;
@@ -546,8 +547,7 @@ int DoVerifyQuit(int pReplace_background) {
         woz_in_race = 1;
         gProgram_state.racing = 0;
     }
-    result = IRandomBetween(1, 3);
-    switch (result) {
+    switch (IRandomBetween(1, 3)) {
     case 1:
         interface_spec.first_opening_flic = 130;
         break;
@@ -559,7 +559,7 @@ int DoVerifyQuit(int pReplace_background) {
         break;
     }
     gMouse_was_started__mainmenu = gMouse_started;
-    if (gMouse_started) {
+    if (gMouse_was_started__mainmenu) {
         RemoveTransientBitmaps(1);
         EndMouseCursor();
     }


### PR DESCRIPTION
Summary
- Match DoVerifyQuit by preserving original control-flow/codegen shape.
- Initializes switched_res, uses direct switch on IRandomBetween, and checks gMouse_was_started__mainmenu after assignment.

Reccmp output
```text
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.6s)
-- Generating done (0.4s)
-- Build files have been written to: Z:/build
[1/2] Building C object src\DETHRACE\CMakeFiles\dethrace_obj.dir\common\mainmenu.c.obj
mainmenu.c
[2/2] Linking C executable CARM95.exe
LINK : warning LNK4044: unrecognized option "pdbtype:sept"; ignored
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44b25a: DoVerifyQuit 100% match.

✨ OK! ✨
```
