### PR TITLE
DoSpecialCameraEffect 100% match

### DIFF
--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -840,8 +840,11 @@ void DoSpecialCameraEffect(br_actor* pCamera, br_matrix34* pCamera_to_world) {
     } else {
         gLast_camera_special_volume = FindSpecialVolume((br_vector3*)pCamera_to_world->m[3], gLast_camera_special_volume);
         if (gLast_camera_special_volume != NULL) {
-            if (gLast_camera_special_volume->camera_special_effect_index == 0) {
+            switch (gLast_camera_special_volume->camera_special_effect_index) {
+            case 0:
                 DoWobbleCamera(pCamera);
+            default:
+                break;
             }
         }
     }


### PR DESCRIPTION
## Match result

```
0x462fdb: DoSpecialCameraEffect 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x462fdb,31 +0x471254,34 @@
0x462fdb : push ebp 	(depth.c:836)
0x462fdc : mov ebp, esp
0x462fde : -sub esp, 4
0x462fe1 : push ebx
0x462fe2 : push esi
0x462fe3 : push edi
0x462fe4 : cmp dword ptr [gOn_drugs (DATA)], 0 	(depth.c:838)
0x462feb : je 0x11
0x462ff1 : mov eax, dword ptr [ebp + 8] 	(depth.c:839)
0x462ff4 : push eax
0x462ff5 : call DoDrugWobbleCamera (FUNCTION)
0x462ffa : add esp, 4
0x462ffd : -jmp 0x5f
         : +jmp 0x45 	(depth.c:840)
0x463002 : mov eax, dword ptr [gLast_camera_special_volume (DATA)] 	(depth.c:841)
0x463007 : push eax
0x463008 : mov eax, dword ptr [ebp + 0xc]
0x46300b : add eax, 0x24
0x46300e : push eax
0x46300f : call FindSpecialVolume (FUNCTION)
0x463014 : add esp, 8
0x463017 : mov dword ptr [gLast_camera_special_volume (DATA)], eax
0x46301c : cmp dword ptr [gLast_camera_special_volume (DATA)], 0 	(depth.c:842)
0x463023 : -je 0x38
         : +je 0x1e
0x463029 : mov eax, dword ptr [gLast_camera_special_volume (DATA)] 	(depth.c:843)
0x46302e : -mov eax, dword ptr [eax + 0x8c]
0x463034 : -mov dword ptr [ebp - 4], eax
0x463037 : -jmp 0x16
         : +cmp dword ptr [eax + 0x8c], 0
         : +jne 0xc
0x46303c : mov eax, dword ptr [ebp + 8] 	(depth.c:844)
0x46303f : push eax
0x463040 : call DoWobbleCamera (FUNCTION)
0x463045 : add esp, 4
         : +pop edi 	(depth.c:848)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DoSpecialCameraEffect is only 76.92% similar to the original, diff above
```

*AI generated. Time taken: 118s, tokens: 15,326*
