### PR TITLE
ChangeAmbientPratcam 100% effective match

### DIFF
--- a/src/DETHRACE/common/pratcam.c
+++ b/src/DETHRACE/common/pratcam.c
@@ -285,23 +285,18 @@ void ChangeAmbientPratcamNow(int pIndex, int pStart_chunk) {
 // FUNCTION: CARM95 0x0044d1f0
 void ChangeAmbientPratcam(int pIndex) {
 
-    if (gRace_finished) {
-        return;
-    }
-    if (gInterface_within_race_mode) {
-        return;
-    }
-    if (pIndex == gCurrent_ambient_prat_sequence) {
-        return;
-    }
-    if (!gProgram_state.prat_cam_on) {
-        return;
-    }
-
-    if (gCurrent_pratcam_index == -1) {
-        ChangeAmbientPratcamNow(pIndex, 0);
+    if (gRace_finished || gInterface_within_race_mode) {
+        ;
     } else {
-        gPending_ambient_prat = pIndex;
+        if (pIndex != gCurrent_ambient_prat_sequence
+            && !gRace_finished
+            && gProgram_state.prat_cam_on) {
+            if (gCurrent_pratcam_index != -1) {
+                gPending_ambient_prat = pIndex;
+            } else {
+                ChangeAmbientPratcamNow(pIndex, 0);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

---
+++
@@ -0x44d1f0,22 +0x4a26be,22 @@
0x44d1f0 : push ebp 	(pratcam.c:286)
0x44d1f1 : mov ebp, esp
0x44d1f3 : push ebx
0x44d1f4 : push esi
0x44d1f5 : push edi
0x44d1f6 : cmp dword ptr [gRace_finished (DATA)], 0 	(pratcam.c:288)
0x44d1fd : jne 0xd
0x44d203 : cmp dword ptr [gInterface_within_race_mode (DATA)], 0
0x44d20a : je 0x5
0x44d210 : -jmp 0x50
0x44d215 : -mov eax, dword ptr [gCurrent_ambient_prat_sequence (DATA)]
0x44d21a : -cmp dword ptr [ebp + 8], eax
         : +jmp 0x51 	(pratcam.c:290)
         : +mov eax, dword ptr [ebp + 8] 	(pratcam.c:293)
         : +cmp dword ptr [gCurrent_ambient_prat_sequence (DATA)], eax
0x44d21d : je 0x42
0x44d223 : cmp dword ptr [gRace_finished (DATA)], 0
0x44d22a : jne 0x35
0x44d230 : cmp dword ptr [gProgram_state+76 (OFFSET)], 0
0x44d237 : je 0x28
0x44d23d : cmp dword ptr [gCurrent_pratcam_index (DATA)], -1 	(pratcam.c:294)
0x44d244 : je 0xd
0x44d24a : mov eax, dword ptr [ebp + 8] 	(pratcam.c:295)
0x44d24d : mov dword ptr [gPending_ambient_prat (DATA)], eax
0x44d252 : jmp 0xe 	(pratcam.c:296)


0x44d1f0: ChangeAmbientPratcam 100% effective match (differs, but only in ways that don't affect behavior).

✨ OK! ✨
```

*AI generated*
