### PR TITLE
DecreaseYon 100% match

### DIFF
--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -938,7 +938,7 @@ void DecreaseYon(void) {
         gCamera_yon = 5.f;
     }
     AssertYons();
-    sprintf(s, GetMiscString(kMiscString_YonDecreasedTo_D), (int)((br_camera*)gCamera_list[1]->type_data)->yon_z);
+    sprintf(s, GetMiscString(kMiscString_YonDecreasedTo_D), (int)ACTOR_CAMERA(gCamera_list[1])->yon_z);
     NewTextHeadupSlot(eHeadupSlot_misc, 0, 2000, -kFont_MEDIUMHD, s);
 }
 

--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -938,9 +938,7 @@ void DecreaseYon(void) {
         gCamera_yon = 5.f;
     }
     AssertYons();
-    camera_ptr = gCamera_list[1]->type_data;
-    i = (int)camera_ptr->yon_z;
-    sprintf(s, GetMiscString(kMiscString_YonDecreasedTo_D), i);
+    sprintf(s, GetMiscString(kMiscString_YonDecreasedTo_D), (int)((br_camera*)gCamera_list[1]->type_data)->yon_z);
     NewTextHeadupSlot(eHeadupSlot_misc, 0, 2000, -kFont_MEDIUMHD, s);
 }
 


### PR DESCRIPTION
## Match result

```
0x4636ef: DecreaseYon 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x463701,22 +0x47152f,26 @@
0x463701 : fsub dword ptr [5.0 (FLOAT)]
0x463707 : fcom dword ptr [5.0 (FLOAT)] 	(depth.c:937)
0x46370d : fstp dword ptr [gCamera_yon (DATA)]
0x463713 : fnstsw ax
0x463715 : test ah, 1
0x463718 : je 0xa
0x46371e : mov dword ptr [gCamera_yon (DATA)], 0x40a00000 	(depth.c:938)
0x463728 : call AssertYons (FUNCTION) 	(depth.c:940)
0x46372d : mov eax, dword ptr [gCamera_list[1] (OFFSET)] 	(depth.c:941)
0x463732 : mov eax, dword ptr [eax + 0x5c]
         : +mov dword ptr [ebp - 0x108], eax
         : +mov eax, dword ptr [ebp - 0x108] 	(depth.c:942)
0x463735 : fld dword ptr [eax + 0xc]
0x463738 : call __ftol (FUNCTION)
         : +mov dword ptr [ebp - 0x104], eax
         : +mov eax, dword ptr [ebp - 0x104] 	(depth.c:943)
0x46373d : push eax
0x46373e : push 0x73
0x463740 : call GetMiscString (FUNCTION)
0x463745 : add esp, 4
0x463748 : push eax
0x463749 : lea eax, [ebp - 0x100]
0x46374f : push eax
0x463750 : call sprintf (FUNCTION)
0x463755 : add esp, 0xc
0x463758 : lea eax, [ebp - 0x100] 	(depth.c:944)


DecreaseYon is only 95.35% similar to the original, diff above
```

*AI generated. Time taken: 87s, tokens: 17,748*
