### PR TITLE
SendAllPedestrianPositions 100% effective match

### DIFF
--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -4067,8 +4067,7 @@ void SendAllPedestrianPositions(tPlayer_ID pPlayer) {
     tNet_contents* the_contents;
 
     gSend_peds = 1;
-    for (i = 0; i < gPed_count; i++) {
-        the_pedestrian = &gPedestrian_array[i];
+    for (i = 0, the_pedestrian = gPedestrian_array; i < gPed_count; i++, the_pedestrian++) {
         if (the_pedestrian->munged) {
             SendPedestrian(the_pedestrian, i);
         }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4610a2,30 +0x4a18bc,30 @@
0x4610a2 : push ebx
0x4610a3 : push esi
0x4610a4 : push edi
0x4610a5 : mov dword ptr [gSend_peds (DATA)], 1 	(pedestrn.c:4069)
0x4610af : mov dword ptr [ebp - 8], 0 	(pedestrn.c:4070)
0x4610b6 : mov eax, dword ptr [gPedestrian_array (DATA)]
0x4610bb : mov dword ptr [ebp - 0xc], eax
0x4610be : jmp 0xa
0x4610c3 : inc dword ptr [ebp - 8]
0x4610c6 : add dword ptr [ebp - 0xc], 0xe4
0x4610cd : -mov eax, dword ptr [gPed_count (DATA)]
0x4610d2 : -cmp dword ptr [ebp - 8], eax
0x4610d5 : -jge 0x25
         : +mov eax, dword ptr [ebp - 8]
         : +cmp dword ptr [gPed_count (DATA)], eax
         : +jle 0x25
0x4610db : mov eax, dword ptr [ebp - 0xc] 	(pedestrn.c:4071)
0x4610de : xor ecx, ecx
0x4610e0 : mov cl, byte ptr [eax + 0x5a]
0x4610e3 : test ecx, ecx
0x4610e5 : je 0x10
0x4610eb : mov eax, dword ptr [ebp - 8] 	(pedestrn.c:4072)
0x4610ee : push eax
0x4610ef : mov eax, dword ptr [ebp - 0xc]
0x4610f2 : push eax
0x4610f3 : call SendPedestrian (FUNCTION)
0x4610f8 : add esp, 8
0x4610fb : -jmp -0x3d
         : +jmp -0x3e 	(pedestrn.c:4074)
0x461100 : pop edi 	(pedestrn.c:4075)
0x461101 : pop esi
0x461102 : pop ebx
0x461103 : leave 
0x461104 : ret 


0x46109c: SendAllPedestrianPositions 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x46109c,33 +0x4a18b6,38 @@
0x46109c : push ebp 	(pedestrn.c:4064)
0x46109d : mov ebp, esp
0x46109f : sub esp, 0xc
0x4610a2 : push ebx
0x4610a3 : push esi
0x4610a4 : push edi
0x4610a5 : mov dword ptr [gSend_peds (DATA)], 1 	(pedestrn.c:4069)
0x4610af : mov dword ptr [ebp - 8], 0 	(pedestrn.c:4070)
0x4610b6 : -mov eax, dword ptr [gPedestrian_array (DATA)]
         : +jmp 0x3
         : +inc dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp - 8]
         : +cmp dword ptr [gPed_count (DATA)], eax
         : +jle 0x3e
         : +mov eax, dword ptr [ebp - 8] 	(pedestrn.c:4071)
         : +mov ecx, eax
         : +shl eax, 3
         : +sub eax, ecx
         : +lea eax, [ecx + eax*8]
         : +shl eax, 2
         : +add eax, dword ptr [gPedestrian_array (DATA)]
0x4610bb : mov dword ptr [ebp - 0xc], eax
0x4610be : -jmp 0xa
0x4610c3 : -inc dword ptr [ebp - 8]
0x4610c6 : -add dword ptr [ebp - 0xc], 0xe4
0x4610cd : -mov eax, dword ptr [gPed_count (DATA)]
0x4610d2 : -cmp dword ptr [ebp - 8], eax
0x4610d5 : -jge 0x25
0x4610db : mov eax, dword ptr [ebp - 0xc] 	(pedestrn.c:4072)
0x4610de : xor ecx, ecx
0x4610e0 : mov cl, byte ptr [eax + 0x5a]
0x4610e3 : test ecx, ecx
0x4610e5 : je 0x10
0x4610eb : mov eax, dword ptr [ebp - 8] 	(pedestrn.c:4073)
0x4610ee : push eax
0x4610ef : mov eax, dword ptr [ebp - 0xc]
0x4610f2 : push eax
0x4610f3 : call SendPedestrian (FUNCTION)
0x4610f8 : add esp, 8
0x4610fb : -jmp -0x3d
         : +jmp -0x50 	(pedestrn.c:4075)
0x461100 : pop edi 	(pedestrn.c:4076)
0x461101 : pop esi
0x461102 : pop ebx
0x461103 : leave 
0x461104 : ret 


SendAllPedestrianPositions is only 70.42% similar to the original, diff above
```

*AI generated. Time taken: 88s, tokens: 17,698*
