### PR TITLE
WriteOutPeds 100% match

### DIFF
--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -3186,17 +3186,17 @@ void WriteOutPeds(void) {
         fprintf(f, "%d\t\t\t\t// Ref num\n", the_pedestrian->ref_number);
         fprintf(f, "%d\t\t\t\t// Number of instructions\n", the_pedestrian->number_of_instructions);
         fprintf(f, "%d\t\t\t\t// Initial instruction\n\n", the_pedestrian->first_instruction + 1);
-        for (j = 0, the_instruction = the_pedestrian->instruction_list; j < the_pedestrian->number_of_instructions; j++, the_instruction++) {
+        for (j = 0, the_instruction = the_pedestrian->instruction_list; j < gPedestrian_array[i].number_of_instructions; j++, the_instruction++) {
             switch (the_instruction->type) {
-            case ePed_instruc_point:
-                fprintf(f, "\tpoint\n");
+            case ePed_instruc_xpoint:
+                fprintf(f, "\txpoint\n");
                 fprintf(f, "\t%.3f,%.3f,%.3f\n",
                     the_instruction->data.point_data.position.v[X],
                     the_instruction->data.point_data.position.v[Y],
                     the_instruction->data.point_data.position.v[Z]);
                 break;
-            case ePed_instruc_xpoint:
-                fprintf(f, "\txpoint\n");
+            case ePed_instruc_point:
+                fprintf(f, "\tpoint\n");
                 fprintf(f, "\t%.3f,%.3f,%.3f\n",
                     the_instruction->data.point_data.position.v[X],
                     the_instruction->data.point_data.position.v[Y],
@@ -3215,7 +3215,6 @@ void WriteOutPeds(void) {
                 for (k = 0, the_choice = the_instruction->data.choice_data.choices; k < the_instruction->data.choice_data.number_of_choices; k++, the_choice++) {
                     fprintf(f, "%d,%d,%d,", the_choice->danger_level, the_choice->percentage_chance, the_choice->marker_ref);
                 }
-                break;
             case ePed_instruc_dead:
                 fprintf(f, "\tdead\n");
                 fprintf(f, "%d", the_instruction->data.death_data.death_sequence);

--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -3215,6 +3215,7 @@ void WriteOutPeds(void) {
                 for (k = 0, the_choice = the_instruction->data.choice_data.choices; k < the_instruction->data.choice_data.number_of_choices; k++, the_choice++) {
                     fprintf(f, "%d,%d,%d,", the_choice->danger_level, the_choice->percentage_chance, the_choice->marker_ref);
                 }
+                // TODO: possible bug, no break in the original code. Should we always add a 'dead' instruction after an fchoice?
             case ePed_instruc_dead:
                 fprintf(f, "\tdead\n");
                 fprintf(f, "%d", the_instruction->data.death_data.death_sequence);


### PR DESCRIPTION
## Match result

```
0x45ee73: WriteOutPeds 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x45eeec,21 +0x49f735,21 @@
0x45eeec : call fprintf (FUNCTION)
0x45eef1 : add esp, 0xc
0x45eef4 : mov dword ptr [ebp - 0x12c], 0 	(pedestrn.c:3184)
0x45eefe : mov eax, dword ptr [gPedestrian_array (DATA)]
0x45ef03 : mov dword ptr [ebp - 0x238], eax
0x45ef09 : jmp 0x10
0x45ef0e : inc dword ptr [ebp - 0x12c]
0x45ef14 : add dword ptr [ebp - 0x238], 0xe4
0x45ef1e : mov eax, dword ptr [gPed_count (DATA)]
0x45ef23 : cmp dword ptr [ebp - 0x12c], eax
0x45ef29 : -jge 0x488
         : +jge 0x47c
0x45ef2f : mov eax, dword ptr [ebp - 0x12c] 	(pedestrn.c:3185)
0x45ef35 : inc eax
0x45ef36 : push eax
0x45ef37 : push "// Pedestrian number %d\n\n" (STRING)
0x45ef3c : mov eax, dword ptr [ebp - 0x128]
0x45ef42 : push eax
0x45ef43 : call fprintf (FUNCTION)
0x45ef48 : add esp, 0xc
0x45ef4b : mov eax, dword ptr [ebp - 0x238] 	(pedestrn.c:3186)
0x45ef51 : xor ecx, ecx

---
+++
@@ -0x45efa1,33 +0x49f7ea,51 @@
0x45efa1 : push eax
0x45efa2 : call fprintf (FUNCTION)
0x45efa7 : add esp, 0xc
0x45efaa : mov dword ptr [ebp - 0x130], 0 	(pedestrn.c:3189)
0x45efb4 : mov eax, dword ptr [ebp - 0x238]
0x45efba : mov eax, dword ptr [eax + 0x50]
0x45efbd : mov dword ptr [ebp - 0x23c], eax
0x45efc3 : jmp 0xd
0x45efc8 : inc dword ptr [ebp - 0x130]
0x45efce : add dword ptr [ebp - 0x23c], 0x14
0x45efd5 : -mov eax, dword ptr [ebp - 0x12c]
0x45efdb : -mov ecx, eax
0x45efdd : -shl eax, 3
0x45efe0 : -sub eax, ecx
0x45efe2 : -lea eax, [ecx + eax*8]
0x45efe5 : -mov ecx, dword ptr [gPedestrian_array (DATA)]
0x45efeb : -movsx eax, byte ptr [ecx + eax*4 + 0x61]
         : +mov eax, dword ptr [ebp - 0x238]
         : +movsx eax, byte ptr [eax + 0x61]
0x45eff0 : cmp eax, dword ptr [ebp - 0x130]
0x45eff6 : -jle 0x3a2
         : +jle 0x3a7
0x45effc : mov eax, dword ptr [ebp - 0x23c] 	(pedestrn.c:3190)
0x45f002 : mov eax, dword ptr [eax]
0x45f004 : mov dword ptr [ebp - 0x24c], eax
0x45f00a : -jmp 0x348
         : +jmp 0x34d
         : +push "\tpoint\n" (STRING) 	(pedestrn.c:3192)
         : +mov eax, dword ptr [ebp - 0x128]
         : +push eax
         : +call fprintf (FUNCTION)
         : +add esp, 8
         : +mov eax, dword ptr [ebp - 0x23c] 	(pedestrn.c:3196)
         : +fld dword ptr [eax + 0xc]
         : +sub esp, 8
         : +fstp qword ptr [esp]
         : +mov eax, dword ptr [ebp - 0x23c]
         : +fld dword ptr [eax + 8]
         : +sub esp, 8
         : +fstp qword ptr [esp]
         : +mov eax, dword ptr [ebp - 0x23c]
         : +fld dword ptr [eax + 4]
         : +sub esp, 8
         : +fstp qword ptr [esp]
         : +push "\t%.3f,%.3f,%.3f\n" (STRING)
         : +mov eax, dword ptr [ebp - 0x128]
         : +push eax
         : +call fprintf (FUNCTION)
         : +add esp, 0x20
         : +jmp 0x335 	(pedestrn.c:3197)
0x45f00f : push "\txpoint\n" (STRING) 	(pedestrn.c:3199)
0x45f014 : mov eax, dword ptr [ebp - 0x128]
0x45f01a : push eax
0x45f01b : call fprintf (FUNCTION)
0x45f020 : add esp, 8
0x45f023 : mov eax, dword ptr [ebp - 0x23c] 	(pedestrn.c:3203)
0x45f029 : fld dword ptr [eax + 0xc]
0x45f02c : sub esp, 8
0x45f02f : fstp qword ptr [esp]
0x45f032 : mov eax, dword ptr [ebp - 0x23c]

---
+++
@@ -0x45f03e,44 +0x49f8d0,21 @@
0x45f03e : fstp qword ptr [esp]
0x45f041 : mov eax, dword ptr [ebp - 0x23c]
0x45f047 : fld dword ptr [eax + 4]
0x45f04a : sub esp, 8
0x45f04d : fstp qword ptr [esp]
0x45f050 : push "\t%.3f,%.3f,%.3f\n" (STRING)
0x45f055 : mov eax, dword ptr [ebp - 0x128]
0x45f05b : push eax
0x45f05c : call fprintf (FUNCTION)
0x45f061 : add esp, 0x20
0x45f064 : -jmp 0x330
0x45f069 : -push "\tpoint\n" (STRING)
0x45f06e : -mov eax, dword ptr [ebp - 0x128]
0x45f074 : -push eax
0x45f075 : -call fprintf (FUNCTION)
0x45f07a : -add esp, 8
0x45f07d : -mov eax, dword ptr [ebp - 0x23c]
0x45f083 : -fld dword ptr [eax + 0xc]
0x45f086 : -sub esp, 8
0x45f089 : -fstp qword ptr [esp]
0x45f08c : -mov eax, dword ptr [ebp - 0x23c]
0x45f092 : -fld dword ptr [eax + 8]
0x45f095 : -sub esp, 8
0x45f098 : -fstp qword ptr [esp]
0x45f09b : -mov eax, dword ptr [ebp - 0x23c]
0x45f0a1 : -fld dword ptr [eax + 4]
0x45f0a4 : -sub esp, 8
0x45f0a7 : -fstp qword ptr [esp]
0x45f0aa : -push "\t%.3f,%.3f,%.3f\n" (STRING)
0x45f0af : -mov eax, dword ptr [ebp - 0x128]
0x45f0b5 : -push eax
0x45f0b6 : -call fprintf (FUNCTION)
0x45f0bb : -add esp, 0x20
0x45f0be : -jmp 0x2d6
         : +jmp 0x2db 	(pedestrn.c:3204)
0x45f0c3 : push "\tbchoice\n" (STRING) 	(pedestrn.c:3206)
0x45f0c8 : mov eax, dword ptr [ebp - 0x128]
0x45f0ce : push eax
0x45f0cf : call fprintf (FUNCTION)
0x45f0d4 : add esp, 8
0x45f0d7 : mov eax, dword ptr [ebp - 0x23c] 	(pedestrn.c:3207)
0x45f0dd : mov eax, dword ptr [eax + 4]
0x45f0e0 : push eax
0x45f0e1 : push "%d" (STRING)
0x45f0e6 : mov eax, dword ptr [ebp - 0x128]

---
+++
@@ -0x45f14d,21 +0x49f985,21 @@
0x45f14d : mov eax, dword ptr [ebp - 0x120]
0x45f153 : xor ecx, ecx
0x45f155 : mov cx, word ptr [eax]
0x45f158 : push ecx
0x45f159 : push "%d,%d,%d," (STRING)
0x45f15e : mov eax, dword ptr [ebp - 0x128]
0x45f164 : push eax
0x45f165 : call fprintf (FUNCTION)
0x45f16a : add esp, 0x14
0x45f16d : jmp -0x5f 	(pedestrn.c:3210)
0x45f172 : -jmp 0x222
         : +jmp 0x227 	(pedestrn.c:3211)
0x45f177 : push "\tfchoice\n" (STRING) 	(pedestrn.c:3213)
0x45f17c : mov eax, dword ptr [ebp - 0x128]
0x45f182 : push eax
0x45f183 : call fprintf (FUNCTION)
0x45f188 : add esp, 8
0x45f18b : mov eax, dword ptr [ebp - 0x23c] 	(pedestrn.c:3214)
0x45f191 : mov eax, dword ptr [eax + 4]
0x45f194 : push eax
0x45f195 : push "%d" (STRING)
0x45f19a : mov eax, dword ptr [ebp - 0x128]

---
+++
@@ -0x45f201,20 +0x49fa39,21 @@
0x45f201 : mov eax, dword ptr [ebp - 0x120]
0x45f207 : xor ecx, ecx
0x45f209 : mov cx, word ptr [eax]
0x45f20c : push ecx
0x45f20d : push "%d,%d,%d," (STRING)
0x45f212 : mov eax, dword ptr [ebp - 0x128]
0x45f218 : push eax
0x45f219 : call fprintf (FUNCTION)
0x45f21e : add esp, 0x14
0x45f221 : jmp -0x5f 	(pedestrn.c:3217)
         : +jmp 0x173 	(pedestrn.c:3218)
0x45f226 : push "\tdead\n" (STRING) 	(pedestrn.c:3220)
0x45f22b : mov eax, dword ptr [ebp - 0x128]
0x45f231 : push eax
0x45f232 : call fprintf (FUNCTION)
0x45f237 : add esp, 8
0x45f23a : mov eax, dword ptr [ebp - 0x23c] 	(pedestrn.c:3221)
0x45f240 : mov eax, dword ptr [eax + 4]
0x45f243 : push eax
0x45f244 : push "%d" (STRING)
0x45f249 : mov eax, dword ptr [ebp - 0x128]

---
+++
@@ -,29 +,36 @@
0x45f344 : push eax
0x45f345 : call fprintf (FUNCTION)
0x45f34a : add esp, 8
0x45f34d : jmp 0x47 	(pedestrn.c:3241)
0x45f352 : jmp 0x42 	(pedestrn.c:3242)
0x45f357 : cmp dword ptr [ebp - 0x24c], 9
0x45f35e : ja 0x35
0x45f364 : mov eax, dword ptr [ebp - 0x24c]
0x45f36a : jmp dword ptr [eax*4 + <OFFSET37>]
 : Jump table:
0x45f371 : -start + 0x1f6
0x45f375 : -start + 0x19c
0x45f379 : -start + 0x250
0x45f37d : -start + 0x304
0x45f381 : -start + 0x3b3
0x45f385 : -start + 0x3ea
0x45f389 : -start + 0x421
0x45f38d : -start + 0x458
0x45f391 : -start + 0x48f
0x45f395 : -start + 0x4c6
0x45f399 : -jmp -0x3d6
         : +start + 0x18b
         : +start + 0x1e5
         : +start + 0x23f
         : +start + 0x2f3
         : +start + 0x3a7
         : +start + 0x3de
         : +start + 0x415
         : +start + 0x44c
         : +start + 0x483
         : +start + 0x4ba
         : +jmp -0x3ca 	(pedestrn.c:3243)
0x45f39e : push "\n\n" (STRING) 	(pedestrn.c:3244)
0x45f3a3 : mov eax, dword ptr [ebp - 0x128]
0x45f3a9 : push eax
0x45f3aa : call fprintf (FUNCTION)
0x45f3af : add esp, 8
0x45f3b2 : -jmp -0x4a9
         : +jmp -0x49d 	(pedestrn.c:3245)
0x45f3b7 : mov eax, dword ptr [ebp - 0x128] 	(pedestrn.c:3246)
0x45f3bd : push eax
         : +call fclose (FUNCTION)
         : +add esp, 4
         : +pop edi 	(pedestrn.c:3247)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


WriteOutPeds is only 85.37% similar to the original, diff above
```

*AI generated. Time taken: 220s*
