### PR TITLE
DRS3ChangeVolume 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -298,10 +298,11 @@ tS3_sound_tag DRS3StartSound2(tS3_outlet_ptr pOutlet, tS3_sound_id pSound, tS3_r
 // FUNCTION: CARM95 0x00464724
 int DRS3ChangeVolume(tS3_sound_tag pSound_tag, tS3_volume pNew_volume) {
 
-    if (gSound_enabled == 0) {
+    if (gSound_enabled != 0) {
+        return S3ChangeVolume(pSound_tag, pNew_volume);
+    } else {
         return 0;
     }
-    return S3ChangeVolume(pSound_tag, pNew_volume);
 }
 
 // IDA: int __usercall DRS3ChangeLRVolume@<EAX>(tS3_sound_tag pSound_tag@<EAX>, tS3_volume pNew_Lvolume@<EDX>, tS3_volume pNew_Rvolume@<EBX>)


### PR DESCRIPTION
## Match result

```
0x464724: DRS3ChangeVolume 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x464724,17 +0x4aa858,21 @@
0x464724 : push ebp 	(sound.c:299)
0x464725 : mov ebp, esp
0x464727 : push ebx
0x464728 : push esi
0x464729 : push edi
0x46472a : cmp dword ptr [gSound_enabled (DATA)], 0 	(sound.c:301)
0x464731 : -je 0x1a
         : +jne 0x7
         : +xor eax, eax 	(sound.c:302)
         : +jmp 0x15
0x464737 : mov eax, dword ptr [ebp + 0xc] 	(sound.c:304)
0x46473a : push eax
0x46473b : mov eax, dword ptr [ebp + 8]
0x46473e : push eax
0x46473f : call S3ChangeVolume (FUNCTION)
0x464744 : add esp, 8
0x464747 : -jmp 0xc
0x46474c : -jmp 0x7
0x464751 : -xor eax, eax
0x464753 : jmp 0x0
         : +pop edi 	(sound.c:305)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRS3ChangeVolume is only 68.42% similar to the original, diff above
```

*AI generated. Time taken: 195s, tokens: 12,992*
