### PR TITLE
DoPartsShop 100% match

### DIFF
--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -1196,6 +1196,7 @@ void DoPartsShop(int pFade_away) {
         NULL
     };
     int result;
+
     LoadParts();
     gFade_away_parts_shop = pFade_away;
     InitialiseFlicPanel(0,

--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -1196,7 +1196,6 @@ void DoPartsShop(int pFade_away) {
         NULL
     };
     int result;
-
     LoadParts();
     gFade_away_parts_shop = pFade_away;
     InitialiseFlicPanel(0,
@@ -1209,7 +1208,7 @@ void DoPartsShop(int pFade_away) {
     gJust_bought_part = 0;
     gRefund_rate = 75;
     CalcPartsIndex();
-    DoInterfaceScreen(&interface_spec, gFaded_palette, 3);
+    result = DoInterfaceScreen(&interface_spec, gFaded_palette, 3);
     DisposeFlicPanel(0);
     UnlockParts();
     gProgram_state.parts_shop_visited = 1;


### PR DESCRIPTION
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
rosetta error: invalid gdt selector index 5
 -- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x450e06: DoPartsShop 100% match.

✨ OK! ✨
```

*AI generated*
