### PR TITLE
TogglePratcam 100% match

### DIFF
--- a/src/DETHRACE/common/pratcam.c
+++ b/src/DETHRACE/common/pratcam.c
@@ -97,8 +97,9 @@ void TogglePratcam(void) {
         the_time = GetTotalTime();
         gProgram_state.prat_cam_on = !gProgram_state.prat_cam_on;
         time_diff = the_time - gProgram_state.pratcam_move_start;
-        gProgram_state.pratcam_move_start = the_time;
-        if (time_diff <= 400) {
+        if (time_diff > 400) {
+            gProgram_state.pratcam_move_start = the_time;
+        } else {
             gProgram_state.pratcam_move_start = the_time - 400 + time_diff;
         }
     }


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44d0ef: TogglePratcam 100% match.

✨ OK! ✨
```

*AI generated*
