### PR TITLE
InstantDepthChange 100% match

### DIFF
--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -230,14 +230,14 @@ void InstantDepthChange(tDepth_effect_type pType, br_pixelmap* pSky_texture, int
     }
 
     gProgram_state.current_depth_effect.sky_texture = pSky_texture;
-    gHorizon_material->colour_map = pSky_texture;
+    gHorizon_material->colour_map = gProgram_state.current_depth_effect.sky_texture;
     BrMaterialUpdate(gHorizon_material, BR_MATU_ALL);
     gProgram_state.current_depth_effect.type = pType;
     gProgram_state.current_depth_effect.start = pStart;
     gProgram_state.current_depth_effect.end = pEnd;
-    gProgram_state.default_depth_effect.type = pType;
-    gProgram_state.default_depth_effect.start = pStart;
-    gProgram_state.default_depth_effect.end = pEnd;
+    gProgram_state.default_depth_effect.type = gProgram_state.current_depth_effect.type;
+    gProgram_state.default_depth_effect.start = gProgram_state.current_depth_effect.start;
+    gProgram_state.default_depth_effect.end = gProgram_state.current_depth_effect.end;
 
 #ifdef DETHRACE_3DFX_PATCH
     if (gMaterial_fogging) {


### PR DESCRIPTION
## Match result

```
0x461670: InstantDepthChange 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x461671,29 +0x46f65e,35 @@
0x461671 : mov ebp, esp
0x461673 : push ebx
0x461674 : push esi
0x461675 : push edi
0x461676 : cmp dword ptr [ebp + 8], -1 	(depth.c:227)
0x46167a : jne 0xe
0x461680 : mov dword ptr [ebp + 0x10], 3 	(depth.c:228)
0x461687 : mov dword ptr [ebp + 0x14], 3 	(depth.c:229)
0x46168e : mov eax, dword ptr [ebp + 0xc] 	(depth.c:232)
0x461691 : mov dword ptr [gProgram_state+7372 (OFFSET)], eax
0x461696 : -mov eax, dword ptr [gProgram_state+7372 (OFFSET)]
         : +mov eax, dword ptr [ebp + 0xc] 	(depth.c:233)
0x46169b : mov ecx, dword ptr [gHorizon_material (DATA)]
0x4616a1 : mov dword ptr [ecx + 0x40], eax
0x4616a4 : push 0x7fff 	(depth.c:234)
0x4616a9 : mov eax, dword ptr [gHorizon_material (DATA)]
0x4616ae : push eax
0x4616af : call BrMaterialUpdate (FUNCTION)
0x4616b4 : add esp, 8
0x4616b7 : mov eax, dword ptr [ebp + 8] 	(depth.c:235)
0x4616ba : mov dword ptr [gProgram_state+7360 (OFFSET)], eax
0x4616bf : mov eax, dword ptr [ebp + 0x10] 	(depth.c:236)
0x4616c2 : mov dword ptr [gProgram_state+7364 (OFFSET)], eax
0x4616c7 : mov eax, dword ptr [ebp + 0x14] 	(depth.c:237)
0x4616ca : mov dword ptr [gProgram_state+7368 (OFFSET)], eax
0x4616cf : -mov eax, dword ptr [gProgram_state+7360 (OFFSET)]
         : +mov eax, dword ptr [ebp + 8] 	(depth.c:238)
0x4616d4 : mov dword ptr [gProgram_state+7344 (OFFSET)], eax
0x4616d9 : -mov eax, dword ptr [gProgram_state+7364 (OFFSET)]
         : +mov eax, dword ptr [ebp + 0x10] 	(depth.c:239)
0x4616de : mov dword ptr [gProgram_state+7348 (OFFSET)], eax
0x4616e3 : -mov eax, dword ptr [gProgram_state+7368 (OFFSET)]
         : +mov eax, dword ptr [ebp + 0x14] 	(depth.c:240)
         : +mov dword ptr [gProgram_state+7352 (OFFSET)], eax
         : +pop edi 	(depth.c:247)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


InstantDepthChange is only 78.79% similar to the original, diff above
```

*AI generated. Time taken: 74s, tokens: 9,767*
