### PR TITLE
Match dr_dprintf

### DIFF
--- a/src/DETHRACE/common/errors.c
+++ b/src/DETHRACE/common/errors.c
@@ -248,36 +248,6 @@ void OpenDiagnostics(void) {
 // This function is stripped from the retail binary, we've guessed at the implementation
 // FUNCTION: CARM95 0x00461645
 void dr_dprintf(char* fmt_string, ...) {
-    static tU32 first_time = 0;
-    va_list args;
-    tU32 the_time;
-
-    if (harness_game_config.enable_diagnostics == 0) {
-        return;
-    }
-
-    if (gDiagnostic_file == NULL) {
-        return;
-    }
-
-    if (first_time == 0) {
-        first_time = GetTotalTime();
-    }
-    the_time = GetTotalTime() - first_time;
-
-    fprintf(gDiagnostic_file, "%7d.%02d: ", the_time / 1000, the_time % 100);
-
-    va_start(args, fmt_string);
-    vfprintf(gDiagnostic_file, fmt_string, args);
-    va_end(args);
-    fputs("\n", gDiagnostic_file);
-    fflush(gDiagnostic_file);
-
-    // Added by dethrace for debugging
-    va_start(args, fmt_string);
-    vprintf(fmt_string, args);
-    va_end(args);
-    printf("\n");
 }
 
 // IDA: int __usercall DoErrorInterface@<EAX>(int pMisc_text_index@<EAX>)


### PR DESCRIPTION
## Match result

```
0x461645: dr_dprintf 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x461645,10 +0x47628e,71 @@
0x461645 : push ebp 	(errors.c:250)
0x461646 : mov ebp, esp
         : +sub esp, 8
0x461648 : push ebx
0x461649 : push esi
0x46164a : push edi
         : +cmp dword ptr [harness_game_config+20 (OFFSET)], 0 	(errors.c:255)
         : +jne 0x5
         : +jmp 0xd2 	(errors.c:256)
         : +cmp dword ptr [gDiagnostic_file (DATA)], 0 	(errors.c:259)
         : +jne 0x5
         : +jmp 0xc0 	(errors.c:260)
         : +cmp dword ptr [first_time (DATA)], 0 	(errors.c:263)
         : +jne 0xa
         : +call GetTotalTime (FUNCTION) 	(errors.c:264)
         : +mov dword ptr [first_time (DATA)], eax
         : +call GetTotalTime (FUNCTION) 	(errors.c:266)
         : +sub eax, dword ptr [first_time (DATA)]
         : +mov dword ptr [ebp - 8], eax
         : +mov ecx, 0x64 	(errors.c:268)
         : +mov eax, dword ptr [ebp - 8]
         : +sub edx, edx
         : +div ecx
         : +push edx
         : +mov ecx, 0x3e8
         : +mov eax, dword ptr [ebp - 8]
         : +sub edx, edx
         : +div ecx
         : +push eax
         : +push "%7d.%02d: " (STRING)
         : +mov eax, dword ptr [gDiagnostic_file (DATA)]
         : +push eax
         : +call fprintf (FUNCTION)
         : +add esp, 0x10
         : +lea eax, [ebp + 0xc] 	(errors.c:270)
         : +mov dword ptr [ebp - 4], eax
         : +mov eax, dword ptr [ebp - 4] 	(errors.c:271)
         : +push eax
         : +mov eax, dword ptr [ebp + 8]
         : +push eax
         : +mov eax, dword ptr [gDiagnostic_file (DATA)]
         : +push eax
         : +call vfprintf (FUNCTION)
         : +add esp, 0xc
         : +mov dword ptr [ebp - 4], 0 	(errors.c:272)
         : +mov eax, dword ptr [gDiagnostic_file (DATA)] 	(errors.c:273)
         : +push eax
         : +push "\n" (STRING)
         : +call fputs (FUNCTION)
         : +add esp, 8
         : +mov eax, dword ptr [gDiagnostic_file (DATA)] 	(errors.c:274)
         : +push eax
         : +call fflush (FUNCTION)
         : +add esp, 4
         : +lea eax, [ebp + 0xc] 	(errors.c:277)
         : +mov dword ptr [ebp - 4], eax
         : +mov eax, dword ptr [ebp - 4] 	(errors.c:278)
         : +push eax
         : +mov eax, dword ptr [ebp + 8]
         : +push eax
         : +call vprintf (FUNCTION)
         : +add esp, 8
         : +mov dword ptr [ebp - 4], 0 	(errors.c:279)
         : +push "\n" (STRING) 	(errors.c:280)
         : +call printf (FUNCTION)
         : +add esp, 4
0x46164b : pop edi 	(errors.c:281)
0x46164c : pop esi
0x46164d : pop ebx
0x46164e : leave 
0x46164f : ret 


dr_dprintf is only 24.69% similar to the original, diff above
```

*AI generated. Time taken: 69s, tokens: 25,529*
