### PR TITLE
SelectRaceDone 100% match

### DIFF
--- a/reccmp/asm-match.sh
+++ b/reccmp/asm-match.sh
@@ -28,6 +28,7 @@ else
 fi
 
 docker run --rm --platform linux/amd64 \
+  -e "XDG_RUNTIME_DIR=/tmp" \
   -e CMAKE_FLAGS="-G Ninja -DCMAKE_BUILD_TYPE=Debug -DMSVC_42_FOR_RECCMP=on" \
   -v "$WORKDIR:/source" \
   -v "$WORKDIR/build_msvc42:/build" \

--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -1331,8 +1331,9 @@ int SelectRaceDone(int pCurrent_choice, int pCurrent_mode, int pGo_ahead, int pE
     DismissSceneyMappyInfoVieweyThing();
     if (pEscaped) {
         return -1;
+    } else {
+        return pCurrent_choice;
     }
-    return pCurrent_choice;
 }
 
 // IDA: int __usercall StartRaceGoAhead@<EAX>(int *pCurrent_choice@<EAX>, int *pCurrent_mode@<EDX>)


### PR DESCRIPTION
```
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

0x450eb9: SelectRaceDone 100% match.

✨ OK! ✨
```

*AI generated*
