### PR TITLE
ToggleDepthMode 100% match

### DIFF
--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -1019,6 +1019,10 @@ void DecreaseAngle(void) {
 void ToggleDepthMode(void) {
 
     switch (gProgram_state.current_depth_effect.type) {
+    case eDepth_effect_fog:
+        InstantDepthChange(eDepth_effect_none, gProgram_state.current_depth_effect.sky_texture, 0, 0);
+        NewTextHeadupSlot(eHeadupSlot_misc, 0, 500, -kFont_ORANGHED, "Depth effects disabled");
+        break;
     case eDepth_effect_none:
         InstantDepthChange(eDepth_effect_darkness, gProgram_state.current_depth_effect.sky_texture, 8, 0);
         NewTextHeadupSlot(eHeadupSlot_misc, 0, 500, -kFont_ORANGHED, "Darkness mode");
@@ -1027,10 +1031,6 @@ void ToggleDepthMode(void) {
         InstantDepthChange(eDepth_effect_none, gProgram_state.current_depth_effect.sky_texture, 0, 0);
         InstantDepthChange(eDepth_effect_fog, gProgram_state.current_depth_effect.sky_texture, 10, 0);
         NewTextHeadupSlot(eHeadupSlot_misc, 0, 500, -kFont_ORANGHED, "Fog mode");
-        break;
-    case eDepth_effect_fog:
-        InstantDepthChange(eDepth_effect_none, gProgram_state.current_depth_effect.sky_texture, 0, 0);
-        NewTextHeadupSlot(eHeadupSlot_misc, 0, 500, -kFont_ORANGHED, "Depth effects disabled");
         break;
     }
     gProgram_state.default_depth_effect.type = gProgram_state.current_depth_effect.type;


### PR DESCRIPTION
## Match result

```
0x46398a: ToggleDepthMode 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x46398a,49 +0x4717d0,34 @@
0x46398a : push ebp 	(depth.c:1019)
0x46398b : mov ebp, esp
0x46398d : sub esp, 4
0x463990 : push ebx
0x463991 : push esi
0x463992 : push edi
0x463993 : mov eax, dword ptr [gProgram_state+7360 (OFFSET)] 	(depth.c:1021)
0x463998 : mov dword ptr [ebp - 4], eax
0x46399b : jmp 0xac
0x4639a0 : -push 0
0x4639a2 : -push 0
0x4639a4 : -mov eax, dword ptr [gProgram_state+7372 (OFFSET)]
0x4639a9 : -push eax
0x4639aa : -push -1
0x4639ac : -call InstantDepthChange (FUNCTION)
0x4639b1 : -add esp, 0x10
0x4639b4 : -push "Depth effects disabled" (STRING)
0x4639b9 : -push -1
0x4639bb : -push 0x1f4
0x4639c0 : -push 0
0x4639c2 : -push 4
0x4639c4 : -call NewTextHeadupSlot (FUNCTION)
0x4639c9 : -add esp, 0x14
0x4639cc : -jmp 0x9e
0x4639d1 : push 0 	(depth.c:1023)
0x4639d3 : push 8
0x4639d5 : mov eax, dword ptr [gProgram_state+7372 (OFFSET)]
0x4639da : push eax
0x4639db : push 0
0x4639dd : call InstantDepthChange (FUNCTION)
0x4639e2 : add esp, 0x10
0x4639e5 : push "Darkness mode" (STRING) 	(depth.c:1024)
0x4639ea : push -1
0x4639ec : push 0x1f4
0x4639f1 : push 0
0x4639f3 : push 4
0x4639f5 : call NewTextHeadupSlot (FUNCTION)
0x4639fa : add esp, 0x14
0x4639fd : -jmp 0x6d
         : +jmp 0x9e 	(depth.c:1025)
0x463a02 : push 0 	(depth.c:1027)
0x463a04 : push 0
0x463a06 : mov eax, dword ptr [gProgram_state+7372 (OFFSET)]
0x463a0b : push eax
0x463a0c : push -1
0x463a0e : call InstantDepthChange (FUNCTION)
0x463a13 : add esp, 0x10
0x463a16 : push 0 	(depth.c:1028)
0x463a18 : push 0xa
0x463a1a : mov eax, dword ptr [gProgram_state+7372 (OFFSET)]

---
+++
@@ -0x463a20,26 +0x471835,41 @@
0x463a20 : push 1
0x463a22 : call InstantDepthChange (FUNCTION)
0x463a27 : add esp, 0x10
0x463a2a : push "Fog mode" (STRING) 	(depth.c:1029)
0x463a2f : push -1
0x463a31 : push 0x1f4
0x463a36 : push 0
0x463a38 : push 4
0x463a3a : call NewTextHeadupSlot (FUNCTION)
0x463a3f : add esp, 0x14
         : +jmp 0x59 	(depth.c:1030)
         : +push 0 	(depth.c:1032)
         : +push 0
         : +mov eax, dword ptr [gProgram_state+7372 (OFFSET)]
         : +push eax
         : +push -1
         : +call InstantDepthChange (FUNCTION)
         : +add esp, 0x10
         : +push "Depth effects disabled" (STRING) 	(depth.c:1033)
         : +push -1
         : +push 0x1f4
         : +push 0
         : +push 4
         : +call NewTextHeadupSlot (FUNCTION)
         : +add esp, 0x14
0x463a42 : jmp 0x28 	(depth.c:1034)
0x463a47 : jmp 0x23 	(depth.c:1035)
0x463a4c : cmp dword ptr [ebp - 4], -1
0x463a50 : -je -0x85
         : +je -0xb6
0x463a56 : cmp dword ptr [ebp - 4], 0
0x463a5a : -je -0x5e
         : +je -0x8f
0x463a60 : cmp dword ptr [ebp - 4], 1
0x463a64 : -je -0xca
         : +je -0x54
0x463a6a : jmp 0x0
0x463a6f : mov eax, dword ptr [gProgram_state+7360 (OFFSET)] 	(depth.c:1036)
0x463a74 : mov dword ptr [gProgram_state+7344 (OFFSET)], eax
0x463a79 : pop edi 	(depth.c:1037)
0x463a7a : pop esi
0x463a7b : pop ebx
0x463a7c : leave 
0x463a7d : ret 


ToggleDepthMode is only 75.00% similar to the original, diff above
```

*AI generated. Time taken: 88s, tokens: 14,943*
