### PR TITLE
DRS3StopOutletSound 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -405,10 +405,11 @@ int DRS3OverallVolume(tS3_volume pVolume) {
 // IDA: int __usercall DRS3StopOutletSound@<EAX>(tS3_outlet_ptr pOutlet@<EAX>)
 // FUNCTION: CARM95 0x00464a39
 int DRS3StopOutletSound(tS3_outlet_ptr pOutlet) {
-    if (!gSound_enabled) {
+    if (gSound_enabled) {
+        return S3StopOutletSound(pOutlet);
+    } else {
         return 0;
     }
-    return S3StopOutletSound(pOutlet);
 }
 
 // IDA: int __cdecl DRS3StopAllOutletSounds()


### PR DESCRIPTION
## Match result

```
0x464a39: DRS3StopOutletSound 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x464a39,15 +0x4aaa55,19 @@
0x464a39 : push ebp 	(sound.c:407)
0x464a3a : mov ebp, esp
0x464a3c : push ebx
0x464a3d : push esi
0x464a3e : push edi
0x464a3f : cmp dword ptr [gSound_enabled (DATA)], 0 	(sound.c:408)
0x464a46 : -je 0x16
         : +jne 0x7
         : +xor eax, eax 	(sound.c:409)
         : +jmp 0x11
0x464a4c : mov eax, dword ptr [ebp + 8] 	(sound.c:411)
0x464a4f : push eax
0x464a50 : call S3StopOutletSound (FUNCTION)
0x464a55 : add esp, 4
0x464a58 : -jmp 0xc
0x464a5d : -jmp 0x7
0x464a62 : -xor eax, eax
0x464a64 : jmp 0x0
         : +pop edi 	(sound.c:412)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRS3StopOutletSound is only 64.71% similar to the original, diff above
```

*AI generated. Time taken: 104s, tokens: 14,125*
