### PR TITLE
LoadDepthTable 100% match

### DIFF
--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -409,8 +409,6 @@ void LoadDepthTable(char* pName, br_pixelmap** pTable, int* pPower) {
     int j;
     tU8 temp;
 
-#define PTABLE_PIXEL_AT(X, Y) ((tU8*)((*pTable)->pixels))[(X) + (Y) * (*pTable)->row_bytes]
-
     PathCat(the_path, gApplication_path, "SHADETAB");
     PathCat(the_path, the_path, pName);
     *pTable = DRPixelmapLoad(the_path);
@@ -420,13 +418,12 @@ void LoadDepthTable(char* pName, br_pixelmap** pTable, int* pPower) {
     *pPower = Log2((*pTable)->height);
     for (i = 0; i < (*pTable)->width; i++) {
         for (j = 0; j < (*pTable)->height / 2; j++) {
-            temp = PTABLE_PIXEL_AT(i, j);
-            PTABLE_PIXEL_AT(i, j) = PTABLE_PIXEL_AT(i, ((*pTable)->height - j - 1));
-            PTABLE_PIXEL_AT(i, ((*pTable)->height - j - 1)) = temp;
+            temp = *((tU8*)(*pTable)->pixels + (*pTable)->row_bytes * j + i);
+            *((tU8*)(*pTable)->pixels + (*pTable)->row_bytes * j + i) =
+                *((tU8*)(*pTable)->pixels + (*pTable)->row_bytes * ((*pTable)->height - j - 1) + i);
+            *((tU8*)(*pTable)->pixels + (*pTable)->row_bytes * ((*pTable)->height - j - 1) + i) = temp;
         }
     }
-
-#undef PTABLE_PIXEL_AT
 }
 
 // IDA: void __cdecl InitDepthEffects()

--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -409,6 +409,8 @@ void LoadDepthTable(char* pName, br_pixelmap** pTable, int* pPower) {
     int j;
     tU8 temp;
 
+#define PTABLE_PIXEL_AT(X, Y) *((tU8*)((*pTable)->pixels) + (*pTable)->row_bytes * (Y) + (X))
+
     PathCat(the_path, gApplication_path, "SHADETAB");
     PathCat(the_path, the_path, pName);
     *pTable = DRPixelmapLoad(the_path);
@@ -418,12 +420,13 @@ void LoadDepthTable(char* pName, br_pixelmap** pTable, int* pPower) {
     *pPower = Log2((*pTable)->height);
     for (i = 0; i < (*pTable)->width; i++) {
         for (j = 0; j < (*pTable)->height / 2; j++) {
-            temp = *((tU8*)(*pTable)->pixels + (*pTable)->row_bytes * j + i);
-            *((tU8*)(*pTable)->pixels + (*pTable)->row_bytes * j + i) =
-                *((tU8*)(*pTable)->pixels + (*pTable)->row_bytes * ((*pTable)->height - j - 1) + i);
-            *((tU8*)(*pTable)->pixels + (*pTable)->row_bytes * ((*pTable)->height - j - 1) + i) = temp;
+            temp = PTABLE_PIXEL_AT(i, j);
+            PTABLE_PIXEL_AT(i, j) = PTABLE_PIXEL_AT(i, ((*pTable)->height - j - 1));
+            PTABLE_PIXEL_AT(i, ((*pTable)->height - j - 1)) = temp;
         }
     }
+
+#undef PTABLE_PIXEL_AT
 }
 
 // IDA: void __cdecl InitDepthEffects()


### PR DESCRIPTION
## Match result

```
0x461c9b: LoadDepthTable 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x461d52,63 +0x4701d4,63 @@
0x461d52 : mov eax, dword ptr [eax]
0x461d54 : xor ecx, ecx
0x461d56 : mov cx, word ptr [eax + 0x36]
0x461d5a : sar ecx, 1
0x461d5c : cmp ecx, dword ptr [ebp - 0xc]
0x461d5f : jle 0x93
0x461d65 : mov eax, dword ptr [ebp + 0xc] 	(depth.c:423)
0x461d68 : mov eax, dword ptr [eax]
0x461d6a : movsx eax, word ptr [eax + 0x28]
0x461d6e : imul eax, dword ptr [ebp - 0xc]
         : +add eax, dword ptr [ebp - 8]
0x461d72 : mov ecx, dword ptr [ebp + 0xc]
0x461d75 : mov ecx, dword ptr [ecx]
0x461d77 : -add eax, dword ptr [ecx + 8]
0x461d7a : -mov ecx, dword ptr [ebp - 8]
         : +mov ecx, dword ptr [ecx + 8]
0x461d7d : mov al, byte ptr [eax + ecx]
0x461d80 : mov byte ptr [ebp - 4], al
0x461d83 : mov eax, dword ptr [ebp + 0xc] 	(depth.c:424)
0x461d86 : mov eax, dword ptr [eax]
0x461d88 : xor ecx, ecx
0x461d8a : mov cx, word ptr [eax + 0x36]
0x461d8e : sub ecx, dword ptr [ebp - 0xc]
0x461d91 : dec ecx
0x461d92 : mov eax, dword ptr [ebp + 0xc]
0x461d95 : mov eax, dword ptr [eax]
0x461d97 : movsx eax, word ptr [eax + 0x28]
0x461d9b : imul ecx, eax
         : +add ecx, dword ptr [ebp - 8]
0x461d9e : mov eax, dword ptr [ebp + 0xc]
0x461da1 : mov eax, dword ptr [eax]
0x461da3 : -add ecx, dword ptr [eax + 8]
0x461da6 : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [eax + 8]
0x461da9 : mov al, byte ptr [ecx + eax]
0x461dac : mov ecx, dword ptr [ebp + 0xc]
0x461daf : mov ecx, dword ptr [ecx]
0x461db1 : movsx ecx, word ptr [ecx + 0x28]
0x461db5 : imul ecx, dword ptr [ebp - 0xc]
         : +add ecx, dword ptr [ebp - 8]
0x461db9 : mov edx, dword ptr [ebp + 0xc]
0x461dbc : mov edx, dword ptr [edx]
0x461dbe : -add ecx, dword ptr [edx + 8]
0x461dc1 : -mov edx, dword ptr [ebp - 8]
         : +mov edx, dword ptr [edx + 8]
0x461dc4 : mov byte ptr [ecx + edx], al
0x461dc7 : mov al, byte ptr [ebp - 4] 	(depth.c:425)
0x461dca : mov ecx, dword ptr [ebp + 0xc]
0x461dcd : mov ecx, dword ptr [ecx]
0x461dcf : xor edx, edx
0x461dd1 : mov dx, word ptr [ecx + 0x36]
0x461dd5 : sub edx, dword ptr [ebp - 0xc]
0x461dd8 : dec edx
0x461dd9 : mov ecx, dword ptr [ebp + 0xc]
0x461ddc : mov ecx, dword ptr [ecx]
0x461dde : movsx ecx, word ptr [ecx + 0x28]
0x461de2 : imul edx, ecx
         : +add edx, dword ptr [ebp - 8]
0x461de5 : mov ecx, dword ptr [ebp + 0xc]
0x461de8 : mov ecx, dword ptr [ecx]
0x461dea : -add edx, dword ptr [ecx + 8]
0x461ded : -mov ecx, dword ptr [ebp - 8]
         : +mov ecx, dword ptr [ecx + 8]
0x461df0 : mov byte ptr [edx + ecx], al
0x461df3 : jmp -0xac 	(depth.c:426)
0x461df8 : jmp -0xd4 	(depth.c:427)
0x461dfd : pop edi 	(depth.c:430)
0x461dfe : pop esi
0x461dff : pop ebx
0x461e00 : leave 
0x461e01 : ret 


LoadDepthTable is only 93.16% similar to the original, diff above
```

*AI generated. Time taken: 704s, tokens: 12,301*
