### PR TITLE
DRS3SoundStillPlaying 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -374,7 +374,11 @@ int DRS3OutletSoundsPlaying(tS3_outlet_ptr pOutlet) {
 // FUNCTION: CARM95 0x0046496f
 int DRS3SoundStillPlaying(tS3_sound_tag pSound_tag) {
 
-    return gSound_enabled && S3SoundStillPlaying(pSound_tag);
+    if (gSound_enabled) {
+        return S3SoundStillPlaying(pSound_tag);
+    } else {
+        return 0;
+    }
 }
 
 // IDA: void __cdecl DRS3ShutDown()


### PR DESCRIPTION
## Match result

```
0x46496f: DRS3SoundStillPlaying 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x46496f,20 +0x4aa9ad,22 @@
0x46496f : push ebp 	(sound.c:375)
0x464970 : mov ebp, esp
0x464972 : push ebx
0x464973 : push esi
0x464974 : push edi
0x464975 : cmp dword ptr [gSound_enabled (DATA)], 0 	(sound.c:377)
0x46497c : -je 0x16
         : +je 0x1e
0x464982 : mov eax, dword ptr [ebp + 8]
0x464985 : push eax
0x464986 : call S3SoundStillPlaying (FUNCTION)
0x46498b : add esp, 4
0x46498e : -jmp 0xc
0x464993 : -jmp 0x7
         : +test eax, eax
         : +je 0xa
         : +mov eax, 1
         : +jmp 0x2
0x464998 : xor eax, eax
0x46499a : jmp 0x0
0x46499f : pop edi 	(sound.c:378)
0x4649a0 : pop esi
0x4649a1 : pop ebx
0x4649a2 : leave 
0x4649a3 : ret 


DRS3SoundStillPlaying is only 80.95% similar to the original, diff above
```

*AI generated. Time taken: 240s, tokens: 24,597*
