### PR TITLE
DRS3ReleaseSound 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -348,10 +348,11 @@ int DRS3LoadSound(tS3_sound_id pThe_sound) {
 // FUNCTION: CARM95 0x004648af
 int DRS3ReleaseSound(tS3_sound_id pThe_sound) {
 
-    if (gSound_enabled == 0) {
+    if (gSound_enabled) {
+        return S3ReleaseSound(pThe_sound);
+    } else {
         return 0;
     }
-    return S3ReleaseSound(pThe_sound);
 }
 
 // IDA: void __cdecl DRS3Service()

--- a/src/S3/s3.c
+++ b/src/S3/s3.c
@@ -197,6 +197,7 @@ void S3CloseDevices(void) {
     AudioBackend_UnInitCDA();
 }
 
+// FUNCTION: CARM95 0x004994b7
 int S3ReleaseSound(tS3_sound_id id) {
     tS3_channel* c;       // [esp+Ch] [ebp-10h]
     tS3_outlet* o;        // [esp+10h] [ebp-Ch]


### PR DESCRIPTION
## Match result

```
0x4648af: DRS3ReleaseSound 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4648af,15 +0x4aa912,19 @@
0x4648af : push ebp 	(sound.c:349)
0x4648b0 : mov ebp, esp
0x4648b2 : push ebx
0x4648b3 : push esi
0x4648b4 : push edi
0x4648b5 : cmp dword ptr [gSound_enabled (DATA)], 0 	(sound.c:351)
0x4648bc : -je 0x16
         : +jne 0x7
         : +xor eax, eax 	(sound.c:352)
         : +jmp 0x11
0x4648c2 : mov eax, dword ptr [ebp + 8] 	(sound.c:354)
0x4648c5 : push eax
0x4648c6 : -call <OFFSET2>
         : +call S3ReleaseSound (FUNCTION)
0x4648cb : add esp, 4
0x4648ce : -jmp 0xc
0x4648d3 : -jmp 0x7
0x4648d8 : -xor eax, eax
0x4648da : jmp 0x0
         : +pop edi 	(sound.c:355)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRS3ReleaseSound is only 58.82% similar to the original, diff above
```

*AI generated. Time taken: 419s, tokens: 62,337*
