### PR TITLE
SquirtPathVertex 100% match

### DIFF
--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -2312,12 +2312,12 @@ void SquirtPathVertex(br_vertex* pFirst_vertex, br_vector3* pPoint) {
     pFirst_vertex[1].p = *pPoint;
     pFirst_vertex[1].p.v[Y] += .1f;
     pFirst_vertex[2].p = *pPoint;
-    pFirst_vertex[2].p.v[X] += -.05f;
     pFirst_vertex[2].p.v[Y] += .05f;
-    pFirst_vertex[2].p.v[Z] += -.05f;
+    pFirst_vertex[2].p.v[X] -= .05f;
+    pFirst_vertex[2].p.v[Z] -= .05f;
     pFirst_vertex[3].p = *pPoint;
-    pFirst_vertex[3].p.v[X] += .05f;
     pFirst_vertex[3].p.v[Y] += .05f;
+    pFirst_vertex[3].p.v[X] += .05f;
     pFirst_vertex[3].p.v[Z] += .05f;
 }
 


### PR DESCRIPTION
## Match result

```
0x45c66a: SquirtPathVertex 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x45c6b1,53 +0x49cda4,53 @@
0x45c6b1 : mov eax, dword ptr [ebp + 0xc] 	(pedestrn.c:2314)
0x45c6b4 : mov ecx, dword ptr [ebp + 8]
0x45c6b7 : add ecx, 0x50
0x45c6ba : mov edx, dword ptr [eax]
0x45c6bc : mov dword ptr [ecx], edx
0x45c6be : mov edx, dword ptr [eax + 4]
0x45c6c1 : mov dword ptr [ecx + 4], edx
0x45c6c4 : mov eax, dword ptr [eax + 8]
0x45c6c7 : mov dword ptr [ecx + 8], eax
0x45c6ca : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:2315)
         : +fld dword ptr [eax + 0x50]
         : +fadd dword ptr [-0.05000000074505806 (FLOAT)]
         : +mov eax, dword ptr [ebp + 8]
         : +fstp dword ptr [eax + 0x50]
         : +mov eax, dword ptr [ebp + 8] 	(pedestrn.c:2316)
0x45c6cd : fld dword ptr [eax + 0x54]
0x45c6d0 : fadd dword ptr [0.05000000074505806 (FLOAT)]
0x45c6d6 : mov eax, dword ptr [ebp + 8]
0x45c6d9 : fstp dword ptr [eax + 0x54]
0x45c6dc : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:2317)
0x45c6df : -fld dword ptr [eax + 0x50]
0x45c6e2 : -fsub dword ptr [0.05000000074505806 (FLOAT)]
0x45c6e8 : -mov eax, dword ptr [ebp + 8]
0x45c6eb : -fstp dword ptr [eax + 0x50]
0x45c6ee : -mov eax, dword ptr [ebp + 8]
0x45c6f1 : fld dword ptr [eax + 0x58]
0x45c6f4 : -fsub dword ptr [0.05000000074505806 (FLOAT)]
         : +fadd dword ptr [-0.05000000074505806 (FLOAT)]
0x45c6fa : mov eax, dword ptr [ebp + 8]
0x45c6fd : fstp dword ptr [eax + 0x58]
0x45c700 : mov eax, dword ptr [ebp + 0xc] 	(pedestrn.c:2318)
0x45c703 : mov ecx, dword ptr [ebp + 8]
0x45c706 : add ecx, 0x78
0x45c709 : mov edx, dword ptr [eax]
0x45c70b : mov dword ptr [ecx], edx
0x45c70d : mov edx, dword ptr [eax + 4]
0x45c710 : mov dword ptr [ecx + 4], edx
0x45c713 : mov eax, dword ptr [eax + 8]
0x45c716 : mov dword ptr [ecx + 8], eax
0x45c719 : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:2319)
         : +fld dword ptr [eax + 0x78]
         : +fadd dword ptr [0.05000000074505806 (FLOAT)]
         : +mov eax, dword ptr [ebp + 8]
         : +fstp dword ptr [eax + 0x78]
         : +mov eax, dword ptr [ebp + 8] 	(pedestrn.c:2320)
0x45c71c : fld dword ptr [eax + 0x7c]
0x45c71f : fadd dword ptr [0.05000000074505806 (FLOAT)]
0x45c725 : mov eax, dword ptr [ebp + 8]
0x45c728 : fstp dword ptr [eax + 0x7c]
0x45c72b : -mov eax, dword ptr [ebp + 8]
0x45c72e : -fld dword ptr [eax + 0x78]
0x45c731 : -fadd dword ptr [0.05000000074505806 (FLOAT)]
0x45c737 : -mov eax, dword ptr [ebp + 8]
0x45c73a : -fstp dword ptr [eax + 0x78]
0x45c73d : mov eax, dword ptr [ebp + 8] 	(pedestrn.c:2321)
0x45c740 : fld dword ptr [eax + 0x80]
0x45c746 : fadd dword ptr [0.05000000074505806 (FLOAT)]
0x45c74c : mov eax, dword ptr [ebp + 8]
0x45c74f : fstp dword ptr [eax + 0x80]
0x45c755 : pop edi 	(pedestrn.c:2322)
0x45c756 : pop esi
0x45c757 : pop ebx
0x45c758 : leave 
0x45c759 : ret 


SquirtPathVertex is only 86.25% similar to the original, diff above
```

*AI generated. Time taken: 810s, tokens: 40,692*
