### PR TITLE
Match OpenDiagnostics

### DIFF
--- a/src/DETHRACE/common/errors.c
+++ b/src/DETHRACE/common/errors.c
@@ -232,16 +232,6 @@ void CloseDiagnostics(void) {
 // This function is stripped from the retail binary, we've guessed at the implementation
 // FUNCTION: CARM95 0x0046163a
 void OpenDiagnostics(void) {
-
-    if (harness_game_config.enable_diagnostics == 0) {
-        return;
-    }
-
-    gDiagnostic_file = fopen("DIAGNOST.TXT", "w");
-
-    fputs("DIAGNOSTIC OUTPUT\n", gDiagnostic_file);
-    // todo: generate a real date
-    fprintf(gDiagnostic_file, "Date / time : %s\n\n\n", "Mon Mar 24 16 : 32 : 33 1997");
 }
 
 // Renamed from dprintf to avoid collisions to stdio


### PR DESCRIPTION
## Match result

```
0x46163a: OpenDiagnostics 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x46163a,10 +0x47622f,29 @@
0x46163a : push ebp 	(errors.c:234)
0x46163b : mov ebp, esp
0x46163d : push ebx
0x46163e : push esi
0x46163f : push edi
         : +cmp dword ptr [harness_game_config+20 (OFFSET)], 0 	(errors.c:236)
         : +jne 0x5
         : +jmp 0x42 	(errors.c:237)
         : +push "w" (STRING) 	(errors.c:240)
         : +push "DIAGNOST.TXT" (STRING)
         : +call fopen (FUNCTION)
         : +add esp, 8
         : +mov dword ptr [gDiagnostic_file (DATA)], eax
         : +mov eax, dword ptr [gDiagnostic_file (DATA)] 	(errors.c:242)
         : +push eax
         : +push "DIAGNOSTIC OUTPUT\n" (STRING)
         : +call fputs (FUNCTION)
         : +add esp, 8
         : +push "Mon Mar 24 16 : 32 : 33 1997" (STRING) 	(errors.c:244)
         : +push "Date / time : %s\n\n\n" (STRING)
         : +mov eax, dword ptr [gDiagnostic_file (DATA)]
         : +push eax
         : +call fprintf (FUNCTION)
         : +add esp, 0xc
0x461640 : pop edi 	(errors.c:245)
0x461641 : pop esi
0x461642 : pop ebx
0x461643 : leave 
0x461644 : ret 


OpenDiagnostics is only 51.28% similar to the original, diff above
```

*AI generated. Time taken: 66s, tokens: 9,154*
