### PR TITLE
DRStdlibAllocate 100% match

### DIFF
--- a/src/DETHRACE/common/drmem.c
+++ b/src/DETHRACE/common/drmem.c
@@ -307,14 +307,21 @@ void* DRStdlibAllocate(br_size_t size, br_uint_8 type) {
 
     if (size == 0) {
         return NULL;
+    } else {
+        p = malloc(size);
+        if (p != NULL) {
+            return p;
+        } else {
+            if (gNon_fatal_allocation_errors) {
+                return NULL;
+            } else {
+                PrintMemoryDump(0, "AT ERROR TIME");
+                sprintf(s, "%s/%d", gMem_names[type], (int)size);
+                FatalError(kFatalError_OOMCarmageddon_S, s);
+                return NULL;
+            }
+        }
     }
-    p = malloc(size);
-    if (p == NULL && !gNon_fatal_allocation_errors) {
-        PrintMemoryDump(0, "AT ERROR TIME");
-        sprintf(s, "%s/%d", gMem_names[type], (int)size);
-        FatalError(kFatalError_OOMCarmageddon_S, s);
-    }
-    return p;
 }
 
 // IDA: void __cdecl DRStdlibFree(void *mem)


### PR DESCRIPTION
## Match result

```
0x463def: DRStdlibAllocate 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x463def,41 +0x475d8f,46 @@
0x463def : push ebp 	(drmem.c:303)
0x463df0 : mov ebp, esp
0x463df2 : sub esp, 0x108
0x463df8 : push ebx
0x463df9 : push esi
0x463dfa : push edi
0x463dfb : cmp dword ptr [ebp + 8], 0 	(drmem.c:308)
0x463dff : -jne 0xc
         : +jne 0x7
0x463e05 : xor eax, eax 	(drmem.c:309)
0x463e07 : -jmp 0x90
0x463e0c : -jmp 0x8b
         : +jmp 0x73
0x463e11 : mov eax, dword ptr [ebp + 8] 	(drmem.c:311)
0x463e14 : push eax
0x463e15 : call malloc (FUNCTION)
0x463e1a : add esp, 4
0x463e1d : mov dword ptr [ebp - 4], eax
0x463e20 : cmp dword ptr [ebp - 4], 0 	(drmem.c:312)
0x463e24 : -je 0xd
0x463e2a : -mov eax, dword ptr [ebp - 4]
0x463e2d : -jmp 0x6a
0x463e32 : -jmp 0x65
         : +jne 0x52
0x463e37 : cmp dword ptr [gNon_fatal_allocation_errors (DATA)], 0
0x463e3e : -je 0xc
0x463e44 : -xor eax, eax
0x463e46 : -jmp 0x51
0x463e4b : -jmp 0x4c
         : +jne 0x45
0x463e50 : push "AT ERROR TIME" (STRING) 	(drmem.c:313)
0x463e55 : push 0
0x463e57 : call PrintMemoryDump (FUNCTION)
0x463e5c : add esp, 8
0x463e5f : mov eax, dword ptr [ebp + 8] 	(drmem.c:314)
0x463e62 : push eax
0x463e63 : xor eax, eax
0x463e65 : mov al, byte ptr [ebp + 0xc]
0x463e68 : mov eax, dword ptr [eax*4 + gMem_names[0] (DATA)]
0x463e6f : push eax
0x463e70 : push "%s/%d" (STRING)
0x463e75 : lea eax, [ebp - 0x104]
0x463e7b : push eax
0x463e7c : call sprintf (FUNCTION)
0x463e81 : add esp, 0x10
         : +lea eax, [ebp - 0x104] 	(drmem.c:315)
         : +push eax
         : +push 0x5e
         : +call FatalError (FUNCTION)
         : +add esp, 8
         : +mov eax, dword ptr [ebp - 4] 	(drmem.c:317)
         : +jmp 0x0
         : +pop edi 	(drmem.c:318)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRStdlibAllocate is only 68.97% similar to the original, diff above
```

*AI generated. Time taken: 538s, tokens: 145,019*
