### PR TITLE
DoGridTransition 100% effective match

### DIFF
--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -2084,15 +2084,12 @@ void DoGridTransition(int pFirst_index, int pSecond_index) {
     tU32 start_time;
     tU32 the_time;
 
-    if (pFirst_index != pSecond_index) {
+    if (pFirst_index == pSecond_index) {
+    } else {
         start_time = PDGetTotalTime();
         gSwap_grid_1 = pFirst_index;
         gSwap_grid_2 = pSecond_index;
-        while (1) {
-            the_time = PDGetTotalTime();
-            if (start_time + 150 <= the_time) {
-                break;
-            }
+        while ((the_time = PDGetTotalTime()) < start_time + 150) {
             RemoveTransientBitmaps(1);
             gGrid_transition_stage = 100 * (the_time - start_time) / 150;
             DrawGrid(gCurrent_graf_data->grid_x_pitch * CalcGridOffset(gOur_starting_position), 0);


### PR DESCRIPTION
```
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.4s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

---
+++
@@ -0x4530ca,18 +0x4a7699,18 @@
0x4530ca : push ebp 	(racestrt.c:2083)
0x4530cb : mov ebp, esp
0x4530cd : sub esp, 8
0x4530d0 : push ebx
0x4530d1 : push esi
0x4530d2 : push edi
0x4530d3 : -mov eax, dword ptr [ebp + 0xc]
0x4530d6 : -cmp dword ptr [ebp + 8], eax
         : +mov eax, dword ptr [ebp + 8] 	(racestrt.c:2087)
         : +cmp dword ptr [ebp + 0xc], eax
0x4530d9 : jne 0x5
0x4530df : jmp 0xeb 	(racestrt.c:2088)
0x4530e4 : call PDGetTotalTime (FUNCTION) 	(racestrt.c:2089)
0x4530e9 : mov dword ptr [ebp - 8], eax
0x4530ec : mov eax, dword ptr [ebp + 8] 	(racestrt.c:2090)
0x4530ef : mov dword ptr [gSwap_grid_1 (DATA)], eax
0x4530f4 : mov eax, dword ptr [ebp + 0xc] 	(racestrt.c:2091)
0x4530f7 : mov dword ptr [gSwap_grid_2 (DATA)], eax
0x4530fc : call PDGetTotalTime (FUNCTION) 	(racestrt.c:2092)
0x453101 : mov dword ptr [ebp - 4], eax


0x4530ca: DoGridTransition 100% effective match (differs, but only in ways that don't affect behavior).

✨ OK! ✨
```

*AI generated*
