### PR TITLE
DrawRaceList 100% effective match

### DIFF
--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -147,18 +147,21 @@ void DrawRaceList(int pOffset) {
         gCurrent_graf_data->choose_race_y_bottom - gCurrent_graf_data->choose_race_y_top,
         0);
     pitch = gCurrent_graf_data->choose_race_y_pitch;
+    font_height = gBig_font->glyph_y;
     for (i = 0; i < gNumber_of_races; i++) {
         y = pitch * i + gCurrent_graf_data->choose_race_curr_y - pOffset;
-        if (gCurrent_graf_data->choose_race_y_top <= (y - (TranslationMode() ? 2 : 0)) && (y + gBig_font->glyph_y) < gCurrent_graf_data->choose_race_line_y) {
-            if ((gProgram_state.rank > gRace_list[i].rank_required || gProgram_state.rank < gRace_list[i].best_rank) && !gProgram_state.game_completed && !gChange_race_net_mode) {
+        if (gCurrent_graf_data->choose_race_y_top <= (y - (TranslationMode() ? 2 : 0)) && (y + font_height) < gCurrent_graf_data->choose_race_line_y) {
+            if (!((gProgram_state.rank > gRace_list[i].rank_required || gProgram_state.rank < gRace_list[i].best_rank) && !gProgram_state.game_completed && !gChange_race_net_mode)) {
+                if (gCurrent_graf_data->choose_race_curr_y == y) {
+                    rank_colour = 5;
+                    text_colour = 1;
+                } else {
+                    rank_colour = 198;
+                    text_colour = 201;
+                }
+            } else {
                 rank_colour = 44;
                 text_colour = 49;
-            } else if (gCurrent_graf_data->choose_race_curr_y == y) {
-                rank_colour = 5;
-                text_colour = 1;
-            } else {
-                rank_colour = 198;
-                text_colour = 201;
             }
             if (!gChange_race_net_mode) {
                 sprintf(rank_str, "%2d", gRace_list[i].rank_required);
@@ -183,7 +186,7 @@ void DrawRaceList(int pOffset) {
 #endif
                     gBack_screen,
                     gCurrent_graf_data->choose_race_bullet_left,
-                    y + (gBig_font->glyph_y - gBullet_image->height) / 2,
+                    y + (font_height - gBullet_image->height) / 2,
                     gBullet_image,
                     0,
                     0,
@@ -192,17 +195,10 @@ void DrawRaceList(int pOffset) {
             }
         }
     }
-    if (gChange_race_net_mode) {
-        strcpy(rank_str, GetMiscString(gNet_race_sequence__racestrt == 1 ? kMiscString_SUBSEQUENT_RACES_WILL_BE_RANDOM : kMiscString_RACES_WILL_CONTINUE_DOWN_THIS_LIST));
-        TransBrPixelmapText(gBack_screen,
-            (right_most + left_most - BrPixelmapTextWidth(gBack_screen, gBig_font, rank_str)) / 2,
-            gCurrent_graf_data->choose_race_current_text_y,
-            5,
-            gBig_font,
-            rank_str);
-    } else {
+    if (!gChange_race_net_mode) {
         sprintf(rank_str, "%s%d", GetMiscString(kMiscString_YourCurrentRankIs), gProgram_state.rank);
-        text_x = (gCurrent_graf_data->choose_race_left + gCurrent_graf_data->choose_race_right) / 2 - BrPixelmapTextWidth(gBack_screen, gBig_font, rank_str) / 2;
+        text_width = BrPixelmapTextWidth(gBack_screen, gBig_font, rank_str);
+        text_x = (gCurrent_graf_data->choose_race_left + gCurrent_graf_data->choose_race_right) / 2 - text_width / 2;
         TransBrPixelmapText(gBack_screen,
             text_x,
             gCurrent_graf_data->choose_race_current_text_y,
@@ -210,8 +206,17 @@ void DrawRaceList(int pOffset) {
             gBig_font,
             GetMiscString(kMiscString_YourCurrentRankIs));
         sprintf(rank_str, "%d", gProgram_state.rank);
+        text_width = BrPixelmapTextWidth(gBack_screen, gBig_font, GetMiscString(kMiscString_YourCurrentRankIs));
         TransBrPixelmapText(gBack_screen,
-            text_x + BrPixelmapTextWidth(gBack_screen, gBig_font, GetMiscString(kMiscString_YourCurrentRankIs)),
+            text_x + text_width,
+            gCurrent_graf_data->choose_race_current_text_y,
+            5,
+            gBig_font,
+            rank_str);
+    } else {
+        strcpy(rank_str, GetMiscString(gNet_race_sequence__racestrt == 1 ? kMiscString_SUBSEQUENT_RACES_WILL_BE_RANDOM : kMiscString_RACES_WILL_CONTINUE_DOWN_THIS_LIST));
+        TransBrPixelmapText(gBack_screen,
+            (right_most + left_most - BrPixelmapTextWidth(gBack_screen, gBig_font, rank_str)) / 2,
             gCurrent_graf_data->choose_race_current_text_y,
             5,
             gBig_font,
@@ -227,7 +232,7 @@ void DrawRaceList(int pOffset) {
         left_most,
         gCurrent_graf_data->choose_race_box_top - 1,
         right_most,
-        2 * gCurrent_graf_data->choose_race_curr_y - gCurrent_graf_data->choose_race_box_top + gBig_font->glyph_y,
+        box_bot = 2 * gCurrent_graf_data->choose_race_curr_y - gCurrent_graf_data->choose_race_box_top + font_height,
         3);
     PDScreenBufferSwap(0);
 }


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

---
+++
@@ -0x44ea11,23 +0x4a324d,23 @@
0x44ea11 : mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(racestrt.c:149)
0x44ea16 : mov eax, dword ptr [eax + 0x160]
0x44ea1c : mov dword ptr [ebp - 0x12c], eax
0x44ea22 : mov eax, dword ptr [gBig_font (DATA)] 	(racestrt.c:150)
0x44ea27 : xor ecx, ecx
0x44ea29 : mov cx, word ptr [eax + 6]
0x44ea2d : mov dword ptr [ebp - 4], ecx
0x44ea30 : mov dword ptr [ebp - 0x120], 0 	(racestrt.c:151)
0x44ea3a : jmp 0x6
0x44ea3f : inc dword ptr [ebp - 0x120]
0x44ea45 : -mov eax, dword ptr [gNumber_of_races (DATA)]
0x44ea4a : -cmp dword ptr [ebp - 0x120], eax
0x44ea50 : -jge 0x259
         : +mov eax, dword ptr [ebp - 0x120]
         : +cmp dword ptr [gNumber_of_races (DATA)], eax
         : +jle 0x259
0x44ea56 : mov eax, dword ptr [ebp - 0x12c] 	(racestrt.c:152)
0x44ea5c : imul eax, dword ptr [ebp - 0x120]
0x44ea63 : mov ecx, dword ptr [gCurrent_graf_data (DATA)]
0x44ea69 : add eax, dword ptr [ecx + 0x164]
0x44ea6f : sub eax, dword ptr [ebp + 8]
0x44ea72 : mov dword ptr [ebp - 0x11c], eax
0x44ea78 : mov ebx, dword ptr [ebp - 0x11c] 	(racestrt.c:153)
0x44ea7e : call TranslationMode (FUNCTION)
0x44ea83 : cmp eax, 1
0x44ea86 : mov eax, 0

---
+++
@@ -0x44ec87,21 +0x4a34c4,21 @@
0x44ec87 : mov ecx, dword ptr [ebp - 0x11c]
0x44ec8d : add ecx, eax
0x44ec8f : push ecx
0x44ec90 : mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x44ec95 : mov eax, dword ptr [eax + 0x14c]
0x44ec9b : push eax
0x44ec9c : mov eax, dword ptr [gBack_screen (DATA)]
0x44eca1 : push eax
0x44eca2 : call BrPixelmapRectangleCopy (FUNCTION)
0x44eca7 : add esp, 0x20
0x44ecaa : -jmp -0x270
         : +jmp -0x271 	(racestrt.c:197)
0x44ecaf : cmp dword ptr [gChange_race_net_mode (DATA)], 0 	(racestrt.c:198)
0x44ecb6 : jne 0x12f
0x44ecbc : mov eax, dword ptr [gProgram_state+28 (OFFSET)] 	(racestrt.c:199)
0x44ecc1 : push eax
0x44ecc2 : push 0x1b
0x44ecc4 : call GetMiscString (FUNCTION)
0x44ecc9 : add esp, 4
0x44eccc : push eax
0x44eccd : push "%s%d" (STRING)
0x44ecd2 : lea eax, [ebp - 0x108]

---
+++
@@ -0x44eda5,22 +0x4a35e2,22 @@
0x44eda5 : and eax, 0xffff
0x44edaa : mov dword ptr [ebp - 0x10c], eax
0x44edb0 : lea eax, [ebp - 0x108] 	(racestrt.c:215)
0x44edb6 : push eax
0x44edb7 : mov eax, dword ptr [gBig_font (DATA)]
0x44edbc : push eax
0x44edbd : push 5
0x44edbf : mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x44edc4 : mov eax, dword ptr [eax + 0x178]
0x44edca : push eax
0x44edcb : -mov eax, dword ptr [ebp - 0x10c]
0x44edd1 : -add eax, dword ptr [ebp - 0x118]
         : +mov eax, dword ptr [ebp - 0x118]
         : +add eax, dword ptr [ebp - 0x10c]
0x44edd7 : push eax
0x44edd8 : mov eax, dword ptr [gBack_screen (DATA)]
0x44eddd : push eax
0x44edde : call TransBrPixelmapText (FUNCTION)
0x44ede3 : add esp, 0x18
0x44ede6 : jmp 0xa0 	(racestrt.c:216)
0x44edeb : mov eax, dword ptr [gNet_race_sequence__racestrt (DATA)] 	(racestrt.c:217)
0x44edf0 : dec eax
0x44edf1 : cmp eax, 1
0x44edf4 : mov eax, 0xcb


0x44e944: DrawRaceList 100% effective match (differs, but only in ways that don't affect behavior).

✨ OK! ✨
```

*AI generated*
