### PR TITLE
MakeSavedGame 100% effective match

### DIFF
--- a/src/DETHRACE/common/loadsave.c
+++ b/src/DETHRACE/common/loadsave.c
@@ -667,10 +667,10 @@ void MakeSavedGame(tSave_game** pSave_record) {
     (*pSave_record)->frank_or_annitude = gProgram_state.frank_or_anniness;
     (*pSave_record)->game_completed = gProgram_state.game_completed;
     (*pSave_record)->current_race_index = gProgram_state.current_race_index;
-    for (i = 0; i < gNumber_of_races; i++) {
+    for (i = 0; gNumber_of_races > i; i++) {
         (*pSave_record)->race_info[i].been_there_done_that = gRace_list[i].been_there_done_that;
     }
-    for (i = 0; i < gNumber_of_racers; i++) {
+    for (i = 0; gNumber_of_racers > i; i++) {
         (*pSave_record)->opponent_info[i].dead = gOpponents[i].dead;
     }
     (*pSave_record)->credits = gProgram_state.credits;
@@ -682,9 +682,7 @@ void MakeSavedGame(tSave_game** pSave_record) {
     (*pSave_record)->number_of_cars = gProgram_state.number_of_cars;
     (*pSave_record)->current_car_index = gProgram_state.current_car_index;
     (*pSave_record)->redo_race_index = gProgram_state.redo_race_index;
-    for (i = 0; i < COUNT_OF(gProgram_state.cars_available); i++) {
-        (*pSave_record)->cars_available[i] = gProgram_state.cars_available[i];
-    }
+    memcpy((*pSave_record)->cars_available, gProgram_state.cars_available, sizeof((*pSave_record)->cars_available));
     for (i = 0; i < COUNT_OF(gProgram_state.current_car.power_up_levels); i++) {
         (*pSave_record)->power_up_levels[i] = gProgram_state.current_car.power_up_levels[i];
     }


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

---
+++
@@ -0x44c4a5,47 +0x48af5b,47 @@
0x44c4a5 : mov ecx, dword ptr [ebp + 8]
0x44c4a8 : mov ecx, dword ptr [ecx]
0x44c4aa : mov dword ptr [ecx + 0x298], eax
0x44c4b0 : mov eax, dword ptr [gProgram_state+120 (OFFSET)] 	(loadsave.c:669)
0x44c4b5 : mov ecx, dword ptr [ebp + 8]
0x44c4b8 : mov ecx, dword ptr [ecx]
0x44c4ba : mov dword ptr [ecx + 0x394], eax
0x44c4c0 : mov dword ptr [ebp - 4], 0 	(loadsave.c:670)
0x44c4c7 : jmp 0x3
0x44c4cc : inc dword ptr [ebp - 4]
0x44c4cf : -mov eax, dword ptr [ebp - 4]
0x44c4d2 : -cmp dword ptr [gNumber_of_races (DATA)], eax
0x44c4d8 : -jle 0x1e
         : +mov eax, dword ptr [gNumber_of_races (DATA)]
         : +cmp dword ptr [ebp - 4], eax
         : +jge 0x1e
0x44c4de : mov eax, dword ptr [ebp - 4] 	(loadsave.c:671)
0x44c4e1 : shl eax, 4
0x44c4e4 : mov eax, dword ptr [eax + eax*2 + gRace_list[0].been_there_done_that (OFFSET)]
0x44c4eb : mov ecx, dword ptr [ebp - 4]
0x44c4ee : mov edx, dword ptr [ebp + 8]
0x44c4f1 : mov edx, dword ptr [edx]
0x44c4f3 : mov dword ptr [edx + ecx*4 + 0x3c], eax
0x44c4f7 : -jmp -0x30
         : +jmp -0x2f 	(loadsave.c:672)
0x44c4fc : mov dword ptr [ebp - 4], 0 	(loadsave.c:673)
0x44c503 : jmp 0x3
0x44c508 : inc dword ptr [ebp - 4]
0x44c50b : -mov eax, dword ptr [ebp - 4]
0x44c50e : -cmp dword ptr [gNumber_of_racers (DATA)], eax
0x44c514 : -jle 0x27
         : +mov eax, dword ptr [gNumber_of_racers (DATA)]
         : +cmp dword ptr [ebp - 4], eax
         : +jge 0x27
0x44c51a : mov eax, dword ptr [ebp - 4] 	(loadsave.c:674)
0x44c51d : lea eax, [eax + eax*8]
0x44c520 : shl eax, 4
0x44c523 : mov ecx, dword ptr [gOpponents (DATA)]
0x44c529 : mov eax, dword ptr [eax + ecx + 0x78]
0x44c52d : mov ecx, dword ptr [ebp - 4]
0x44c530 : mov edx, dword ptr [ebp + 8]
0x44c533 : mov edx, dword ptr [edx]
0x44c535 : mov dword ptr [edx + ecx*4 + 0x1cc], eax
0x44c53c : -jmp -0x39
         : +jmp -0x38 	(loadsave.c:675)
0x44c541 : mov eax, dword ptr [gProgram_state (DATA)] 	(loadsave.c:676)
0x44c546 : mov ecx, dword ptr [ebp + 8]
0x44c549 : mov ecx, dword ptr [ecx]
0x44c54b : mov dword ptr [ecx + 0x28c], eax
0x44c551 : mov eax, dword ptr [gProgram_state+28 (OFFSET)] 	(loadsave.c:677)
0x44c556 : mov ecx, dword ptr [ebp + 8]
0x44c559 : mov ecx, dword ptr [ecx]
0x44c55b : mov dword ptr [ecx + 0x290], eax
0x44c561 : lea edi, [gProgram_state+7030 (OFFSET)] 	(loadsave.c:678)
0x44c567 : mov ecx, 0xffffffff

---
+++
@@ -0x44c649,10 +0x48b0fd,12 @@
0x44c649 : mov eax, dword ptr [ebp - 4] 	(loadsave.c:687)
0x44c64c : mov eax, dword ptr [eax*4 + gProgram_state+6972 (OFFSET)]
0x44c653 : mov ecx, dword ptr [ebp - 4]
0x44c656 : mov edx, dword ptr [ebp + 8]
0x44c659 : mov edx, dword ptr [edx]
0x44c65b : mov dword ptr [edx + ecx*4 + 0x3a0], eax
0x44c662 : jmp -0x2b 	(loadsave.c:688)
0x44c667 : pop edi 	(loadsave.c:689)
0x44c668 : pop esi
0x44c669 : pop ebx
         : +leave 
         : +ret 


0x44c443: MakeSavedGame 100% effective match (differs, but only in ways that don't affect behavior).

✨ OK! ✨
```

*AI generated*
