### PR TITLE
NonFatalError 100% match

### DIFF
--- a/src/DETHRACE/common/errors.c
+++ b/src/DETHRACE/common/errors.c
@@ -193,27 +193,18 @@ void NonFatalError(int pStr_index, ...) {
     char temp_str[256];
     char* sub_pt;
     va_list ap;
-    int i;
-
+    strcpy(the_str, gError_messages[pStr_index]);
     va_start(ap, pStr_index);
 
-    strcpy(the_str, gError_messages[pStr_index - 1]);
-    sub_pt = temp_str;
-
-    for (i = 0; i < strlen(the_str); i++) {
-        if (the_str[i] == '%') {
-            sub_str = va_arg(ap, char*);
-            StripCR(sub_str);
-            strcpy(sub_pt, sub_str);
-            sub_pt += strlen(sub_str);
-        } else {
-            *sub_pt = the_str[i];
-            sub_pt++;
-        }
+    while ((sub_pt = strchr(the_str, '%')) != NULL) {
+        sub_str = va_arg(ap, char*);
+        StripCR(sub_str);
+        strcpy(temp_str, sub_pt + 1);
+        strcpy(sub_pt, sub_str);
+        strcat(the_str, temp_str);
     }
-    *sub_pt = 0;
     va_end(ap);
-    PDNonFatalError(temp_str);
+    PDNonFatalError(the_str);
 }
 
 // IDA: void __cdecl CloseDiagnostics()


### PR DESCRIPTION
## Match result

```
0x4614f1: NonFatalError 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4614f1,102 +0x4760b2,90 @@
0x4614f1 : push ebp 	(errors.c:190)
0x4614f2 : mov ebp, esp
0x4614f4 : -sub esp, 0x20c
         : +sub esp, 0x210
0x4614fa : push ebx
0x4614fb : push esi
0x4614fc : push edi
         : +lea eax, [ebp + 0xc] 	(errors.c:198)
         : +mov dword ptr [ebp - 0x210], eax
0x4614fd : mov eax, dword ptr [ebp + 8] 	(errors.c:200)
0x461500 : -mov edi, dword ptr [eax*4 + gError_messages[0] (DATA)]
         : +mov edi, dword ptr [eax*4 + "d" (STRING)]
0x461507 : mov ecx, 0xffffffff
0x46150c : sub eax, eax
0x46150e : repne scasb al, byte ptr es:[edi]
0x461510 : not ecx
0x461512 : sub edi, ecx
0x461514 : mov eax, ecx
0x461516 : mov edx, edi
0x461518 : -lea edi, [ebp - 0x208]
         : +lea edi, [ebp - 0x20c]
0x46151e : mov esi, edx
0x461520 : shr ecx, 2
0x461523 : rep movsd dword ptr es:[edi], dword ptr [esi]
0x461525 : mov ecx, eax
0x461527 : and ecx, 3
0x46152a : rep movsb byte ptr es:[edi], byte ptr [esi]
0x46152c : -lea eax, [ebp + 0xc]
0x46152f : -mov dword ptr [ebp - 0x20c], eax
0x461535 : -push 0x25
0x461537 : -lea eax, [ebp - 0x208]
0x46153d : -push eax
0x46153e : -call strchr (FUNCTION)
0x461543 : -add esp, 8
         : +lea eax, [ebp - 0x100] 	(errors.c:201)
0x461546 : mov dword ptr [ebp - 0x104], eax
0x46154c : -cmp dword ptr [ebp - 0x104], 0
0x461553 : -je 0xb8
0x461559 : -add dword ptr [ebp - 0x20c], 4
0x461560 : -mov eax, dword ptr [ebp - 0x20c]
         : +mov dword ptr [ebp - 0x10c], 0 	(errors.c:203)
         : +jmp 0x6
         : +inc dword ptr [ebp - 0x10c]
         : +lea edi, [ebp - 0x20c]
         : +mov ecx, 0xffffffff
         : +sub eax, eax
         : +repne scasb al, byte ptr es:[edi]
         : +not ecx
         : +lea eax, [ecx - 1]
         : +cmp eax, dword ptr [ebp - 0x10c]
         : +jbe 0xa6
         : +mov eax, dword ptr [ebp - 0x10c] 	(errors.c:204)
         : +movsx eax, byte ptr [ebp + eax - 0x20c]
         : +cmp eax, 0x25
         : +jne 0x6f
         : +add dword ptr [ebp - 0x210], 4 	(errors.c:205)
         : +mov eax, dword ptr [ebp - 0x210]
0x461566 : mov eax, dword ptr [eax - 4]
0x461569 : mov dword ptr [ebp - 0x108], eax
0x46156f : mov eax, dword ptr [ebp - 0x108] 	(errors.c:206)
0x461575 : push eax
0x461576 : call StripCR (FUNCTION)
0x46157b : add esp, 4
0x46157e : -mov edi, dword ptr [ebp - 0x104]
0x461584 : -inc edi
0x461585 : -mov ecx, 0xffffffff
0x46158a : -sub eax, eax
0x46158c : -repne scasb al, byte ptr es:[edi]
0x46158e : -not ecx
0x461590 : -sub edi, ecx
0x461592 : -mov eax, ecx
0x461594 : -mov edx, edi
0x461596 : -lea edi, [ebp - 0x100]
0x46159c : -mov esi, edx
0x46159e : -shr ecx, 2
0x4615a1 : -rep movsd dword ptr es:[edi], dword ptr [esi]
0x4615a3 : -mov ecx, eax
0x4615a5 : -and ecx, 3
0x4615a8 : -rep movsb byte ptr es:[edi], byte ptr [esi]
0x4615aa : mov edi, dword ptr [ebp - 0x108] 	(errors.c:207)
0x4615b0 : mov ecx, 0xffffffff
0x4615b5 : sub eax, eax
0x4615b7 : repne scasb al, byte ptr es:[edi]
0x4615b9 : not ecx
0x4615bb : sub edi, ecx
0x4615bd : mov eax, ecx
0x4615bf : mov edx, edi
0x4615c1 : mov edi, dword ptr [ebp - 0x104]
0x4615c7 : mov esi, edx
0x4615c9 : shr ecx, 2
0x4615cc : rep movsd dword ptr es:[edi], dword ptr [esi]
0x4615ce : mov ecx, eax
0x4615d0 : and ecx, 3
0x4615d3 : rep movsb byte ptr es:[edi], byte ptr [esi]
0x4615d5 : -lea edi, [ebp - 0x100]
         : +mov edi, dword ptr [ebp - 0x108] 	(errors.c:208)
0x4615db : mov ecx, 0xffffffff
0x4615e0 : sub eax, eax
0x4615e2 : repne scasb al, byte ptr es:[edi]
0x4615e4 : not ecx
0x4615e6 : -sub edi, ecx
0x4615e8 : -mov edx, edi
0x4615ea : -mov ebx, ecx
0x4615ec : -lea edi, [ebp - 0x208]
0x4615f2 : -mov ecx, 0xffffffff
0x4615f7 : -sub eax, eax
0x4615f9 : -repne scasb al, byte ptr es:[edi]
0x4615fb : -dec edi
0x4615fc : -mov esi, edx
0x4615fe : -mov ecx, ebx
0x461600 : -shr ecx, 2
0x461603 : -rep movsd dword ptr es:[edi], dword ptr [esi]
0x461605 : -mov ecx, ebx
0x461607 : -and ecx, 3
0x46160a : -rep movsb byte ptr es:[edi], byte ptr [esi]
0x46160c : -jmp -0xdc
0x461611 : -mov dword ptr [ebp - 0x20c], 0
0x46161b : -lea eax, [ebp - 0x208]
         : +lea eax, [ecx - 1]
         : +add dword ptr [ebp - 0x104], eax
         : +jmp 0x1b 	(errors.c:209)
         : +mov eax, dword ptr [ebp - 0x10c] 	(errors.c:210)
         : +mov al, byte ptr [ebp + eax - 0x20c]
         : +mov ecx, dword ptr [ebp - 0x104]
         : +mov byte ptr [ecx], al
         : +inc dword ptr [ebp - 0x104] 	(errors.c:211)
         : +jmp -0xcc 	(errors.c:213)
         : +mov eax, dword ptr [ebp - 0x104] 	(errors.c:214)
         : +mov byte ptr [eax], 0
         : +mov dword ptr [ebp - 0x210], 0 	(errors.c:215)
         : +lea eax, [ebp - 0x100] 	(errors.c:216)
0x461621 : push eax
0x461622 : call PDNonFatalError (FUNCTION)
0x461627 : add esp, 4
0x46162a : pop edi 	(errors.c:217)
0x46162b : pop esi
0x46162c : pop ebx
0x46162d : leave 
0x46162e : ret 


NonFatalError is only 55.21% similar to the original, diff above
```

*AI generated. Time taken: 351s, tokens: 37,792*
