### PR TITLE
GenerateContinuousSmoke 100% match

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -1349,11 +1349,11 @@ void GenerateContinuousSmoke(tCar_spec* pCar, int wheel, tU32 pTime) {
     BrVector3Cross(&tv, &pCar->omega, &pCar->wpos[wheel]);
     BrVector3Scale(&vcs, &pCar->velocity_car_space, WORLD_SCALE * 1000.0f);
     BrVector3Accumulate(&vcs, &tv);
-    ts = BrVector3LengthSquared(&vcs);
+    ts = vcs.v[1] * vcs.v[1] + vcs.v[2] * vcs.v[2] + vcs.v[0] * vcs.v[0];
     if (ts < 25.0f) {
         return;
     }
-    decay_factor = sqrt(ts) / 25.0f;
+    decay_factor = (br_scalar)sqrt(ts) / 25.0f;
     if (decay_factor > 1.0f) {
         decay_factor = 1.0f;
     }
@@ -1361,17 +1361,17 @@ void GenerateContinuousSmoke(tCar_spec* pCar, int wheel, tU32 pTime) {
     tv.v[1] -= pCar->oldd[wheel] / WORLD_SCALE_D;
 
     alpha = -1000.0f;
-    if (vcs.v[2] > 0.0f) {
-        alpha = (pCar->bounds[0].min.v[2] - tv.v[2]) / vcs.v[2];
-    } else if (vcs.v[2] < 0.0f) {
+    if (vcs.v[2] < 0.0f) {
         alpha = (pCar->bounds[0].max.v[2] - tv.v[2]) / vcs.v[2];
+    } else if (vcs.v[2] > 0.0f) {
+        alpha = (pCar->bounds[0].min.v[2] - tv.v[2]) / vcs.v[2];
     }
 
     beta = -1000.0f;
-    if (vcs.v[0] > 0.0f) {
-        beta = (pCar->bounds[0].min.v[0] - tv.v[0]) / vcs.v[0];
-    } else if (vcs.v[0] < 0.0f) {
+    if (vcs.v[0] < 0.0f) {
         beta = (pCar->bounds[0].max.v[0] - tv.v[0]) / vcs.v[0];
+    } else if (vcs.v[0] > 0.0f) {
+        beta = (pCar->bounds[0].min.v[0] - tv.v[0]) / vcs.v[0];
     }
 
     ts = MAX(alpha, beta);
@@ -1380,7 +1380,7 @@ void GenerateContinuousSmoke(tCar_spec* pCar, int wheel, tU32 pTime) {
     BrMatrix34ApplyP(&pos, &tv, &pCar->car_master_actor->t.t.mat);
     BrMatrix34ApplyV(&v, &vcs, &pCar->car_master_actor->t.t.mat);
 
-    colour = gDust_rotate + gCurrent_race.material_modifiers[pCar->material_index[wheel]].smoke_type - 2;
+    colour = gCurrent_race.material_modifiers[pCar->material_index[wheel]].smoke_type - 2 + gDust_rotate;
     while (colour >= gNum_dust_tables) {
         colour -= gNum_dust_tables;
     }


### PR DESCRIPTION
## Match result

```
0x4687dc: GenerateContinuousSmoke 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x468940,37 +0x4aff97,37 @@
0x468940 : fstp dword ptr [ebp - 0x3c]
0x468943 : fld dword ptr [ebp - 0x2c] 	(spark.c:1351)
0x468946 : fadd dword ptr [ebp - 0x44]
0x468949 : fstp dword ptr [ebp - 0x44]
0x46894c : fld dword ptr [ebp - 0x28]
0x46894f : fadd dword ptr [ebp - 0x40]
0x468952 : fstp dword ptr [ebp - 0x40]
0x468955 : fld dword ptr [ebp - 0x24]
0x468958 : fadd dword ptr [ebp - 0x3c]
0x46895b : fstp dword ptr [ebp - 0x3c]
         : +fld dword ptr [ebp - 0x3c] 	(spark.c:1352)
         : +fmul dword ptr [ebp - 0x3c]
0x46895e : fld dword ptr [ebp - 0x40]
0x468961 : fmul dword ptr [ebp - 0x40]
0x468964 : -fld dword ptr [ebp - 0x3c]
0x468967 : -fmul dword ptr [ebp - 0x3c]
0x46896a : faddp st(1)
0x46896c : fld dword ptr [ebp - 0x44]
0x46896f : fmul dword ptr [ebp - 0x44]
0x468972 : faddp st(1)
0x468974 : fcom dword ptr [25.0 (FLOAT)] 	(spark.c:1353)
0x46897a : fstp dword ptr [ebp - 0x20]
0x46897d : fnstsw ax
0x46897f : test ah, 1
0x468982 : je 0x5
0x468988 : jmp 0x233 	(spark.c:1354)
0x46898d : fld dword ptr [ebp - 0x20] 	(spark.c:1356)
0x468990 : call __CIsqrt (FUNCTION)
0x468995 : -fdiv dword ptr [25.0 (FLOAT)]
         : +fdiv qword ptr [25.0 (FLOAT)]
0x46899b : fcom dword ptr [1.0 (FLOAT)] 	(spark.c:1357)
0x4689a1 : fstp dword ptr [ebp - 0xc]
0x4689a4 : fnstsw ax
0x4689a6 : test ah, 0x41
0x4689a9 : jne 0x7
0x4689af : mov dword ptr [ebp - 0xc], 0x3f800000 	(spark.c:1358)
0x4689b6 : mov eax, dword ptr [ebp + 0xc] 	(spark.c:1360)
0x4689b9 : lea eax, [eax + eax*2]
0x4689bc : mov ecx, dword ptr [ebp + 8]
0x4689bf : fld dword ptr [ecx + eax*4 + 0x14cc]

---
+++
@@ -0x468a01,57 +0x4b0058,57 @@
0x468a01 : mov eax, dword ptr [ebp + 0xc] 	(spark.c:1361)
0x468a04 : mov ecx, dword ptr [ebp + 8]
0x468a07 : fld dword ptr [ecx + eax*4 + 0x1508]
0x468a0e : fdiv qword ptr [6.9 (FLOAT)]
0x468a14 : fsubr dword ptr [ebp - 0x28]
0x468a17 : fstp dword ptr [ebp - 0x28]
0x468a1a : mov dword ptr [ebp - 4], 0xc47a0000 	(spark.c:1363)
0x468a21 : fld dword ptr [ebp - 0x3c] 	(spark.c:1364)
0x468a24 : fcomp dword ptr [0.0 (FLOAT)]
0x468a2a : fnstsw ax
0x468a2c : -test ah, 1
0x468a2f : -je 0x17
         : +test ah, 0x41
         : +jne 0x17
0x468a35 : mov eax, dword ptr [ebp + 8] 	(spark.c:1365)
0x468a38 : -fld dword ptr [eax + 0xf8]
         : +fld dword ptr [eax + 0xec]
0x468a3e : fsub dword ptr [ebp - 0x24]
0x468a41 : fdiv dword ptr [ebp - 0x3c]
0x468a44 : fstp dword ptr [ebp - 4]
0x468a47 : jmp 0x26 	(spark.c:1366)
0x468a4c : fld dword ptr [ebp - 0x3c]
0x468a4f : fcomp dword ptr [0.0 (FLOAT)]
0x468a55 : fnstsw ax
0x468a57 : -test ah, 0x41
0x468a5a : -jne 0x12
         : +test ah, 1
         : +je 0x12
0x468a60 : mov eax, dword ptr [ebp + 8] 	(spark.c:1367)
0x468a63 : -fld dword ptr [eax + 0xec]
         : +fld dword ptr [eax + 0xf8]
0x468a69 : fsub dword ptr [ebp - 0x24]
0x468a6c : fdiv dword ptr [ebp - 0x3c]
0x468a6f : fstp dword ptr [ebp - 4]
0x468a72 : mov dword ptr [ebp - 8], 0xc47a0000 	(spark.c:1370)
0x468a79 : fld dword ptr [ebp - 0x44] 	(spark.c:1371)
0x468a7c : fcomp dword ptr [0.0 (FLOAT)]
0x468a82 : fnstsw ax
0x468a84 : -test ah, 1
0x468a87 : -je 0x17
         : +test ah, 0x41
         : +jne 0x17
0x468a8d : mov eax, dword ptr [ebp + 8] 	(spark.c:1372)
0x468a90 : -fld dword ptr [eax + 0xf0]
         : +fld dword ptr [eax + 0xe4]
0x468a96 : fsub dword ptr [ebp - 0x2c]
0x468a99 : fdiv dword ptr [ebp - 0x44]
0x468a9c : fstp dword ptr [ebp - 8]
0x468a9f : jmp 0x26 	(spark.c:1373)
0x468aa4 : fld dword ptr [ebp - 0x44]
0x468aa7 : fcomp dword ptr [0.0 (FLOAT)]
0x468aad : fnstsw ax
0x468aaf : -test ah, 0x41
0x468ab2 : -jne 0x12
         : +test ah, 1
         : +je 0x12
0x468ab8 : mov eax, dword ptr [ebp + 8] 	(spark.c:1374)
0x468abb : -fld dword ptr [eax + 0xe4]
         : +fld dword ptr [eax + 0xf0]
0x468ac1 : fsub dword ptr [ebp - 0x2c]
0x468ac4 : fdiv dword ptr [ebp - 0x44]
0x468ac7 : fstp dword ptr [ebp - 8]
0x468aca : fld dword ptr [ebp - 8] 	(spark.c:1377)
0x468acd : fld dword ptr [ebp - 4]
0x468ad0 : fcom st(1)
0x468ad2 : fnstsw ax
0x468ad4 : test ah, 1
0x468ad7 : jne 0x2
0x468add : fxch st(1)

---
+++
@@ -0x468b41,22 +0x4b0198,22 @@
0x468b41 : push eax
0x468b42 : lea eax, [ebp - 0x18]
0x468b45 : push eax
0x468b46 : call BrMatrix34ApplyV (FUNCTION)
0x468b4b : add esp, 0xc
0x468b4e : mov eax, dword ptr [ebp + 0xc] 	(spark.c:1383)
0x468b51 : mov ecx, dword ptr [ebp + 8]
0x468b54 : mov eax, dword ptr [ecx + eax*4 + 0x1518]
0x468b5b : lea eax, [eax + eax*4]
0x468b5e : mov eax, dword ptr [eax*8 + gCurrent_race+4060 (OFFSET)]
         : +add eax, dword ptr [gDust_rotate (DATA)]
0x468b65 : sub eax, 2
0x468b68 : -add eax, dword ptr [gDust_rotate (DATA)]
0x468b6e : mov dword ptr [ebp - 0x1c], eax
0x468b71 : mov eax, dword ptr [ebp - 0x1c] 	(spark.c:1384)
0x468b74 : cmp dword ptr [gNum_dust_tables (DATA)], eax
0x468b7a : jg 0x12
0x468b80 : xor eax, eax 	(spark.c:1385)
0x468b82 : sub eax, dword ptr [gNum_dust_tables (DATA)]
0x468b88 : neg eax
0x468b8a : sub dword ptr [ebp - 0x1c], eax
0x468b8d : jmp -0x21 	(spark.c:1386)
0x468b92 : mov eax, dword ptr [ebp + 8] 	(spark.c:1387)


GenerateContinuousSmoke is only 94.20% similar to the original, diff above
```

*AI generated. Time taken: 172s, tokens: 39,601*
