### PR TITLE
PartsArrowsOn 100% match

### DIFF
--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -1080,12 +1080,12 @@ int PartsArrowsOn(int* pCurrent_choice, int* pCurrent_mode) {
 
     AddToFlicQueue(
         gStart_interface_spec->flicker_on_flics[5].flic_index,
-        gStart_interface_spec->flicker_on_flics[5].x[gGraf_data_index],
-        gStart_interface_spec->flicker_on_flics[5].y[gGraf_data_index],
+        gStart_interface_spec->flicker_on_flics[5].x[gGraf_data_index * 1],
+        gStart_interface_spec->flicker_on_flics[5].y[gGraf_data_index * 1],
         1);
     AddToFlicQueue(gStart_interface_spec->flicker_on_flics[6].flic_index,
-        gStart_interface_spec->flicker_on_flics[6].x[gGraf_data_index],
-        gStart_interface_spec->flicker_on_flics[6].y[gGraf_data_index],
+        gStart_interface_spec->flicker_on_flics[6].x[gGraf_data_index * 1],
+        gStart_interface_spec->flicker_on_flics[6].y[gGraf_data_index * 1],
         1);
     return 0;
 }


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x45093f: PartsArrowsOn 100% match.

✨ OK! ✨
```

*AI generated*
