### PR TITLE
ReplayShrapnel 100% match

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -892,11 +892,12 @@ void ReplayShrapnel(tU32 pTime) {
 
     for (i = 0; i < COUNT_OF(gShrapnel); i++) {
         mat = &gShrapnel[i].actor->t.t.mat;
-        if (TEST_BIT(gShrapnel_flags, i)) {
-            gShrapnel[i].age += GetReplayRate() * pTime;
-            DrMatrix34Rotate(mat, gShrapnel[i].age * BrDegreeToAngle(1), &gShrapnel[i].axis);
-            BrMatrix34PreShearX(mat, gShrapnel[i].shear1, gShrapnel[i].shear2);
+        if (!TEST_BIT(gShrapnel_flags, i)) {
+            continue;
         }
+        gShrapnel[i].age += GetReplayRate() * pTime;
+        DrMatrix34Rotate(mat, gShrapnel[i].age * BrDegreeToAngle(1), &gShrapnel[i].axis);
+        BrMatrix34PreShearX(mat, gShrapnel[i].shear1, gShrapnel[i].shear2);
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4685a0: ReplayShrapnel 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4685a0,35 +0x4ae608,34 @@
0x4685a0 : push ebp 	(spark.c:889)
0x4685a1 : mov ebp, esp
0x4685a3 : sub esp, 0x18
0x4685a6 : push ebx
0x4685a7 : push esi
0x4685a8 : push edi
0x4685a9 : mov dword ptr [ebp - 8], 0 	(spark.c:893)
0x4685b0 : jmp 0x3
0x4685b5 : inc dword ptr [ebp - 8]
0x4685b8 : cmp dword ptr [ebp - 8], 0xf
0x4685bc : -jge 0x101
         : +jge 0xfc
0x4685c2 : mov eax, dword ptr [ebp - 8] 	(spark.c:894)
0x4685c5 : mov ecx, eax
0x4685c7 : lea eax, [eax + eax*4]
0x4685ca : lea eax, [eax + eax*8]
0x4685cd : sub eax, ecx
0x4685cf : mov eax, dword ptr [eax + gShrapnel[0].actor (DATA)]
0x4685d5 : add eax, 0x2c
0x4685d8 : mov dword ptr [ebp - 4], eax
0x4685db : mov eax, 1 	(spark.c:895)
0x4685e0 : mov cl, byte ptr [ebp - 8]
0x4685e3 : shl eax, cl
0x4685e5 : test dword ptr [gShrapnel_flags (DATA)], eax
0x4685eb : -jne 0x5
0x4685f1 : -jmp -0x41
         : +je 0xc8
0x4685f6 : call GetReplayRate (FUNCTION) 	(spark.c:896)
0x4685fb : mov eax, dword ptr [ebp + 8]
0x4685fe : mov dword ptr [ebp - 0x10], eax
0x468601 : mov dword ptr [ebp - 0xc], 0
0x468608 : fild qword ptr [ebp - 0x10]
0x46860b : fmulp st(1)
0x46860d : mov eax, dword ptr [ebp - 8]
0x468610 : mov ecx, eax
0x468612 : lea eax, [eax + eax*4]
0x468615 : lea eax, [eax + eax*8]

---
+++
@@ -0x4686a1,11 +0x4ae704,16 @@
0x4686a1 : mov ecx, eax
0x4686a3 : lea eax, [eax + eax*4]
0x4686a6 : lea eax, [eax + eax*8]
0x4686a9 : sub eax, ecx
0x4686ab : mov eax, dword ptr [eax + gShrapnel[0].shear1 (OFFSET)]
0x4686b1 : push eax
0x4686b2 : mov eax, dword ptr [ebp - 4]
0x4686b5 : push eax
0x4686b6 : call BrMatrix34PreShearX (FUNCTION)
0x4686bb : add esp, 0xc
0x4686be : -jmp -0x10e
         : +jmp -0x109 	(spark.c:900)
         : +pop edi 	(spark.c:901)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


ReplayShrapnel is only 93.55% similar to the original, diff above
```

*AI generated. Time taken: 69s, tokens: 12,075*
