### PR TITLE
DRStdioRead 100% match

### DIFF
--- a/src/DETHRACE/common/drfile.c
+++ b/src/DETHRACE/common/drfile.c
@@ -49,7 +49,8 @@ void DRStdioClose(void* f) {
 // FUNCTION: CARM95 0x0044cfa1
 br_size_t DRStdioRead(void* buf, br_size_t size, unsigned int n, void* f) {
     br_size_t result;
-    return gOld_file_system->read(buf, size, n, f);
+    result = gOld_file_system->read(buf, size, n, f);
+    return result;
 }
 
 // IDA: br_size_t __cdecl DRStdioWrite(void *buf, br_size_t size, unsigned int n, void *f)


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44cfa1: DRStdioRead 100% match.

✨ OK! ✨
```

*AI generated*
