### PR TITLE
SetSkyTextureOn 100% effective match

### DIFF
--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -1046,20 +1046,8 @@ int GetSkyTextureOn(void) {
 // IDA: void __usercall SetSkyTextureOn(int pOn@<EAX>)
 // FUNCTION: CARM95 0x00463a93
 void SetSkyTextureOn(int pOn) {
-    br_pixelmap* tmp;
-
     if (pOn != gSky_on) {
-        tmp = gProgram_state.current_depth_effect.sky_texture;
-        gProgram_state.current_depth_effect.sky_texture = gSwap_sky_texture;
-        gProgram_state.default_depth_effect.sky_texture = gSwap_sky_texture;
-        gSwap_sky_texture = tmp;
-
-        if (gHorizon_material) {
-            if (gSwap_sky_texture) {
-                gHorizon_material->colour_map = gSwap_sky_texture;
-                BrMaterialUpdate(gHorizon_material, -1);
-            }
-        }
+        ToggleSkyQuietly();
     }
     gSky_on = pOn;
 }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x463a93,15 +0x4718d9,16 @@
0x463a93 : push ebp 	(depth.c:1048)
0x463a94 : mov ebp, esp
0x463a96 : push ebx
0x463a97 : push esi
0x463a98 : push edi
0x463a99 : -mov eax, dword ptr [ebp + 8]
0x463a9c : -cmp dword ptr [gSky_on (DATA)], eax
         : +mov eax, dword ptr [gSky_on (DATA)] 	(depth.c:1049)
         : +cmp dword ptr [ebp + 8], eax
0x463aa2 : je 0x5
0x463aa8 : call ToggleSkyQuietly (FUNCTION) 	(depth.c:1050)
0x463aad : mov eax, dword ptr [ebp + 8] 	(depth.c:1052)
0x463ab0 : mov dword ptr [gSky_on (DATA)], eax
0x463ab5 : pop edi 	(depth.c:1053)
0x463ab6 : pop esi
0x463ab7 : pop ebx
0x463ab8 : leave 
         : +ret 


0x463a93: SetSkyTextureOn 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x463a93,16 +0x4718d9,36 @@
0x463a93 : push ebp 	(depth.c:1048)
0x463a94 : mov ebp, esp
         : +sub esp, 4
0x463a96 : push ebx
0x463a97 : push esi
0x463a98 : push edi
0x463a99 : -mov eax, dword ptr [ebp + 8]
0x463a9c : -cmp dword ptr [gSky_on (DATA)], eax
0x463aa2 : -je 0x5
0x463aa8 : -call ToggleSkyQuietly (FUNCTION)
         : +mov eax, dword ptr [gSky_on (DATA)] 	(depth.c:1051)
         : +cmp dword ptr [ebp + 8], eax
         : +je 0x5f
         : +mov eax, dword ptr [gProgram_state+7372 (OFFSET)] 	(depth.c:1052)
         : +mov dword ptr [ebp - 4], eax
         : +mov eax, dword ptr [gSwap_sky_texture (DATA)] 	(depth.c:1053)
         : +mov dword ptr [gProgram_state+7372 (OFFSET)], eax
         : +mov eax, dword ptr [gSwap_sky_texture (DATA)] 	(depth.c:1054)
         : +mov dword ptr [gProgram_state+7356 (OFFSET)], eax
         : +mov eax, dword ptr [ebp - 4] 	(depth.c:1055)
         : +mov dword ptr [gSwap_sky_texture (DATA)], eax
         : +cmp dword ptr [gHorizon_material (DATA)], 0 	(depth.c:1057)
         : +je 0x2e
         : +cmp dword ptr [gSwap_sky_texture (DATA)], 0 	(depth.c:1058)
         : +je 0x21
         : +mov eax, dword ptr [gSwap_sky_texture (DATA)] 	(depth.c:1059)
         : +mov ecx, dword ptr [gHorizon_material (DATA)]
         : +mov dword ptr [ecx + 0x40], eax
         : +push 0xffff 	(depth.c:1060)
         : +mov eax, dword ptr [gHorizon_material (DATA)]
         : +push eax
         : +call BrMaterialUpdate (FUNCTION)
         : +add esp, 8
0x463aad : mov eax, dword ptr [ebp + 8] 	(depth.c:1064)
0x463ab0 : mov dword ptr [gSky_on (DATA)], eax
0x463ab5 : pop edi 	(depth.c:1065)
0x463ab6 : pop esi
0x463ab7 : pop ebx
0x463ab8 : leave 
0x463ab9 : ret 


SetSkyTextureOn is only 46.15% similar to the original, diff above
```

*AI generated. Time taken: 168s, tokens: 22,194*
