### PR TITLE
DRS3StartSound 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -259,13 +259,14 @@ void InitSound(void) {
 // IDA: tS3_sound_tag __usercall DRS3StartSound@<EAX>(tS3_outlet_ptr pOutlet@<EAX>, tS3_sound_id pSound@<EDX>)
 // FUNCTION: CARM95 0x0046458b
 tS3_sound_tag DRS3StartSound(tS3_outlet_ptr pOutlet, tS3_sound_id pSound) {
-    if (!gSound_enabled) {
+    if (gSound_enabled) {
+        if (pSound != 1000 && (pSound < 3000 || pSound > 3007) && (pSound < 5300 || pSound > 5320)) {
+            PipeSingleSound(pOutlet, pSound, 0, 0, -1, 0);
+        }
+        return S3StartSound(pOutlet, pSound);
+    } else {
         return 0;
     }
-    if (pSound != 1000 && (pSound < 3000 || pSound > 3007) && (pSound < 5300 || pSound > 5320)) {
-        PipeSingleSound(pOutlet, pSound, 0, 0, -1, 0);
-    }
-    return S3StartSound(pOutlet, pSound);
 }
 
 // IDA: tS3_sound_tag __usercall DRS3StartSoundNoPiping@<EAX>(tS3_outlet_ptr pOutlet@<EAX>, tS3_sound_id pSound@<EDX>)


### PR DESCRIPTION
## Match result

```
0x46458b: DRS3StartSound 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x46458b,17 +0x4aa6ce,19 @@
0x46458b : push ebp 	(sound.c:261)
0x46458c : mov ebp, esp
0x46458e : push ebx
0x46458f : push esi
0x464590 : push edi
0x464591 : cmp dword ptr [gSound_enabled (DATA)], 0 	(sound.c:262)
0x464598 : -je 0x73
         : +jne 0x7
         : +xor eax, eax 	(sound.c:263)
         : +jmp 0x6e
0x46459e : cmp dword ptr [ebp + 0xc], 0x3e8 	(sound.c:265)
0x4645a5 : je 0x4c
0x4645ab : cmp dword ptr [ebp + 0xc], 0xbb8
0x4645b2 : jl 0xd
0x4645b8 : cmp dword ptr [ebp + 0xc], 0xbbf
0x4645bf : jle 0x32
0x4645c5 : cmp dword ptr [ebp + 0xc], 0x14b4
0x4645cc : jl 0xd
0x4645d2 : cmp dword ptr [ebp + 0xc], 0x14c8
0x4645d9 : jle 0x18

---
+++
@@ -0x4645eb,14 +0x4aa735,16 @@
0x4645eb : mov eax, dword ptr [ebp + 8]
0x4645ee : push eax
0x4645ef : call PipeSingleSound (FUNCTION)
0x4645f4 : add esp, 0x18
0x4645f7 : mov eax, dword ptr [ebp + 0xc] 	(sound.c:268)
0x4645fa : push eax
0x4645fb : mov eax, dword ptr [ebp + 8]
0x4645fe : push eax
0x4645ff : call S3StartSound (FUNCTION)
0x464604 : add esp, 8
0x464607 : -jmp 0xc
0x46460c : -jmp 0x7
0x464611 : -xor eax, eax
0x464613 : jmp 0x0
         : +pop edi 	(sound.c:269)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRS3StartSound is only 84.62% similar to the original, diff above
```

*AI generated. Time taken: 157s, tokens: 18,656*
