### PR TITLE
ReplaySparks 100% match

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -428,25 +428,22 @@ void ReplaySparks(br_pixelmap* pRender_screen, br_pixelmap* pDepth_buffer, br_ac
     br_vector3 new_pos;
 
     for (i = 0; i < COUNT_OF(gSparks); i++) {
-        if (TEST_BIT(gSpark_flags, i)) {
-            if (gSparks[i].car == NULL) {
-                BrVector3Copy(&pos, &gSparks[i].pos);
-            } else {
-                BrMatrix34ApplyP(&tv, &o, &gSparks[i].car->car_master_actor->t.t.mat);
-                BrVector3Copy(&o, &tv);
-                BrMatrix34ApplyP(&pos, &gSparks[i].pos, &gSparks[i].car->car_master_actor->t.t.mat);
-            }
-            BrVector3Add(&o, &pos, &gSparks[i].length);
-            BrVector3Sub(&tv, &pos, (br_vector3*)gCamera_to_world.m[3]);
-            BrMatrix34TApplyV(&new_pos, &tv, &gCamera_to_world);
-            BrVector3Sub(&tv, &o, (br_vector3*)gCamera_to_world.m[3]);
-            BrMatrix34TApplyV(&p, &tv, &gCamera_to_world);
-            if (gSparks[i].colour) {
-                DrawLine3D(&p, &new_pos, pRender_screen, pDepth_buffer, gFog_shade_table);
-            } else {
-                DrawLine3D(&p, &new_pos, pRender_screen, pDepth_buffer, gAcid_shade_table);
-            }
+        if (!TEST_BIT(gSpark_flags, i)) {
+            continue;
         }
+        if (gSparks[i].car != NULL) {
+            BrMatrix34ApplyP(&tv, &pos, &gSparks[i].car->car_master_actor->t.t.mat);
+            BrVector3Copy(&pos, &tv);
+            BrMatrix34ApplyP(&new_pos, &gSparks[i].pos, &gSparks[i].car->car_master_actor->t.t.mat);
+        } else {
+            BrVector3Copy(&new_pos, &gSparks[i].pos);
+        }
+        BrVector3Add(&pos, &new_pos, &gSparks[i].length);
+        BrVector3Sub(&tv, &new_pos, (br_vector3*)gCamera_to_world.m[3]);
+        BrMatrix34TApplyV(&p, &tv, &gCamera_to_world);
+        BrVector3Sub(&tv, &pos, (br_vector3*)gCamera_to_world.m[3]);
+        BrMatrix34TApplyV(&o, &tv, &gCamera_to_world);
+        DrawLine3D(&o, &p, pRender_screen, pDepth_buffer, gSparks[i].colour ? gFog_shade_table : gAcid_shade_table);
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x466c92: ReplaySparks 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x466c92,143 +0x4ac5d4,150 @@
0x466c92 : push ebp 	(spark.c:422)
0x466c93 : mov ebp, esp
0x466c95 : -sub esp, 0x44
         : +sub esp, 0x40
0x466c98 : push ebx
0x466c99 : push esi
0x466c9a : push edi
0x466c9b : mov dword ptr [ebp - 0x1c], 0 	(spark.c:430)
0x466ca2 : jmp 0x3
0x466ca7 : inc dword ptr [ebp - 0x1c]
0x466caa : cmp dword ptr [ebp - 0x1c], 0x20
0x466cae : -jge 0x1b7
         : +jge 0x1c2
0x466cb4 : mov eax, 1 	(spark.c:431)
0x466cb9 : mov cl, byte ptr [ebp - 0x1c]
0x466cbc : shl eax, cl
0x466cbe : test dword ptr [gSpark_flags (DATA)], eax
0x466cc4 : -jne 0x5
0x466cca : -jmp -0x28
         : +je 0x1a7
0x466ccf : mov eax, dword ptr [ebp - 0x1c] 	(spark.c:432)
0x466cd2 : shl eax, 6
0x466cd5 : cmp dword ptr [eax + gSparks[0].car (OFFSET)], 0
0x466cdc : -je 0x68
         : +jne 0x32
         : +mov eax, dword ptr [ebp - 0x1c] 	(spark.c:433)
         : +shl eax, 6
         : +mov eax, dword ptr [eax + gSparks[0].pos (OFFSET)]
         : +mov dword ptr [ebp - 0x34], eax
         : +mov eax, dword ptr [ebp - 0x1c]
         : +shl eax, 6
         : +mov eax, dword ptr [eax + gSparks[0].pos+4 (OFFSET)]
         : +mov dword ptr [ebp - 0x30], eax
         : +mov eax, dword ptr [ebp - 0x1c]
         : +shl eax, 6
         : +mov eax, dword ptr [eax + gSparks[0].pos+8 (OFFSET)]
         : +mov dword ptr [ebp - 0x2c], eax
         : +jmp 0x63 	(spark.c:434)
0x466ce2 : mov eax, dword ptr [ebp - 0x1c] 	(spark.c:435)
0x466ce5 : shl eax, 6
0x466ce8 : mov eax, dword ptr [eax + gSparks[0].car (OFFSET)]
0x466cee : mov eax, dword ptr [eax + 0xc]
0x466cf1 : add eax, 0x2c
0x466cf4 : push eax
0x466cf5 : -lea eax, [ebp - 0x34]
         : +lea eax, [ebp - 0x40]
0x466cf8 : push eax
0x466cf9 : lea eax, [ebp - 0x28]
0x466cfc : push eax
0x466cfd : call BrMatrix34ApplyP (FUNCTION)
0x466d02 : add esp, 0xc
0x466d05 : mov eax, dword ptr [ebp - 0x28] 	(spark.c:436)
0x466d08 : -mov dword ptr [ebp - 0x34], eax
         : +mov dword ptr [ebp - 0x40], eax
0x466d0b : mov eax, dword ptr [ebp - 0x24]
0x466d0e : -mov dword ptr [ebp - 0x30], eax
         : +mov dword ptr [ebp - 0x3c], eax
0x466d11 : mov eax, dword ptr [ebp - 0x20]
0x466d14 : -mov dword ptr [ebp - 0x2c], eax
         : +mov dword ptr [ebp - 0x38], eax
0x466d17 : mov eax, dword ptr [ebp - 0x1c] 	(spark.c:437)
0x466d1a : shl eax, 6
0x466d1d : mov eax, dword ptr [eax + gSparks[0].car (OFFSET)]
0x466d23 : mov eax, dword ptr [eax + 0xc]
0x466d26 : add eax, 0x2c
0x466d29 : push eax
0x466d2a : mov eax, dword ptr [ebp - 0x1c]
0x466d2d : shl eax, 6
0x466d30 : add eax, gSparks[0].count (DATA)
0x466d35 : add eax, 4
0x466d38 : push eax
0x466d39 : -lea eax, [ebp - 0xc]
         : +lea eax, [ebp - 0x34]
0x466d3c : push eax
0x466d3d : call BrMatrix34ApplyP (FUNCTION)
0x466d42 : add esp, 0xc
0x466d45 : -jmp 0x2d
0x466d4a : -mov eax, dword ptr [ebp - 0x1c]
0x466d4d : -shl eax, 6
0x466d50 : -mov eax, dword ptr [eax + gSparks[0].pos (OFFSET)]
0x466d56 : -mov dword ptr [ebp - 0xc], eax
0x466d59 : -mov eax, dword ptr [ebp - 0x1c]
0x466d5c : -shl eax, 6
0x466d5f : -mov eax, dword ptr [eax + gSparks[0].pos+4 (OFFSET)]
0x466d65 : -mov dword ptr [ebp - 8], eax
0x466d68 : -mov eax, dword ptr [ebp - 0x1c]
0x466d6b : -shl eax, 6
0x466d6e : -mov eax, dword ptr [eax + gSparks[0].pos+8 (OFFSET)]
0x466d74 : -mov dword ptr [ebp - 4], eax
0x466d77 : mov eax, dword ptr [ebp - 0x1c] 	(spark.c:439)
0x466d7a : shl eax, 6
0x466d7d : fld dword ptr [eax + gSparks[0].length (OFFSET)]
0x466d83 : -fadd dword ptr [ebp - 0xc]
0x466d86 : -fstp dword ptr [ebp - 0x34]
         : +fadd dword ptr [ebp - 0x34]
         : +fstp dword ptr [ebp - 0x40]
0x466d89 : mov eax, dword ptr [ebp - 0x1c]
0x466d8c : shl eax, 6
0x466d8f : fld dword ptr [eax + gSparks[0].length+4 (OFFSET)]
0x466d95 : -fadd dword ptr [ebp - 8]
0x466d98 : -fstp dword ptr [ebp - 0x30]
         : +fadd dword ptr [ebp - 0x30]
         : +fstp dword ptr [ebp - 0x3c]
0x466d9b : mov eax, dword ptr [ebp - 0x1c]
0x466d9e : shl eax, 6
0x466da1 : fld dword ptr [eax + gSparks[0].length+8 (OFFSET)]
0x466da7 : -fadd dword ptr [ebp - 4]
0x466daa : -fstp dword ptr [ebp - 0x2c]
0x466dad : -fld dword ptr [ebp - 0xc]
0x466db0 : -fsub dword ptr [gCamera_to_world+36 (OFFSET)]
0x466db6 : -fstp dword ptr [ebp - 0x28]
0x466db9 : -fld dword ptr [ebp - 8]
0x466dbc : -fsub dword ptr [gCamera_to_world+40 (OFFSET)]
0x466dc2 : -fstp dword ptr [ebp - 0x24]
0x466dc5 : -fld dword ptr [ebp - 4]
0x466dc8 : -fsub dword ptr [gCamera_to_world+44 (OFFSET)]
0x466dce : -fstp dword ptr [ebp - 0x20]
0x466dd1 : -push gCamera_to_world (DATA)
0x466dd6 : -lea eax, [ebp - 0x28]
0x466dd9 : -push eax
0x466dda : -lea eax, [ebp - 0x18]
0x466ddd : -push eax
0x466dde : -call BrMatrix34TApplyV (FUNCTION)
0x466de3 : -add esp, 0xc
         : +fadd dword ptr [ebp - 0x2c]
         : +fstp dword ptr [ebp - 0x38]
0x466de6 : fld dword ptr [ebp - 0x34] 	(spark.c:440)
0x466de9 : fsub dword ptr [gCamera_to_world+36 (OFFSET)]
0x466def : fstp dword ptr [ebp - 0x28]
0x466df2 : fld dword ptr [ebp - 0x30]
0x466df5 : fsub dword ptr [gCamera_to_world+40 (OFFSET)]
0x466dfb : fstp dword ptr [ebp - 0x24]
0x466dfe : fld dword ptr [ebp - 0x2c]
0x466e01 : fsub dword ptr [gCamera_to_world+44 (OFFSET)]
0x466e07 : fstp dword ptr [ebp - 0x20]
0x466e0a : push gCamera_to_world (DATA) 	(spark.c:441)
0x466e0f : lea eax, [ebp - 0x28]
0x466e12 : push eax
0x466e13 : -lea eax, [ebp - 0x40]
         : +lea eax, [ebp - 0xc]
         : +push eax
         : +call BrMatrix34TApplyV (FUNCTION)
         : +add esp, 0xc
         : +fld dword ptr [ebp - 0x40] 	(spark.c:442)
         : +fsub dword ptr [gCamera_to_world+36 (OFFSET)]
         : +fstp dword ptr [ebp - 0x28]
         : +fld dword ptr [ebp - 0x3c]
         : +fsub dword ptr [gCamera_to_world+40 (OFFSET)]
         : +fstp dword ptr [ebp - 0x24]
         : +fld dword ptr [ebp - 0x38]
         : +fsub dword ptr [gCamera_to_world+44 (OFFSET)]
         : +fstp dword ptr [ebp - 0x20]
         : +push gCamera_to_world (DATA) 	(spark.c:443)
         : +lea eax, [ebp - 0x28]
         : +push eax
         : +lea eax, [ebp - 0x18]
0x466e16 : push eax
0x466e17 : call BrMatrix34TApplyV (FUNCTION)
0x466e1c : add esp, 0xc
0x466e1f : mov eax, dword ptr [ebp - 0x1c] 	(spark.c:444)
0x466e22 : shl eax, 6
0x466e25 : xor ecx, ecx
0x466e27 : mov cl, byte ptr [eax + gSparks[0].colour (OFFSET)]
0x466e2d : test ecx, ecx
0x466e2f : -je 0xd
         : +je 0x23
0x466e35 : mov eax, dword ptr [gFog_shade_table (DATA)] 	(spark.c:445)
0x466e3a : -mov dword ptr [ebp - 0x44], eax
0x466e3d : -jmp 0x8
0x466e42 : -mov eax, dword ptr [gAcid_shade_table (DATA)]
0x466e47 : -mov dword ptr [ebp - 0x44], eax
0x466e4a : -mov eax, dword ptr [ebp - 0x44]
0x466e4d : push eax
0x466e4e : mov eax, dword ptr [ebp + 0xc]
0x466e51 : push eax
0x466e52 : mov eax, dword ptr [ebp + 8]
0x466e55 : push eax
         : +lea eax, [ebp - 0xc]
         : +push eax
0x466e56 : lea eax, [ebp - 0x18]
0x466e59 : -push eax
0x466e5a : -lea eax, [ebp - 0x40]
0x466e5d : push eax
0x466e5e : call DrawLine3D (FUNCTION)
0x466e63 : add esp, 0x14
0x466e66 : -jmp -0x1c4
         : +jmp 0x1e 	(spark.c:446)
         : +mov eax, dword ptr [gAcid_shade_table (DATA)] 	(spark.c:447)
         : +push eax
         : +mov eax, dword ptr [ebp + 0xc]
         : +push eax
         : +mov eax, dword ptr [ebp + 8]
         : +push eax
         : +lea eax, [ebp - 0xc]
         : +push eax
         : +lea eax, [ebp - 0x18]
         : +push eax
         : +call DrawLine3D (FUNCTION)
         : +add esp, 0x14
         : +jmp -0x1cf 	(spark.c:450)
0x466e6b : pop edi 	(spark.c:451)
0x466e6c : pop esi
0x466e6d : pop ebx
0x466e6e : leave 
0x466e6f : ret 


ReplaySparks is only 60.07% similar to the original, diff above
```

*AI generated. Time taken: 583s, tokens: 160,919*
