### PR TITLE
SetDepthCueingOn 100% match

### DIFF
--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -1105,10 +1105,7 @@ int GetDepthCueingOn(void) {
 // FUNCTION: CARM95 0x00463bda
 void SetDepthCueingOn(int pOn) {
     if (pOn != gDepth_cueing_on && gHorizon_material) {
-        InstantDepthChange(gSwap_depth_effect_type, gProgram_state.current_depth_effect.sky_texture, gSwap_depth_effect_start, gSwap_depth_effect_end);
-        gSwap_depth_effect_type = gProgram_state.current_depth_effect.type;
-        gSwap_depth_effect_start = gProgram_state.current_depth_effect.start;
-        gSwap_depth_effect_end = gProgram_state.current_depth_effect.end;
+        ToggleDepthCueingQuietly();
     }
     gDepth_cueing_on = pOn;
 }


### PR DESCRIPTION
## Match result

```
0x463bda: SetDepthCueingOn 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x463bda,18 +0x471a7c,33 @@
0x463bda : push ebp 	(depth.c:1106)
0x463bdb : mov ebp, esp
0x463bdd : push ebx
0x463bde : push esi
0x463bdf : push edi
0x463be0 : mov eax, dword ptr [gDepth_cueing_on (DATA)] 	(depth.c:1107)
0x463be5 : cmp dword ptr [ebp + 8], eax
0x463be8 : -je 0x12
         : +je 0x4b
0x463bee : cmp dword ptr [gHorizon_material (DATA)], 0
0x463bf5 : -je 0x5
0x463bfb : -call ToggleDepthCueingQuietly (FUNCTION)
         : +je 0x3e
         : +mov eax, dword ptr [gSwap_depth_effect_end (DATA)] 	(depth.c:1108)
         : +push eax
         : +mov eax, dword ptr [gSwap_depth_effect_start (DATA)]
         : +push eax
         : +mov eax, dword ptr [gProgram_state+7372 (OFFSET)]
         : +push eax
         : +mov eax, dword ptr [gSwap_depth_effect_type (DATA)]
         : +push eax
         : +call InstantDepthChange (FUNCTION)
         : +add esp, 0x10
         : +mov eax, dword ptr [gProgram_state+7360 (OFFSET)] 	(depth.c:1109)
         : +mov dword ptr [gSwap_depth_effect_type (DATA)], eax
         : +mov eax, dword ptr [gProgram_state+7364 (OFFSET)] 	(depth.c:1110)
         : +mov dword ptr [gSwap_depth_effect_start (DATA)], eax
         : +mov eax, dword ptr [gProgram_state+7368 (OFFSET)] 	(depth.c:1111)
         : +mov dword ptr [gSwap_depth_effect_end (DATA)], eax
0x463c00 : mov eax, dword ptr [ebp + 8] 	(depth.c:1113)
0x463c03 : mov dword ptr [gDepth_cueing_on (DATA)], eax
0x463c08 : pop edi 	(depth.c:1114)
0x463c09 : pop esi
0x463c0a : pop ebx
0x463c0b : leave 
0x463c0c : ret 


SetDepthCueingOn is only 58.82% similar to the original, diff above
```

*AI generated. Time taken: 61s, tokens: 17,185*
