### PR TITLE
ChangeRace 100% match

### DIFF
--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -388,7 +388,7 @@ int ChangeRace(int* pRace_index, int pNet_mode, tNet_sequence_type pNet_race_seq
     gChange_race_net_mode = pNet_mode;
     gStart_interface_spec = &interface_spec;
     gCurrent_race_index = *pRace_index;
-    if (pNet_mode != 0) {
+    if (pNet_mode) {
         gBullet_image = NULL;
     } else {
         gBullet_image = LoadPixelmap("BULLET.PIX");

--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -388,10 +388,10 @@ int ChangeRace(int* pRace_index, int pNet_mode, tNet_sequence_type pNet_race_seq
     gChange_race_net_mode = pNet_mode;
     gStart_interface_spec = &interface_spec;
     gCurrent_race_index = *pRace_index;
-    if (pNet_mode == 0) {
-        gBullet_image = LoadPixelmap("BULLET.PIX");
-    } else {
+    if (pNet_mode != 0) {
         gBullet_image = NULL;
+    } else {
+        gBullet_image = LoadPixelmap("BULLET.PIX");
     }
     result = DoInterfaceScreen(&interface_spec, pNet_mode != 0, 0);
     if (result == 0) {


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44f131: ChangeRace 100% match.

✨ OK! ✨
```

*AI generated*
