### PR TITLE
SoundService 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -444,13 +444,13 @@ void ToggleSoundEnable(void) {
 // IDA: void __cdecl SoundService()
 // FUNCTION: CARM95 0x00464adc
 void SoundService(void) {
+    tU32 this_service;
     br_matrix34 mat;
-    tU32 total_time;
 
     if (gSound_enabled && !gServicing_sound) {
         gServicing_sound = 1;
-        total_time = PDGetTotalTime();
-        gLast_sound_service = total_time;
+        this_service = PDGetTotalTime();
+        gLast_sound_service = this_service;
         if (gCDA_is_playing) {
             if (!S3IsCDAPlaying()) {
                 StopMusic();

--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -445,11 +445,13 @@ void ToggleSoundEnable(void) {
 // FUNCTION: CARM95 0x00464adc
 void SoundService(void) {
     br_matrix34 mat;
+    tU32 total_time;
 
     if (gSound_enabled && !gServicing_sound) {
         gServicing_sound = 1;
-        gLast_sound_service = PDGetTotalTime();
-        if (gCDA_tag) {
+        total_time = PDGetTotalTime();
+        gLast_sound_service = total_time;
+        if (gCDA_is_playing) {
             if (!S3IsCDAPlaying()) {
                 StopMusic();
                 StartMusic();


### PR DESCRIPTION
## Match result

```
0x464adc: SoundService 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x464adc,23 +0x4aaaeb,27 @@
0x464adc : push ebp 	(sound.c:446)
0x464add : mov ebp, esp
0x464adf : -sub esp, 0x34
         : +sub esp, 0x30
0x464ae2 : push ebx
0x464ae3 : push esi
0x464ae4 : push edi
0x464ae5 : cmp dword ptr [gSound_enabled (DATA)], 0 	(sound.c:449)
0x464aec : -je 0x5a
         : +je 0x54
0x464af2 : cmp dword ptr [gServicing_sound (DATA)], 0
0x464af9 : -jne 0x4d
         : +jne 0x47
0x464aff : mov dword ptr [gServicing_sound (DATA)], 1 	(sound.c:450)
0x464b09 : call PDGetTotalTime (FUNCTION) 	(sound.c:451)
0x464b0e : -mov dword ptr [ebp - 0x34], eax
0x464b11 : -mov eax, dword ptr [ebp - 0x34]
0x464b14 : mov dword ptr [gLast_sound_service (DATA)], eax
0x464b19 : -cmp dword ptr [gCDA_is_playing (DATA)], 0
         : +cmp dword ptr [gCDA_tag (DATA)], 0 	(sound.c:452)
0x464b20 : je 0x17
0x464b26 : call S3IsCDAPlaying (FUNCTION) 	(sound.c:453)
0x464b2b : test eax, eax
0x464b2d : jne 0xa
0x464b33 : call StopMusic (FUNCTION) 	(sound.c:454)
0x464b38 : call StartMusic (FUNCTION) 	(sound.c:455)
0x464b3d : call DRS3Service (FUNCTION) 	(sound.c:458)
         : +mov dword ptr [gServicing_sound (DATA)], 0 	(sound.c:459)
         : +pop edi 	(sound.c:461)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


SoundService is only 68.00% similar to the original, diff above
```

*AI generated. Time taken: 624s, tokens: 70,728*
