### PR TITLE
DrawDot 100% match

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -146,9 +146,9 @@ tShrapnel gShrapnel[15];
 // IDA: void __cdecl DrawDot(br_scalar z, tU8 *scr_ptr, tU16 *depth_ptr, tU8 *shade_ptr)
 // FUNCTION: CARM95 0x00466310
 void DrawDot(br_scalar z, tU8* scr_ptr, tU16* depth_ptr, tU8* shade_ptr) {
-
-    if (*depth_ptr > (1.0 - z) * 32768.0f) {
-        *depth_ptr = (1.0 - z) * 32768.0f;
+    z = (1.0f - z) * 32768.0f;
+    if (*depth_ptr > z) {
+        *depth_ptr = z;
         *scr_ptr = shade_ptr[*scr_ptr];
     }
 }


### PR DESCRIPTION
## Match result

```
0x466310: DrawDot 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x466310,30 +0x4ab880,31 @@
0x466310 : push ebp 	(spark.c:148)
0x466311 : mov ebp, esp
0x466313 : sub esp, 4
0x466316 : push ebx
0x466317 : push esi
0x466318 : push edi
0x466319 : -fld dword ptr [1.0 (FLOAT)]
         : +fld qword ptr [1.0 (FLOAT)] 	(spark.c:150)
0x46631f : fsub dword ptr [ebp + 8]
0x466322 : -fmul dword ptr [32768.0 (FLOAT)]
0x466328 : -fstp dword ptr [ebp + 8]
         : +fmul qword ptr [32768.0 (FLOAT)]
0x46632b : mov eax, dword ptr [ebp + 0x10]
0x46632e : xor ecx, ecx
0x466330 : mov cx, word ptr [eax]
0x466333 : mov dword ptr [ebp - 4], ecx
0x466336 : fild dword ptr [ebp - 4]
0x466339 : -fcomp dword ptr [ebp + 8]
         : +fcompp 
0x46633c : fnstsw ax
0x46633e : test ah, 0x41
0x466341 : -jne 0x20
0x466347 : -fld dword ptr [ebp + 8]
         : +jne 0x2c
         : +fld qword ptr [1.0 (FLOAT)] 	(spark.c:151)
         : +fsub dword ptr [ebp + 8]
         : +fmul qword ptr [32768.0 (FLOAT)]
0x46634a : call __ftol (FUNCTION)
0x46634f : mov ecx, dword ptr [ebp + 0x10]
0x466352 : mov word ptr [ecx], ax
0x466355 : mov eax, dword ptr [ebp + 0xc] 	(spark.c:152)
0x466358 : xor ecx, ecx
0x46635a : mov cl, byte ptr [eax]
0x46635c : mov eax, dword ptr [ebp + 0x14]
0x46635f : mov al, byte ptr [ecx + eax]
0x466362 : mov ecx, dword ptr [ebp + 0xc]
0x466365 : mov byte ptr [ecx], al


DrawDot is only 81.69% similar to the original, diff above
```

*AI generated. Time taken: 61s, tokens: 14,410*
