### PR TITLE
Match SetPartsImage

### DIFF
--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -892,8 +892,8 @@ void DrawPartsText(void) {
 void SetPartsImage(void) {
 
     ChangePanelFlic(0,
-        gProgram_state.current_car.power_ups[gPart_category].info[gPart_index].data_ptr,
-        gProgram_state.current_car.power_ups[gPart_category].info[gPart_index].data_length);
+        ((tPart_info*)((char*)gProgram_state.current_car.power_ups[gPart_category].info + gPart_index * sizeof(tPart_info)))->data_ptr,
+        ((tPart_info*)((char*)gProgram_state.current_car.power_ups[gPart_category].info + gPart_index * sizeof(tPart_info)))->data_length);
     TellyInImage(GetPanelPixelmap(0), gCurrent_graf_data->parts_image_x, gCurrent_graf_data->parts_image_y);
     DrawPartsText();
 }


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x44ff71: SetPartsImage 100% match.

✨ OK! ✨
```

*AI generated*
