### PR TITLE
CalcPartsIndex 100% match

### DIFF
--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -919,10 +919,14 @@ int GetPartsMax(void) {
 void CalcPartsIndex(void) {
     int current_index;
 
-    gPart_index = gProgram_state.current_car.power_up_levels[gPart_category];
-    if (gPart_index + 1 < gProgram_state.current_car.power_ups[gPart_category].number_of_parts && (gProgram_state.rank <= gProgram_state.current_car.power_ups[gPart_category].info[gPart_index + 1].rank_required || gProgram_state.game_completed)) {
-        gPart_index += 1;
+    current_index = gProgram_state.current_car.power_up_levels[gPart_category];
+    if (current_index < gProgram_state.current_car.power_ups[gPart_category].number_of_parts - 1) {
+        if (gProgram_state.rank <= gProgram_state.current_car.power_ups[gPart_category].info[current_index + 1].rank_required || gProgram_state.game_completed) {
+            gPart_index = current_index + 1;
+            return;
+        }
     }
+    gPart_index = current_index;
 }
 
 // IDA: void __cdecl DoExchangePart()


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x45039b: CalcPartsIndex 100% match.

✨ OK! ✨
```

*AI generated*
