### PR TITLE
DRS3StartSoundNoPiping 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -271,10 +271,11 @@ tS3_sound_tag DRS3StartSound(tS3_outlet_ptr pOutlet, tS3_sound_id pSound) {
 // IDA: tS3_sound_tag __usercall DRS3StartSoundNoPiping@<EAX>(tS3_outlet_ptr pOutlet@<EAX>, tS3_sound_id pSound@<EDX>)
 // FUNCTION: CARM95 0x0046461d
 tS3_sound_tag DRS3StartSoundNoPiping(tS3_outlet_ptr pOutlet, tS3_sound_id pSound) {
-    if (!gSound_enabled) {
+    if (gSound_enabled) {
+        return S3StartSound(pOutlet, pSound);
+    } else {
         return 0;
     }
-    return S3StartSound(pOutlet, pSound);
 }
 
 // IDA: tS3_sound_tag __usercall DRS3StartSound2@<EAX>(tS3_outlet_ptr pOutlet@<EAX>, tS3_sound_id pSound@<EDX>, tS3_repeats pRepeats@<EBX>, tS3_volume pLVolume@<ECX>, tS3_volume pRVolume, tS3_pitch pPitch, tS3_speed pSpeed)


### PR DESCRIPTION
## Match result

```
0x46461d: DRS3StartSoundNoPiping 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x46461d,17 +0x4aa75b,21 @@
0x46461d : push ebp 	(sound.c:273)
0x46461e : mov ebp, esp
0x464620 : push ebx
0x464621 : push esi
0x464622 : push edi
0x464623 : cmp dword ptr [gSound_enabled (DATA)], 0 	(sound.c:274)
0x46462a : -je 0x1a
         : +jne 0x7
         : +xor eax, eax 	(sound.c:275)
         : +jmp 0x15
0x464630 : mov eax, dword ptr [ebp + 0xc] 	(sound.c:277)
0x464633 : push eax
0x464634 : mov eax, dword ptr [ebp + 8]
0x464637 : push eax
0x464638 : call S3StartSound (FUNCTION)
0x46463d : add esp, 8
0x464640 : -jmp 0xc
0x464645 : -jmp 0x7
0x46464a : -xor eax, eax
0x46464c : jmp 0x0
         : +pop edi 	(sound.c:278)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRS3StartSoundNoPiping is only 68.42% similar to the original, diff above
```

*AI generated. Time taken: 124s, tokens: 26,912*
