### PR TITLE
DoMainMenuInterface 100% match

### DIFF
--- a/src/DETHRACE/common/mainmenu.c
+++ b/src/DETHRACE/common/mainmenu.c
@@ -204,6 +204,7 @@ int DoMainMenuInterface(tU32 pTime_out, int pContinue_allowed) {
         { { 58, 116 }, { 139, 334 }, { 265, 530 }, { 149, 358 }, 6, 0, 0, NULL },
         { { 64, 128 }, { 155, 372 }, { 265, 530 }, { 165, 396 }, 7, 0, 0, NULL }
     };
+    // GLOBAL: CARM95 0x0050D708
     static tInterface_spec interface_spec1 = {
         0,                      // initial_imode
         0,                      // first_opening_flic
@@ -285,6 +286,8 @@ int DoMainMenuInterface(tU32 pTime_out, int pContinue_allowed) {
         { { 52, 104 }, { 119, 286 }, { 265, 530 }, { 129, 310 }, 3, 0, 0, NULL },
         { { 58, 116 }, { 142, 341 }, { 265, 530 }, { 152, 365 }, 4, 0, 0, NULL }
     };
+
+    // GLOBAL: CARM95 0x0050DA60
     static tInterface_spec interface_spec2 = {
         0,                      // initial_imode
         31,                     // first_opening_flic
@@ -343,7 +346,7 @@ int DoMainMenuInterface(tU32 pTime_out, int pContinue_allowed) {
     if (pContinue_allowed) {
         gMain_menu_spec = &interface_spec1;
         result = DoInterfaceScreen(&interface_spec1, gFaded_palette | 2, 0);
-        if (result == 0 || result == 1 || result == 2 || result == 7) {
+        if (result == 7 || result == 0 || result == 1 || result == 2) {
             FadePaletteDown();
         } else {
             RunFlic(12);
@@ -365,40 +368,31 @@ int DoMainMenuInterface(tU32 pTime_out, int pContinue_allowed) {
             return 1;
         case 7:
             return 7;
-        default:
-            break;
         }
-        result = -1;
     } else {
         interface_spec2.time_out = pTime_out;
         result = DoInterfaceScreen(&interface_spec2, gFaded_palette, 0);
-        if (result == -1 || result == 4) {
+        if (result == 4 || result == -1) {
             FadePaletteDown();
         } else {
             RunFlic(32);
         }
         switch (result) {
+        case -1:
+            return -1;
         case 0:
-            result = 4;
-            break;
+            return 4;
         case 1:
-            result = 5;
-            break;
+            return 5;
         case 2:
-            result = 6;
-            break;
+            return 6;
         case 3:
-            result = 3;
-            break;
+            return 3;
         case 4:
-            result = 7;
-            break;
-        default:
-            result = -1;
-            break;
+            return 7;
         }
     }
-    return result;
+    return -1;
 }
 
 // IDA: tMM_result __usercall GetMainMenuOption@<EAX>(tU32 pTime_out@<EAX>, int pContinue_allowed@<EDX>)


### PR DESCRIPTION
Matched `DoMainMenuInterface` by aligning switch/default fallthrough and return-site control-flow in `mainmenu.c`.

```text
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.6s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44b7cc: DoMainMenuInterface 100% match.

✨ OK! ✨
```

_AI generated_
