### PR TITLE
SaveGoAhead 100% match

### DIFF
--- a/src/DETHRACE/common/loadsave.c
+++ b/src/DETHRACE/common/loadsave.c
@@ -739,19 +739,19 @@ int SaveGoAhead(int* pCurrent_choice, int* pCurrent_mode) {
 
     if (gTyping_slot != 0) {
         sprintf(s1, VARLZEROINT, 2, gProgram_state.rank);
-        if (gSaved_games[*pCurrent_choice] == NULL) {
-            s2[0] = '\0';
-        } else {
+        if (gSaved_games[*pCurrent_choice] != NULL) {
             sprintf(s2, VARLZEROINT, 2, gSaved_games[*pCurrent_choice]->rank);
+        } else {
+            s2[0] = '\0';
         }
         ChangeTextTo(gCurrent_graf_data->save_slot_rank_x_offset,
             gCurrent_graf_data->save_slot_y_offset + *pCurrent_choice * gCurrent_graf_data->rolling_letter_y_pitch,
             s1, s2);
         sprintf(s1, VARLZEROINT, 6, gProgram_state.credits);
-        if (gSaved_games[*pCurrent_choice] == NULL) {
-            s2[0] = '\0';
-        } else {
+        if (gSaved_games[*pCurrent_choice] != NULL) {
             sprintf(s2, VARLZEROINT, 6, gSaved_games[*pCurrent_choice]->credits);
+        } else {
+            s2[0] = '\0';
         }
         ChangeTextTo(gCurrent_graf_data->save_slot_credits_x_offset,
             gCurrent_graf_data->save_slot_y_offset + *pCurrent_choice * gCurrent_graf_data->rolling_letter_y_pitch,


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44cb2d: SaveGoAhead 100% match.

✨ OK! ✨
```

*AI generated*
