### PR TITLE
DRStdioWrite 100% match

### DIFF
--- a/src/DETHRACE/common/drfile.c
+++ b/src/DETHRACE/common/drfile.c
@@ -56,7 +56,8 @@ br_size_t DRStdioRead(void* buf, br_size_t size, unsigned int n, void* f) {
 // FUNCTION: CARM95 0x0044cfd5
 br_size_t DRStdioWrite(void* buf, br_size_t size, unsigned int n, void* f) {
     br_size_t result;
-    return gOld_file_system->write(buf, size, n, f);
+    result = gOld_file_system->write(buf, size, n, f);
+    return result;
 }
 
 // IDA: void __cdecl InstallDRFileCalls()


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44cfd5: DRStdioWrite 100% match.

✨ OK! ✨
```

*AI generated*
