### PR TITLE
DisposeSoundSources 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -537,22 +537,18 @@ void DisposeSoundSources(void) {
     }
     if (gSound_sources_inited) {
         DRS3StopOutletSound(gEngine_outlet);
-        if (gProgram_state.cockpit_on && gProgram_state.cockpit_image_index >= 0) {
-            S3Service(1, 0);
-        } else {
-            S3Service(0, 0);
-        }
+        S3Service(gProgram_state.cockpit_on && gProgram_state.cockpit_image_index >= 0, 0);
         for (cat = eVehicle_self; cat <= eVehicle_rozzer; cat++) {
-            if (cat) {
-                car_count = GetCarCount(cat);
-            } else {
+            if (!cat) {
                 car_count = 1;
+            } else {
+                car_count = GetCarCount(cat);
             }
             for (i = 0; i < car_count; ++i) {
-                if (cat) {
-                    the_car = GetCarSpec(cat, i);
-                } else {
+                if (!cat) {
                     the_car = &gProgram_state.current_car;
+                } else {
+                    the_car = GetCarSpec(cat, i);
                 }
                 if (the_car->driver == eDriver_local_human || gSound_detail_level == 2 || cat == eVehicle_rozzer) {
                     if (the_car->sound_source) {


### PR DESCRIPTION
## Match result

```
0x464d79: DisposeSoundSources 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x464d79,74 +0x4aadb0,75 @@
0x464d79 : push ebp 	(sound.c:523)
0x464d7a : mov ebp, esp
0x464d7c : -sub esp, 0x18
         : +sub esp, 0x14
0x464d7f : push ebx
0x464d80 : push esi
0x464d81 : push edi
0x464d82 : mov dword ptr [ebp - 8], 0 	(sound.c:530)
0x464d89 : cmp dword ptr [gSound_available (DATA)], 0 	(sound.c:531)
0x464d90 : jne 0x5
0x464d96 : -jmp 0x199
         : +jmp 0x195 	(sound.c:532)
0x464d9b : cmp dword ptr [gSound_enabled (DATA)], 0 	(sound.c:534)
0x464da2 : jne 0xc
0x464da8 : call ToggleSoundEnable (FUNCTION) 	(sound.c:535)
0x464dad : mov dword ptr [ebp - 8], 1 	(sound.c:536)
0x464db4 : cmp dword ptr [gSound_sources_inited (DATA)], 0 	(sound.c:538)
0x464dbb : -je 0x164
         : +je 0x160
0x464dc1 : mov eax, dword ptr [gEngine_outlet (DATA)] 	(sound.c:539)
0x464dc6 : push eax
0x464dc7 : call DRS3StopOutletSound (FUNCTION)
0x464dcc : add esp, 4
0x464dcf : cmp dword ptr [gProgram_state+80 (OFFSET)], 0 	(sound.c:540)
0x464dd6 : -je 0x19
         : +je 0x1e
0x464ddc : cmp dword ptr [gProgram_state+84 (OFFSET)], 0
0x464de3 : -jl 0xc
0x464de9 : -mov dword ptr [ebp - 0x18], 1
0x464df0 : -jmp 0x7
0x464df5 : -mov dword ptr [ebp - 0x18], 0
         : +jl 0x11
0x464dfc : push 0 	(sound.c:541)
0x464dfe : -mov eax, dword ptr [ebp - 0x18]
0x464e01 : -push eax
         : +push 1
         : +call S3Service (FUNCTION)
         : +add esp, 8
         : +jmp 0xc 	(sound.c:542)
         : +push 0 	(sound.c:543)
         : +push 0
0x464e02 : call S3Service (FUNCTION)
0x464e07 : add esp, 8
0x464e0a : mov dword ptr [ebp - 0x14], 0 	(sound.c:545)
0x464e11 : jmp 0x3
0x464e16 : inc dword ptr [ebp - 0x14]
0x464e19 : cmp dword ptr [ebp - 0x14], 3
0x464e1d : jg 0xf8
0x464e23 : cmp dword ptr [ebp - 0x14], 0 	(sound.c:546)
0x464e27 : -jne 0xc
0x464e2d : -mov dword ptr [ebp - 0xc], 1
0x464e34 : -jmp 0xf
         : +je 0x14
0x464e39 : mov eax, dword ptr [ebp - 0x14] 	(sound.c:547)
0x464e3c : push eax
0x464e3d : call GetCarCount (FUNCTION)
0x464e42 : add esp, 4
0x464e45 : mov dword ptr [ebp - 0xc], eax
         : +jmp 0x7 	(sound.c:548)
         : +mov dword ptr [ebp - 0xc], 1 	(sound.c:549)
0x464e48 : mov dword ptr [ebp - 0x10], 0 	(sound.c:551)
0x464e4f : jmp 0x3
0x464e54 : inc dword ptr [ebp - 0x10]
0x464e57 : mov eax, dword ptr [ebp - 0xc]
0x464e5a : cmp dword ptr [ebp - 0x10], eax
0x464e5d : jge 0xb3
0x464e63 : cmp dword ptr [ebp - 0x14], 0 	(sound.c:552)
0x464e67 : -jne 0x12
0x464e6d : -mov eax, gProgram_state (DATA)
0x464e72 : -add eax, 0xb0
0x464e77 : -mov dword ptr [ebp - 4], eax
0x464e7a : -jmp 0x13
         : +je 0x18
0x464e7f : mov eax, dword ptr [ebp - 0x10] 	(sound.c:553)
0x464e82 : push eax
0x464e83 : mov eax, dword ptr [ebp - 0x14]
0x464e86 : push eax
0x464e87 : call GetCarSpec (FUNCTION)
0x464e8c : add esp, 8
         : +mov dword ptr [ebp - 4], eax
         : +jmp 0xd 	(sound.c:554)
         : +mov eax, gProgram_state (DATA) 	(sound.c:555)
         : +add eax, 0xb0
0x464e8f : mov dword ptr [ebp - 4], eax
0x464e92 : mov eax, dword ptr [ebp - 4] 	(sound.c:557)
0x464e95 : cmp dword ptr [eax + 8], 4
0x464e99 : je 0x17
0x464e9f : cmp dword ptr [gSound_detail_level (DATA)], 2
0x464ea6 : je 0xa
0x464eac : cmp dword ptr [ebp - 0x14], 3
0x464eb0 : jne 0x5b
0x464eb6 : mov eax, dword ptr [ebp - 4] 	(sound.c:558)
0x464eb9 : cmp dword ptr [eax + 0x15fc], 0

---
+++
@@ -0x464f01,10 +0x4aaf34,14 @@
0x464f01 : add esp, 4
0x464f04 : mov eax, dword ptr [ebp - 4] 	(sound.c:562)
0x464f07 : mov dword ptr [eax + 0x15fc], 0
0x464f11 : jmp -0xc2 	(sound.c:564)
0x464f16 : jmp -0x105 	(sound.c:565)
0x464f1b : mov dword ptr [gSound_sources_inited (DATA)], 0 	(sound.c:566)
0x464f25 : cmp dword ptr [ebp - 8], 0 	(sound.c:568)
0x464f29 : je 0x5
0x464f2f : call ToggleSoundEnable (FUNCTION) 	(sound.c:569)
0x464f34 : pop edi 	(sound.c:571)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DisposeSoundSources is only 80.57% similar to the original, diff above
```

*AI generated. Time taken: 89s, tokens: 25,552*
