### PR TITLE
DRS3SetOutletVolume 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -391,10 +391,11 @@ void DRS3ShutDown(void) {
 // FUNCTION: CARM95 0x004649cb
 int DRS3SetOutletVolume(tS3_outlet_ptr pOutlet, tS3_volume pVolume) {
 
-    if (!gSound_enabled) {
+    if (gSound_enabled) {
+        return S3SetOutletVolume(pOutlet, pVolume);
+    } else {
         return 0;
     }
-    return S3SetOutletVolume(pOutlet, pVolume);
 }
 
 // IDA: int __usercall DRS3OverallVolume@<EAX>(tS3_volume pVolume@<EAX>)


### PR DESCRIPTION
## Match result

```
0x4649cb: DRS3SetOutletVolume 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4649cb,17 +0x4aaa11,21 @@
0x4649cb : push ebp 	(sound.c:392)
0x4649cc : mov ebp, esp
0x4649ce : push ebx
0x4649cf : push esi
0x4649d0 : push edi
0x4649d1 : cmp dword ptr [gSound_enabled (DATA)], 0 	(sound.c:394)
0x4649d8 : -je 0x1a
         : +jne 0x7
         : +xor eax, eax 	(sound.c:395)
         : +jmp 0x15
0x4649de : mov eax, dword ptr [ebp + 0xc] 	(sound.c:397)
0x4649e1 : push eax
0x4649e2 : mov eax, dword ptr [ebp + 8]
0x4649e5 : push eax
0x4649e6 : call S3SetOutletVolume (FUNCTION)
0x4649eb : add esp, 8
0x4649ee : -jmp 0xc
0x4649f3 : -jmp 0x7
0x4649f8 : -xor eax, eax
0x4649fa : jmp 0x0
         : +pop edi 	(sound.c:398)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRS3SetOutletVolume is only 68.42% similar to the original, diff above
```

*AI generated. Time taken: 172s, tokens: 14,632*
