### PR TITLE
RevivePedestrian 100% match

### DIFF
--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -2413,10 +2413,11 @@ void RevivePedestrian(tPedestrian_data* pPedestrian, int pAnimate) {
     pPedestrian->hit_points = 10;
     pPedestrian->current_instruction = pPedestrian->first_instruction;
     pPedestrian->killers_ID = -1;
+    pPedestrian->murderer = -1;
     pPedestrian->fate = NULL;
     gInitial_instruction = NULL;
     PedestrianNextInstruction(pPedestrian, 0.f, 1, 0);
-    BrVector3Copy(&pPedestrian->from_pos, &pPedestrian->actor->t.t.translate.t);
+    pPedestrian->from_pos = pPedestrian->actor->t.t.translate.t;
     MungePedModel(pPedestrian);
     pPedestrian->pos.v[Y] += pPedestrian->sequences[pPedestrian->current_sequence].frames[0].offset.v[Y];
 }


### PR DESCRIPTION
## Match result

```
0x459282: RevivePedestrian 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4593bb,42 +0x49d1a0,44 @@
0x4593bb : mov dword ptr [eax + 0x8c], 0
0x4593c5 : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:2413)
0x4593c8 : mov dword ptr [eax + 0x1c], 0xa
0x4593cf : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:2414)
0x4593d2 : mov al, byte ptr [eax + 0x62]
0x4593d5 : mov ecx, dword ptr [ebp + 8]
0x4593d8 : mov byte ptr [ecx + 0x63], al
0x4593db : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:2415)
0x4593de : mov word ptr [eax + 0x38], 0xffff
0x4593e4 : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:2416)
0x4593e7 : -mov dword ptr [eax + 0x4c], 0xffffffff
0x4593ee : -mov eax, dword ptr [ebp + 8]
0x4593f1 : mov dword ptr [eax + 0x44], 0
0x4593f8 : mov dword ptr [gInitial_instruction (DATA)], 0 	(pedestrn.c:2417)
0x459402 : push 0 	(pedestrn.c:2418)
0x459404 : push 1
0x459406 : push 0
0x459408 : mov eax, dword ptr [ebp + 8]
0x45940b : push eax
0x45940c : call PedestrianNextInstruction (FUNCTION)
0x459411 : add esp, 0x10
0x459414 : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:2419)
0x459417 : mov eax, dword ptr [eax + 0x48]
0x45941a : -add eax, 0x50
0x45941d : mov ecx, dword ptr [ebp + 8]
0x459420 : -add ecx, 0xac
0x459426 : -mov edx, dword ptr [eax]
0x459428 : -mov dword ptr [ecx], edx
0x45942a : -mov edx, dword ptr [eax + 4]
0x45942d : -mov dword ptr [ecx + 4], edx
0x459430 : -mov eax, dword ptr [eax + 8]
0x459433 : -mov dword ptr [ecx + 8], eax
         : +mov eax, dword ptr [eax + 0x50]
         : +mov dword ptr [ecx + 0xac], eax
         : +mov eax, dword ptr [ebp + 8]
         : +mov eax, dword ptr [eax + 0x48]
         : +mov ecx, dword ptr [ebp + 8]
         : +mov eax, dword ptr [eax + 0x54]
         : +mov dword ptr [ecx + 0xb0], eax
         : +mov eax, dword ptr [ebp + 8]
         : +mov eax, dword ptr [eax + 0x48]
         : +mov ecx, dword ptr [ebp + 8]
         : +mov eax, dword ptr [eax + 0x58]
         : +mov dword ptr [ecx + 0xb4], eax
0x459436 : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:2420)
0x459439 : push eax
0x45943a : call MungePedModel (FUNCTION)
0x45943f : add esp, 4
0x459442 : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:2421)
0x459445 : movsx eax, byte ptr [eax + 0x6a]
0x459449 : shl eax, 2
0x45944c : lea eax, [eax + eax*4]
0x45944f : lea eax, [eax + eax*8]
0x459452 : mov ecx, dword ptr [ebp + 8]


RevivePedestrian is only 91.97% similar to the original, diff above
```

*AI generated. Time taken: 114s, tokens: 16,068*
