### PR TITLE
DoExchangePart 100% match

### DIFF
--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -932,14 +932,14 @@ void DoExchangePart(void) {
     int cost;
 
     CalcPartPrice(gPart_category, gPart_index, &price, &cost);
-    if (cost == 0 || gProgram_state.credits < cost) {
-        DRS3StartSound(gEffects_outlet, 3100);
-    } else {
+    if (cost != 0 && gProgram_state.credits >= cost) {
         gJust_bought_part = 1;
         DRS3StartSound(gEffects_outlet, 3101);
         BuyPart(gPart_category, gPart_index);
         ErasePartsText(1);
         DrawPartsText();
+    } else {
+        DRS3StartSound(gEffects_outlet, 3100);
     }
 }
 


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.6s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x450429: DoExchangePart 100% match.

✨ OK! ✨
```

*AI generated*
