### PR TITLE
Match CloseDiagnostics

### DIFF
--- a/src/DETHRACE/common/errors.c
+++ b/src/DETHRACE/common/errors.c
@@ -220,12 +220,6 @@ void NonFatalError(int pStr_index, ...) {
 // This function is stripped from the retail binary, we've guessed at the implementation
 // FUNCTION: CARM95 0x0046162f
 void CloseDiagnostics(void) {
-
-    if (harness_game_config.enable_diagnostics == 0) {
-        return;
-    }
-
-    fclose(gDiagnostic_file);
 }
 
 // IDA: void __cdecl OpenDiagnostics()


### PR DESCRIPTION
## Match result

```
0x46162f: CloseDiagnostics 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x46162f,10 +0x476204,17 @@
0x46162f : push ebp 	(errors.c:222)
0x461630 : mov ebp, esp
0x461632 : push ebx
0x461633 : push esi
0x461634 : push edi
         : +cmp dword ptr [harness_game_config+20 (OFFSET)], 0 	(errors.c:224)
         : +jne 0x5
         : +jmp 0xe 	(errors.c:225)
         : +mov eax, dword ptr [gDiagnostic_file (DATA)] 	(errors.c:228)
         : +push eax
         : +call fclose (FUNCTION)
         : +add esp, 4
0x461635 : pop edi 	(errors.c:229)
0x461636 : pop esi
0x461637 : pop ebx
0x461638 : leave 
0x461639 : ret 


CloseDiagnostics is only 74.07% similar to the original, diff above
```

*AI generated. Time taken: 69s, tokens: 7,963*
