### PR TITLE
CreateStainlessClasses 100% match

### DIFF
--- a/src/DETHRACE/common/drmem.c
+++ b/src/DETHRACE/common/drmem.c
@@ -362,7 +362,7 @@ void CreateStainlessClasses(void) {
     for (i = 129; i < 246; i++) {
         gStainless_classes[i - 129].res_class = i;
         if (!BrResClassAdd(&gStainless_classes[i - 129])) {
-            FatalError(kFatalError_OOMCarmageddon_S, gStainless_classes[i - 129].identifier);
+            FatalError(kFatalError_OOMCarmageddon_S);
         }
     }
 }

--- a/src/DETHRACE/common/drmem.c
+++ b/src/DETHRACE/common/drmem.c
@@ -362,7 +362,11 @@ void CreateStainlessClasses(void) {
     for (i = 129; i < 246; i++) {
         gStainless_classes[i - 129].res_class = i;
         if (!BrResClassAdd(&gStainless_classes[i - 129])) {
+#ifdef DETHRACE_FIX_BUGS
+            FatalError(kFatalError_OOMCarmageddon_S, gStainless_classes[i - 129].identifier);
+#else
             FatalError(kFatalError_OOMCarmageddon_S);
+#endif      
         }
     }
 }


### PR DESCRIPTION
## Match result

```
0x463f27: CreateStainlessClasses 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x463f27,33 +0x475eaa,37 @@
0x463f27 : push ebp 	(drmem.c:359)
0x463f28 : mov ebp, esp
0x463f2a : sub esp, 4
0x463f2d : push ebx
0x463f2e : push esi
0x463f2f : push edi
0x463f30 : mov dword ptr [ebp - 4], 0x81 	(drmem.c:362)
0x463f37 : jmp 0x3
0x463f3c : inc dword ptr [ebp - 4]
0x463f3f : cmp dword ptr [ebp - 4], 0xf6
0x463f46 : -jge 0x46
         : +jge 0x58
0x463f4c : mov al, byte ptr [ebp - 4] 	(drmem.c:363)
0x463f4f : mov ecx, dword ptr [ebp - 4]
0x463f52 : lea ecx, [ecx*4 - 0x204]
0x463f59 : mov byte ptr [ecx + ecx*4 + gStainless_classes[0].res_class (OFFSET)], al
0x463f60 : mov eax, dword ptr [ebp - 4] 	(drmem.c:364)
0x463f63 : lea eax, [eax*4 - 0x204]
0x463f6a : lea eax, [eax + eax*4]
0x463f6d : add eax, gStainless_classes[0].reserved (DATA)
0x463f72 : push eax
0x463f73 : call BrResClassAdd (FUNCTION)
0x463f78 : add esp, 4
0x463f7b : test eax, eax
0x463f7d : -jne 0xa
         : +jne 0x1c
         : +mov eax, dword ptr [ebp - 4] 	(drmem.c:365)
         : +lea eax, [eax*4 - 0x204]
         : +mov eax, dword ptr [eax + eax*4 + gStainless_classes[0].identifier (OFFSET)]
         : +push eax
0x463f83 : push 0x5e
0x463f85 : call FatalError (FUNCTION)
0x463f8a : -add esp, 4
0x463f8d : -jmp -0x56
         : +add esp, 8
         : +jmp -0x68 	(drmem.c:367)
0x463f92 : pop edi 	(drmem.c:368)
0x463f93 : pop esi
0x463f94 : pop ebx
0x463f95 : leave 
0x463f96 : ret 


CreateStainlessClasses is only 82.86% similar to the original, diff above
```

*AI generated. Time taken: 55s, tokens: 10,605*
