### PR TITLE
BurstPedestrian 100% effective match

### DIFF
--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -505,30 +505,30 @@ int BurstPedestrian(tPedestrian_data* pPedestrian, float pSplattitudinalitude, i
     }
 
     the_time = GetTotalTime();
-    size_threshold = COUNT_OF(gMin_ped_gib_speeds) - 1;
+    next_gib_index = 0;
+    the_ped_gib = &gPed_gibs[0];
+    max_size = COUNT_OF(gMin_ped_gib_speeds) - 1;
     for (i = 1; i < COUNT_OF(gMin_ped_gib_speeds); i++) {
         if (gMin_ped_gib_speeds[i] <= pSplattitudinalitude) {
-            size_threshold = i;
+            max_size = i;
             break;
         }
     }
     if (gExploding_pedestrians) {
-        size_threshold = 1;
-    } else if (size_threshold == 1 && (!pAllow_explosion || !PercentageChance(50))) {
-        size_threshold = 2;
+        max_size = 1;
+    } else if (max_size == 1 && (!pAllow_explosion || !PercentageChance(50))) {
+        max_size = 2;
     }
     gib_count = pSplattitudinalitude * 10000.f;
     if (gib_count > 15) {
         gib_count = 15;
     }
-    gib_index = 0;
-    the_ped_gib = &gPed_gibs[gib_index];
-    if (size_threshold == 1) {
+    if (max_size == 1) {
         while (the_ped_gib->size >= 0) {
-            gib_index++;
             the_ped_gib++;
-            if (gib_index >= COUNT_OF(gPed_gibs)) {
-                return 0;
+            next_gib_index++;
+            if (next_gib_index >= COUNT_OF(gPed_gibs)) {
+                return exploded;
             }
         }
         if (pPedestrian->number_of_exploding_sounds != 0) {
@@ -563,20 +563,20 @@ int BurstPedestrian(tPedestrian_data* pPedestrian, float pSplattitudinalitude, i
         exploded = 1;
     }
     current_size = 4;
-    j = 0;
+    size_threshold = 0;
     for (i = 0; i < gib_count; i++) {
         while (the_ped_gib->size >= 0) {
-            gib_index++;
             the_ped_gib++;
-            if (gib_index >= COUNT_OF(gPed_gibs)) {
+            next_gib_index++;
+            if (next_gib_index >= COUNT_OF(gPed_gibs)) {
                 return exploded;
             }
         }
-        if (j <= i && size_threshold < current_size && current_size > 1) {
+        if (size_threshold <= i && max_size < current_size && current_size > 1) {
             current_size--;
-            j += gib_count * gPed_gib_distrib[current_size];
-            min_speed = gPed_gib_speeds[current_size] * pSplattitudinalitude * .003f + .00005f;
-            max_speed = gPed_gib_speeds[current_size] * pSplattitudinalitude * .2f + .00030f;
+            size_threshold += gib_count * gPed_gib_distrib[current_size];
+            min_speed = gPed_gib_speeds[current_size] * pSplattitudinalitude * .003 + .00005;
+            max_speed = gPed_gib_speeds[current_size] * pSplattitudinalitude * .2 + .00030;
         }
         the_ped_gib->size = current_size;
         the_ped_gib->start_time = the_time + 150;
@@ -598,11 +598,11 @@ int BurstPedestrian(tPedestrian_data* pPedestrian, float pSplattitudinalitude, i
         BrMatrix34Identity(&the_ped_gib->actor->t.t.mat);
         the_ped_gib->actor->t.t.translate.t.v[Y] += pPedestrian->actor->t.t.mat.m[1][1] / (pPedestrian->height2 * 2.f);
         do {
-            next_gib_index = IRandomBetween(0, gPed_gib_materials[the_ped_gib->size].count - 1);
-        } while (gPed_gib_maxes[the_ped_gib->size][next_gib_index] <= gPed_gib_counts[the_ped_gib->size][next_gib_index]);
-        gPed_gib_counts[the_ped_gib->size][next_gib_index]++;
-        the_ped_gib->actor->material = gPed_gib_materials[the_ped_gib->size].materials[next_gib_index];
-        the_ped_gib->gib_index = next_gib_index;
+            gib_index = IRandomBetween(0, gPed_gib_materials[the_ped_gib->size].count - 1);
+        } while (gPed_gib_counts[the_ped_gib->size][gib_index] >= gPed_gib_maxes[the_ped_gib->size][gib_index]);
+        gPed_gib_counts[the_ped_gib->size][gib_index]++;
+        the_ped_gib->actor->material = gPed_gib_materials[the_ped_gib->size].materials[gib_index];
+        the_ped_gib->gib_index = gib_index;
         the_ped_gib->parent_index = GET_PEDESTRIAN_INDEX(pPedestrian);
         MungeModelSize(the_ped_gib->actor, .0023f);
     }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4584e6,23 +0x49727f,23 @@
0x4584e6 : mov eax, dword ptr [ebp - 0x24] 	(pedestrn.c:602)
0x4584e9 : mov eax, dword ptr [eax + 0xc]
0x4584ec : shl eax, 2
0x4584ef : lea eax, [eax + eax*4]
0x4584f2 : mov ecx, dword ptr [ebp - 8]
0x4584f5 : mov edx, dword ptr [ebp - 0x24]
0x4584f8 : mov edx, dword ptr [edx + 0xc]
0x4584fb : shl edx, 2
0x4584fe : lea edx, [edx + edx*4]
0x458501 : mov ebx, dword ptr [ebp - 8]
0x458504 : -mov edx, dword ptr [edx + ebx*4 + gPed_gib_counts[0].[0] (DATA)]
0x45850b : -cmp dword ptr [eax + ecx*4 + gPed_gib_maxes[0].[0] (DATA)], edx
0x458512 : -jle -0x51
         : +mov edx, dword ptr [edx + ebx*4 + gPed_gib_maxes[0].[0] (DATA)]
         : +cmp dword ptr [eax + ecx*4 + gPed_gib_counts[0].[0] (DATA)], edx
         : +jge -0x51
0x458518 : mov eax, dword ptr [ebp - 0x24] 	(pedestrn.c:603)
0x45851b : mov eax, dword ptr [eax + 0xc]
0x45851e : shl eax, 2
0x458521 : lea eax, [eax + eax*4]
0x458524 : mov ecx, dword ptr [ebp - 8]
0x458527 : inc dword ptr [eax + ecx*4 + gPed_gib_counts[0].[0] (DATA)]
0x45852e : mov eax, dword ptr [ebp - 0x24] 	(pedestrn.c:604)
0x458531 : mov eax, dword ptr [eax + 0xc]
0x458534 : lea eax, [eax + eax*2]
0x458537 : mov ecx, dword ptr [ebp - 8]


0x457ff5: BurstPedestrian 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x45803a,71 +0x496dd3,74 @@
0x45803a : jle 0x1c
0x458040 : mov eax, dword ptr [ebp - 0x28] 	(pedestrn.c:503)
0x458043 : shl eax, 2
0x458046 : lea eax, [eax + eax*4]
0x458049 : mov ecx, dword ptr [ebp - 0x2c]
0x45804c : mov dword ptr [eax + ecx*4 + gPed_gib_counts[0].[0] (DATA)], 0
0x458057 : jmp -0x32 	(pedestrn.c:504)
0x45805c : jmp -0x50 	(pedestrn.c:505)
0x458061 : call GetTotalTime (FUNCTION) 	(pedestrn.c:507)
0x458066 : mov dword ptr [ebp - 0x1c], eax
0x458069 : -mov dword ptr [ebp - 0xc], 0
0x458070 : -mov dword ptr [ebp - 0x24], gPed_gibs[0].actor (DATA)
0x458077 : -mov dword ptr [ebp - 0x10], 3
         : +mov dword ptr [ebp - 0x18], 3 	(pedestrn.c:508)
0x45807e : mov dword ptr [ebp - 0x28], 1 	(pedestrn.c:509)
0x458085 : jmp 0x3
0x45808a : inc dword ptr [ebp - 0x28]
0x45808d : cmp dword ptr [ebp - 0x28], 4
0x458091 : jge 0x28
0x458097 : mov eax, dword ptr [ebp - 0x28] 	(pedestrn.c:510)
0x45809a : fld dword ptr [eax*4 + gMin_ped_gib_speeds[0] (DATA)]
0x4580a1 : fcomp dword ptr [ebp + 0xc]
0x4580a4 : fnstsw ax
0x4580a6 : test ah, 0x41
0x4580a9 : je 0xb
0x4580af : mov eax, dword ptr [ebp - 0x28] 	(pedestrn.c:511)
0x4580b2 : -mov dword ptr [ebp - 0x10], eax
         : +mov dword ptr [ebp - 0x18], eax
0x4580b5 : jmp 0x5 	(pedestrn.c:512)
0x4580ba : jmp -0x35 	(pedestrn.c:514)
0x4580bf : cmp dword ptr [gExploding_pedestrians (DATA)], 0 	(pedestrn.c:515)
0x4580c6 : je 0xc
0x4580cc : -mov dword ptr [ebp - 0x10], 1
         : +mov dword ptr [ebp - 0x18], 1 	(pedestrn.c:516)
0x4580d3 : jmp 0x2d 	(pedestrn.c:517)
0x4580d8 : -cmp dword ptr [ebp - 0x10], 1
         : +cmp dword ptr [ebp - 0x18], 1
0x4580dc : jne 0x23
0x4580e2 : cmp dword ptr [ebp + 0x10], 0
0x4580e6 : je 0x12
0x4580ec : push 0x32
0x4580ee : call PercentageChance (FUNCTION)
0x4580f3 : add esp, 4
0x4580f6 : test eax, eax
0x4580f8 : jne 0x7
0x4580fe : -mov dword ptr [ebp - 0x10], 2
         : +mov dword ptr [ebp - 0x18], 2 	(pedestrn.c:518)
0x458105 : fld dword ptr [ebp + 0xc] 	(pedestrn.c:520)
0x458108 : fmul dword ptr [10000.0 (FLOAT)]
0x45810e : call __ftol (FUNCTION)
0x458113 : mov dword ptr [ebp - 0x14], eax
0x458116 : cmp dword ptr [ebp - 0x14], 0xf 	(pedestrn.c:521)
0x45811a : jle 0x7
0x458120 : mov dword ptr [ebp - 0x14], 0xf 	(pedestrn.c:522)
0x458127 : -cmp dword ptr [ebp - 0x10], 1
0x45812b : -jne 0x1a8
         : +mov dword ptr [ebp - 8], 0 	(pedestrn.c:524)
         : +mov eax, dword ptr [ebp - 8] 	(pedestrn.c:525)
         : +lea eax, [eax + eax*4]
         : +lea eax, [eax*8 + gPed_gibs[0].actor (DATA)]
         : +mov dword ptr [ebp - 0x24], eax
         : +cmp dword ptr [ebp - 0x18], 1 	(pedestrn.c:526)
         : +jne 0x1a7
0x458131 : mov eax, dword ptr [ebp - 0x24] 	(pedestrn.c:527)
0x458134 : cmp dword ptr [eax + 0xc], 0
0x458138 : -jl 0x1e
         : +jl 0x1d
         : +inc dword ptr [ebp - 8] 	(pedestrn.c:528)
0x45813e : add dword ptr [ebp - 0x24], 0x28 	(pedestrn.c:529)
0x458142 : -inc dword ptr [ebp - 0xc]
0x458145 : -cmp dword ptr [ebp - 0xc], 0x1e
0x458149 : -jl 0x8
0x45814f : -mov eax, dword ptr [ebp - 0x30]
         : +cmp dword ptr [ebp - 8], 0x1e 	(pedestrn.c:530)
         : +jl 0x7
         : +xor eax, eax 	(pedestrn.c:531)
0x458152 : jmp 0x495
0x458157 : -jmp -0x2b
         : +jmp -0x2a 	(pedestrn.c:533)
0x45815c : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:534)
0x45815f : cmp dword ptr [eax + 0x20], 0
0x458163 : je 0x5d
0x458169 : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:535)
0x45816c : mov eax, dword ptr [eax + 0xdc]
0x458172 : push eax
0x458173 : call DRS3StopSound (FUNCTION)
0x458178 : add esp, 4
0x45817b : push -1 	(pedestrn.c:542)
0x45817d : fld dword ptr [65536.0 (FLOAT)]

---
+++
@@ -0x4582bb,68 +0x49705c,68 @@
0x4582bb : mov dword ptr [ecx + 0x18], eax
0x4582be : mov eax, dword ptr [gExploding_ped_scale[0] (DATA)] 	(pedestrn.c:562)
0x4582c3 : push eax
0x4582c4 : mov eax, dword ptr [ebp - 0x24]
0x4582c7 : mov eax, dword ptr [eax]
0x4582c9 : push eax
0x4582ca : call MungeModelSize (FUNCTION)
0x4582cf : add esp, 8
0x4582d2 : mov dword ptr [ebp - 0x30], 1 	(pedestrn.c:563)
0x4582d9 : mov dword ptr [ebp - 0x34], 4 	(pedestrn.c:565)
0x4582e0 : -mov dword ptr [ebp - 0x18], 0
         : +mov dword ptr [ebp - 0x2c], 0 	(pedestrn.c:566)
0x4582e7 : mov dword ptr [ebp - 0x28], 0 	(pedestrn.c:567)
0x4582ee : jmp 0x3
0x4582f3 : inc dword ptr [ebp - 0x28]
0x4582f6 : mov eax, dword ptr [ebp - 0x28]
0x4582f9 : cmp dword ptr [ebp - 0x14], eax
0x4582fc : jle 0x282
0x458302 : mov eax, dword ptr [ebp - 0x24] 	(pedestrn.c:568)
0x458305 : cmp dword ptr [eax + 0xc], 0
0x458309 : jl 0x1e
         : +inc dword ptr [ebp - 8] 	(pedestrn.c:569)
0x45830f : add dword ptr [ebp - 0x24], 0x28 	(pedestrn.c:570)
0x458313 : -inc dword ptr [ebp - 0xc]
0x458316 : -cmp dword ptr [ebp - 0xc], 0x1e
         : +cmp dword ptr [ebp - 8], 0x1e 	(pedestrn.c:571)
0x45831a : jl 0x8
0x458320 : mov eax, dword ptr [ebp - 0x30] 	(pedestrn.c:572)
0x458323 : jmp 0x2c4
0x458328 : jmp -0x2b 	(pedestrn.c:574)
0x45832d : mov eax, dword ptr [ebp - 0x28] 	(pedestrn.c:575)
0x458330 : -cmp dword ptr [ebp - 0x18], eax
         : +cmp dword ptr [ebp - 0x2c], eax
0x458333 : jg 0x77
0x458339 : -mov eax, dword ptr [ebp - 0x34]
0x45833c : -cmp dword ptr [ebp - 0x10], eax
0x45833f : -jge 0x6b
         : +mov eax, dword ptr [ebp - 0x18]
         : +cmp dword ptr [ebp - 0x34], eax
         : +jle 0x6b
0x458345 : cmp dword ptr [ebp - 0x34], 1
0x458349 : jle 0x61
0x45834f : dec dword ptr [ebp - 0x34] 	(pedestrn.c:576)
0x458352 : mov eax, dword ptr [ebp - 0x34] 	(pedestrn.c:577)
0x458355 : mov ecx, dword ptr [ebp - 0x14]
0x458358 : mov dword ptr [ebp - 0x38], ecx
0x45835b : fild dword ptr [ebp - 0x38]
0x45835e : fmul dword ptr [eax*4 + gPed_gib_distrib[0] (DATA)]
0x458365 : -mov eax, dword ptr [ebp - 0x18]
         : +mov eax, dword ptr [ebp - 0x2c]
0x458368 : mov dword ptr [ebp - 0x3c], eax
0x45836b : fild dword ptr [ebp - 0x3c]
0x45836e : faddp st(1)
0x458370 : call __ftol (FUNCTION)
0x458375 : -mov dword ptr [ebp - 0x18], eax
         : +mov dword ptr [ebp - 0x2c], eax
0x458378 : mov eax, dword ptr [ebp - 0x34] 	(pedestrn.c:578)
0x45837b : fld dword ptr [eax*4 + gPed_gib_speeds[0] (DATA)]
0x458382 : fmul dword ptr [ebp + 0xc]
0x458385 : -fmul qword ptr [0.003 (FLOAT)]
0x45838b : -fadd qword ptr [5e-05 (FLOAT)]
         : +fmul dword ptr [0.003000000026077032 (FLOAT)]
         : +fadd dword ptr [4.999999873689376e-05 (FLOAT)]
0x458391 : fstp dword ptr [ebp - 0x20]
0x458394 : mov eax, dword ptr [ebp - 0x34] 	(pedestrn.c:579)
0x458397 : fld dword ptr [eax*4 + gPed_gib_speeds[0] (DATA)]
0x45839e : fmul dword ptr [ebp + 0xc]
0x4583a1 : -fmul qword ptr [0.2 (FLOAT)]
0x4583a7 : -fadd qword ptr [0.0003 (FLOAT)]
         : +fmul dword ptr [0.20000000298023224 (FLOAT)]
         : +fadd dword ptr [0.0003000000142492354 (FLOAT)]
0x4583ad : fstp dword ptr [ebp - 4]
0x4583b0 : mov eax, dword ptr [ebp - 0x34] 	(pedestrn.c:581)
0x4583b3 : mov ecx, dword ptr [ebp - 0x24]
0x4583b6 : mov dword ptr [ecx + 0xc], eax
0x4583b9 : mov eax, dword ptr [ebp - 0x1c] 	(pedestrn.c:582)
0x4583bc : add eax, 0x96
0x4583c1 : mov ecx, dword ptr [ebp - 0x24]
0x4583c4 : mov dword ptr [ecx + 0x1c], eax
0x4583c7 : mov eax, dword ptr [ebp - 0x1c] 	(pedestrn.c:583)
0x4583ca : add eax, 0x7d0

---
+++
@@ -0x4584c4,50 +0x497265,50 @@
0x4584c4 : fstp dword ptr [eax + 0x54]
0x4584c7 : mov eax, dword ptr [ebp - 0x24] 	(pedestrn.c:601)
0x4584ca : mov eax, dword ptr [eax + 0xc]
0x4584cd : lea eax, [eax + eax*2]
0x4584d0 : mov eax, dword ptr [eax*8 + gPed_gib_materials[0].count (DATA)]
0x4584d7 : dec eax
0x4584d8 : push eax
0x4584d9 : push 0
0x4584db : call IRandomBetween (FUNCTION)
0x4584e0 : add esp, 8
0x4584e3 : -mov dword ptr [ebp - 8], eax
         : +mov dword ptr [ebp - 0xc], eax
0x4584e6 : mov eax, dword ptr [ebp - 0x24] 	(pedestrn.c:602)
0x4584e9 : mov eax, dword ptr [eax + 0xc]
0x4584ec : shl eax, 2
0x4584ef : lea eax, [eax + eax*4]
0x4584f2 : -mov ecx, dword ptr [ebp - 8]
         : +mov ecx, dword ptr [ebp - 0xc]
0x4584f5 : mov edx, dword ptr [ebp - 0x24]
0x4584f8 : mov edx, dword ptr [edx + 0xc]
0x4584fb : shl edx, 2
0x4584fe : lea edx, [edx + edx*4]
0x458501 : -mov ebx, dword ptr [ebp - 8]
0x458504 : -mov edx, dword ptr [edx + ebx*4 + gPed_gib_counts[0].[0] (DATA)]
0x45850b : -cmp dword ptr [eax + ecx*4 + gPed_gib_maxes[0].[0] (DATA)], edx
0x458512 : -jle -0x51
         : +mov ebx, dword ptr [ebp - 0xc]
         : +mov edx, dword ptr [edx + ebx*4 + gPed_gib_maxes[0].[0] (DATA)]
         : +cmp dword ptr [eax + ecx*4 + gPed_gib_counts[0].[0] (DATA)], edx
         : +jge -0x51
0x458518 : mov eax, dword ptr [ebp - 0x24] 	(pedestrn.c:603)
0x45851b : mov eax, dword ptr [eax + 0xc]
0x45851e : shl eax, 2
0x458521 : lea eax, [eax + eax*4]
0x458524 : -mov ecx, dword ptr [ebp - 8]
         : +mov ecx, dword ptr [ebp - 0xc]
0x458527 : inc dword ptr [eax + ecx*4 + gPed_gib_counts[0].[0] (DATA)]
0x45852e : mov eax, dword ptr [ebp - 0x24] 	(pedestrn.c:604)
0x458531 : mov eax, dword ptr [eax + 0xc]
0x458534 : lea eax, [eax + eax*2]
0x458537 : -mov ecx, dword ptr [ebp - 8]
         : +mov ecx, dword ptr [ebp - 0xc]
0x45853a : shl ecx, 2
0x45853d : mov eax, dword ptr [ecx + eax*8 + gPed_gib_materials[0].materials (OFFSET)]
0x458544 : mov ecx, dword ptr [ebp - 0x24]
0x458547 : mov ecx, dword ptr [ecx]
0x458549 : mov dword ptr [ecx + 0x1c], eax
0x45854c : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp - 0xc] 	(pedestrn.c:605)
0x45854f : mov ecx, dword ptr [ebp - 0x24]
0x458552 : mov dword ptr [ecx + 0x14], eax
0x458555 : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:606)
0x458558 : sub eax, dword ptr [gPedestrian_array (DATA)]
0x45855e : mov ecx, 0xe4
0x458563 : cdq 
0x458564 : idiv ecx
0x458566 : mov ecx, dword ptr [ebp - 0x24]
0x458569 : mov dword ptr [ecx + 0x18], eax
0x45856c : push 0x3b16bb99 	(pedestrn.c:607)


BurstPedestrian is only 90.84% similar to the original, diff above
```

*AI generated. Time taken: 172s, tokens: 30,208*
