### PR TITLE
NetSynchRaceStart2 100% match

### DIFF
--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -2803,6 +2803,8 @@ tSO_result NetSynchRaceStart2(tNet_synch_mode pMode) {
         { { 219, 480 }, { 172, 379 }, { 282, 182 }, { 192, 427 }, 0, 0, 0, NULL },
         { { 39, 112 }, { 172, 362 }, { 102, 182 }, { 192, 379 }, 1, 0, 0, NULL },
     };
+
+    // GLOBAL: CARM95 0x00510840
     static tInterface_spec interface_spec_hf = {
         0,
         203,
@@ -2867,6 +2869,7 @@ tSO_result NetSynchRaceStart2(tNet_synch_mode pMode) {
     static tMouse_area mouse_areas_hs[1] = {
         { { 219, 480 }, { 172, 379 }, { 282, 182 }, { 192, 427 }, 0, 0, 0, NULL },
     };
+    // GLOBAL: CARM95 0x005109E8
     static tInterface_spec interface_spec_hs = {
         0, 209, 0, 0, 0, 0, 8,
         { -1, 0 }, { 1, 0 }, { 0, 0 }, { 1, 0 }, { NULL, NULL },
@@ -2891,6 +2894,8 @@ tSO_result NetSynchRaceStart2(tNet_synch_mode pMode) {
     static tMouse_area mouse_areas_c[1] = {
         { { 219, 112 }, { 172, 362 }, { 282, 182 }, { 192, 379 }, 0, 0, 0, NULL },
     };
+
+    // GLOBAL: CARM95 0x00510B90
     static tInterface_spec interface_spec_c = {
         0, 204, 0, 0, 0, 0, 8,
         { -1, 0 }, { 1, 0 }, { 0, 0 }, { 1, 0 }, { NULL, NULL },
@@ -2904,7 +2909,6 @@ tSO_result NetSynchRaceStart2(tNet_synch_mode pMode) {
         COUNT_OF(mouse_areas_c), mouse_areas_c, 0, NULL
     };
     int result;
-    int result_copy;
 
     if (pMode != eNet_synch_client) {
         if (gCurrent_net_game->status.stage == eNet_game_starting) {
@@ -2925,13 +2929,10 @@ tSO_result NetSynchRaceStart2(tNet_synch_mode pMode) {
     case eNet_synch_client:
         result = DoInterfaceScreen(&interface_spec_c, 0, -1);
         break;
-    default:
-        break;
     }
     TurnOffPaletteConversion();
     FadePaletteDown();
-    result_copy = result;
-    switch (result_copy) {
+    switch (result) {
     case -1:
     case 0:
         NetLeaveGame(gCurrent_net_game);

--- a/src/DETHRACE/common/racestrt.c
+++ b/src/DETHRACE/common/racestrt.c
@@ -2904,6 +2904,7 @@ tSO_result NetSynchRaceStart2(tNet_synch_mode pMode) {
         COUNT_OF(mouse_areas_c), mouse_areas_c, 0, NULL
     };
     int result;
+    int result_copy;
 
     if (pMode != eNet_synch_client) {
         if (gCurrent_net_game->status.stage == eNet_game_starting) {
@@ -2913,6 +2914,7 @@ tSO_result NetSynchRaceStart2(tNet_synch_mode pMode) {
         gNet_synch_start = PDGetTotalTime();
     }
     TurnOnPaletteConversion();
+
     switch (pMode) {
     case eNet_synch_host_first:
         result = DoInterfaceScreen(&interface_spec_hf, 0, 1);
@@ -2928,8 +2930,14 @@ tSO_result NetSynchRaceStart2(tNet_synch_mode pMode) {
     }
     TurnOffPaletteConversion();
     FadePaletteDown();
-    if (result > -2 && result < 1) {
+    result_copy = result;
+    switch (result_copy) {
+    case -1:
+    case 0:
         NetLeaveGame(gCurrent_net_game);
+        return eSO_continue;
+    case 1:
+        return eSO_continue;
     }
     return eSO_continue;
 }


### PR DESCRIPTION
## Match result

```
0x454196: NetSynchRaceStart2 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x454196,64 +0x4a8af3,67 @@
0x454196 : push ebp 	(racestrt.c:2789)
0x454197 : mov ebp, esp
0x454199 : -sub esp, 0xc
         : +sub esp, 8
0x45419c : push ebx
0x45419d : push esi
0x45419e : push edi
0x45419f : cmp dword ptr [ebp + 8], 2 	(racestrt.c:2908)
0x4541a3 : je 0x2a
0x4541a9 : mov eax, dword ptr [gCurrent_net_game (DATA)] 	(racestrt.c:2909)
0x4541ae : cmp dword ptr [eax + 0x40], 0
0x4541b2 : jne 0xc
0x4541b8 : mov eax, dword ptr [gCurrent_net_game (DATA)] 	(racestrt.c:2910)
0x4541bd : mov dword ptr [eax + 0x40], 1
0x4541c4 : call SetUpNetCarPositions (FUNCTION) 	(racestrt.c:2912)
0x4541c9 : call PDGetTotalTime (FUNCTION) 	(racestrt.c:2913)
0x4541ce : mov dword ptr [gNet_synch_start (DATA)], eax
0x4541d3 : call TurnOnPaletteConversion (FUNCTION) 	(racestrt.c:2915)
0x4541d8 : mov eax, dword ptr [ebp + 8] 	(racestrt.c:2916)
0x4541db : mov dword ptr [ebp - 8], eax
0x4541de : -jmp 0x50
         : +jmp 0x55
0x4541e3 : push 1 	(racestrt.c:2918)
0x4541e5 : push 0
0x4541e7 : -push <OFFSET6>
         : +push interface_spec_hf (DATA)
0x4541ec : call DoInterfaceScreen (FUNCTION)
0x4541f1 : add esp, 0xc
0x4541f4 : mov dword ptr [ebp - 4], eax
0x4541f7 : -jmp 0x5a
         : +jmp 0x5f 	(racestrt.c:2919)
0x4541fc : push -1 	(racestrt.c:2921)
0x4541fe : push 0
0x454200 : -push <OFFSET8>
         : +push interface_spec_hs (DATA)
0x454205 : call DoInterfaceScreen (FUNCTION)
0x45420a : add esp, 0xc
0x45420d : mov dword ptr [ebp - 4], eax
0x454210 : -jmp 0x41
         : +jmp 0x46 	(racestrt.c:2922)
0x454215 : push -1 	(racestrt.c:2924)
0x454217 : push 0
0x454219 : -push <OFFSET9>
         : +push interface_spec_c (DATA)
0x45421e : call DoInterfaceScreen (FUNCTION)
0x454223 : add esp, 0xc
0x454226 : mov dword ptr [ebp - 4], eax
         : +jmp 0x2d 	(racestrt.c:2925)
0x454229 : jmp 0x28 	(racestrt.c:2927)
0x45422e : jmp 0x23 	(racestrt.c:2928)
0x454233 : cmp dword ptr [ebp - 8], 0
0x454237 : -je -0x5a
         : +je -0x5f
0x45423d : cmp dword ptr [ebp - 8], 1
0x454241 : -je -0x4b
         : +je -0x50
0x454247 : cmp dword ptr [ebp - 8], 2
0x45424b : -je -0x3c
         : +je -0x41
0x454251 : jmp 0x0
0x454256 : call TurnOffPaletteConversion (FUNCTION) 	(racestrt.c:2929)
0x45425b : call FadePaletteDown (FUNCTION) 	(racestrt.c:2930)
0x454260 : -mov eax, dword ptr [ebp - 4]
0x454263 : -mov dword ptr [ebp - 0xc], eax
0x454266 : -jmp 0x27
         : +cmp dword ptr [ebp - 4], -2 	(racestrt.c:2931)
         : +jle 0x18
         : +cmp dword ptr [ebp - 4], 1
         : +jge 0xe
0x45426b : mov eax, dword ptr [gCurrent_net_game (DATA)] 	(racestrt.c:2932)
0x454270 : push eax
0x454271 : call NetLeaveGame (FUNCTION)
0x454276 : add esp, 4
0x454279 : mov eax, 3 	(racestrt.c:2934)
0x45427e : -jmp 0x3c
0x454283 : -mov eax, 3
0x454288 : -jmp 0x32
0x45428d : -jmp 0x23
0x454292 : -cmp dword ptr [ebp - 0xc], -1
         : +jmp 0x0
         : +pop edi 	(racestrt.c:2935)
         : +pop esi
         : +pop ebx
         : +leave
         : +ret


NetSynchRaceStart2 is only 70.23% similar to the original, diff above
```

*AI generated. Time taken: 77s, tokens: 21,729*
