### PR TITLE
Sound is not playing when the backend has not yet been initialized

### DIFF
--- a/src/harness/audio/miniaudio.c
+++ b/src/harness/audio/miniaudio.c
@@ -178,6 +178,10 @@ int AudioBackend_SoundIsPlaying(void* type_struct_sample) {
     miniaudio = (tMiniaudio_sample*)type_struct_sample;
     assert(miniaudio != NULL);
 
+    if (!miniaudio->initialized) {
+        return 0;
+    }
+
     if (ma_sound_is_playing(&miniaudio->sound)) {
         return 1;
     }


### PR DESCRIPTION
This fixes a ubsan warning from within miniaudio about member access within null pointer of type 'const struct ma_engine'.