### PR TITLE
ChangeActionTo 100% match

### DIFF
--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -1230,32 +1230,29 @@ void ChangeActionTo(tPedestrian_data* pPedestrian, int pAction_index, int pRedo_
     int the_sound;
     tU32 the_pitch;
 
-    if (pAction_index == pPedestrian->current_action || pAction_index >= pPedestrian->number_of_actions) {
-        return;
-    }
-
-    pPedestrian->last_action_change = GetTotalTime();
-    pPedestrian->current_action = pAction_index;
-    pPedestrian->current_frame = -1;
-    pPedestrian->last_frame = 0;
-    pPedestrian->done_initial = 0;
-    if (pRedo_frames_etc) {
-        MungePedestrianSequence(pPedestrian, 1);
-        MungePedestrianFrames(pPedestrian);
-        MungePedModel(pPedestrian);
-    }
-    the_action = &pPedestrian->action_list[pAction_index];
-    if (!gPed_sound_disable && the_action->number_of_sounds != 0) {
-        if (pAction_index == pPedestrian->last_sound_action && GetTotalTime() - pPedestrian->last_sound_make < 4000) {
-            return;
+    if (pAction_index != pPedestrian->current_action && pPedestrian->number_of_actions > pAction_index) {
+        pPedestrian->last_action_change = GetTotalTime();
+        pPedestrian->current_action = pAction_index;
+        pPedestrian->current_frame = -1;
+        pPedestrian->last_frame = 0;
+        pPedestrian->done_initial = 0;
+        if (pRedo_frames_etc) {
+            MungePedestrianSequence(pPedestrian, 1);
+            MungePedestrianFrames(pPedestrian);
+            MungePedModel(pPedestrian);
         }
-        DRS3StopSound(pPedestrian->last_sound);
-        the_sound = the_action->sounds[IRandomBetween(0, the_action->number_of_sounds - 1)];
-        the_pitch = 65536.f / gPed_scale_factor * gZombie_factor;
-        pPedestrian->last_sound = DRS3StartSound3D(gPedestrians_outlet, the_sound, &pPedestrian->pos, &gZero_v__pedestrn, 1, 255, the_pitch, -1);
-        pPedestrian->last_sound_action = pAction_index;
-        pPedestrian->last_sound_make = GetTotalTime();
-        PipeSingleSound(gPedestrians_outlet, the_sound, 255, 0, the_pitch, &pPedestrian->pos);
+        the_action = &pPedestrian->action_list[pAction_index];
+        if (!gPed_sound_disable && the_action->number_of_sounds != 0) {
+            if (pAction_index != pPedestrian->last_sound_action || GetTotalTime() - pPedestrian->last_sound_make >= 4000) {
+                DRS3StopSound(pPedestrian->last_sound);
+                the_sound = the_action->sounds[IRandomBetween(0, the_action->number_of_sounds - 1)];
+                the_pitch = 65536.f / gPed_scale_factor * gZombie_factor;
+                pPedestrian->last_sound = DRS3StartSound3D(gPedestrians_outlet, the_sound, &pPedestrian->pos, &gZero_v__pedestrn, 1, 255, the_pitch, -1);
+                pPedestrian->last_sound_action = pAction_index;
+                pPedestrian->last_sound_make = GetTotalTime();
+                PipeSingleSound(gPedestrians_outlet, the_sound, 255, 0, the_pitch, &pPedestrian->pos);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x45654d: ChangeActionTo 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x45654d,24 +0x4990bb,25 @@
0x45654d : push ebp 	(pedestrn.c:1228)
0x45654e : mov ebp, esp
0x456550 : sub esp, 0xc
0x456553 : push ebx
0x456554 : push esi
0x456555 : push edi
0x456556 : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:1233)
0x456559 : movsx eax, byte ptr [eax + 0x6b]
0x45655d : cmp eax, dword ptr [ebp + 0xc]
0x456560 : -je 0x183
         : +je 0x10
0x456566 : mov eax, dword ptr [ebp + 8]
0x456569 : movsx eax, byte ptr [eax + 0x60]
0x45656d : cmp eax, dword ptr [ebp + 0xc]
0x456570 : -jle 0x173
         : +jg 0x5
         : +jmp 0x178 	(pedestrn.c:1234)
0x456576 : call GetTotalTime (FUNCTION) 	(pedestrn.c:1237)
0x45657b : mov ecx, dword ptr [ebp + 8]
0x45657e : mov dword ptr [ecx + 0x88], eax
0x456584 : mov al, byte ptr [ebp + 0xc] 	(pedestrn.c:1238)
0x456587 : mov ecx, dword ptr [ebp + 8]
0x45658a : mov byte ptr [ecx + 0x6b], al
0x45658d : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:1239)
0x456590 : mov byte ptr [eax + 0x6d], 0xff
0x456594 : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:1240)
0x456597 : mov dword ptr [eax + 0x84], 0

---
+++
@@ -0x4565d0,33 +0x499143,34 @@
0x4565d0 : call MungePedModel (FUNCTION)
0x4565d5 : add esp, 4
0x4565d8 : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:1247)
0x4565db : mov eax, dword ptr [eax + 0x54]
0x4565de : mov ecx, dword ptr [ebp + 0xc]
0x4565e1 : shl ecx, 5
0x4565e4 : lea ecx, [ecx + ecx*2]
0x4565e7 : add eax, ecx
0x4565e9 : mov dword ptr [ebp - 8], eax
0x4565ec : cmp dword ptr [gPed_sound_disable (DATA)], 0 	(pedestrn.c:1248)
0x4565f3 : -jne 0xf0
         : +jne 0xf5
0x4565f9 : mov eax, dword ptr [ebp - 8]
0x4565fc : cmp dword ptr [eax + 0xc], 0
0x456600 : -je 0xe3
         : +je 0xe8
0x456606 : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:1249)
0x456609 : mov ecx, dword ptr [ebp + 0xc]
0x45660c : cmp dword ptr [eax + 0x34], ecx
0x45660f : -jne 0x19
         : +jne 0x1e
0x456615 : call GetTotalTime (FUNCTION)
0x45661a : mov ecx, dword ptr [ebp + 8]
0x45661d : sub eax, dword ptr [ecx + 0x8c]
0x456623 : cmp eax, 0xfa0
0x456628 : -jb 0xbb
         : +jae 0x5
         : +jmp 0xbb 	(pedestrn.c:1250)
0x45662e : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:1252)
0x456631 : mov eax, dword ptr [eax + 0xdc]
0x456637 : push eax
0x456638 : call DRS3StopSound (FUNCTION)
0x45663d : add esp, 4
0x456640 : mov eax, dword ptr [ebp - 8] 	(pedestrn.c:1253)
0x456643 : mov eax, dword ptr [eax + 0xc]
0x456646 : dec eax
0x456647 : push eax
0x456648 : push 0


ChangeActionTo is only 94.35% similar to the original, diff above
```

*AI generated. Time taken: 250s, tokens: 29,641*
