### PR TITLE
DRS3OutletSoundsPlaying 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -371,7 +371,11 @@ void DRS3Service(void) {
 // IDA: int __usercall DRS3OutletSoundsPlaying@<EAX>(tS3_outlet_ptr pOutlet@<EAX>)
 // FUNCTION: CARM95 0x0046493a
 int DRS3OutletSoundsPlaying(tS3_outlet_ptr pOutlet) {
-    NOT_IMPLEMENTED();
+    if (gSound_enabled) {
+        return S3OutletSoundsPlaying(pOutlet);
+    } else {
+        return 0;
+    }
 }
 
 // IDA: int __usercall DRS3SoundStillPlaying@<EAX>(tS3_sound_tag pSound_tag@<EAX>)

--- a/src/S3/include/s3/s3.h
+++ b/src/S3/include/s3/s3.h
@@ -32,33 +32,36 @@ void S3Shutdown(void);
 void S3Disable(void);
 void S3Enable(void);
 
-void S3Set3DSoundEnvironment(float a1, float a2, float a3);
-int S3BindAmbientSoundToOutlet(tS3_outlet_ptr pOutlet, int pSound, tS3_sound_source* source, float pMax_distance, int pPeriod, int pRepeats, int pVolume, int pPitch, int pSpeed);
-
-tS3_sound_tag S3StartSound3D(tS3_outlet_ptr pOutlet, tS3_sound_id pSound, tS3_vector3* pInitial_position, tS3_vector3* pInitial_velocity, tS3_repeats pRepeats, tS3_volume pVolume, tS3_pitch pPitch, tS3_speed pSpeed);
-
-tS3_outlet_ptr S3CreateOutlet(int unk1, int pChannel_count);
-void S3ReleaseOutlet(tS3_outlet_ptr outlet);
-int S3ReleaseSound(tS3_sound_id id);
-int S3ReleaseSoundSource(tS3_sound_source_ptr src);
-
-int S3ChangeVolume(tS3_sound_tag pTag, tS3_volume pVolume);
-
 void S3Service(int inside_cockpit, int unk1);
 
+// Sample
 int S3LoadSample(tS3_sound_id id);
-tS3_sound_tag S3StartSound(tS3_outlet_ptr pOutlet, tS3_sound_id pSound);
-tS3_sound_tag S3StartSound2(tS3_outlet_ptr pOutlet, tS3_sound_id pSound, tS3_repeats pRepeats, tS3_volume pLVolume, tS3_volume pRVolume, tS3_pitch pPitch, tS3_speed pSpeed);
-int S3StopAllOutletSounds(void);
-int S3SoundStillPlaying(tS3_sound_tag pSound);
-int S3ChangePitchSpeed(tS3_sound_tag pTag, tS3_pitch pNew_pitch);
-int S3StopSound(tS3_sound_tag pSound_tag);
-int S3StopOutletSound(tS3_outlet_ptr pOutlet);
-int S3SetOutletVolume(tS3_outlet_ptr pOutlet, tS3_volume pVolume);
-void S3UpdateSoundSource(tS3_outlet_ptr outlet, tS3_sound_tag tag, tS3_sound_source_ptr src, float pMax_distance_squared, int pPeriod, tS3_repeats pAmbient_repeats, tS3_volume pVolume, int pPitch, tS3_speed pSpeed);
-
 int S3RegisterSampleFilters(tS3_sample_filter* filter1, tS3_sample_filter* filter2);
 int S3GetSampleLength(tS3_sound_tag tag);
+
+// Sound
+tS3_sound_tag S3StartSound(tS3_outlet_ptr pOutlet, tS3_sound_id pSound);
+tS3_sound_tag S3StartSound2(tS3_outlet_ptr pOutlet, tS3_sound_id pSound, tS3_repeats pRepeats, tS3_volume pLVolume, tS3_volume pRVolume, tS3_pitch pPitch, tS3_speed pSpeed);
+int S3SoundStillPlaying(tS3_sound_tag pSound);
+int S3ChangePitchSpeed(tS3_sound_tag pTag, tS3_pitch pNew_pitch);
+int S3ChangeVolume(tS3_sound_tag pTag, tS3_volume pVolume);
+int S3StopSound(tS3_sound_tag pSound_tag);
+int S3ReleaseSound(tS3_sound_id id);
+
+// Outlet
+tS3_outlet_ptr S3CreateOutlet(int unk1, int pChannel_count);
+void S3ReleaseOutlet(tS3_outlet_ptr outlet);
+int S3StopOutletSound(tS3_outlet_ptr pOutlet);
+int S3SetOutletVolume(tS3_outlet_ptr pOutlet, tS3_volume pVolume);
+int S3OutletSoundsPlaying(tS3_outlet* pOutlet);
+void S3StopAllOutletSounds(void);
+
+// 3d
+void S3UpdateSoundSource(tS3_outlet_ptr outlet, tS3_sound_tag tag, tS3_sound_source_ptr src, float pMax_distance_squared, int pPeriod, tS3_repeats pAmbient_repeats, tS3_volume pVolume, int pPitch, tS3_speed pSpeed);
+void S3Set3DSoundEnvironment(float a1, float a2, float a3);
+int S3BindAmbientSoundToOutlet(tS3_outlet_ptr pOutlet, int pSound, tS3_sound_source* source, float pMax_distance, int pPeriod, int pRepeats, int pVolume, int pPitch, int pSpeed);
+tS3_sound_tag S3StartSound3D(tS3_outlet_ptr pOutlet, tS3_sound_id pSound, tS3_vector3* pInitial_position, tS3_vector3* pInitial_velocity, tS3_repeats pRepeats, tS3_volume pVolume, tS3_pitch pPitch, tS3_speed pSpeed);
+int S3ReleaseSoundSource(tS3_sound_source_ptr src);
 
 // CDA
 int S3CDAEnabled(void);

--- a/src/S3/include/s3/s3.h
+++ b/src/S3/include/s3/s3.h
@@ -54,7 +54,7 @@ void S3ReleaseOutlet(tS3_outlet_ptr outlet);
 int S3StopOutletSound(tS3_outlet_ptr pOutlet);
 int S3SetOutletVolume(tS3_outlet_ptr pOutlet, tS3_volume pVolume);
 int S3OutletSoundsPlaying(tS3_outlet* pOutlet);
-void S3StopAllOutletSounds(void);
+int S3StopAllOutletSounds(void);
 
 // 3d
 void S3UpdateSoundSource(tS3_outlet_ptr outlet, tS3_sound_tag tag, tS3_sound_source_ptr src, float pMax_distance_squared, int pPeriod, tS3_repeats pAmbient_repeats, tS3_volume pVolume, int pPitch, tS3_speed pSpeed);

--- a/src/S3/s3.c
+++ b/src/S3/s3.c
@@ -1224,12 +1224,10 @@ int S3OutletSoundsPlaying(tS3_outlet* pOutlet) {
     if (!gS3_enabled) {
         return 0;
     }
-    c = pOutlet->channel_list;
-    while (c) {
+    for (c = pOutlet->channel_list; c != NULL; c = c->next) {
         if (c->active) {
             sound_count++;
         }
-        c = c->next;
     }
     return sound_count;
 }

--- a/src/S3/s3.c
+++ b/src/S3/s3.c
@@ -1215,6 +1215,25 @@ int S3StopSound(tS3_sound_tag pTag) {
     return 0;
 }
 
+// FUNCTION: CARM95 0x0049C6E2
+int S3OutletSoundsPlaying(tS3_outlet* pOutlet) {
+    int sound_count;
+    tS3_channel* c;
+
+    sound_count = 0;
+    if (!gS3_enabled) {
+        return 0;
+    }
+    c = pOutlet->channel_list;
+    while (c) {
+        if (c->active) {
+            sound_count++;
+        }
+        c = c->next;
+    }
+    return sound_count;
+}
+
 // FUNCTION: CARM95 0x0049C748
 int S3StopOutletSound(tS3_outlet* pOutlet) {
     tS3_channel* c; // [esp+Ch] [ebp-4h]


### PR DESCRIPTION
## Match result

```
0x46493a: DRS3OutletSoundsPlaying 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x46493a,6 +0x4aa996,11 @@
0x46493a : push ebp 	(sound.c:373)
0x46493b : mov ebp, esp
0x46493d : push ebx
0x46493e : push esi
0x46493f : push edi
0x464940 : -cmp dword ptr [gSound_enabled (DATA)], 0
         : +call abort (FUNCTION) 	(sound.c:374)
         : +pop edi 	(sound.c:375)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRS3OutletSoundsPlaying is only 58.82% similar to the original, diff above
```

*AI generated. Time taken: 387s, tokens: 235,018*
