### PR TITLE
DRS3StartSound2 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -281,17 +281,18 @@ tS3_sound_tag DRS3StartSoundNoPiping(tS3_outlet_ptr pOutlet, tS3_sound_id pSound
 // FUNCTION: CARM95 0x00464656
 tS3_sound_tag DRS3StartSound2(tS3_outlet_ptr pOutlet, tS3_sound_id pSound, tS3_repeats pRepeats, tS3_volume pLVolume, tS3_volume pRVolume, tS3_pitch pPitch, tS3_speed pSpeed) {
 
-    if (!gSound_enabled) {
+    if (gSound_enabled) {
+        if (pOutlet != gMusic_outlet
+            && pSound != 1000
+            && (pSound < 3000 || pSound > 3007)
+            && (pSound < 5300 || pSound > 5320)
+            && (pLVolume || pRVolume)) {
+            PipeSingleSound(pOutlet, pSound, pLVolume, pRVolume, pPitch, 0);
+        }
+        return S3StartSound2(pOutlet, pSound, pRepeats, pLVolume, pRVolume, pPitch, pSpeed);
+    } else {
         return 0;
     }
-    if (pOutlet != gMusic_outlet
-        && pSound != 1000
-        && (pSound < 3000 || pSound > 3007)
-        && (pSound < 5300 || pSound > 5320)
-        && (pLVolume || pRVolume)) {
-        PipeSingleSound(pOutlet, pSound, pLVolume, pRVolume, pPitch, 0);
-    }
-    return S3StartSound2(pOutlet, pSound, pRepeats, pLVolume, pRVolume, pPitch, pSpeed);
 }
 
 // IDA: int __usercall DRS3ChangeVolume@<EAX>(tS3_sound_tag pSound_tag@<EAX>, tS3_volume pNew_volume@<EDX>)


### PR DESCRIPTION
## Match result

```
0x464656: DRS3StartSound2 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x464656,17 +0x4aa78f,19 @@
0x464656 : push ebp 	(sound.c:282)
0x464657 : mov ebp, esp
0x464659 : push ebx
0x46465a : push esi
0x46465b : push edi
0x46465c : cmp dword ptr [gSound_enabled (DATA)], 0 	(sound.c:284)
0x464663 : -je 0xaf
         : +jne 0x7
         : +xor eax, eax 	(sound.c:285)
         : +jmp 0xaa
0x464669 : mov eax, dword ptr [gMusic_outlet (DATA)] 	(sound.c:291)
0x46466e : cmp dword ptr [ebp + 8], eax
0x464671 : je 0x73
0x464677 : cmp dword ptr [ebp + 0xc], 0x3e8
0x46467e : je 0x66
0x464684 : cmp dword ptr [ebp + 0xc], 0xbb8
0x46468b : jl 0xd
0x464691 : cmp dword ptr [ebp + 0xc], 0xbbf
0x464698 : jle 0x4c
0x46469e : cmp dword ptr [ebp + 0xc], 0x14b4

---
+++
@@ -0x4646f6,14 +0x4aa836,16 @@
0x4646f6 : mov eax, dword ptr [ebp + 0x14]
0x4646f9 : push eax
0x4646fa : mov eax, dword ptr [ebp + 0x10]
0x4646fd : push eax
0x4646fe : mov eax, dword ptr [ebp + 0xc]
0x464701 : push eax
0x464702 : mov eax, dword ptr [ebp + 8]
0x464705 : push eax
0x464706 : call S3StartSound2 (FUNCTION)
0x46470b : add esp, 0x1c
0x46470e : -jmp 0xc
0x464713 : -jmp 0x7
0x464718 : -xor eax, eax
0x46471a : jmp 0x0
         : +pop edi 	(sound.c:295)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRS3StartSound2 is only 89.83% similar to the original, diff above
```

*AI generated. Time taken: 140s, tokens: 24,815*
