### PR TITLE
IncreaseYon 100% match

### DIFF
--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -920,9 +920,7 @@ void IncreaseYon(void) {
 
     gCamera_yon = gCamera_yon + 5.f;
     AssertYons();
-    camera_ptr = gCamera_list[1]->type_data;
-    i = (int)camera_ptr->yon_z;
-    sprintf(s, GetMiscString(kMiscString_YonIncreasedTo_D), i);
+    sprintf(s, GetMiscString(kMiscString_YonIncreasedTo_D), (int)((br_camera*)gCamera_list[1]->type_data)->yon_z);
     NewTextHeadupSlot(eHeadupSlot_misc, 0, 2000, -kFont_MEDIUMHD, s);
 }
 

--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -920,7 +920,7 @@ void IncreaseYon(void) {
 
     gCamera_yon = gCamera_yon + 5.f;
     AssertYons();
-    sprintf(s, GetMiscString(kMiscString_YonIncreasedTo_D), (int)((br_camera*)gCamera_list[1]->type_data)->yon_z);
+    sprintf(s, GetMiscString(kMiscString_YonIncreasedTo_D), (int)CAMERA_PTR(gCamera_list[1])->yon_z);
     NewTextHeadupSlot(eHeadupSlot_misc, 0, 2000, -kFont_MEDIUMHD, s);
 }
 


### PR DESCRIPTION
## Match result

```
0x463682: IncreaseYon 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x463685,22 +0x47149b,26 @@
0x463685 : sub esp, 0x108
0x46368b : push ebx
0x46368c : push esi
0x46368d : push edi
0x46368e : fld dword ptr [gCamera_yon (DATA)] 	(depth.c:921)
0x463694 : fadd dword ptr [5.0 (FLOAT)]
0x46369a : fstp dword ptr [gCamera_yon (DATA)]
0x4636a0 : call AssertYons (FUNCTION) 	(depth.c:922)
0x4636a5 : mov eax, dword ptr [gCamera_list[1] (OFFSET)] 	(depth.c:923)
0x4636aa : mov eax, dword ptr [eax + 0x5c]
         : +mov dword ptr [ebp - 0x108], eax
         : +mov eax, dword ptr [ebp - 0x108] 	(depth.c:924)
0x4636ad : fld dword ptr [eax + 0xc]
0x4636b0 : call __ftol (FUNCTION)
         : +mov dword ptr [ebp - 0x104], eax
         : +mov eax, dword ptr [ebp - 0x104] 	(depth.c:925)
0x4636b5 : push eax
0x4636b6 : push 0x72
0x4636b8 : call GetMiscString (FUNCTION)
0x4636bd : add esp, 4
0x4636c0 : push eax
0x4636c1 : lea eax, [ebp - 0x100]
0x4636c7 : push eax
0x4636c8 : call sprintf (FUNCTION)
0x4636cd : add esp, 0xc
0x4636d0 : lea eax, [ebp - 0x100] 	(depth.c:926)


IncreaseYon is only 94.74% similar to the original, diff above
```

*AI generated. Time taken: 227s, tokens: 35,821*
