### PR TITLE
DoSaveGame 100% match

### DIFF
--- a/src/DETHRACE/common/loadsave.c
+++ b/src/DETHRACE/common/loadsave.c
@@ -1020,7 +1020,10 @@ void DoSaveGame(int pSave_allowed) {
     }
 #endif
 
-    if (gNet_mode == eNet_mode_none) {
+    if (gNet_mode != eNet_mode_none) {
+        SuspendPendingFlic();
+        DoErrorInterface(kMiscString_CannotSaveGameInNetworkPlay);
+    } else {
         DRS3StopOutletSound(gEffects_outlet);
         gProgram_state.saving = 1;
         gSave_allowed = pSave_allowed;
@@ -1038,8 +1041,5 @@ void DoSaveGame(int pSave_allowed) {
         }
         DisposeSavedGames();
         gProgram_state.saving = 0;
-    } else {
-        SuspendPendingFlic();
-        DoErrorInterface(kMiscString_CannotSaveGameInNetworkPlay);
     }
 }


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44cdfd: DoSaveGame 100% match.

✨ OK! ✨
```

*AI generated*
