### PR TITLE
GetPartsMax 100% match

### DIFF
--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -904,10 +904,7 @@ int GetPartsMax(void) {
     int i;
 
     for (i = gProgram_state.current_car.power_ups[gPart_category].number_of_parts - 1; i >= 0; i--) {
-        if (gProgram_state.rank <= gProgram_state.current_car.power_ups[gPart_category].info[i].rank_required) {
-            return i;
-        }
-        if (gProgram_state.game_completed) {
+        if (gProgram_state.rank <= gProgram_state.current_car.power_ups[gPart_category].info[i].rank_required || gProgram_state.game_completed) {
             return i;
         }
     }


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x4506e4: GetPartsMax 100% match.

✨ OK! ✨
```

*AI generated*
