### PR TITLE
ResetAllPedestrians 100% match

### DIFF
--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -2327,8 +2327,7 @@ void ResetAllPedestrians(void) {
     int i;
     tPedestrian_data* the_pedestrian;
 
-    for (i = 0; i < gPed_count; i++) {
-        the_pedestrian = &gPedestrian_array[i];
+    for (i = 0, the_pedestrian = gPedestrian_array; i < gPed_count; i++, the_pedestrian++) {
         the_pedestrian->actor->render_style = BR_RSTYLE_NONE;
     }
 }


### PR DESCRIPTION
## Match result

```
0x459239: ResetAllPedestrians 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x459239,24 +0x49ce4d,29 @@
0x459239 : push ebp 	(pedestrn.c:2326)
0x45923a : mov ebp, esp
0x45923c : sub esp, 8
0x45923f : push ebx
0x459240 : push esi
0x459241 : push edi
0x459242 : mov dword ptr [ebp - 4], 0 	(pedestrn.c:2330)
0x459249 : -mov eax, dword ptr [gPedestrian_array (DATA)]
0x45924e : -mov dword ptr [ebp - 8], eax
0x459251 : -jmp 0xa
         : +jmp 0x3
0x459256 : inc dword ptr [ebp - 4]
0x459259 : -add dword ptr [ebp - 8], 0xe4
0x459260 : mov eax, dword ptr [gPed_count (DATA)]
0x459265 : cmp dword ptr [ebp - 4], eax
0x459268 : -jge 0xf
         : +jge 0x28
         : +mov eax, dword ptr [ebp - 4] 	(pedestrn.c:2331)
         : +mov ecx, eax
         : +shl eax, 3
         : +sub eax, ecx
         : +lea eax, [ecx + eax*8]
         : +shl eax, 2
         : +add eax, dword ptr [gPedestrian_array (DATA)]
         : +mov dword ptr [ebp - 8], eax
0x45926e : mov eax, dword ptr [ebp - 8] 	(pedestrn.c:2332)
0x459271 : mov eax, dword ptr [eax + 0x48]
0x459274 : mov byte ptr [eax + 0x20], 1
0x459278 : -jmp -0x27
         : +jmp -0x39 	(pedestrn.c:2333)
0x45927d : pop edi 	(pedestrn.c:2334)
0x45927e : pop esi
0x45927f : pop ebx
0x459280 : leave 
0x459281 : ret 


ResetAllPedestrians is only 67.92% similar to the original, diff above
```

*AI generated. Time taken: 60s, tokens: 15,443*
