### PR TITLE
BuyPart 100% match

### DIFF
--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -776,16 +776,18 @@ int BuyPart(int pCategory, int pIndex) {
     int cost;
 
     CalcPartPrice(pCategory, pIndex, &price, &cost);
-    if (cost == 0) {
-        return 1;
-    } else if (gProgram_state.credits < cost) {
-        return 0;
-    } else {
-        gProgram_state.credits -= cost;
-        if (gProgram_state.credits > 999999) {
-            gProgram_state.credits = 999999;
+    if (cost != 0) {
+        if (gProgram_state.credits >= cost) {
+            gProgram_state.credits -= cost;
+            if (gProgram_state.credits > 999999) {
+                gProgram_state.credits = 999999;
+            }
+            gProgram_state.current_car.power_up_levels[pCategory] = pIndex;
+            return 1;
+        } else {
+            return 0;
         }
-        gProgram_state.current_car.power_up_levels[pCategory] = pIndex;
+    } else {
         return 1;
     }
 }


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x4504c4: BuyPart 100% match.

✨ OK! ✨
```

*AI generated*
