### PR TITLE
InitSoundSources 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -478,35 +478,33 @@ void InitSoundSources(void) {
         ToggleSoundEnable();
         toggle = 1;
     }
-    gCamera_position = *(br_vector3*)&gCamera_to_world.m[3][0];
-    gCamera_left.v[0] = gCamera_to_world.m[0][0] * -1.0;
-    gCamera_left.v[1] = gCamera_to_world.m[0][1] * -1.0;
-    gCamera_left.v[2] = gCamera_to_world.m[0][2] * -1.0;
+    gCamera_position.v[0] = gCamera_to_world.m[3][0];
+    gCamera_position.v[1] = gCamera_to_world.m[3][1];
+    gCamera_position.v[2] = gCamera_to_world.m[3][2];
+    gCamera_left.v[0] = gCamera_to_world.m[0][0] * -1.0f;
+    gCamera_left.v[1] = gCamera_to_world.m[0][1] * -1.0f;
+    gCamera_left.v[2] = gCamera_to_world.m[0][2] * -1.0f;
     S3BindListenerPositionBRender(&gCamera_position);
     S3BindListenerVelocityBRender(&gCamera_velocity);
     S3BindListenerLeftBRender(&gCamera_left);
     if (!gSound_sources_inited) {
         for (cat = eVehicle_self; cat <= eVehicle_rozzer; ++cat) {
-            if (cat) {
-                car_count = GetCarCount(cat);
-            } else {
+            if (!cat) {
                 car_count = 1;
+            } else {
+                car_count = GetCarCount(cat);
             }
             for (i = 0; i < car_count; i++) {
                 PossibleService();
-                if (cat) {
-                    the_car = GetCarSpec(cat, i);
-                } else {
+                if (!cat) {
                     the_car = &gProgram_state.current_car;
+                } else {
+                    the_car = GetCarSpec(cat, i);
                 }
                 if (the_car->driver == eDriver_local_human || gSound_detail_level == 2 || cat == eVehicle_rozzer) {
                     the_car->sound_source = S3CreateSoundSourceBR(&the_car->pos, &the_car->velocity_bu_per_sec, gEngine_outlet);
                     if (the_car->sound_source) {
-                        if (cat == eVehicle_rozzer) {
-                            S3BindAmbientSoundToOutlet(gEngine_outlet, 5350, the_car->sound_source, 250.0, 0, 0, 0, 0x10000, 0x10000);
-                        } else {
-                            S3BindAmbientSoundToOutlet(gEngine_outlet, the_car->engine_noises[0], the_car->sound_source, 250.0, 0, 0, 0, 0x10000, 0x10000);
-                        }
+                        S3BindAmbientSoundToOutlet(gEngine_outlet, cat != eVehicle_rozzer ? the_car->engine_noises[0] : 5350, the_car->sound_source, 250.0, 0, 0, 0, 0x10000, 0x10000);
                     }
                 }
             }


### PR DESCRIPTION
## Match result

```
0x464b51: InitSoundSources 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x464b51,129 +0x4aab64,143 @@
0x464b51 : push ebp 	(sound.c:466)
0x464b52 : mov ebp, esp
0x464b54 : -sub esp, 0x18
         : +sub esp, 0x14
0x464b57 : push ebx
0x464b58 : push esi
0x464b59 : push edi
0x464b5a : mov dword ptr [ebp - 8], 0 	(sound.c:473)
0x464b61 : cmp dword ptr [gSound_available (DATA)], 0 	(sound.c:474)
0x464b68 : jne 0x5
0x464b6e : -jmp 0x201
         : +jmp 0x225 	(sound.c:475)
0x464b73 : cmp dword ptr [gSound_enabled (DATA)], 0 	(sound.c:477)
0x464b7a : jne 0xc
0x464b80 : call ToggleSoundEnable (FUNCTION) 	(sound.c:478)
0x464b85 : mov dword ptr [ebp - 8], 1 	(sound.c:479)
0x464b8c : -mov eax, dword ptr [gCamera_to_world+36 (OFFSET)]
0x464b91 : -mov dword ptr [gCamera_position (DATA)], eax
0x464b96 : -mov eax, dword ptr [gCamera_to_world+40 (OFFSET)]
0x464b9b : -mov dword ptr [gCamera_position+4 (OFFSET)], eax
0x464ba0 : -mov eax, dword ptr [gCamera_to_world+44 (OFFSET)]
0x464ba5 : -mov dword ptr [gCamera_position+8 (OFFSET)], eax
         : +mov eax, gCamera_to_world (DATA) 	(sound.c:481)
         : +add eax, 0x24
         : +mov ecx, gCamera_position (DATA)
         : +mov edx, dword ptr [eax]
         : +mov dword ptr [ecx], edx
         : +mov edx, dword ptr [eax + 4]
         : +mov dword ptr [ecx + 4], edx
         : +mov eax, dword ptr [eax + 8]
         : +mov dword ptr [ecx + 8], eax
0x464baa : fld dword ptr [gCamera_to_world (DATA)] 	(sound.c:482)
0x464bb0 : -fmul dword ptr [-1.0 (FLOAT)]
         : +fmul qword ptr [-1.0 (FLOAT)]
0x464bb6 : fstp dword ptr [gCamera_left (DATA)]
0x464bbc : fld dword ptr [gCamera_to_world+4 (OFFSET)] 	(sound.c:483)
0x464bc2 : -fmul dword ptr [-1.0 (FLOAT)]
         : +fmul qword ptr [-1.0 (FLOAT)]
0x464bc8 : fstp dword ptr [gCamera_left+4 (OFFSET)]
0x464bce : fld dword ptr [gCamera_to_world+8 (OFFSET)] 	(sound.c:484)
0x464bd4 : -fmul dword ptr [-1.0 (FLOAT)]
         : +fmul qword ptr [-1.0 (FLOAT)]
0x464bda : fstp dword ptr [gCamera_left+8 (OFFSET)]
0x464be0 : push gCamera_position (DATA) 	(sound.c:485)
0x464be5 : call S3BindListenerPositionBRender (FUNCTION)
0x464bea : add esp, 4
0x464bed : push gCamera_velocity (DATA) 	(sound.c:486)
0x464bf2 : call S3BindListenerVelocityBRender (FUNCTION)
0x464bf7 : add esp, 4
0x464bfa : push gCamera_left (DATA) 	(sound.c:487)
0x464bff : call S3BindListenerLeftBRender (FUNCTION)
0x464c04 : add esp, 4
0x464c07 : cmp dword ptr [gSound_sources_inited (DATA)], 0 	(sound.c:488)
0x464c0e : -jne 0x151
         : +jne 0x176
0x464c14 : mov dword ptr [ebp - 0x14], 0 	(sound.c:489)
0x464c1b : jmp 0x3
0x464c20 : inc dword ptr [ebp - 0x14]
0x464c23 : cmp dword ptr [ebp - 0x14], 3
0x464c27 : -jg 0x12e
         : +jg 0x153
0x464c2d : cmp dword ptr [ebp - 0x14], 0 	(sound.c:490)
0x464c31 : -jne 0xc
0x464c37 : -mov dword ptr [ebp - 0xc], 1
0x464c3e : -jmp 0xf
         : +je 0x14
0x464c43 : mov eax, dword ptr [ebp - 0x14] 	(sound.c:491)
0x464c46 : push eax
0x464c47 : call GetCarCount (FUNCTION)
0x464c4c : add esp, 4
0x464c4f : mov dword ptr [ebp - 0xc], eax
         : +jmp 0x7 	(sound.c:492)
         : +mov dword ptr [ebp - 0xc], 1 	(sound.c:493)
0x464c52 : mov dword ptr [ebp - 0x10], 0 	(sound.c:495)
0x464c59 : jmp 0x3
0x464c5e : inc dword ptr [ebp - 0x10]
0x464c61 : mov eax, dword ptr [ebp - 0xc]
0x464c64 : cmp dword ptr [ebp - 0x10], eax
0x464c67 : -jge 0xe9
         : +jge 0x10e
0x464c6d : call PossibleService (FUNCTION) 	(sound.c:496)
0x464c72 : cmp dword ptr [ebp - 0x14], 0 	(sound.c:497)
0x464c76 : -jne 0x12
0x464c7c : -mov eax, gProgram_state (DATA)
0x464c81 : -add eax, 0xb0
0x464c86 : -mov dword ptr [ebp - 4], eax
0x464c89 : -jmp 0x13
         : +je 0x18
0x464c8e : mov eax, dword ptr [ebp - 0x10] 	(sound.c:498)
0x464c91 : push eax
0x464c92 : mov eax, dword ptr [ebp - 0x14]
0x464c95 : push eax
0x464c96 : call GetCarSpec (FUNCTION)
0x464c9b : add esp, 8
0x464c9e : mov dword ptr [ebp - 4], eax
         : +jmp 0xd 	(sound.c:499)
         : +mov eax, gProgram_state (DATA) 	(sound.c:500)
         : +add eax, 0xb0
         : +mov dword ptr [ebp - 4], eax
0x464ca1 : mov eax, dword ptr [ebp - 4] 	(sound.c:502)
0x464ca4 : cmp dword ptr [eax + 8], 4
0x464ca8 : je 0x17
0x464cae : cmp dword ptr [gSound_detail_level (DATA)], 2
0x464cb5 : je 0xa
0x464cbb : cmp dword ptr [ebp - 0x14], 3
0x464cbf : -jne 0x8c
         : +jne 0xb1
0x464cc5 : mov eax, dword ptr [gEngine_outlet (DATA)] 	(sound.c:503)
0x464cca : push eax
0x464ccb : mov eax, dword ptr [ebp - 4]
0x464cce : add eax, 0x1658
0x464cd3 : push eax
0x464cd4 : mov eax, dword ptr [ebp - 4]
0x464cd7 : add eax, 0x9c
0x464cdc : push eax
0x464cdd : call S3CreateSoundSourceBR (FUNCTION)
0x464ce2 : add esp, 0xc
0x464ce5 : mov ecx, dword ptr [ebp - 4]
0x464ce8 : mov dword ptr [ecx + 0x15fc], eax
0x464cee : mov eax, dword ptr [ebp - 4] 	(sound.c:504)
0x464cf1 : cmp dword ptr [eax + 0x15fc], 0
0x464cf8 : -je 0x53
         : +je 0x78
0x464cfe : cmp dword ptr [ebp - 0x14], 3 	(sound.c:505)
0x464d02 : -je 0x11
0x464d08 : -mov eax, dword ptr [ebp - 4]
0x464d0b : -mov eax, dword ptr [eax + 0x6e0]
0x464d11 : -mov dword ptr [ebp - 0x18], eax
0x464d14 : -jmp 0x7
0x464d19 : -mov dword ptr [ebp - 0x18], 0x14e6
         : +jne 0x37
0x464d20 : push 0x10000 	(sound.c:506)
0x464d25 : push 0x10000
0x464d2a : push 0
0x464d2c : push 0
0x464d2e : push 0
0x464d30 : push 0x437a0000
0x464d35 : mov eax, dword ptr [ebp - 4]
0x464d38 : mov eax, dword ptr [eax + 0x15fc]
0x464d3e : push eax
0x464d3f : -mov eax, dword ptr [ebp - 0x18]
         : +push 0x14e6
         : +mov eax, dword ptr [gEngine_outlet (DATA)]
         : +push eax
         : +call S3BindAmbientSoundToOutlet (FUNCTION)
         : +add esp, 0x24
         : +jmp 0x37 	(sound.c:507)
         : +push 0x10000 	(sound.c:508)
         : +push 0x10000
         : +push 0
         : +push 0
         : +push 0
         : +push 0x437a0000
         : +mov eax, dword ptr [ebp - 4]
         : +mov eax, dword ptr [eax + 0x15fc]
         : +push eax
         : +mov eax, dword ptr [ebp - 4]
         : +mov eax, dword ptr [eax + 0x6e0]
0x464d42 : push eax
0x464d43 : mov eax, dword ptr [gEngine_outlet (DATA)]
0x464d48 : push eax
0x464d49 : call S3BindAmbientSoundToOutlet (FUNCTION)
0x464d4e : add esp, 0x24
0x464d51 : -jmp -0xf8
0x464d56 : -jmp -0x13b
         : +jmp -0x11d 	(sound.c:512)
         : +jmp -0x160 	(sound.c:513)
0x464d5b : mov dword ptr [gSound_sources_inited (DATA)], 1 	(sound.c:514)
0x464d65 : cmp dword ptr [ebp - 8], 0 	(sound.c:516)
0x464d69 : je 0x5
0x464d6f : call ToggleSoundEnable (FUNCTION) 	(sound.c:517)
0x464d74 : pop edi 	(sound.c:519)
0x464d75 : pop esi
0x464d76 : pop ebx
0x464d77 : leave 
0x464d78 : ret 


InitSoundSources is only 70.59% similar to the original, diff above
```

*AI generated. Time taken: 117s, tokens: 17,425*
