### PR TITLE
ExitWhenReady 100% match

### DIFF
--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -2771,16 +2771,16 @@ int NetSynchStartGoAhead(int* pCurrent_choice, int* pCurrent_mode) {
 // FUNCTION: CARM95 0x0045412d
 int ExitWhenReady(int* pCurrent_choice, int* pCurrent_mode) {
 
-    if (!gSynch_race_start && gProgram_state.prog_status != eProg_game_starting) {
+    if (gSynch_race_start || gProgram_state.prog_status == eProg_game_starting) {
+        *pCurrent_choice = 1;
+        return 1;
+    } else {
         if (gProgram_state.prog_status == eProg_idling) {
             *pCurrent_choice = 0;
             return 1;
         } else {
             return 0;
         }
-    } else {
-        *pCurrent_choice = 1;
-        return 1;
     }
 }
 


### PR DESCRIPTION
## Match result
```
0x45412d: ExitWhenReady 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x45412d,28 +0x4a8a8a,28 @@
0x45412d : push ebp 	(racestrt.c:2772)
0x45412e : mov ebp, esp
0x454130 : push ebx
0x454131 : push esi
0x454132 : push edi
0x454133 : cmp dword ptr [gSynch_race_start (DATA)], 0 	(racestrt.c:2774)
0x45413a : -jne 0xd
         : +jne 0x3e
0x454140 : cmp dword ptr [gProgram_state+164 (OFFSET)], 4
0x454147 : -jne 0x18
0x45414d : -mov eax, dword ptr [ebp + 8]
0x454150 : -mov dword ptr [eax], 1
0x454156 : -mov eax, 1
0x45415b : -jmp 0x31
0x454160 : -jmp 0x2c
         : +je 0x31
0x454165 : cmp dword ptr [gProgram_state+164 (OFFSET)], 2 	(racestrt.c:2775)
0x45416c : jne 0x18
0x454172 : mov eax, dword ptr [ebp + 8] 	(racestrt.c:2776)
0x454175 : mov dword ptr [eax], 0
0x45417b : mov eax, 1 	(racestrt.c:2777)
0x454180 : -jmp 0xc
         : +jmp 0x24
0x454185 : jmp 0x7 	(racestrt.c:2778)
0x45418a : xor eax, eax 	(racestrt.c:2779)
         : +jmp 0x18
         : +jmp 0x13 	(racestrt.c:2781)
         : +mov eax, dword ptr [ebp + 8] 	(racestrt.c:2782)
         : +mov dword ptr [eax], 1
         : +mov eax, 1 	(racestrt.c:2783)
0x45418c : jmp 0x0
0x454191 : pop edi 	(racestrt.c:2785)
0x454192 : pop esi
0x454193 : pop ebx
0x454194 : leave 
0x454195 : ret 


ExitWhenReady is only 71.43% similar to the original, diff above
```

*AI generated. Time taken: 871.15s, tokens: 1871151*
