### PR TITLE
DisposeShrapnel 100% match

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -878,10 +878,10 @@ void DisposeShrapnel(void) {
         BrActorFree(gShrapnel[i].actor);
     }
     gShrapnel_flags = 0;
-    for (i = 0; i < COUNT_OF(gShrapnel_model); i++) {
-        BrModelRemove(gShrapnel_model[i]);
-        BrModelFree(gShrapnel_model[i]);
-    }
+    BrModelRemove(gShrapnel_model[0]);
+    BrModelRemove(gShrapnel_model[1]);
+    BrModelFree(gShrapnel_model[0]);
+    BrModelFree(gShrapnel_model[1]);
 }
 
 // IDA: void __usercall ReplayShrapnel(tU32 pTime@<EAX>)


### PR DESCRIPTION
## Match result

```
0x467fa0: DisposeShrapnel 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x467ff7,31 +0x4ae5a3,31 @@
0x467ff7 : mov ecx, eax
0x467ff9 : lea eax, [eax + eax*4]
0x467ffc : lea eax, [eax + eax*8]
0x467fff : sub eax, ecx
0x468001 : mov eax, dword ptr [eax + gShrapnel[0].actor (DATA)]
0x468007 : push eax
0x468008 : call BrActorFree (FUNCTION)
0x46800d : add esp, 4
0x468010 : jmp -0x60 	(spark.c:879)
0x468015 : mov dword ptr [gShrapnel_flags (DATA)], 0 	(spark.c:880)
0x46801f : -mov eax, dword ptr [gShrapnel_model[0] (DATA)]
         : +mov dword ptr [ebp - 4], 0 	(spark.c:881)
         : +jmp 0x3
         : +inc dword ptr [ebp - 4]
         : +cmp dword ptr [ebp - 4], 2
         : +jge 0x2b
         : +mov eax, dword ptr [ebp - 4] 	(spark.c:882)
         : +mov eax, dword ptr [eax*4 + gShrapnel_model[0] (DATA)]
0x468024 : push eax
0x468025 : call BrModelRemove (FUNCTION)
0x46802a : add esp, 4
0x46802d : -mov eax, dword ptr [gShrapnel_model[1] (OFFSET)]
0x468032 : -push eax
0x468033 : -call BrModelRemove (FUNCTION)
0x468038 : -add esp, 4
0x46803b : -mov eax, dword ptr [gShrapnel_model[0] (DATA)]
         : +mov eax, dword ptr [ebp - 4] 	(spark.c:883)
         : +mov eax, dword ptr [eax*4 + gShrapnel_model[0] (DATA)]
0x468040 : push eax
0x468041 : call BrModelFree (FUNCTION)
0x468046 : add esp, 4
0x468049 : -mov eax, dword ptr [gShrapnel_model[1] (OFFSET)]
0x46804e : -push eax
0x46804f : -call BrModelFree (FUNCTION)
0x468054 : -add esp, 4
         : +jmp -0x38 	(spark.c:884)
0x468057 : pop edi 	(spark.c:885)
0x468058 : pop esi
0x468059 : pop ebx
0x46805a : leave 
0x46805b : ret 


DisposeShrapnel is only 82.46% similar to the original, diff above
```

*AI generated. Time taken: 59s, tokens: 8,077*
