### PR TITLE
DrMatrix34Rotate 100% match

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -969,8 +969,9 @@ void DrMatrix34Rotate(br_matrix34* mat, br_angle r, br_vector3* a) {
     s = FastScalarSinAngle(r);
     c = FastScalarCosAngle(r);
     t = 1.0f - c;
-    txy = t * a->v[0] * a->v[1];
-    txz = t * a->v[0] * a->v[2];
+    txy = t * a->v[0];
+    txz = txy * a->v[2];
+    txy = a->v[1] * txy;
     tyz = t * a->v[1] * a->v[2];
     sx = a->v[0] * s;
     sy = a->v[1] * s;


### PR DESCRIPTION
## Match result

```
0x4686c8: DrMatrix34Rotate 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4686d4,31 +0x4aec42,33 @@
0x4686d4 : push eax
0x4686d5 : call FastScalarSinAngle (FUNCTION)
0x4686da : add esp, 4
0x4686dd : fstp dword ptr [ebp - 8]
0x4686e0 : mov eax, dword ptr [ebp + 0xc] 	(spark.c:970)
0x4686e3 : push eax
0x4686e4 : call FastScalarCosAngle (FUNCTION)
0x4686e9 : add esp, 4
0x4686ec : fst dword ptr [ebp - 4]
0x4686ef : fsubr dword ptr [1.0 (FLOAT)] 	(spark.c:971)
0x4686f5 : -fst dword ptr [ebp - 0xc]
         : +fstp dword ptr [ebp - 0xc]
         : +mov eax, dword ptr [ebp + 0x10] 	(spark.c:972)
         : +fld dword ptr [eax + 4]
0x4686f8 : mov eax, dword ptr [ebp + 0x10]
0x4686fb : fmul dword ptr [eax]
0x4686fd : -fst dword ptr [ebp - 0x10]
         : +fmul dword ptr [ebp - 0xc]
         : +fstp dword ptr [ebp - 0x10]
0x468700 : mov eax, dword ptr [ebp + 0x10] 	(spark.c:973)
0x468703 : -fmul dword ptr [eax + 8]
         : +fld dword ptr [eax + 8]
         : +mov eax, dword ptr [ebp + 0x10]
         : +fmul dword ptr [eax]
         : +fmul dword ptr [ebp - 0xc]
0x468706 : fstp dword ptr [ebp - 0x14]
0x468709 : -mov eax, dword ptr [ebp + 0x10]
0x46870c : -fld dword ptr [eax + 4]
0x46870f : -fmul dword ptr [ebp - 0x10]
0x468712 : -fstp dword ptr [ebp - 0x10]
0x468715 : mov eax, dword ptr [ebp + 0x10] 	(spark.c:974)
0x468718 : fld dword ptr [eax + 4]
0x46871b : mov eax, dword ptr [ebp + 0x10]
0x46871e : fmul dword ptr [eax + 8]
0x468721 : fmul dword ptr [ebp - 0xc]
0x468724 : fstp dword ptr [ebp - 0x24]
0x468727 : mov eax, dword ptr [ebp + 0x10] 	(spark.c:975)
0x46872a : fld dword ptr [eax]
0x46872c : fmul dword ptr [ebp - 8]
0x46872f : fstp dword ptr [ebp - 0x18]


DrMatrix34Rotate is only 92.00% similar to the original, diff above
```

*AI generated. Time taken: 63s, tokens: 7,149*
