### PR TITLE
DrawPartsLabel 100% match

### DIFF
--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -837,7 +837,6 @@ void DrawPartsLabel(void) {
         break;
     case eParts_offensive:
         RunFlicAt(264, gCurrent_graf_data->parts_label_x, gCurrent_graf_data->parts_label_y);
-        break;
     default:
         break;
     }


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44fdd1: DrawPartsLabel 100% match.

✨ OK! ✨
```

*AI generated*
