### PR TITLE
DoMainMenuScreen 100% match

### DIFF
--- a/src/DETHRACE/common/mainmenu.c
+++ b/src/DETHRACE/common/mainmenu.c
@@ -665,10 +665,18 @@ void DoMainMenuScreen(tU32 pTime_out, int pSave_allowed, int pContinue_allowed) 
     NetPlayerStatusChanged(ePlayer_status_main_menu);
     PreloadBunchOfFlics(0);
     switch (DoMainMenu(pTime_out, pSave_allowed, pContinue_allowed)) {
+    case eMM_quit:
+        gProgram_state.prog_status = eProg_quit;
+        break;
     case eMM_end_game:
         gProgram_state.prog_status = eProg_idling;
         break;
+    case eMM_timeout:
+        gProgram_state.prog_status = eProg_demo;
+        break;
     case eMM_1_start:
+        gProgram_state.prog_status = eProg_game_starting;
+        break;
     case eMM_n_start:
         gProgram_state.prog_status = eProg_game_starting;
         break;
@@ -676,14 +684,6 @@ void DoMainMenuScreen(tU32 pTime_out, int pSave_allowed, int pContinue_allowed) 
         if (gGame_to_load < 0) {
             gProgram_state.prog_status = eProg_game_starting;
         }
-        break;
-    case eMM_quit:
-        gProgram_state.prog_status = eProg_quit;
-        break;
-    case eMM_timeout:
-        gProgram_state.prog_status = eProg_demo;
-        break;
-    default:
         break;
     }
     UnlockBunchOfFlics(0);


### PR DESCRIPTION
Summary
- Reorder `DoMainMenuScreen` switch cases to match the original control-flow/codegen shape while preserving behavior.
- Result is a full assembly match.

Reccmp output
```text
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44b3c3: DoMainMenuScreen 100% match.

✨ OK! ✨
```
