### PR TITLE
DoHorizon 100% match

### DIFF
--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -639,37 +639,36 @@ void DoHorizon(br_pixelmap* pRender_buffer, br_pixelmap* pDepth_buffer, br_actor
     br_actor* actor;
 
     yaw = BrRadianToAngle(atan2(pCamera_to_world->m[2][0], pCamera_to_world->m[2][2]));
-    if (!gProgram_state.cockpit_on && !gAction_replay_mode && gAction_replay_camera_mode != eAction_replay_standard
+    if (gProgram_state.cockpit_on
+        || (gAction_replay_mode * gAction_replay_camera_mode) != 0
 
 #ifdef DETHRACE_3DFX_PATCH
-        && !gBlitting_is_slow
+        || gBlitting_is_slow
 #endif
     ) {
-        return;
-    }
-
-    if (gRendering_mirror) {
-        actor = gRearview_sky_actor;
-    } else {
-        actor = gForward_sky_actor;
-        if (ACTOR_CAMERA(gCamera)->field_of_view != gOld_fov || ACTOR_CAMERA(gCamera)->yon_z != gOld_yon) {
-            gOld_fov = ACTOR_CAMERA(gCamera)->field_of_view;
-            gOld_yon = ACTOR_CAMERA(gCamera)->yon_z;
-            MungeSkyModel(gCamera, gForward_sky_model);
+        if (gRendering_mirror) {
+            actor = gRearview_sky_actor;
+        } else {
+            actor = gForward_sky_actor;
+            if (ACTOR_CAMERA(gCamera)->field_of_view != gOld_fov || ACTOR_CAMERA(gCamera)->yon_z != gOld_yon) {
+                gOld_fov = ACTOR_CAMERA(gCamera)->field_of_view;
+                gOld_yon = ACTOR_CAMERA(gCamera)->yon_z;
+                MungeSkyModel(gCamera, gForward_sky_model);
+            }
         }
+        BrMatrix34RotateY(&actor->t.t.mat, yaw);
+        BrVector3Copy(&actor->t.t.translate.t, (br_vector3*)pCamera_to_world->m[3]);
+        gHorizon_material->map_transform.m[0][0] = 1.f;
+        gHorizon_material->map_transform.m[0][1] = 0.f;
+        gHorizon_material->map_transform.m[1][0] = 0.f;
+        gHorizon_material->map_transform.m[1][1] = 1.f;
+        gHorizon_material->map_transform.m[2][0] = -BrFixedToFloat(yaw) / BrFixedToFloat(gSky_image_width);
+        gHorizon_material->map_transform.m[2][1] = 0.f;
+        BrMaterialUpdate(gHorizon_material, BR_MATU_ALL);
+        actor->render_style = BR_RSTYLE_FACES;
+        BrZbSceneRenderAdd(actor);
+        actor->render_style = BR_RSTYLE_NONE;
     }
-    BrMatrix34RotateY(&actor->t.t.mat, yaw);
-    BrVector3Copy(&actor->t.t.translate.t, (br_vector3*)pCamera_to_world->m[3]);
-    gHorizon_material->map_transform.m[0][0] = 1.f;
-    gHorizon_material->map_transform.m[0][1] = 0.f;
-    gHorizon_material->map_transform.m[1][0] = 0.f;
-    gHorizon_material->map_transform.m[1][1] = 1.f;
-    gHorizon_material->map_transform.m[2][0] = -BrFixedToFloat(yaw) / BrFixedToFloat(gSky_image_width);
-    gHorizon_material->map_transform.m[2][1] = 0.f;
-    BrMaterialUpdate(gHorizon_material, BR_MATU_ALL);
-    actor->render_style = BR_RSTYLE_FACES;
-    BrZbSceneRenderAdd(actor);
-    actor->render_style = BR_RSTYLE_NONE;
 }
 
 // IDA: void __usercall DoDepthCue(br_pixelmap *pRender_buffer@<EAX>, br_pixelmap *pDepth_buffer@<EDX>)


### PR DESCRIPTION
## Match result

```
0x462658: DoHorizon 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x462660,25 +0x470b5c,26 @@
0x462660 : push edi
0x462661 : mov eax, dword ptr [ebp + 0x14] 	(depth.c:641)
0x462664 : fld dword ptr [eax + 0x18]
0x462667 : mov eax, dword ptr [ebp + 0x14]
0x46266a : fld dword ptr [eax + 0x20]
0x46266d : call __CIatan2 (DATA)
0x462672 : fmul qword ptr [10430.378350470453 (FLOAT)]
0x462678 : call __ftol (FUNCTION)
0x46267d : mov word ptr [ebp - 4], ax
0x462681 : cmp dword ptr [gProgram_state+80 (OFFSET)], 0 	(depth.c:647)
0x462688 : -jne 0x14
0x46268e : -mov eax, dword ptr [gAction_replay_mode (DATA)]
0x462693 : -imul eax, dword ptr [gAction_replay_camera_mode (DATA)]
0x46269a : -test eax, eax
0x46269c : -je 0x166
         : +jne 0x1f
         : +cmp dword ptr [gAction_replay_mode (DATA)], 0
         : +jne 0x12
         : +cmp dword ptr [gAction_replay_camera_mode (DATA)], 0
         : +je 0x5
         : +jmp 0x166 	(depth.c:648)
0x4626a2 : cmp dword ptr [gRendering_mirror (DATA)], 0 	(depth.c:651)
0x4626a9 : je 0xd
0x4626af : mov eax, dword ptr [gRearview_sky_actor (DATA)] 	(depth.c:652)
0x4626b4 : mov dword ptr [ebp - 8], eax
0x4626b7 : jmp 0x78 	(depth.c:653)
0x4626bc : mov eax, dword ptr [gForward_sky_actor (DATA)] 	(depth.c:654)
0x4626c1 : mov dword ptr [ebp - 8], eax
0x4626c4 : mov eax, dword ptr [gCamera (DATA)] 	(depth.c:655)
0x4626c9 : mov eax, dword ptr [eax + 0x5c]
0x4626cc : xor ecx, ecx


DoHorizon is only 95.32% similar to the original, diff above
```

*AI generated. Time taken: 349s, tokens: 40,106*
