### PR TITLE
DoMainMenu 100% match

### DIFF
--- a/reccmp/AGENTS.md
+++ b/reccmp/AGENTS.md
@@ -43,6 +43,8 @@ Continue making changes and running the command until it shows a 100% match or y
 - Keep odd or redundant locals and branches if they help codegen, even when logically unnecessary.
 - Treat reccmp `+` and `-` lines as assembly-shape guidance, not direct C line add/remove instructions.
 - For matching tasks, make one control-flow change at a time and rerun reccmp after each change.
+- For enum-based `switch` matching, `default:` can change jump-table targets even when behavior is equivalent.
+- A `default: break;` often creates a separate shared break block; retail may instead route missing/unhandled entries directly to function epilogue.
 
 ## Aborting
 
@@ -100,3 +102,4 @@ This workflow is mandatory after any function matching task. Execute it automati
    - Switch auth back after PR creation.
    - `gh auth switch -u dethrace-labs`
 9. If result is not 100%, still push the branch and report abort reason in the final message.
+10. Switch back to `main` and unstash from (2)

--- a/reccmp/AGENTS.md
+++ b/reccmp/AGENTS.md
@@ -99,6 +99,7 @@ This workflow is mandatory after any function matching task. Execute it automati
    - PR body must include:
      - brief summary
      - full reccmp output in a fenced code block
+   - The last line of body should be "_AI generated_"
    - Switch auth back after PR creation.
    - `gh auth switch -u dethrace-labs`
 9. If result is not 100%, still push the branch and report abort reason in the final message.

--- a/src/DETHRACE/CMakeLists.txt
+++ b/src/DETHRACE/CMakeLists.txt
@@ -194,7 +194,8 @@ if(MSVC_42_FOR_RECCMP)
     target_link_options(dethrace PRIVATE /INCREMENTAL:NO /subsystem:windows /ENTRY:mainCRTStartup)
     target_link_libraries(dethrace PRIVATE ws2_32)
 
-    set_source_files_properties(common/network.c PROPERTIES COMPILE_FLAGS "/FAs")
+    file(GLOB DETHRACE_COMMON_C_FILES "${CMAKE_CURRENT_SOURCE_DIR}/common/*.c")
+    set_source_files_properties(${DETHRACE_COMMON_C_FILES} PROPERTIES COMPILE_FLAGS "/FA")
 
     reccmp_add_target(dethrace ID CARM95)
     reccmp_configure()

--- a/src/DETHRACE/common/mainmenu.c
+++ b/src/DETHRACE/common/mainmenu.c
@@ -600,6 +600,11 @@ tMM_result DoMainMenu(tU32 pTime_out, int pSave_allowed, int pContinue_allowed) 
     }
     the_result = GetMainMenuOption(pTime_out, pContinue_allowed);
     switch (the_result) {
+    case eMM_quit:
+        if (!DoVerifyQuit(0)) {
+            the_result = eMM_none;
+        }
+        break;
     case eMM_end_game:
         if (gNet_mode) {
             gProgram_state.prog_status = eProg_idling;
@@ -636,19 +641,12 @@ tMM_result DoMainMenu(tU32 pTime_out, int pSave_allowed, int pContinue_allowed) 
         DoOptions();
         FreeSoundOptionsData();
         break;
-    case eMM_quit:
-        if (!DoVerifyQuit(0)) {
-            the_result = eMM_none;
-        }
+    case eMM_abort_race:
+        gAbandon_game = 1;
         break;
     case eMM_recover:
         SetRecovery();
         break;
-    case eMM_abort_race:
-        gAbandon_game = 1;
-        break;
-    default:
-        return the_result;
     }
     return the_result;
 }


### PR DESCRIPTION
Summary
- Match `DoMainMenu` (`0x0044b51b`) to 100% by reordering `switch` case labels to align jump-table layout.
- Apply `/FA` assembly listing compile flag to all `src/DETHRACE/common/*.c` files in reccmp MSVC42 builds.
- Update `reccmp/AGENTS.md` with switch/jump-table matching heuristics and workflow note.

Reccmp output
```text
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.6s)
-- Generating done (0.4s)
-- Build files have been written to: Z:/build
[1/2] Building C object src\DETHRACE\CMakeFiles\dethrace_obj.dir\common\mainmenu.c.obj
mainmenu.c
[2/2] Linking C executable CARM95.exe
LINK : warning LNK4044: unrecognized option "pdbtype:sept"; ignored
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44b51b: DoMainMenu 100% match.

✨ OK! ✨
```

_AI generated_
