### PR TITLE
DRS3StopAllOutletSounds 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -416,9 +416,10 @@ int DRS3StopOutletSound(tS3_outlet_ptr pOutlet) {
 int DRS3StopAllOutletSounds(void) {
 
     if (gSound_enabled) {
-        S3StopAllOutletSounds();
+        return S3StopAllOutletSounds();
+    } else {
+        return 0;
     }
-    return 0;
 }
 
 // IDA: void __cdecl ToggleSoundEnable()


### PR DESCRIPTION
## Match result

```
0x464a6e: DRS3StopAllOutletSounds 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x464a6e,11 +0x4aaa85,15 @@
0x464a6e : push ebp 	(sound.c:416)
0x464a6f : mov ebp, esp
0x464a71 : push ebx
0x464a72 : push esi
0x464a73 : push edi
0x464a74 : cmp dword ptr [gSound_enabled (DATA)], 0 	(sound.c:418)
0x464a7b : -je 0xf
         : +je 0x5
0x464a81 : call S3StopAllOutletSounds (FUNCTION) 	(sound.c:419)
0x464a86 : -jmp 0xc
0x464a8b : -jmp 0x7
0x464a90 : xor eax, eax 	(sound.c:421)
         : +jmp 0x0
         : +pop edi 	(sound.c:422)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRS3StopAllOutletSounds is only 61.54% similar to the original, diff above
```

*AI generated. Time taken: 561s, tokens: 97,017*
