### PR TITLE
DeletePedPoint 100% effective match

### DIFF
--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -3737,18 +3737,15 @@ void DeletePedPath(void) {
 // IDA: void __cdecl DeletePedPoint()
 // FUNCTION: CARM95 0x0046010f
 void DeletePedPoint(void) {
-
-    if (gPed_instruc_count == 0) {
-        return;
-    }
-    if (gPed_instruc_count == 1) {
-        ScrubPedestrian();
-    } else {
-        if (gInit_ped_instruc == gPed_instruc_count) {
-            gInit_ped_instruc--;
+    if (gPed_instruc_count != 0) {
+        if (gPed_instruc_count == 1) {
+            ScrubPedestrian();
+        } else {
+            if (gPed_instruc_count-- == gInit_ped_instruc) {
+                gInit_ped_instruc--;
+            }
+            MungeShowPedPath();
         }
-        gPed_instruc_count--;
-        MungeShowPedPath();
     }
 }
 


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x46010f,24 +0x4a092f,25 @@
0x46010f : push ebp 	(pedestrn.c:3739)
0x460110 : mov ebp, esp
0x460112 : sub esp, 4
0x460115 : push ebx
0x460116 : push esi
0x460117 : push edi
0x460118 : cmp dword ptr [gPed_instruc_count (DATA)], 0 	(pedestrn.c:3740)
0x46011f : -je 0x3f
         : +je 0x3e
0x460125 : cmp dword ptr [gPed_instruc_count (DATA)], 1 	(pedestrn.c:3741)
0x46012c : jne 0xa
0x460132 : call ScrubPedestrian (FUNCTION) 	(pedestrn.c:3742)
0x460137 : -jmp 0x28
         : +jmp 0x27 	(pedestrn.c:3743)
0x46013c : mov eax, dword ptr [gPed_instruc_count (DATA)] 	(pedestrn.c:3744)
0x460141 : mov dword ptr [ebp - 4], eax
0x460144 : dec dword ptr [gPed_instruc_count (DATA)]
0x46014a : -mov eax, dword ptr [ebp - 4]
0x46014d : -cmp dword ptr [gInit_ped_instruc (DATA)], eax
         : +mov eax, dword ptr [gInit_ped_instruc (DATA)]
         : +cmp dword ptr [ebp - 4], eax
0x460153 : jne 0x6
0x460159 : dec dword ptr [gInit_ped_instruc (DATA)] 	(pedestrn.c:3745)
0x46015f : call MungeShowPedPath (FUNCTION) 	(pedestrn.c:3747)
0x460164 : pop edi 	(pedestrn.c:3750)
0x460165 : pop esi
0x460166 : pop ebx
0x460167 : leave 
         : +ret 


0x46010f: DeletePedPoint 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x46010f,21 +0x4a092f,23 @@
0x46010f : push ebp 	(pedestrn.c:3739)
0x460110 : mov ebp, esp
0x460112 : -sub esp, 4
0x460115 : push ebx
0x460116 : push esi
0x460117 : push edi
0x460118 : cmp dword ptr [gPed_instruc_count (DATA)], 0 	(pedestrn.c:3741)
0x46011f : -je 0x3f
         : +jne 0x5
         : +jmp 0x39 	(pedestrn.c:3742)
0x460125 : cmp dword ptr [gPed_instruc_count (DATA)], 1 	(pedestrn.c:3744)
0x46012c : jne 0xa
0x460132 : call ScrubPedestrian (FUNCTION) 	(pedestrn.c:3745)
0x460137 : -jmp 0x28
0x46013c : -mov eax, dword ptr [gPed_instruc_count (DATA)]
0x460141 : -mov dword ptr [ebp - 4], eax
0x460144 : -dec dword ptr [gPed_instruc_count (DATA)]
0x46014a : -mov eax, dword ptr [ebp - 4]
0x46014d : -cmp dword ptr [gInit_ped_instruc (DATA)], eax
         : +jmp 0x22 	(pedestrn.c:3746)
         : +mov eax, dword ptr [gInit_ped_instruc (DATA)] 	(pedestrn.c:3747)
         : +cmp dword ptr [gPed_instruc_count (DATA)], eax
0x460153 : jne 0x6
0x460159 : dec dword ptr [gInit_ped_instruc (DATA)] 	(pedestrn.c:3748)
         : +dec dword ptr [gPed_instruc_count (DATA)] 	(pedestrn.c:3750)
0x46015f : call MungeShowPedPath (FUNCTION) 	(pedestrn.c:3751)
0x460164 : pop edi 	(pedestrn.c:3753)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DeletePedPoint is only 59.09% similar to the original, diff above
```

*AI generated. Time taken: 167s*
