### PR TITLE
GridClickCar 100% effective match

### DIFF
--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -2370,16 +2370,20 @@ int GridClickCar(int* pCurrent_choice, int* pCurrent_mode, int pX_offset, int pY
     int base_pos;
     int x_coord;
 
-    rel_pos = ((gCurrent_graf_data->grid_bottom_clip - gCurrent_graf_data->grid_top_clip) / 2) < pY_offset;
-    if (rel_pos) {
+    if (((gCurrent_graf_data->grid_bottom_clip - gCurrent_graf_data->grid_top_clip) / 2) < pY_offset) {
+        rel_pos = 1;
         pX_offset -= gCurrent_graf_data->grid_x_stagger;
+    } else {
+        rel_pos = 0;
     }
     x_coord = pX_offset / gCurrent_graf_data->grid_x_pitch;
     if (x_coord > 2) {
         x_coord = 2;
     }
-    new_pos = 2 * x_coord + rel_pos + (gOur_starting_position & ~1) - 2;
-    if (new_pos >= 0 && new_pos < gCurrent_race.number_of_racers && gProgram_state.rank < gCurrent_race.opponent_list[new_pos].ranking) {
+    rel_pos += 2 * x_coord;
+    base_pos = (gOur_starting_position & ~1) - 2;
+    new_pos = rel_pos + base_pos;
+    if (new_pos >= 0 && new_pos < gCurrent_race.number_of_racers && gProgram_state.rank <= gCurrent_race.opponent_list[new_pos].ranking) {
         DRS3StartSound(gEffects_outlet, 3000);
         DoGridTransition(gOur_starting_position, new_pos);
     }


### PR DESCRIPTION
```
-- dethrace version unknown
-- Configuring done (0.5s)
-- Generating done (0.3s)
-- Build files have been written to: Z:/build
ninja: no work to do.
[INFO] Found CARM95 -> /original/CARM95.EXE
[INFO] Updating /source/reccmp-user.yml
[INFO] Parsing /build/CARM95.pdb ...
[ERROR] Failed to match function at 0x4ea9e0 with name '$$$00001(1)'

---
+++
@@ -0x4535df,22 +0x4a7fe6,22 @@
0x4535df : cmp dword ptr [ebp - 0xc], 2 	(racestrt.c:2380)
0x4535e3 : jle 0x7
0x4535e9 : mov dword ptr [ebp - 0xc], 2 	(racestrt.c:2381)
0x4535f0 : mov eax, dword ptr [ebp - 0xc] 	(racestrt.c:2383)
0x4535f3 : add eax, eax
0x4535f5 : add dword ptr [ebp - 8], eax
0x4535f8 : mov eax, dword ptr [gOur_starting_position (DATA)] 	(racestrt.c:2384)
0x4535fd : and eax, 0xfffffffe
0x453600 : sub eax, 2
0x453603 : mov dword ptr [ebp - 0x10], eax
0x453606 : -mov eax, dword ptr [ebp - 8]
0x453609 : -add eax, dword ptr [ebp - 0x10]
         : +mov eax, dword ptr [ebp - 0x10] 	(racestrt.c:2385)
         : +add eax, dword ptr [ebp - 8]
0x45360c : mov dword ptr [ebp - 4], eax
0x45360f : cmp dword ptr [ebp - 4], 0 	(racestrt.c:2386)
0x453613 : jl 0x4c
0x453619 : mov eax, dword ptr [ebp - 4]
0x45361c : cmp dword ptr [gCurrent_race+176 (OFFSET)], eax
0x453622 : jle 0x3d
0x453628 : mov eax, dword ptr [ebp - 4]
0x45362b : shl eax, 4
0x45362e : mov ecx, dword ptr [gProgram_state+28 (OFFSET)]
0x453634 : cmp dword ptr [eax + gCurrent_race+3456 (OFFSET)], ecx


0x453578: GridClickCar 100% effective match (differs, but only in ways that don't affect behavior).

✨ OK! ✨
```

*AI generated*
