### PR TITLE
DRS3StartCDA 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -733,15 +733,11 @@ int GetIndexFromOutlet(tS3_outlet_ptr pOutlet) {
 int DRS3StartCDA(tS3_sound_id pCDA_id) {
 
     if (!gCD_is_disabled && gMusic_available) {
-        if (!gCDA_is_playing && !gCDA_tag) {
+        if (!gCDA_tag && !gCDA_is_playing) {
             if (S3CDAEnabled()) {
                 S3StopOutletSound(gMusic_outlet);
                 if (gSound_enabled) {
-                    if (gProgram_state.cockpit_on && gProgram_state.cockpit_image_index >= 0) {
-                        S3Service(1, 0);
-                    } else {
-                        S3Service(0, 0);
-                    }
+                    S3Service(gProgram_state.cockpit_on && gProgram_state.cockpit_image_index >= 0, 0);
 #if defined(DETHRACE_FIX_BUGS)
                     int random_track = pCDA_id == 9999;
                     int retries_remaining = 5;
@@ -768,8 +764,8 @@ int DRS3StartCDA(tS3_sound_id pCDA_id) {
                     // Initial CD music volume was not set correctly
                     DRS3SetOutletVolume(gMusic_outlet, 42 * gProgram_state.music_volume);
 #endif
-                    gCDA_is_playing = gCDA_tag != 0;
-                    if (gCDA_tag == 0) {
+                    gCDA_is_playing = gCDA_tag;
+                    if (gCDA_is_playing == 0) {
                         gCD_is_disabled = 1;
                         S3DisableCDA();
                     }


### PR DESCRIPTION
## Match result

```
0x465719: DRS3StartCDA 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x465719,43 +0x4ab6b3,43 @@
0x465719 : push ebp 	(sound.c:733)
0x46571a : mov ebp, esp
0x46571c : -sub esp, 4
0x46571f : push ebx
0x465720 : push esi
0x465721 : push edi
0x465722 : cmp dword ptr [gCD_is_disabled (DATA)], 0 	(sound.c:735)
0x465729 : -jne 0x10a
         : +jne 0x122
0x46572f : cmp dword ptr [gMusic_available (DATA)], 0
0x465736 : -je 0xfd
         : +je 0x115
         : +cmp dword ptr [gCDA_is_playing (DATA)], 0 	(sound.c:736)
         : +jne 0x108
0x46573c : cmp dword ptr [gCDA_tag (DATA)], 0
0x465743 : -jne 0xf0
0x465749 : -cmp dword ptr [gCDA_is_playing (DATA)], 0
0x465750 : -jne 0xe3
         : +jne 0xfb
0x465756 : call S3CDAEnabled (FUNCTION) 	(sound.c:737)
0x46575b : test eax, eax
0x46575d : -je 0xd6
         : +je 0xee
0x465763 : mov eax, dword ptr [gMusic_outlet (DATA)] 	(sound.c:738)
0x465768 : push eax
0x465769 : call S3StopOutletSound (FUNCTION)
0x46576e : add esp, 4
0x465771 : cmp dword ptr [gSound_enabled (DATA)], 0 	(sound.c:739)
0x465778 : -je 0xbb
         : +je 0xd3
0x46577e : cmp dword ptr [gProgram_state+80 (OFFSET)], 0 	(sound.c:740)
0x465785 : -je 0x19
         : +je 0x1e
0x46578b : cmp dword ptr [gProgram_state+84 (OFFSET)], 0
0x465792 : -jl 0xc
0x465798 : -mov dword ptr [ebp - 4], 1
0x46579f : -jmp 0x7
0x4657a4 : -mov dword ptr [ebp - 4], 0
         : +jl 0x11
0x4657ab : push 0 	(sound.c:741)
0x4657ad : -mov eax, dword ptr [ebp - 4]
0x4657b0 : -push eax
         : +push 1
         : +call S3Service (FUNCTION)
         : +add esp, 8
         : +jmp 0xc 	(sound.c:742)
         : +push 0 	(sound.c:743)
         : +push 0
0x4657b1 : call S3Service (FUNCTION)
0x4657b6 : add esp, 8
0x4657b9 : cmp dword ptr [ebp + 8], 0x270f 	(sound.c:750)
0x4657c0 : jne 0x24
0x4657c6 : push 7 	(sound.c:752)
0x4657c8 : push 0
0x4657ca : call IRandomBetween (FUNCTION)
0x4657cf : add esp, 8
0x4657d2 : mov eax, dword ptr [eax*4 + gRandom_CDA_tunes[0] (DATA)]
0x4657d9 : mov dword ptr [ebp + 8], eax

---
+++
@@ -0x4657e4,23 +0x4ab777,26 @@
0x4657e4 : je -0x24
0x4657ea : mov eax, dword ptr [ebp + 8] 	(sound.c:755)
0x4657ed : mov dword ptr [gLast_tune (DATA)], eax
0x4657f2 : mov eax, dword ptr [ebp + 8] 	(sound.c:757)
0x4657f5 : push eax
0x4657f6 : mov eax, dword ptr [gMusic_outlet (DATA)]
0x4657fb : push eax
0x4657fc : call DRS3StartSoundNoPiping (FUNCTION)
0x465801 : add esp, 8
0x465804 : mov dword ptr [gCDA_tag (DATA)], eax
0x465809 : -mov eax, dword ptr [gCDA_tag (DATA)]
0x46580e : -mov dword ptr [gCDA_is_playing (DATA)], eax
0x465813 : -cmp dword ptr [gCDA_is_playing (DATA)], 0
         : +cmp dword ptr [gCDA_tag (DATA)], 0 	(sound.c:771)
         : +je 0xf
         : +mov dword ptr [gCDA_is_playing (DATA)], 1
         : +jmp 0xa
         : +mov dword ptr [gCDA_is_playing (DATA)], 0
         : +cmp dword ptr [gCDA_tag (DATA)], 0 	(sound.c:772)
0x46581a : jne 0xf
0x465820 : mov dword ptr [gCD_is_disabled (DATA)], 1 	(sound.c:773)
0x46582a : call S3DisableCDA (FUNCTION) 	(sound.c:774)
0x46582f : mov dword ptr [gSong_repeat_count (DATA)], 0 	(sound.c:776)
0x465839 : mov eax, dword ptr [gCDA_is_playing (DATA)] 	(sound.c:781)
0x46583e : jmp 0x0
0x465843 : pop edi 	(sound.c:782)
0x465844 : pop esi
0x465845 : pop ebx
0x465846 : leave 


DRS3StartCDA is only 72.34% similar to the original, diff above
```

*AI generated. Time taken: 133s, tokens: 18,619*
