### PR TITLE
ActorIsPedestrian 100% match

### DIFF
--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -257,14 +257,9 @@ void PedModelUpdate(br_model* pModel, br_scalar x0, br_scalar y0, br_scalar x1, 
 // IDA: int __usercall ActorIsPedestrian@<EAX>(br_actor *pActor@<EAX>)
 // FUNCTION: CARM95 0x00455870
 int ActorIsPedestrian(br_actor* pActor) {
-
-    if (pActor->model == NULL) {
-        return 0;
-    }
-    if (pActor->type_data == NULL) {
-        return 0;
-    }
-    return ActorToPedestrianData(pActor)->magic_number == PEDESTRIAN_MAGIC;
+    return pActor->model != NULL && 
+           pActor->type_data != NULL && 
+           ActorToPedestrianData(pActor)->magic_number == PEDESTRIAN_MAGIC;
 }
 
 // IDA: br_scalar __usercall PedHeightFromActor@<ST0>(br_actor *pActor@<EAX>)


### PR DESCRIPTION
## Match result

```
0x455870: ActorIsPedestrian 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x455870,21 +0x4962eb,25 @@
0x455870 : push ebp 	(pedestrn.c:259)
0x455871 : mov ebp, esp
0x455873 : push ebx
0x455874 : push esi
0x455875 : push edi
0x455876 : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:261)
0x455879 : cmp dword ptr [eax + 0x18], 0
0x45587d : -je 0x29
         : +jne 0x7
         : +xor eax, eax 	(pedestrn.c:262)
         : +jmp 0x37
0x455883 : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:264)
0x455886 : cmp dword ptr [eax + 0x5c], 0
0x45588a : -je 0x1c
         : +jne 0x7
         : +xor eax, eax 	(pedestrn.c:265)
         : +jmp 0x23
0x455890 : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:267)
0x455893 : mov eax, dword ptr [eax + 0x5c]
0x455896 : cmp dword ptr [eax], 0x50656421
0x45589c : jne 0xa
0x4558a2 : mov eax, 1
0x4558a7 : jmp 0x2
0x4558ac : xor eax, eax
0x4558ae : jmp 0x0
0x4558b3 : pop edi 	(pedestrn.c:268)
0x4558b4 : pop esi


ActorIsPedestrian is only 84.62% similar to the original, diff above
```

*AI generated. Time taken: 263s, tokens: 235,917*
