### PR TITLE
MoveRaceList 100% effective match

### DIFF
--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -241,12 +241,10 @@ void MoveRaceList(int pFrom, int pTo, tS32 pTime_to_move) {
     int pitch;
 
     pitch = gCurrent_graf_data->choose_race_y_pitch;
+    move_distance = (pTo - pFrom) * pitch;
     start_time = PDGetTotalTime();
-    while (1) {
-        the_time = PDGetTotalTime();
-        if (start_time + pTime_to_move <= the_time)
-            break;
-        DrawRaceList((the_time - start_time) * (pTo - pFrom) * pitch / pTime_to_move + pitch * pFrom);
+    while (start_time + pTime_to_move > (the_time = PDGetTotalTime())) {
+        DrawRaceList((the_time - start_time) * move_distance / pTime_to_move + pitch * pFrom);
     }
     DrawRaceList(pitch * pTo);
 }


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

---
+++
@@ -0x44e8d5,36 +0x4a3755,36 @@
0x44e8d5 : mov eax, dword ptr [eax + 0x160]
0x44e8db : mov dword ptr [ebp - 0xc], eax
0x44e8de : mov eax, dword ptr [ebp + 0xc] 	(racestrt.c:244)
0x44e8e1 : sub eax, dword ptr [ebp + 8]
0x44e8e4 : imul eax, dword ptr [ebp - 0xc]
0x44e8e8 : mov dword ptr [ebp - 4], eax
0x44e8eb : call PDGetTotalTime (FUNCTION) 	(racestrt.c:245)
0x44e8f0 : mov dword ptr [ebp - 0x10], eax
0x44e8f3 : call PDGetTotalTime (FUNCTION) 	(racestrt.c:246)
0x44e8f8 : mov dword ptr [ebp - 8], eax
0x44e8fb : -mov eax, dword ptr [ebp - 0x10]
0x44e8fe : -add eax, dword ptr [ebp + 0x10]
         : +mov eax, dword ptr [ebp + 0x10]
         : +add eax, dword ptr [ebp - 0x10]
0x44e901 : cmp eax, dword ptr [ebp - 8]
0x44e904 : jle 0x25
0x44e90a : mov eax, dword ptr [ebp - 8] 	(racestrt.c:247)
0x44e90d : sub eax, dword ptr [ebp - 0x10]
0x44e910 : imul eax, dword ptr [ebp - 4]
0x44e914 : cdq 
0x44e915 : idiv dword ptr [ebp + 0x10]
0x44e918 : -mov ecx, dword ptr [ebp - 0xc]
0x44e91b : -imul ecx, dword ptr [ebp + 8]
         : +mov ecx, dword ptr [ebp + 8]
         : +imul ecx, dword ptr [ebp - 0xc]
0x44e91f : add eax, ecx
0x44e921 : push eax
0x44e922 : call DrawRaceList (FUNCTION)
0x44e927 : add esp, 4
0x44e92a : jmp -0x3c 	(racestrt.c:248)
0x44e92f : -mov eax, dword ptr [ebp - 0xc]
0x44e932 : -imul eax, dword ptr [ebp + 0xc]
         : +mov eax, dword ptr [ebp + 0xc] 	(racestrt.c:249)
         : +imul eax, dword ptr [ebp - 0xc]
0x44e936 : push eax
0x44e937 : call DrawRaceList (FUNCTION)
0x44e93c : add esp, 4
0x44e93f : pop edi 	(racestrt.c:250)
0x44e940 : pop esi
0x44e941 : pop ebx
0x44e942 : leave 
0x44e943 : ret 


0x44e8c7: MoveRaceList 100% effective match (differs, but only in ways that don't affect behavior).

✨ OK! ✨
```

*AI generated*
