### PR TITLE
UsePathFileToDetermineIfFullInstallation 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -105,15 +105,10 @@ extern int gS3_last_error;
 // IDA: void __cdecl UsePathFileToDetermineIfFullInstallation()
 // FUNCTION: CARM95 0x00463fb0
 void UsePathFileToDetermineIfFullInstallation(void) {
-    // changed by dethrace for compatibility
-    // char line1[80];
-    // char line2[80];
-    // char line3[80];
-    // char path_file[80];
-    char line1[MAX_PATH_LENGTH];
-    char line2[MAX_PATH_LENGTH];
-    char line3[MAX_PATH_LENGTH];
-    char path_file[MAX_PATH_LENGTH];
+    char line1[80];
+    char line2[80];
+    char line3[80];
+    char path_file[80];
     FILE* fp;
 
     strcpy(path_file, gApplication_path);


### PR DESCRIPTION
## Match result

```
0x463fb0: UsePathFileToDetermineIfFullInstallation 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x463fb0,103 +0x4aa0c0,104 @@
0x463fb0 : push ebp 	(sound.c:107)
0x463fb1 : mov ebp, esp
0x463fb3 : -sub esp, 0x144
         : +mov eax, 0x1004
         : +call $$$00001(1) (FUNCTION)
0x463fb9 : push ebx
0x463fba : push esi
0x463fbb : push edi
0x463fbc : mov edi, gApplication_path[0] (DATA) 	(sound.c:119)
0x463fc1 : mov ecx, 0xffffffff
0x463fc6 : sub eax, eax
0x463fc8 : repne scasb al, byte ptr es:[edi]
0x463fca : not ecx
0x463fcc : sub edi, ecx
0x463fce : mov eax, ecx
0x463fd0 : mov edx, edi
0x463fd2 : -lea edi, [ebp - 0xa0]
         : +lea edi, [ebp - 0x800]
0x463fd8 : mov esi, edx
0x463fda : shr ecx, 2
0x463fdd : rep movsd dword ptr es:[edi], dword ptr [esi]
0x463fdf : mov ecx, eax
0x463fe1 : and ecx, 3
0x463fe4 : rep movsb byte ptr es:[edi], byte ptr [esi]
0x463fe6 : mov edi, gDir_separator[0] (DATA) 	(sound.c:120)
0x463feb : mov ecx, 0xffffffff
0x463ff0 : sub eax, eax
0x463ff2 : repne scasb al, byte ptr es:[edi]
0x463ff4 : not ecx
0x463ff6 : sub edi, ecx
0x463ff8 : mov edx, edi
0x463ffa : mov ebx, ecx
0x463ffc : -lea edi, [ebp - 0xa0]
         : +lea edi, [ebp - 0x800]
0x464002 : mov ecx, 0xffffffff
0x464007 : sub eax, eax
0x464009 : repne scasb al, byte ptr es:[edi]
0x46400b : dec edi
0x46400c : mov esi, edx
0x46400e : mov ecx, ebx
0x464010 : shr ecx, 2
0x464013 : rep movsd dword ptr es:[edi], dword ptr [esi]
0x464015 : mov ecx, ebx
0x464017 : and ecx, 3
0x46401a : rep movsb byte ptr es:[edi], byte ptr [esi]
0x46401c : mov edx, "PATHS.TXT" (STRING) 	(sound.c:121)
0x464021 : -lea edi, [ebp - 0xa0]
         : +lea edi, [ebp - 0x800]
0x464027 : mov ecx, 0xffffffff
0x46402c : sub eax, eax
0x46402e : repne scasb al, byte ptr es:[edi]
0x464030 : dec edi
0x464031 : mov eax, dword ptr [edx]
0x464033 : mov dword ptr [edi], eax
0x464035 : mov eax, dword ptr [edx + 4]
0x464038 : mov dword ptr [edi + 4], eax
0x46403b : mov ax, word ptr [edx + 8]
0x46403f : mov word ptr [edi + 8], ax
0x464043 : -lea eax, [ebp - 0xa0]
         : +lea eax, [ebp - 0x800] 	(sound.c:122)
0x464049 : push eax
0x46404a : call PDCheckDriveExists (FUNCTION)
0x46404f : add esp, 4
0x464052 : test eax, eax
0x464054 : -je 0xae
         : +je 0xb4
0x46405a : push "rt" (STRING) 	(sound.c:123)
0x46405f : -lea eax, [ebp - 0xa0]
         : +lea eax, [ebp - 0x800]
0x464065 : push eax
0x464066 : call fopen (FUNCTION)
0x46406b : add esp, 8
0x46406e : -mov dword ptr [ebp - 0x144], eax
0x464074 : -cmp dword ptr [ebp - 0x144], 0
0x46407b : -je 0x82
0x464081 : -mov byte ptr [ebp - 0x50], 0
0x464085 : -mov byte ptr [ebp - 0xf0], 0
0x46408c : -mov byte ptr [ebp - 0x140], 0
0x464093 : -lea eax, [ebp - 0x50]
         : +mov dword ptr [ebp - 0x1004], eax
         : +cmp dword ptr [ebp - 0x1004], 0 	(sound.c:124)
         : +je 0x88
         : +mov byte ptr [ebp - 0x400], 0 	(sound.c:125)
         : +mov byte ptr [ebp - 0xc00], 0 	(sound.c:126)
         : +mov byte ptr [ebp - 0x1000], 0 	(sound.c:127)
         : +lea eax, [ebp - 0x400] 	(sound.c:128)
0x464096 : push eax
0x464097 : -mov eax, dword ptr [ebp - 0x144]
         : +mov eax, dword ptr [ebp - 0x1004]
0x46409d : push eax
0x46409e : call GetALineWithNoPossibleService (FUNCTION)
0x4640a3 : add esp, 8
0x4640a6 : -lea eax, [ebp - 0xf0]
         : +lea eax, [ebp - 0xc00] 	(sound.c:129)
0x4640ac : push eax
0x4640ad : -mov eax, dword ptr [ebp - 0x144]
         : +mov eax, dword ptr [ebp - 0x1004]
0x4640b3 : push eax
0x4640b4 : call GetALineWithNoPossibleService (FUNCTION)
0x4640b9 : add esp, 8
0x4640bc : -lea eax, [ebp - 0x140]
         : +lea eax, [ebp - 0x1000] 	(sound.c:130)
0x4640c2 : push eax
0x4640c3 : -mov eax, dword ptr [ebp - 0x144]
         : +mov eax, dword ptr [ebp - 0x1004]
0x4640c9 : push eax
0x4640ca : call GetALineWithNoPossibleService (FUNCTION)
0x4640cf : add esp, 8
0x4640d2 : -mov eax, dword ptr [ebp - 0x144]
         : +mov eax, dword ptr [ebp - 0x1004] 	(sound.c:131)
0x4640d8 : push eax
0x4640d9 : call fclose (FUNCTION)
0x4640de : add esp, 4
0x4640e1 : -lea esi, [ebp - 0x140]
         : +lea esi, [ebp - 0x1000] 	(sound.c:132)
0x4640e7 : mov edi, "Full" (STRING)
0x4640ec : mov ecx, 5
0x4640f1 : repe cmpsb byte ptr [esi], byte ptr es:[edi]
0x4640f3 : jne 0xa
0x4640f9 : mov dword ptr [gCD_fully_installed (DATA)], 1 	(sound.c:133)
0x464103 : jmp 0xa 	(sound.c:136)
0x464108 : mov dword ptr [gCD_fully_installed (DATA)], 1 	(sound.c:137)
0x464112 : pop edi 	(sound.c:139)
0x464113 : pop esi
0x464114 : pop ebx


UsePathFileToDetermineIfFullInstallation is only 79.62% similar to the original, diff above
```

*AI generated. Time taken: 60s, tokens: 21,122*
