### PR TITLE
GetMainMenuOption 100% match

### DIFF
--- a/src/DETHRACE/common/mainmenu.c
+++ b/src/DETHRACE/common/mainmenu.c
@@ -414,6 +414,8 @@ tMM_result GetMainMenuOption(tU32 pTime_out, int pContinue_allowed) {
         return eMM_continue;
     }
     switch (result) {
+    case 0:
+        return eMM_continue;
     case 1:
         return eMM_end_game;
     case 2:
@@ -433,8 +435,9 @@ tMM_result GetMainMenuOption(tU32 pTime_out, int pContinue_allowed) {
     case 9:
         return eMM_abort_race;
     default:
-        return eMM_continue;
+        break;
     }
+    return eMM_continue;
 }
 
 // IDA: void __cdecl QuitVerifyStart()

--- a/src/DETHRACE/common/mainmenu.c
+++ b/src/DETHRACE/common/mainmenu.c
@@ -409,35 +409,36 @@ tMM_result GetMainMenuOption(tU32 pTime_out, int pContinue_allowed) {
     result = DoMainMenuInterface(pTime_out, pContinue_allowed);
     if (result < 0) {
         return eMM_timeout;
+    } else {
+        if (gProgram_state.prog_status == eProg_game_starting) {
+            return eMM_continue;
+        } else {
+            switch (result) {
+            case 0:
+                return eMM_continue;
+            case 1:
+                return eMM_end_game;
+            case 2:
+                return eMM_save;
+            case 3:
+                return eMM_loaded;
+            case 4:
+                return eMM_1_start;
+            case 5:
+                return eMM_n_start;
+            case 6:
+                return eMM_options;
+            case 7:
+                return eMM_quit;
+            case 8:
+                return eMM_recover;
+            case 9:
+                return eMM_abort_race;
+            default:
+                return eMM_continue;
+            }
+        }
     }
-    if (gProgram_state.prog_status == eProg_game_starting) {
-        return eMM_continue;
-    }
-    switch (result) {
-    case 0:
-        return eMM_continue;
-    case 1:
-        return eMM_end_game;
-    case 2:
-        return eMM_save;
-    case 3:
-        return eMM_loaded;
-    case 4:
-        return eMM_1_start;
-    case 5:
-        return eMM_n_start;
-    case 6:
-        return eMM_options;
-    case 7:
-        return eMM_quit;
-    case 8:
-        return eMM_recover;
-    case 9:
-        return eMM_abort_race;
-    default:
-        break;
-    }
-    return eMM_continue;
 }
 
 // IDA: void __cdecl QuitVerifyStart()


### PR DESCRIPTION
Brief summary
- Match `GetMainMenuOption` at `0x0044b6bc` to 100%.

```text
-- dethrace version unknown
-- Configuring done (0.6s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
[1/2] Building C object src\DETHRACE\CMakeFiles\dethrace_obj.dir\common\mainmenu.c.obj
mainmenu.c
[2/2] Linking C executable CARM95.exe
LINK : warning LNK4044: unrecognized option "pdbtype:sept"; ignored

0x44b6bc: GetMainMenuOption 100% match.

[32m✨ OK! ✨[0m


```

_AI generated_
