### PR TITLE
DRS3StopCDA 100% match

### DIFF
--- a/src/DETHRACE/common/sound.c
+++ b/src/DETHRACE/common/sound.c
@@ -785,10 +785,10 @@ int DRS3StartCDA(tS3_sound_id pCDA_id) {
 // FUNCTION: CARM95 0x00465848
 int DRS3StopCDA(void) {
 
-    if (gMusic_available && gCDA_tag != 0) {
-        S3StopSound(gCDA_tag);
-        gCDA_is_playing = 0;
+    if (gMusic_available && gCDA_is_playing != 0) {
+        S3StopSound(gCDA_is_playing);
         gCDA_tag = 0;
+        gCDA_is_playing = 0;
     }
     return gCDA_is_playing;
 }


### PR DESCRIPTION
## Match result

```
0x465848: DRS3StopCDA 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x465848,22 +0x4ab7f7,22 @@
0x465848 : push ebp 	(sound.c:786)
0x465849 : mov ebp, esp
0x46584b : push ebx
0x46584c : push esi
0x46584d : push edi
0x46584e : cmp dword ptr [gMusic_available (DATA)], 0 	(sound.c:788)
0x465855 : je 0x2f
0x46585b : -cmp dword ptr [gCDA_is_playing (DATA)], 0
         : +cmp dword ptr [gCDA_tag (DATA)], 0
0x465862 : je 0x22
0x465868 : -mov eax, dword ptr [gCDA_is_playing (DATA)]
         : +mov eax, dword ptr [gCDA_tag (DATA)] 	(sound.c:789)
0x46586d : push eax
0x46586e : call S3StopSound (FUNCTION)
0x465873 : add esp, 4
         : +mov dword ptr [gCDA_is_playing (DATA)], 0 	(sound.c:790)
0x465876 : mov dword ptr [gCDA_tag (DATA)], 0 	(sound.c:791)
0x465880 : -mov dword ptr [gCDA_is_playing (DATA)], 0
0x46588a : mov eax, dword ptr [gCDA_is_playing (DATA)] 	(sound.c:793)
0x46588f : jmp 0x0
0x465894 : pop edi 	(sound.c:794)
0x465895 : pop esi
0x465896 : pop ebx
0x465897 : leave 
0x465898 : ret 


DRS3StopCDA is only 86.36% similar to the original, diff above
```

*AI generated. Time taken: 57s, tokens: 13,985*
