### PR TITLE
DisposePedestrians 100% match

### DIFF
--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -3771,21 +3771,15 @@ void DisposePedestrians(void) {
     }
     for (i = 0; i < COUNT_OF(gPed_gib_materials); i++) {
         for (j = 0; j < gPed_size_counts[i]; j++) {
-            BrMapRemove(gPed_gib_materials[i].materials[j]->colour_map);
-            BrPixelmapFree(gPed_gib_materials[i].materials[j]->colour_map);
-            gPed_gib_materials[i].materials[j]->colour_map = NULL;
-            BrMaterialRemove(gPed_gib_materials[i].materials[j]);
-            BrMaterialFree(gPed_gib_materials[i].materials[j]);
+            BrMapRemove((gPed_gib_materials + i)->materials[j * 1]->colour_map);
+            BrPixelmapFree((gPed_gib_materials + i)->materials[j * 1]->colour_map);
+            (gPed_gib_materials + i)->materials[j * 1]->colour_map = NULL;
+            BrMaterialRemove((gPed_gib_materials + i)->materials[j * 1]);
+            BrMaterialFree((gPed_gib_materials + i)->materials[j * 1]);
         }
     }
 
-    // AddPed->CreatePedestrian needs the gPedestrian array.
-    if (gPed_instruc_count != 0) {
-        AddPed();
-    }
-
-    for (i = 0; i < gPed_count; i++) {
-        the_pedestrian = &gPedestrian_array[i];
+    for (i = 0, the_pedestrian = gPedestrian_array; i < gPed_count; i++, the_pedestrian++) {
         PossibleService();
         BrActorRemove(the_pedestrian->actor);
         BrActorFree(the_pedestrian->actor);
@@ -3799,6 +3793,12 @@ void DisposePedestrians(void) {
     BrMemFree(gPedestrian_array);
     BrTableRemove(gProx_ray_shade_table);
     BrPixelmapFree(gProx_ray_shade_table);
+
+    // AddPed->CreatePedestrian needs the gPedestrian array.
+    if (gPed_instruc_count != 0) {
+        AddPed();
+    }
+
     DisposePedPaths();
 }
 

--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -3771,11 +3771,11 @@ void DisposePedestrians(void) {
     }
     for (i = 0; i < COUNT_OF(gPed_gib_materials); i++) {
         for (j = 0; j < gPed_size_counts[i]; j++) {
-            BrMapRemove((gPed_gib_materials + i)->materials[j * 1]->colour_map);
-            BrPixelmapFree((gPed_gib_materials + i)->materials[j * 1]->colour_map);
-            (gPed_gib_materials + i)->materials[j * 1]->colour_map = NULL;
-            BrMaterialRemove((gPed_gib_materials + i)->materials[j * 1]);
-            BrMaterialFree((gPed_gib_materials + i)->materials[j * 1]);
+            BrMapRemove(gPed_gib_materials[i].materials[j * 1]->colour_map);
+            BrPixelmapFree(gPed_gib_materials[i].materials[j * 1]->colour_map);
+            gPed_gib_materials[i].materials[j * 1]->colour_map = NULL;
+            BrMaterialRemove(gPed_gib_materials[i].materials[j * 1]);
+            BrMaterialFree(gPed_gib_materials[i].materials[j * 1]);
         }
     }
 


### PR DESCRIPTION
## Match result

```
0x460169: DisposePedestrians 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x460227,71 +0x4a0a43,79 @@
0x460227 : inc dword ptr [ebp - 4]
0x46022a : cmp dword ptr [ebp - 4], 4
0x46022e : jge 0xbc
0x460234 : mov dword ptr [ebp - 8], 0 	(pedestrn.c:3773)
0x46023b : jmp 0x3
0x460240 : inc dword ptr [ebp - 8]
0x460243 : mov eax, dword ptr [ebp - 4]
0x460246 : mov ecx, dword ptr [ebp - 8]
0x460249 : cmp dword ptr [eax*4 + gPed_size_counts[0] (DATA)], ecx
0x460250 : jle 0x95
0x460256 : -mov eax, dword ptr [ebp - 8]
0x460259 : -mov ecx, dword ptr [ebp - 4]
0x46025c : -lea ecx, [ecx + ecx*2]
0x46025f : -shl ecx, 3
0x460262 : -mov eax, dword ptr [ecx + eax*4 + gPed_gib_materials[0].materials (OFFSET)]
         : +mov eax, dword ptr [ebp - 4] 	(pedestrn.c:3774)
         : +lea eax, [eax + eax*2]
         : +mov ecx, dword ptr [ebp - 8]
         : +shl ecx, 2
         : +mov eax, dword ptr [ecx + eax*8 + gPed_gib_materials[0].materials (OFFSET)]
0x460269 : mov eax, dword ptr [eax + 0x40]
0x46026c : push eax
0x46026d : call BrMapRemove (FUNCTION)
0x460272 : add esp, 4
0x460275 : -mov eax, dword ptr [ebp - 8]
0x460278 : -mov ecx, dword ptr [ebp - 4]
0x46027b : -lea ecx, [ecx + ecx*2]
0x46027e : -shl ecx, 3
0x460281 : -mov eax, dword ptr [ecx + eax*4 + gPed_gib_materials[0].materials (OFFSET)]
         : +mov eax, dword ptr [ebp - 4] 	(pedestrn.c:3775)
         : +lea eax, [eax + eax*2]
         : +mov ecx, dword ptr [ebp - 8]
         : +shl ecx, 2
         : +mov eax, dword ptr [ecx + eax*8 + gPed_gib_materials[0].materials (OFFSET)]
0x460288 : mov eax, dword ptr [eax + 0x40]
0x46028b : push eax
0x46028c : call BrPixelmapFree (FUNCTION)
0x460291 : add esp, 4
0x460294 : -mov eax, dword ptr [ebp - 8]
0x460297 : -mov ecx, dword ptr [ebp - 4]
0x46029a : -lea ecx, [ecx + ecx*2]
0x46029d : -shl ecx, 3
0x4602a0 : -mov eax, dword ptr [ecx + eax*4 + gPed_gib_materials[0].materials (OFFSET)]
         : +mov eax, dword ptr [ebp - 4] 	(pedestrn.c:3776)
         : +lea eax, [eax + eax*2]
         : +mov ecx, dword ptr [ebp - 8]
         : +shl ecx, 2
         : +mov eax, dword ptr [ecx + eax*8 + gPed_gib_materials[0].materials (OFFSET)]
0x4602a7 : mov dword ptr [eax + 0x40], 0
0x4602ae : -mov eax, dword ptr [ebp - 8]
0x4602b1 : -mov ecx, dword ptr [ebp - 4]
0x4602b4 : -lea ecx, [ecx + ecx*2]
0x4602b7 : -shl ecx, 3
0x4602ba : -mov eax, dword ptr [ecx + eax*4 + gPed_gib_materials[0].materials (OFFSET)]
         : +mov eax, dword ptr [ebp - 4] 	(pedestrn.c:3777)
         : +lea eax, [eax + eax*2]
         : +mov ecx, dword ptr [ebp - 8]
         : +shl ecx, 2
         : +mov eax, dword ptr [ecx + eax*8 + gPed_gib_materials[0].materials (OFFSET)]
0x4602c1 : push eax
0x4602c2 : call BrMaterialRemove (FUNCTION)
0x4602c7 : add esp, 4
0x4602ca : -mov eax, dword ptr [ebp - 8]
0x4602cd : -mov ecx, dword ptr [ebp - 4]
0x4602d0 : -lea ecx, [ecx + ecx*2]
0x4602d3 : -shl ecx, 3
0x4602d6 : -mov eax, dword ptr [ecx + eax*4 + gPed_gib_materials[0].materials (OFFSET)]
         : +mov eax, dword ptr [ebp - 4] 	(pedestrn.c:3778)
         : +lea eax, [eax + eax*2]
         : +mov ecx, dword ptr [ebp - 8]
         : +shl ecx, 2
         : +mov eax, dword ptr [ecx + eax*8 + gPed_gib_materials[0].materials (OFFSET)]
0x4602dd : push eax
0x4602de : call BrMaterialFree (FUNCTION)
0x4602e3 : add esp, 4
0x4602e6 : jmp -0xab 	(pedestrn.c:3779)
0x4602eb : jmp -0xc9 	(pedestrn.c:3780)
         : +cmp dword ptr [gPed_instruc_count (DATA)], 0 	(pedestrn.c:3783)
         : +je 0x5
         : +call AddPed (FUNCTION) 	(pedestrn.c:3784)
0x4602f0 : mov dword ptr [ebp - 4], 0 	(pedestrn.c:3787)
0x4602f7 : -mov eax, dword ptr [gPedestrian_array (DATA)]
0x4602fc : -mov dword ptr [ebp - 0xc], eax
0x4602ff : -jmp 0xa
         : +jmp 0x3
0x460304 : inc dword ptr [ebp - 4]
0x460307 : -add dword ptr [ebp - 0xc], 0xe4
0x46030e : mov eax, dword ptr [gPed_count (DATA)]
0x460313 : cmp dword ptr [ebp - 4], eax
0x460316 : -jge 0x67
         : +jge 0x80
         : +mov eax, dword ptr [ebp - 4] 	(pedestrn.c:3788)
         : +mov ecx, eax
         : +shl eax, 3
         : +sub eax, ecx
         : +lea eax, [ecx + eax*8]
         : +shl eax, 2
         : +add eax, dword ptr [gPedestrian_array (DATA)]
         : +mov dword ptr [ebp - 0xc], eax
0x46031c : call PossibleService (FUNCTION) 	(pedestrn.c:3789)
0x460321 : mov eax, dword ptr [ebp - 0xc] 	(pedestrn.c:3790)
0x460324 : mov eax, dword ptr [eax + 0x48]
0x460327 : push eax
0x460328 : call BrActorRemove (FUNCTION)
0x46032d : add esp, 4
0x460330 : mov eax, dword ptr [ebp - 0xc] 	(pedestrn.c:3791)
0x460333 : mov eax, dword ptr [eax + 0x48]
0x460336 : push eax
0x460337 : call BrActorFree (FUNCTION)

---
+++
@@ -0x46035d,35 +0x4a0b95,32 @@
0x46035d : mov eax, dword ptr [ebp - 0xc] 	(pedestrn.c:3794)
0x460360 : mov eax, dword ptr [eax + 0x54]
0x460363 : push eax
0x460364 : call BrMemFree (FUNCTION)
0x460369 : add esp, 4
0x46036c : mov eax, dword ptr [ebp - 0xc] 	(pedestrn.c:3795)
0x46036f : mov eax, dword ptr [eax + 0xd8]
0x460375 : push eax
0x460376 : call BrMemFree (FUNCTION)
0x46037b : add esp, 4
0x46037e : -jmp -0x7f
         : +jmp -0x91 	(pedestrn.c:3797)
0x460383 : push gPedestrians_storage_space (DATA) 	(pedestrn.c:3798)
0x460388 : call ClearOutStorageSpace (FUNCTION)
0x46038d : add esp, 4
0x460390 : mov eax, dword ptr [gPedestrian_array (DATA)] 	(pedestrn.c:3799)
0x460395 : push eax
0x460396 : call BrMemFree (FUNCTION)
0x46039b : add esp, 4
0x46039e : mov eax, dword ptr [gProx_ray_shade_table (DATA)] 	(pedestrn.c:3800)
0x4603a3 : push eax
0x4603a4 : call BrTableRemove (FUNCTION)
0x4603a9 : add esp, 4
0x4603ac : mov eax, dword ptr [gProx_ray_shade_table (DATA)] 	(pedestrn.c:3801)
0x4603b1 : push eax
0x4603b2 : call BrPixelmapFree (FUNCTION)
0x4603b7 : add esp, 4
0x4603ba : -cmp dword ptr [gPed_instruc_count (DATA)], 0
0x4603c1 : -je 0x5
0x4603c7 : -call AddPed (FUNCTION)
0x4603cc : call DisposePedPaths (FUNCTION) 	(pedestrn.c:3802)
0x4603d1 : pop edi 	(pedestrn.c:3803)
0x4603d2 : pop esi
0x4603d3 : pop ebx
0x4603d4 : leave 
0x4603d5 : ret 


DisposePedestrians is only 78.21% similar to the original, diff above
```

*AI generated. Time taken: 374s, tokens: 29,587*
