### PR TITLE
PratcamEvent 100% match

### DIFF
--- a/src/DETHRACE/common/pratcam.c
+++ b/src/DETHRACE/common/pratcam.c
@@ -317,10 +317,7 @@ void PratcamEventNow(int pIndex) {
 // FUNCTION: CARM95 0x0044d517
 void PratcamEvent(int pIndex) {
 
-    if (gRace_finished) {
-        return;
-    }
-    if (gInterface_within_race_mode) {
+    if (gRace_finished || gInterface_within_race_mode) {
         return;
     }
 #if defined(DETHRACE_FIX_BUGS)
@@ -329,13 +326,11 @@ void PratcamEvent(int pIndex) {
         return;
     }
 #endif
-    if (gPratcam_sequences[pIndex].precedence <= gCurrent_pratcam_precedence) {
-        return;
+    if (gPratcam_sequences[pIndex].precedence > gCurrent_pratcam_precedence) {
+        if (gRace_finished == 0 && gProgram_state.prat_cam_on) {
+            PratcamEventNow(pIndex);
+        }
     }
-    if (!gProgram_state.prat_cam_on) {
-        return;
-    }
-    PratcamEventNow(pIndex);
 }
 
 // IDA: int __cdecl HighResPratBufferWidth()

--- a/src/DETHRACE/common/pratcam.c
+++ b/src/DETHRACE/common/pratcam.c
@@ -327,7 +327,7 @@ void PratcamEvent(int pIndex) {
     }
 #endif
     if (gPratcam_sequences[pIndex].precedence > gCurrent_pratcam_precedence) {
-        if (gRace_finished == 0 && gProgram_state.prat_cam_on) {
+        if (!gRace_finished && gProgram_state.prat_cam_on) {
             PratcamEventNow(pIndex);
         }
     }


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44d517: PratcamEvent 100% match.

✨ OK! ✨
```

*AI generated*
