### PR TITLE
DRS3StopSound 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -334,10 +334,11 @@ int DRS3ChangePitchSpeed(tS3_sound_tag pTag, tS3_pitch pNew_pitch) {
 // FUNCTION: CARM95 0x00464845
 int DRS3StopSound(tS3_sound_tag pSound_tag) {
 
-    if (!gSound_enabled) {
+    if (gSound_enabled) {
+        return S3StopSound(pSound_tag);
+    } else {
         return 0;
     }
-    return S3StopSound(pSound_tag);
 }
 
 // IDA: int __usercall DRS3LoadSound@<EAX>(tS3_sound_id pThe_sound@<EAX>)


### PR DESCRIPTION
## Match result

```
0x464845: DRS3StopSound 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x464845,15 +0x4aa8f7,19 @@
0x464845 : push ebp 	(sound.c:335)
0x464846 : mov ebp, esp
0x464848 : push ebx
0x464849 : push esi
0x46484a : push edi
0x46484b : cmp dword ptr [gSound_enabled (DATA)], 0 	(sound.c:337)
0x464852 : -je 0x16
         : +jne 0x7
         : +xor eax, eax 	(sound.c:338)
         : +jmp 0x11
0x464858 : mov eax, dword ptr [ebp + 8] 	(sound.c:340)
0x46485b : push eax
0x46485c : call S3StopSound (FUNCTION)
0x464861 : add esp, 4
0x464864 : -jmp 0xc
0x464869 : -jmp 0x7
0x46486e : -xor eax, eax
0x464870 : jmp 0x0
         : +pop edi 	(sound.c:341)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRS3StopSound is only 64.71% similar to the original, diff above
```

*AI generated. Time taken: 121s, tokens: 22,762*
