### PR TITLE
MoveGrid 100% effective match

### DIFF
--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -2038,15 +2038,12 @@ void MoveGrid(int pFrom, int pTo, tS32 pTime_to_move) {
     int pitch;
 
     pitch = gCurrent_graf_data->grid_x_pitch;
+    move_distance = (pTo - pFrom) * pitch;
     start_time = PDGetTotalTime();
-    while (1) {
-        the_time = PDGetTotalTime();
-        if (start_time + pTime_to_move <= the_time) {
-            break;
-        }
-        DrawGrid(pitch * pFrom + pitch * (pTo - pFrom) * (the_time - start_time) / pTime_to_move, 1);
+    while (pTime_to_move + start_time > (the_time = PDGetTotalTime())) {
+        DrawGrid(move_distance * (the_time - start_time) / pTime_to_move + pFrom * pitch, 1);
     }
-    DrawGrid(pitch * pTo, 1);
+    DrawGrid(pTo * pitch, 1);
 }
 
 // IDA: int __usercall CalcGridOffset@<EAX>(int pPosition@<EAX>)


### PR DESCRIPTION
```
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

---
+++
@@ -0x4531e2,38 +0x4a752c,38 @@
0x4531e2 : mov eax, dword ptr [eax + 0x180]
0x4531e8 : mov dword ptr [ebp - 0xc], eax
0x4531eb : mov eax, dword ptr [ebp + 0xc] 	(racestrt.c:2041)
0x4531ee : sub eax, dword ptr [ebp + 8]
0x4531f1 : imul eax, dword ptr [ebp - 0xc]
0x4531f5 : mov dword ptr [ebp - 4], eax
0x4531f8 : call PDGetTotalTime (FUNCTION) 	(racestrt.c:2042)
0x4531fd : mov dword ptr [ebp - 0x10], eax
0x453200 : call PDGetTotalTime (FUNCTION) 	(racestrt.c:2043)
0x453205 : mov dword ptr [ebp - 8], eax
0x453208 : -mov eax, dword ptr [ebp + 0x10]
0x45320b : -add eax, dword ptr [ebp - 0x10]
         : +mov eax, dword ptr [ebp - 0x10]
         : +add eax, dword ptr [ebp + 0x10]
0x45320e : cmp eax, dword ptr [ebp - 8]
0x453211 : jle 0x27
0x453217 : push 1 	(racestrt.c:2044)
0x453219 : mov eax, dword ptr [ebp - 8]
0x45321c : sub eax, dword ptr [ebp - 0x10]
0x45321f : imul eax, dword ptr [ebp - 4]
0x453223 : cdq 
0x453224 : idiv dword ptr [ebp + 0x10]
0x453227 : -mov ecx, dword ptr [ebp + 8]
0x45322a : -imul ecx, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp - 0xc]
         : +imul ecx, dword ptr [ebp + 8]
0x45322e : add eax, ecx
0x453230 : push eax
0x453231 : call DrawGrid (FUNCTION)
0x453236 : add esp, 8
0x453239 : jmp -0x3e 	(racestrt.c:2045)
0x45323e : push 1 	(racestrt.c:2046)
0x453240 : -mov eax, dword ptr [ebp + 0xc]
0x453243 : -imul eax, dword ptr [ebp - 0xc]
         : +mov eax, dword ptr [ebp - 0xc]
         : +imul eax, dword ptr [ebp + 0xc]
0x453247 : push eax
0x453248 : call DrawGrid (FUNCTION)
0x45324d : add esp, 8
0x453250 : pop edi 	(racestrt.c:2047)
0x453251 : pop esi
0x453252 : pop ebx
0x453253 : leave 
0x453254 : ret 


0x4531d4: MoveGrid 100% effective match (differs, but only in ways that don't affect behavior).

✨ OK! ✨
```

*AI generated*
