### PR TITLE
SetPedMaterialForRender 100% match

### DIFF
--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -396,7 +396,7 @@ void InitPedGibs(void) {
 // FUNCTION: CARM95 0x00455a76
 void SetPedMaterialForRender(br_actor* pActor) {
     tPedestrian_data* ped;
-    int changed;
+    int changed = 0;
 
     ped = ActorToPedestrianData(pActor);
     pActor->material->colour_map = ped->colour_map;


### PR DESCRIPTION
## Match result

```
0x455a76: SetPedMaterialForRender 100% match.

✨ OK! ✨
```

#### Original match

```

```

*AI generated. Time taken: 90s, tokens: 16,130*
