### PR TITLE
DRS3Service 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -360,11 +360,7 @@ int DRS3ReleaseSound(tS3_sound_id pThe_sound) {
 void DRS3Service(void) {
 
     if (gSound_enabled) {
-        if (gProgram_state.cockpit_on && gProgram_state.cockpit_image_index >= 0) {
-            S3Service(1, 1);
-        } else {
-            S3Service(0, 1);
-        }
+        S3Service(gProgram_state.cockpit_on && gProgram_state.cockpit_image_index >= 0, 1);
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4648e4: DRS3Service 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4648e4,19 +0x4aa947,25 @@
0x4648e4 : push ebp 	(sound.c:360)
0x4648e5 : mov ebp, esp
0x4648e7 : -sub esp, 4
0x4648ea : push ebx
0x4648eb : push esi
0x4648ec : push edi
0x4648ed : cmp dword ptr [gSound_enabled (DATA)], 0 	(sound.c:362)
0x4648f4 : -je 0x3b
         : +je 0x37
0x4648fa : cmp dword ptr [gProgram_state+80 (OFFSET)], 0 	(sound.c:363)
0x464901 : -je 0x19
         : +je 0x1e
0x464907 : cmp dword ptr [gProgram_state+84 (OFFSET)], 0
0x46490e : -jl 0xc
0x464914 : -mov dword ptr [ebp - 4], 1
0x46491b : -jmp 0x7
0x464920 : -mov dword ptr [ebp - 4], 0
         : +jl 0x11
0x464927 : push 1 	(sound.c:364)
0x464929 : -mov eax, dword ptr [ebp - 4]
0x46492c : -push eax
         : +push 1
0x46492d : call S3Service (FUNCTION)
         : +add esp, 8
         : +jmp 0xc 	(sound.c:365)
         : +push 1 	(sound.c:366)
         : +push 0
         : +call S3Service (FUNCTION)
         : +add esp, 8
         : +pop edi 	(sound.c:369)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRS3Service is only 45.45% similar to the original, diff above
```

*AI generated. Time taken: 166s, tokens: 18,410*
