### PR TITLE
DRS3LoadSound 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -338,10 +338,11 @@ int DRS3StopSound(tS3_sound_tag pSound_tag) {
 // FUNCTION: CARM95 0x0046487a
 int DRS3LoadSound(tS3_sound_id pThe_sound) {
 
-    if (!gSound_enabled) {
+    if (gSound_enabled) {
+        return S3LoadSample(pThe_sound);
+    } else {
         return 0;
     }
-    return S3LoadSample(pThe_sound);
 }
 
 // IDA: int __usercall DRS3ReleaseSound@<EAX>(tS3_sound_id pThe_sound@<EAX>)


### PR DESCRIPTION
## Match result

```
0x46487a: DRS3LoadSound 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x46487a,15 +0x4aa8e2,19 @@
0x46487a : push ebp 	(sound.c:339)
0x46487b : mov ebp, esp
0x46487d : push ebx
0x46487e : push esi
0x46487f : push edi
0x464880 : cmp dword ptr [gSound_enabled (DATA)], 0 	(sound.c:341)
0x464887 : -je 0x16
         : +jne 0x7
         : +xor eax, eax 	(sound.c:342)
         : +jmp 0x11
0x46488d : mov eax, dword ptr [ebp + 8] 	(sound.c:344)
0x464890 : push eax
0x464891 : call S3LoadSample (FUNCTION)
0x464896 : add esp, 4
0x464899 : -jmp 0xc
0x46489e : -jmp 0x7
0x4648a3 : -xor eax, eax
0x4648a5 : jmp 0x0
         : +pop edi 	(sound.c:345)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRS3LoadSound is only 64.71% similar to the original, diff above
```

*AI generated. Time taken: 59s, tokens: 11,315*
