### PR TITLE
PartsShopGoAhead 100% match

### DIFF
--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -952,8 +952,9 @@ int PartsShopGoAhead(int* pCurrent_choice, int* pCurrent_mode) {
         RemoveTransientBitmaps(1);
         DontLetFlicFuckWithPalettes();
         TurnFlicTransparencyOn();
+        flic_index = gStart_interface_spec->pushed_flics[*pCurrent_choice].flic_index;
         RunFlicAt(
-            gStart_interface_spec->pushed_flics[*pCurrent_choice].flic_index,
+            flic_index,
             gStart_interface_spec->pushed_flics[*pCurrent_choice].x[gGraf_data_index],
             gStart_interface_spec->pushed_flics[*pCurrent_choice].y[gGraf_data_index]);
         TurnFlicTransparencyOff();
@@ -966,8 +967,8 @@ int PartsShopGoAhead(int* pCurrent_choice, int* pCurrent_mode) {
         RunFlic(261);
         AddToFlicQueue(
             gStart_interface_spec->flicker_on_flics[*pCurrent_choice].flic_index,
-            gStart_interface_spec->flicker_on_flics[*pCurrent_choice].x[gGraf_data_index],
-            gStart_interface_spec->flicker_on_flics[*pCurrent_choice].y[gGraf_data_index],
+            *(int*)((char*)gStart_interface_spec->flicker_on_flics + *pCurrent_choice * 20 + gGraf_data_index * 4 + 4),
+            *(int*)((char*)gStart_interface_spec->flicker_on_flics + *pCurrent_choice * 20 + gGraf_data_index * 4 + 12),
             1);
         DrawPartsLabel();
         SetPartsImage();
@@ -977,9 +978,9 @@ int PartsShopGoAhead(int* pCurrent_choice, int* pCurrent_mode) {
         return 0;
     } else if (*pCurrent_mode == 1) {
         AddToFlicQueue(
-            gStart_interface_spec->flicker_on_flics[4].flic_index,
-            gStart_interface_spec->flicker_on_flics[4].x[gGraf_data_index],
-            gStart_interface_spec->flicker_on_flics[4].y[gGraf_data_index],
+            gStart_interface_spec->pushed_flics[4].flic_index,
+            gStart_interface_spec->pushed_flics[4].x[gGraf_data_index],
+            gStart_interface_spec->pushed_flics[4].y[gGraf_data_index],
             1);
         DoExchangePart();
         return 0;

--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -967,8 +967,8 @@ int PartsShopGoAhead(int* pCurrent_choice, int* pCurrent_mode) {
         RunFlic(261);
         AddToFlicQueue(
             gStart_interface_spec->flicker_on_flics[*pCurrent_choice].flic_index,
-            *(int*)((char*)gStart_interface_spec->flicker_on_flics + *pCurrent_choice * 20 + gGraf_data_index * 4 + 4),
-            *(int*)((char*)gStart_interface_spec->flicker_on_flics + *pCurrent_choice * 20 + gGraf_data_index * 4 + 12),
+            gStart_interface_spec->flicker_on_flics[*pCurrent_choice].x[gGraf_data_index],
+            gStart_interface_spec->flicker_on_flics[*pCurrent_choice].y[gGraf_data_index],
             1);
         DrawPartsLabel();
         SetPartsImage();


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44fbb7: PartsShopGoAhead 100% match.

✨ OK! ✨
```

*AI generated*
