### PR TITLE
LoadSavedGames 100% match

### DIFF
--- a/src/DETHRACE/common/loadsave.c
+++ b/src/DETHRACE/common/loadsave.c
@@ -138,22 +138,23 @@ void LoadSavedGames(void) {
     for (i = 0; i < COUNT_OF(gSaved_games); i++) {
         the_path[strlen(the_path) - 1] = '0' + i;
         f = DRfopen(the_path, "rb");
-        if (f == NULL) {
-            continue;
-        }
-        the_size = GetFileLength(f);
-        if (the_size == sizeof(tSave_game)) {
-            gSaved_games[i] = BrMemCalloc(1, sizeof(tSave_game), kMem_saved_game);
-            fread(gSaved_games[i], 1, the_size, f);
-            CorrectLoadByteOrdering(i);
-            if (CalcLSChecksum(gSaved_games[i]) != gSaved_games[i]->checksum || gSaved_games[i]->version != SAVEGAME_VERSION) {
-                BrMemFree(gSaved_games[i]);
+        if (f != NULL) {
+            the_size = GetFileLength(f);
+            if (the_size != sizeof(tSave_game)) {
                 gSaved_games[i] = NULL;
+            } else {
+                gSaved_games[i] = BrMemCalloc(1, sizeof(tSave_game), kMem_saved_game);
+                fread(gSaved_games[i], 1, the_size, f);
+                CorrectLoadByteOrdering(i);
+                if (CalcLSChecksum(gSaved_games[i]) != gSaved_games[i]->checksum || gSaved_games[i]->version != SAVEGAME_VERSION) {
+                    BrMemFree(gSaved_games[i]);
+                    gSaved_games[i] = NULL;
+                }
             }
+            fclose(f);
         } else {
             gSaved_games[i] = NULL;
         }
-        fclose(f);
     }
 }
 


### PR DESCRIPTION
Matched `LoadSavedGames` by restoring the original control-flow shape for file-open and size/checksum validation branches.

```text
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44b9b0: LoadSavedGames 100% match.

✨ OK! ✨
```

_AI generated_
