### PR TITLE
DRS3StartSound3D 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -247,7 +247,7 @@ void InitSound(void) {
 // IDA: tS3_sound_tag __usercall DRS3StartSound@<EAX>(tS3_outlet_ptr pOutlet@<EAX>, tS3_sound_id pSound@<EDX>)
 // FUNCTION: CARM95 0x0046458b
 tS3_sound_tag DRS3StartSound(tS3_outlet_ptr pOutlet, tS3_sound_id pSound) {
-    if (gSound_enabled) {
+    if (gSound_enabled != 0) {
         if (pSound != 1000 && (pSound < 3000 || pSound > 3007) && (pSound < 5300 || pSound > 5320)) {
             PipeSingleSound(pOutlet, pSound, 0, 0, -1, 0);
         }
@@ -575,13 +575,15 @@ void DisposeSoundSources(void) {
 tS3_sound_tag DRS3StartSound3D(tS3_outlet_ptr pOutlet, tS3_sound_id pSound, br_vector3* pInitial_position, br_vector3* pInitial_velocity, tS3_repeats pRepeats, tS3_volume pVolume, tS3_pitch pPitch, tS3_speed pSpeed) {
     tS3_sound_tag tag;
 
-    if (!gSound_enabled) {
+    if (gSound_enabled) {
+        if (pVolume && pSound != 1000 && (pSound < 3000 || pSound > 3007) && (pSound < 5300 || pSound > 5320)) {
+            PipeSingleSound(pOutlet, pSound, pVolume, 0, pPitch, pInitial_position);
+        }
+        tag = S3StartSound3D(pOutlet, pSound, (tS3_vector3*)pInitial_position, (tS3_vector3*)pInitial_velocity, pRepeats, pVolume, pPitch, pSpeed);
+        return tag;
+    } else {
         return 0;
     }
-    if (pVolume && pSound != 1000 && (pSound < 3000 || pSound > 3007) && (pSound < 5300 || pSound > 5320)) {
-        PipeSingleSound(pOutlet, pSound, pVolume, 0, pPitch, pInitial_position);
-    }
-    return S3StartSound3D(pOutlet, pSound, (tS3_vector3*)pInitial_position, (tS3_vector3*)pInitial_velocity, pRepeats, pVolume, pPitch, pSpeed);
 }
 
 // IDA: tS3_sound_tag __usercall DRS3StartSoundFromSource3@<EAX>(tS3_sound_source_ptr pSource@<EAX>, tS3_sound_id pSound@<EDX>, tS3_repeats pRepeats@<EBX>, tS3_volume pVolume@<ECX>, tS3_pitch pPitch, tS3_speed pSpeed)


### PR DESCRIPTION
## Match result

```
0x464f39: DRS3StartSound3D 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x464f39,18 +0x4aaf6c,20 @@
0x464f39 : push ebp 	(sound.c:575)
0x464f3a : mov ebp, esp
0x464f3c : sub esp, 4
0x464f3f : push ebx
0x464f40 : push esi
0x464f41 : push edi
0x464f42 : cmp dword ptr [gSound_enabled (DATA)], 0 	(sound.c:578)
0x464f49 : -je 0xa1
         : +jne 0x7
         : +xor eax, eax 	(sound.c:579)
         : +jmp 0x96
0x464f4f : cmp dword ptr [ebp + 0x1c], 0 	(sound.c:581)
0x464f53 : je 0x5f
0x464f59 : cmp dword ptr [ebp + 0xc], 0x3e8
0x464f60 : je 0x52
0x464f66 : cmp dword ptr [ebp + 0xc], 0xbb8
0x464f6d : jl 0xd
0x464f73 : cmp dword ptr [ebp + 0xc], 0xbbf
0x464f7a : jle 0x38
0x464f80 : cmp dword ptr [ebp + 0xc], 0x14b4
0x464f87 : jl 0xd

---
+++
@@ -0x464fc8,14 +0x4ab002,16 @@
0x464fc8 : mov eax, dword ptr [ebp + 0x14]
0x464fcb : push eax
0x464fcc : mov eax, dword ptr [ebp + 0x10]
0x464fcf : push eax
0x464fd0 : mov eax, dword ptr [ebp + 0xc]
0x464fd3 : push eax
0x464fd4 : mov eax, dword ptr [ebp + 8]
0x464fd7 : push eax
0x464fd8 : call S3StartSound3D (FUNCTION)
0x464fdd : add esp, 0x20
0x464fe0 : -mov dword ptr [ebp - 4], eax
0x464fe3 : -mov eax, dword ptr [ebp - 4]
0x464fe6 : -jmp 0xc
0x464feb : -jmp 0x7
         : +jmp 0x0
         : +pop edi 	(sound.c:585)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRS3StartSound3D is only 87.72% similar to the original, diff above
```

*AI generated. Time taken: 650s, tokens: 72,263*
