### PR TITLE
GetPedPos 100% match

### DIFF
--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -3610,6 +3610,7 @@ void GetPedPos(int* pPed_index, int* pPoint_index) {
 
     min_distance = BR_SCALAR_MAX;
     for (i = 0; i < gPed_count; i++) {
+        point_count = 0;
         for (j = 0; j < gPedestrian_array[i].number_of_instructions; j++) {
             if (gPedestrian_array[i].instruction_list[j].type == ePed_instruc_point || gPedestrian_array[i].instruction_list[j].type == ePed_instruc_xpoint) {
                 the_point = gPedestrian_array[i].instruction_list[j].data.point_data.position;
@@ -3623,12 +3624,12 @@ void GetPedPos(int* pPed_index, int* pPoint_index) {
                 }
                 the_distance = Vector3DistanceSquared(&the_point, gOur_pos);
                 if (the_distance < min_distance) {
+                    min_distance = the_distance;
                     *pPed_index = i;
                     *pPoint_index = j;
-                    min_distance = the_distance;
                 }
             }
-            // last_point = the_point;
+            last_point = the_point;
         }
     }
 }


### PR DESCRIPTION
## Match result

```
0x45faba: GetPedPos 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x45fabd,34 +0x4a03c2,33 @@
0x45fabd : sub esp, 0x2c
0x45fac0 : push ebx
0x45fac1 : push esi
0x45fac2 : push edi
0x45fac3 : mov dword ptr [ebp - 8], 0x7f7fffff 	(pedestrn.c:3611)
0x45faca : mov dword ptr [ebp - 0x1c], 0 	(pedestrn.c:3612)
0x45fad1 : jmp 0x3
0x45fad6 : inc dword ptr [ebp - 0x1c]
0x45fad9 : mov eax, dword ptr [gPed_count (DATA)]
0x45fade : cmp dword ptr [ebp - 0x1c], eax
0x45fae1 : -jge 0x1aa
0x45fae7 : -mov dword ptr [ebp - 4], 0
         : +jge 0x18d
0x45faee : mov dword ptr [ebp - 0x20], 0 	(pedestrn.c:3613)
0x45faf5 : jmp 0x3
0x45fafa : inc dword ptr [ebp - 0x20]
0x45fafd : mov eax, dword ptr [ebp - 0x1c]
0x45fb00 : mov ecx, eax
0x45fb02 : shl eax, 3
0x45fb05 : sub eax, ecx
0x45fb07 : lea eax, [ecx + eax*8]
0x45fb0a : mov ecx, dword ptr [gPedestrian_array (DATA)]
0x45fb10 : movsx eax, byte ptr [ecx + eax*4 + 0x61]
0x45fb15 : cmp eax, dword ptr [ebp - 0x20]
0x45fb18 : -jle 0x16e
         : +jle 0x158
0x45fb1e : mov eax, dword ptr [ebp - 0x1c] 	(pedestrn.c:3614)
0x45fb21 : mov ecx, eax
0x45fb23 : shl eax, 3
0x45fb26 : sub eax, ecx
0x45fb28 : lea eax, [ecx + eax*8]
0x45fb2b : mov ecx, dword ptr [gPedestrian_array (DATA)]
0x45fb31 : mov eax, dword ptr [ecx + eax*4 + 0x50]
0x45fb35 : mov ecx, dword ptr [ebp - 0x20]
0x45fb38 : shl ecx, 2
0x45fb3b : lea ecx, [ecx + ecx*4]

---
+++
@@ -0x45fc3c,21 +0x4a053a,25 @@
0x45fc3c : fld dword ptr [ebp - 0x2c]
0x45fc3f : mov eax, dword ptr [gOur_pos (DATA)]
0x45fc44 : fsub dword ptr [eax]
0x45fc46 : fmulp st(1)
0x45fc48 : faddp st(1)
0x45fc4a : fcom dword ptr [ebp - 8] 	(pedestrn.c:3625)
0x45fc4d : fstp dword ptr [ebp - 0x18]
0x45fc50 : fnstsw ax
0x45fc52 : test ah, 1
0x45fc55 : je 0x16
0x45fc5b : -mov eax, dword ptr [ebp - 0x18]
0x45fc5e : -mov dword ptr [ebp - 8], eax
0x45fc61 : mov eax, dword ptr [ebp - 0x1c] 	(pedestrn.c:3626)
0x45fc64 : mov ecx, dword ptr [ebp + 8]
0x45fc67 : mov dword ptr [ecx], eax
0x45fc69 : mov eax, dword ptr [ebp - 0x20] 	(pedestrn.c:3627)
0x45fc6c : mov ecx, dword ptr [ebp + 0xc]
0x45fc6f : mov dword ptr [ecx], eax
0x45fc71 : -lea eax, [ebp - 0x2c]
0x45fc74 : -lea ecx, [ebp - 0x14]
0x45fc77 : -mov edx, dword ptr [eax]
         : +mov eax, dword ptr [ebp - 0x18] 	(pedestrn.c:3628)
         : +mov dword ptr [ebp - 8], eax
         : +jmp -0x17c 	(pedestrn.c:3632)
         : +jmp -0x19e 	(pedestrn.c:3633)
         : +pop edi 	(pedestrn.c:3634)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


GetPedPos is only 92.83% similar to the original, diff above
```

*AI generated. Time taken: 179s, tokens: 25,724*
