### PR TITLE
PedHeightFromActor 100% match

### DIFF
--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -271,11 +271,8 @@ int ActorIsPedestrian(br_actor* pActor) {
 // FUNCTION: CARM95 0x004558b8
 br_scalar PedHeightFromActor(br_actor* pActor) {
     br_scalar height;
-    if (ActorIsPedestrian(pActor)) {
-        height = ActorToPedestrianData(pActor)->height2;
-    } else {
-        height = 0;
-    }
+
+    height = ActorIsPedestrian(pActor) ? ActorToPedestrianData(pActor)->height2 : 0;
     return height;
 }
 

--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -270,10 +270,13 @@ int ActorIsPedestrian(br_actor* pActor) {
 // IDA: br_scalar __usercall PedHeightFromActor@<ST0>(br_actor *pActor@<EAX>)
 // FUNCTION: CARM95 0x004558b8
 br_scalar PedHeightFromActor(br_actor* pActor) {
-    if (!ActorIsPedestrian(pActor)) {
-        return 0.f;
+    br_scalar height;
+    if (ActorIsPedestrian(pActor)) {
+        height = ActorToPedestrianData(pActor)->height2;
+    } else {
+        height = 0;
     }
-    return ActorToPedestrianData(pActor)->height2;
+    return height;
 }
 
 // IDA: int __usercall GetPedestrianValue@<EAX>(br_actor *pActor@<EAX>)


### PR DESCRIPTION
## Match result

```
0x4558b8: PedHeightFromActor 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4558b8,19 +0x496341,22 @@
0x4558b8 : push ebp 	(pedestrn.c:272)
0x4558b9 : mov ebp, esp
0x4558bb : -sub esp, 4
0x4558be : push ebx
0x4558bf : push esi
0x4558c0 : push edi
0x4558c1 : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:273)
0x4558c4 : push eax
0x4558c5 : call ActorIsPedestrian (FUNCTION)
0x4558ca : add esp, 4
0x4558cd : test eax, eax
0x4558cf : -je 0x11
         : +jne 0xb
         : +fld dword ptr [0.0 (FLOAT)] 	(pedestrn.c:274)
         : +jmp 0xe
0x4558d5 : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:276)
0x4558d8 : mov eax, dword ptr [eax + 0x5c]
0x4558db : -mov eax, dword ptr [eax + 0x40]
0x4558de : -mov dword ptr [ebp - 4], eax
0x4558e1 : -jmp 0x7
0x4558e6 : -mov dword ptr [ebp - 4], 0
0x4558ed : -fld dword ptr [ebp - 4]
         : +fld dword ptr [eax + 0x40]
         : +jmp 0x0
         : +pop edi 	(pedestrn.c:277)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


PedHeightFromActor is only 58.54% similar to the original, diff above
```

*AI generated. Time taken: 237s, tokens: 286,990*
