### PR TITLE
FatalError 100% match

### DIFF
--- a/src/DETHRACE/common/cutscene.c
+++ b/src/DETHRACE/common/cutscene.c
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <time.h>
 
+// GLOBAL: CARM95 0x0051D424
 tS32 gLast_demo_end_anim = -90000;
 
 // IDA: void __usercall ShowCutScene(int pIndex@<EAX>, int pWait_end@<EDX>, int pSound_ID@<EBX>, br_scalar pDelay)

--- a/src/DETHRACE/common/errors.c
+++ b/src/DETHRACE/common/errors.c
@@ -159,20 +159,13 @@ void FatalError(int pStr_index, ...) {
     char temp_str[1024];
     char* sub_pt;
     va_list ap;
-    int i;
-
-    va_start(ap, pStr_index);
 
     gLast_demo_end_anim = 0x20000000 + PDGetTotalTime();
     strcpy(the_str, gError_messages[pStr_index]);
-    sub_pt = temp_str;
+    va_start(ap, pStr_index);
 
-    while (1) {
+    while ((sub_pt = strchr(the_str, '%'))) {
 
-        sub_pt = strchr(the_str, '%');
-        if (!sub_pt) {
-            break;
-        }
         sub_str = va_arg(ap, char*);
         StripCR(sub_str);
         strcpy(temp_str, sub_pt + 1);


### PR DESCRIPTION
## Match result

```
0x461390: FatalError 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x461390,47 +0x475f40,50 @@
0x461390 : push ebp 	(errors.c:156)
0x461391 : mov ebp, esp
0x461393 : -sub esp, 0x80c
         : +sub esp, 0x810
0x461399 : push ebx
0x46139a : push esi
0x46139b : push edi
         : +lea eax, [ebp + 0xc] 	(errors.c:164)
         : +mov dword ptr [ebp - 0x810], eax
0x46139c : call PDGetTotalTime (FUNCTION) 	(errors.c:166)
0x4613a1 : add eax, 0x20000000
0x4613a6 : -mov dword ptr ["p\xa0\xfe\xffCUTSCENE" (STRING)], eax
         : +mov dword ptr [gLast_demo_end_anim (DATA)], eax
0x4613ab : mov eax, dword ptr [ebp + 8] 	(errors.c:167)
0x4613ae : mov edi, dword ptr [eax*4 + gError_messages[0] (DATA)]
0x4613b5 : mov ecx, 0xffffffff
0x4613ba : sub eax, eax
0x4613bc : repne scasb al, byte ptr es:[edi]
0x4613be : not ecx
0x4613c0 : sub edi, ecx
0x4613c2 : mov eax, ecx
0x4613c4 : mov edx, edi
0x4613c6 : -lea edi, [ebp - 0x808]
         : +lea edi, [ebp - 0x80c]
0x4613cc : mov esi, edx
0x4613ce : shr ecx, 2
0x4613d1 : rep movsd dword ptr es:[edi], dword ptr [esi]
0x4613d3 : mov ecx, eax
0x4613d5 : and ecx, 3
0x4613d8 : rep movsb byte ptr es:[edi], byte ptr [esi]
0x4613da : -lea eax, [ebp + 0xc]
0x4613dd : -mov dword ptr [ebp - 0x80c], eax
         : +lea eax, [ebp - 0x400] 	(errors.c:168)
         : +mov dword ptr [ebp - 0x404], eax
0x4613e3 : push 0x25 	(errors.c:172)
0x4613e5 : -lea eax, [ebp - 0x808]
         : +lea eax, [ebp - 0x80c]
0x4613eb : push eax
0x4613ec : call strchr (FUNCTION)
0x4613f1 : add esp, 8
0x4613f4 : mov dword ptr [ebp - 0x404], eax
0x4613fa : cmp dword ptr [ebp - 0x404], 0 	(errors.c:173)
0x461401 : -je 0xb8
0x461407 : -add dword ptr [ebp - 0x80c], 4
0x46140e : -mov eax, dword ptr [ebp - 0x80c]
         : +jne 0x5
         : +jmp 0xb8 	(errors.c:174)
         : +add dword ptr [ebp - 0x810], 4 	(errors.c:176)
         : +mov eax, dword ptr [ebp - 0x810]
0x461414 : mov eax, dword ptr [eax - 4]
0x461417 : mov dword ptr [ebp - 0x408], eax
0x46141d : mov eax, dword ptr [ebp - 0x408] 	(errors.c:177)
0x461423 : push eax
0x461424 : call StripCR (FUNCTION)
0x461429 : add esp, 4
0x46142c : mov edi, dword ptr [ebp - 0x404] 	(errors.c:178)
0x461432 : inc edi
0x461433 : mov ecx, 0xffffffff
0x461438 : sub eax, eax

---
+++
@@ -0x46147e,38 +0x47603f,38 @@
0x46147e : and ecx, 3
0x461481 : rep movsb byte ptr es:[edi], byte ptr [esi]
0x461483 : lea edi, [ebp - 0x400] 	(errors.c:180)
0x461489 : mov ecx, 0xffffffff
0x46148e : sub eax, eax
0x461490 : repne scasb al, byte ptr es:[edi]
0x461492 : not ecx
0x461494 : sub edi, ecx
0x461496 : mov edx, edi
0x461498 : mov ebx, ecx
0x46149a : -lea edi, [ebp - 0x808]
         : +lea edi, [ebp - 0x80c]
0x4614a0 : mov ecx, 0xffffffff
0x4614a5 : sub eax, eax
0x4614a7 : repne scasb al, byte ptr es:[edi]
0x4614a9 : dec edi
0x4614aa : mov esi, edx
0x4614ac : mov ecx, ebx
0x4614ae : shr ecx, 2
0x4614b1 : rep movsd dword ptr es:[edi], dword ptr [esi]
0x4614b3 : mov ecx, ebx
0x4614b5 : and ecx, 3
0x4614b8 : rep movsb byte ptr es:[edi], byte ptr [esi]
0x4614ba : -jmp -0xdc
0x4614bf : -mov dword ptr [ebp - 0x80c], 0
0x4614c9 : -lea eax, [ebp - 0x808]
         : +jmp -0xe1 	(errors.c:181)
         : +mov dword ptr [ebp - 0x810], 0 	(errors.c:182)
         : +lea eax, [ebp - 0x80c] 	(errors.c:183)
0x4614cf : push eax
0x4614d0 : call dr_dprintf (FUNCTION)
0x4614d5 : add esp, 4
0x4614d8 : call FadePaletteUp (FUNCTION) 	(errors.c:184)
0x4614dd : -lea eax, [ebp - 0x808]
         : +lea eax, [ebp - 0x80c] 	(errors.c:185)
0x4614e3 : push eax
0x4614e4 : call PDFatalError (FUNCTION)
0x4614e9 : add esp, 4
0x4614ec : pop edi 	(errors.c:186)
0x4614ed : pop esi
0x4614ee : pop ebx
0x4614ef : leave 
0x4614f0 : ret 


FatalError is only 86.10% similar to the original, diff above
```

*AI generated. Time taken: 901s, tokens: 165,765*
