### PR TITLE
AdjustProxRay 100% match

### DIFF
--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -3932,7 +3932,7 @@ void RenderProximityRays(br_pixelmap* pRender_screen, br_pixelmap* pDepth_buffer
 // FUNCTION: CARM95 0x00460ac5
 void AdjustProxRay(int pRay_index, tU16 pCar_ID, tU16 pPed_index, tU32 pTime) {
 
-    if ((pCar_ID & 0xff00) == 0) {
+    if ((pCar_ID >> 8) == 0) {
         gProximity_rays[pRay_index].car = &gProgram_state.current_car;
     } else {
         gProximity_rays[pRay_index].car = GetCarSpec(pCar_ID >> 8, pCar_ID & 0xff);


### PR DESCRIPTION
## Match result

```
0x460ac5: AdjustProxRay 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x460ac5,20 +0x4a130c,16 @@
0x460ac5 : push ebp 	(pedestrn.c:3933)
0x460ac6 : mov ebp, esp
0x460ac8 : push ebx
0x460ac9 : push esi
0x460aca : push edi
0x460acb : -mov eax, dword ptr [ebp + 0xc]
0x460ace : -and eax, 0xff00
0x460ad3 : -xor ecx, ecx
0x460ad5 : -and ecx, 0xffffff00
0x460adb : -cmp eax, ecx
         : +cmp byte ptr [ebp + 0xd], 0 	(pedestrn.c:3935)
0x460add : jne 0x1c
0x460ae3 : mov eax, gProgram_state (DATA) 	(pedestrn.c:3936)
0x460ae8 : add eax, 0xb0
0x460aed : mov ecx, dword ptr [ebp + 8]
0x460af0 : lea ecx, [ecx + ecx*2]
0x460af3 : mov dword ptr [ecx*4 + gProximity_rays[0].car (DATA)], eax
0x460afa : jmp 0x2a 	(pedestrn.c:3937)
0x460aff : mov eax, dword ptr [ebp + 0xc] 	(pedestrn.c:3938)
0x460b02 : and eax, 0xff
0x460b07 : push eax

---
+++
@@ -0x460b33,10 +0x4a136c,17 @@
0x460b33 : shl eax, 3
0x460b36 : sub eax, ecx
0x460b38 : lea eax, [ecx + eax*8]
0x460b3b : shl eax, 2
0x460b3e : add eax, dword ptr [gPedestrian_array (DATA)]
0x460b44 : mov ecx, dword ptr [ebp + 8]
0x460b47 : lea ecx, [ecx + ecx*2]
0x460b4a : mov dword ptr [ecx*4 + gProximity_rays[0].ped (OFFSET)], eax
0x460b51 : mov eax, dword ptr [ebp + 0x14] 	(pedestrn.c:3941)
0x460b54 : mov ecx, dword ptr [ebp + 8]
         : +lea ecx, [ecx + ecx*2]
         : +mov dword ptr [ecx*4 + gProximity_rays[0].start_time (OFFSET)], eax
         : +pop edi 	(pedestrn.c:3942)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


AdjustProxRay is only 85.06% similar to the original, diff above
```

*AI generated. Time taken: 103s, tokens: 32,838*
