### PR TITLE
CalculateWrappingMultiplier 100% match

### DIFF
--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -148,14 +148,14 @@ br_scalar CalculateWrappingMultiplier(br_scalar pValue, br_scalar pYon) {
     br_scalar trunc_k;
     int int_k;
 
-    k = pYon * 1.3f * TAU / pValue;
+    k = (br_scalar)(pYon * 1.3f) * 6.2831855f / pValue;
     int_k = (int)k;
-    if (k - int_k <= .5f) {
-        trunc_k = int_k;
+    trunc_k = int_k;
+    if (k - trunc_k > .5f) {
+        return (trunc_k + 1.f) / 6.2831855f * pValue;
     } else {
-        trunc_k = int_k + 1.f;
+        return trunc_k / 6.2831855f * pValue;
     }
-    return trunc_k / TAU * pValue;
 }
 
 // IDA: br_scalar __usercall DepthCueingShiftToDistance@<ST0>(int pShift@<EAX>)


### PR DESCRIPTION
## Match result

```
0x462ebc: CalculateWrappingMultiplier 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x462ebc,37 +0x46f3cb,40 @@
0x462ebc : push ebp 	(depth.c:146)
0x462ebd : mov ebp, esp
0x462ebf : -sub esp, 0x10
         : +sub esp, 0x18
0x462ec2 : push ebx
0x462ec3 : push esi
0x462ec4 : push edi
0x462ec5 : fld dword ptr [ebp + 0xc] 	(depth.c:151)
0x462ec8 : fmul dword ptr [1.2999999523162842 (FLOAT)]
0x462ece : -fmul dword ptr [6.2831854820251465 (FLOAT)]
         : +fmul qword ptr [6.283185307179586 (FLOAT)]
0x462ed4 : fdiv dword ptr [ebp + 8]
0x462ed7 : fst dword ptr [ebp - 8]
0x462eda : call __ftol (FUNCTION) 	(depth.c:152)
0x462edf : mov dword ptr [ebp - 0xc], eax
0x462ee2 : mov eax, dword ptr [ebp - 0xc] 	(depth.c:153)
0x462ee5 : mov dword ptr [ebp - 0x10], eax
0x462ee8 : fild dword ptr [ebp - 0x10]
0x462eeb : -fst dword ptr [ebp - 4]
0x462eee : fsubr dword ptr [ebp - 8]
0x462ef1 : fcomp dword ptr [0.5 (FLOAT)]
0x462ef7 : fnstsw ax
0x462ef9 : test ah, 0x41
0x462efc : -jne 0x1c
         : +je 0x11
         : +mov eax, dword ptr [ebp - 0xc] 	(depth.c:154)
         : +mov dword ptr [ebp - 0x14], eax
         : +fild dword ptr [ebp - 0x14]
         : +fstp dword ptr [ebp - 4]
         : +jmp 0x12 	(depth.c:155)
         : +mov eax, dword ptr [ebp - 0xc] 	(depth.c:156)
         : +mov dword ptr [ebp - 0x18], eax
         : +fild dword ptr [ebp - 0x18]
         : +fadd dword ptr [1.0 (FLOAT)]
         : +fstp dword ptr [ebp - 4]
0x462f02 : fld dword ptr [ebp - 4] 	(depth.c:158)
0x462f05 : -fadd dword ptr [1.0 (FLOAT)]
0x462f0b : -fdiv dword ptr [6.2831854820251465 (FLOAT)]
0x462f11 : -fmul dword ptr [ebp + 8]
0x462f14 : -jmp 0x16
0x462f19 : -jmp 0x11
0x462f1e : -fld dword ptr [ebp - 4]
0x462f21 : -fdiv dword ptr [6.2831854820251465 (FLOAT)]
         : +fdiv qword ptr [6.283185307179586 (FLOAT)]
0x462f27 : fmul dword ptr [ebp + 8]
0x462f2a : jmp 0x0
0x462f2f : pop edi 	(depth.c:159)
0x462f30 : pop esi
0x462f31 : pop ebx
0x462f32 : leave 
0x462f33 : ret 


CalculateWrappingMultiplier is only 67.53% similar to the original, diff above
```

*AI generated. Time taken: 1145s, tokens: 97,297*
