### PR TITLE
DRS3ChangePitchSpeed 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -324,10 +324,11 @@ int DRS3ChangeSpeed(tS3_sound_tag pTag, tS3_pitch pNew_speed) {
 // FUNCTION: CARM95 0x0046480c
 int DRS3ChangePitchSpeed(tS3_sound_tag pTag, tS3_pitch pNew_pitch) {
 
-    if (!gSound_enabled) {
+    if (gSound_enabled != 0) {
+        return S3ChangePitchSpeed(pTag, pNew_pitch);
+    } else {
         return 0;
     }
-    return S3ChangePitchSpeed(pTag, pNew_pitch);
 }
 
 // IDA: int __usercall DRS3StopSound@<EAX>(tS3_sound_tag pSound_tag@<EAX>)


### PR DESCRIPTION
## Match result

```
0x46480c: DRS3ChangePitchSpeed 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x46480c,17 +0x4aa8c3,21 @@
0x46480c : push ebp 	(sound.c:325)
0x46480d : mov ebp, esp
0x46480f : push ebx
0x464810 : push esi
0x464811 : push edi
0x464812 : cmp dword ptr [gSound_enabled (DATA)], 0 	(sound.c:327)
0x464819 : -je 0x1a
         : +jne 0x7
         : +xor eax, eax 	(sound.c:328)
         : +jmp 0x15
0x46481f : mov eax, dword ptr [ebp + 0xc] 	(sound.c:330)
0x464822 : push eax
0x464823 : mov eax, dword ptr [ebp + 8]
0x464826 : push eax
0x464827 : call S3ChangePitchSpeed (FUNCTION)
0x46482c : add esp, 8
0x46482f : -jmp 0xc
0x464834 : -jmp 0x7
0x464839 : -xor eax, eax
0x46483b : jmp 0x0
         : +pop edi 	(sound.c:331)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRS3ChangePitchSpeed is only 68.42% similar to the original, diff above
```

*AI generated. Time taken: 187s, tokens: 14,169*
