### PR TITLE
ResetAllPedGibs 100% match

### DIFF
--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -624,8 +624,8 @@ void ResetAllPedGibs(void) {
     int i;
     tPed_gib* the_ped_gib;
 
-    for (i = 0; i < COUNT_OF(gPed_gibs); i++) {
-        the_ped_gib = &gPed_gibs[i];
+    the_ped_gib = &gPed_gibs[0];
+    for (i = 0; i < COUNT_OF(gPed_gibs); i++, the_ped_gib++) {
         if (the_ped_gib->size >= 0) {
             the_ped_gib->size = -1;
             if (the_ped_gib->actor->parent != NULL) {

--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -624,8 +624,7 @@ void ResetAllPedGibs(void) {
     int i;
     tPed_gib* the_ped_gib;
 
-    the_ped_gib = &gPed_gibs[0];
-    for (i = 0; i < COUNT_OF(gPed_gibs); i++, the_ped_gib++) {
+    for (i = 0, the_ped_gib = &gPed_gibs[0]; i < COUNT_OF(gPed_gibs); i++, the_ped_gib++) {
         if (the_ped_gib->size >= 0) {
             the_ped_gib->size = -1;
             if (the_ped_gib->actor->parent != NULL) {

--- a/src/library_msvc.h
+++ b/src/library_msvc.h
@@ -216,8 +216,8 @@
 // LIBRARY: CARM95 0x004F7440
 // __loctotime_t
 
-// LIBRARY: CARM95 0x004EA9E0
-// $$$00001(1)
+// LIBRARY: CARM95 0x004EA9E0 SYMBOL
+// __chkstk
 
 // GLOBAL: CARM95 0x0052D39C
 // __mb_cur_max


### PR DESCRIPTION
## Match result

```
0x455df2: ResetAllPedGibs 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x455df2,39 +0x497392,41 @@
0x455df2 : push ebp 	(pedestrn.c:623)
0x455df3 : mov ebp, esp
0x455df5 : sub esp, 8
0x455df8 : push ebx
0x455df9 : push esi
0x455dfa : push edi
0x455dfb : mov dword ptr [ebp - 8], 0 	(pedestrn.c:627)
0x455e02 : -mov dword ptr [ebp - 4], gPed_gibs[0].actor (DATA)
0x455e09 : -jmp 0x7
         : +jmp 0x3
0x455e0e : inc dword ptr [ebp - 8]
0x455e11 : -add dword ptr [ebp - 4], 0x28
0x455e15 : cmp dword ptr [ebp - 8], 0x1e
0x455e19 : -jge 0x4e
         : +jge 0x5e
         : +mov eax, dword ptr [ebp - 8] 	(pedestrn.c:628)
         : +lea eax, [eax + eax*4]
         : +lea eax, [eax*8 + gPed_gibs[0].actor (DATA)]
         : +mov dword ptr [ebp - 4], eax
0x455e1f : mov eax, dword ptr [ebp - 4] 	(pedestrn.c:629)
0x455e22 : cmp dword ptr [eax + 0xc], 0
0x455e26 : jl 0x3c
0x455e2c : mov eax, dword ptr [ebp - 4] 	(pedestrn.c:630)
0x455e2f : mov dword ptr [eax + 0xc], 0xffffffff
0x455e36 : mov eax, dword ptr [ebp - 4] 	(pedestrn.c:631)
0x455e39 : mov eax, dword ptr [eax]
0x455e3b : cmp dword ptr [eax + 0xc], 0
0x455e3f : je 0xe
0x455e45 : mov eax, dword ptr [ebp - 4] 	(pedestrn.c:632)
0x455e48 : mov eax, dword ptr [eax]
0x455e4a : push eax
0x455e4b : call BrActorRemove (FUNCTION)
0x455e50 : add esp, 4
0x455e53 : mov eax, dword ptr [ebp - 4] 	(pedestrn.c:634)
0x455e56 : mov eax, dword ptr [eax]
0x455e58 : mov dword ptr [eax + 0xc], 0
0x455e5f : mov eax, dword ptr [ebp - 4] 	(pedestrn.c:635)
0x455e62 : mov eax, dword ptr [eax]
0x455e64 : mov byte ptr [eax + 0x20], 1
0x455e68 : -jmp -0x5f
         : +jmp -0x6b 	(pedestrn.c:637)
0x455e6d : pop edi 	(pedestrn.c:638)
0x455e6e : pop esi
0x455e6f : pop ebx
0x455e70 : leave 
0x455e71 : ret 


ResetAllPedGibs is only 85.00% similar to the original, diff above
```

*AI generated. Time taken: 61s, tokens: 13,740*
