### PR TITLE
SmokeLine 100% effective match

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -992,33 +992,37 @@ void DrMatrix34Rotate(br_matrix34* mat, br_angle r, br_vector3* a) {
 // FUNCTION: CARM95 0x00469fc0
 void SmokeLine(int l, int x, br_scalar zbuff, int r_squared, tU8* scr_ptr, tU16* depth_ptr, tU8* shade_ptr, br_scalar r_multiplier, br_scalar z_multiplier, br_scalar shade_offset) {
     int i;
+#if defined(DETHRACE_FIX_BUGS)
     int offset; /* Added by dethrace. */
+#endif
     int r_multiplier_int;
     int shade_offset_int;
     tU16 z;
 
+    z = (1.f - zbuff) * 32768.0f;
     scr_ptr += gOffset;
     if (gProgram_state.cockpit_on) {
         depth_ptr += gOffset;
     }
-    z = (1.f - zbuff) * 32768.0f;
     r_multiplier_int = r_multiplier * 65536.0f;
     shade_offset_int = shade_offset * 65536.0f;
 
     for (i = 0; i < l; i++) {
         if (*depth_ptr > z) {
-            offset = ((shade_offset_int - r_squared * r_multiplier_int) >> 8) & 0xffffff00;
 #if defined(DETHRACE_FIX_BUGS)
+            offset = ((shade_offset_int - r_squared * r_multiplier_int) >> 8) & 0xffffff00;
             /* Prevent buffer underflows by capping negative offsets. */
             offset = MAX(0, offset);
-#endif
             *scr_ptr = shade_ptr[*scr_ptr + offset];
+#else
+            *scr_ptr = shade_ptr[*scr_ptr + (((shade_offset_int - r_squared * r_multiplier_int) >> 8) & 0xffffff00)];
+#endif
         }
-        r_multiplier = x + r_squared;
+        r_squared += x;
         scr_ptr++;
         x++;
         depth_ptr++;
-        r_squared = x + r_multiplier;
+        r_squared += x;
     }
 }
 


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x46a003,23 +0x4aed92,23 @@
0x46a003 : fmul dword ptr [65536.0 (FLOAT)]
0x46a009 : call __ftol (FUNCTION)
0x46a00e : mov dword ptr [ebp - 0xc], eax
0x46a011 : fld dword ptr [ebp + 0x2c] 	(spark.c:1008)
0x46a014 : fmul dword ptr [65536.0 (FLOAT)]
0x46a01a : call __ftol (FUNCTION)
0x46a01f : mov dword ptr [ebp - 0x10], eax
0x46a022 : mov dword ptr [ebp - 4], 0 	(spark.c:1010)
0x46a029 : jmp 0x3
0x46a02e : inc dword ptr [ebp - 4]
0x46a031 : -mov eax, dword ptr [ebp + 8]
0x46a034 : -cmp dword ptr [ebp - 4], eax
0x46a037 : -jge 0x5b
         : +mov eax, dword ptr [ebp - 4]
         : +cmp dword ptr [ebp + 8], eax
         : +jle 0x5b
0x46a03d : mov eax, dword ptr [ebp + 0x1c] 	(spark.c:1011)
0x46a040 : xor ecx, ecx
0x46a042 : mov cx, word ptr [eax]
0x46a045 : mov eax, dword ptr [ebp - 8]
0x46a048 : and eax, 0xffff
0x46a04d : cmp ecx, eax
0x46a04f : jle 0x28
0x46a055 : mov eax, dword ptr [ebp - 0x10] 	(spark.c:1018)
0x46a058 : mov ecx, dword ptr [ebp - 0xc]
0x46a05b : imul ecx, dword ptr [ebp + 0x14]


0x469fc0: SmokeLine 100% effective match (differs, but only in ways that don't affect behavior).

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x469fc0,66 +0x4aed4f,74 @@
0x469fc0 : push ebp 	(spark.c:993)
0x469fc1 : mov ebp, esp
0x469fc3 : -sub esp, 0x10
         : +sub esp, 0x1c
0x469fc6 : push ebx
0x469fc7 : push esi
0x469fc8 : push edi
0x469fc9 : -fld dword ptr [1.0 (FLOAT)]
0x469fcf : -fsub dword ptr [ebp + 0x10]
0x469fd2 : -fmul dword ptr [32768.0 (FLOAT)]
0x469fd8 : -call __ftol (FUNCTION)
0x469fdd : -mov word ptr [ebp - 8], ax
0x469fe1 : mov eax, dword ptr [gOffset (DATA)] 	(spark.c:1000)
0x469fe6 : add dword ptr [ebp + 0x18], eax
0x469fe9 : cmp dword ptr [gProgram_state+80 (OFFSET)], 0 	(spark.c:1001)
0x469ff0 : je 0xa
0x469ff6 : mov eax, dword ptr [gOffset (DATA)] 	(spark.c:1002)
0x469ffb : add eax, eax
0x469ffd : add dword ptr [ebp + 0x1c], eax
         : +fld dword ptr [1.0 (FLOAT)] 	(spark.c:1004)
         : +fsub dword ptr [ebp + 0x10]
         : +fmul dword ptr [32768.0 (FLOAT)]
         : +call __ftol (FUNCTION)
         : +mov word ptr [ebp - 0xc], ax
0x46a000 : fld dword ptr [ebp + 0x24] 	(spark.c:1005)
0x46a003 : fmul dword ptr [65536.0 (FLOAT)]
0x46a009 : call __ftol (FUNCTION)
0x46a00e : -mov dword ptr [ebp - 0xc], eax
         : +mov dword ptr [ebp - 0x10], eax
0x46a011 : fld dword ptr [ebp + 0x2c] 	(spark.c:1006)
0x46a014 : fmul dword ptr [65536.0 (FLOAT)]
0x46a01a : call __ftol (FUNCTION)
0x46a01f : -mov dword ptr [ebp - 0x10], eax
0x46a022 : -mov dword ptr [ebp - 4], 0
         : +mov dword ptr [ebp - 0x14], eax
         : +mov dword ptr [ebp - 8], 0 	(spark.c:1008)
0x46a029 : jmp 0x3
0x46a02e : -inc dword ptr [ebp - 4]
0x46a031 : -mov eax, dword ptr [ebp + 8]
0x46a034 : -cmp dword ptr [ebp - 4], eax
0x46a037 : -jge 0x5b
         : +inc dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp - 8]
         : +cmp dword ptr [ebp + 8], eax
         : +jle 0x76
0x46a03d : mov eax, dword ptr [ebp + 0x1c] 	(spark.c:1009)
0x46a040 : xor ecx, ecx
0x46a042 : mov cx, word ptr [eax]
0x46a045 : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp - 0xc]
0x46a048 : and eax, 0xffff
0x46a04d : cmp ecx, eax
0x46a04f : -jle 0x28
0x46a055 : -mov eax, dword ptr [ebp - 0x10]
0x46a058 : -mov ecx, dword ptr [ebp - 0xc]
         : +jle 0x2c
         : +mov eax, dword ptr [ebp - 0x14] 	(spark.c:1010)
         : +mov ecx, dword ptr [ebp - 0x10]
0x46a05b : imul ecx, dword ptr [ebp + 0x14]
0x46a05f : sub eax, ecx
0x46a061 : sar eax, 8
0x46a064 : and eax, 0xffffff00
0x46a069 : -mov ecx, dword ptr [ebp + 0x18]
0x46a06c : -xor edx, edx
0x46a06e : -mov dl, byte ptr [ecx]
0x46a070 : -add eax, edx
0x46a072 : -mov ecx, dword ptr [ebp + 0x20]
0x46a075 : -mov al, byte ptr [eax + ecx]
         : +mov dword ptr [ebp - 4], eax
         : +mov eax, dword ptr [ebp + 0x18] 	(spark.c:1015)
         : +xor ecx, ecx
         : +mov cl, byte ptr [eax]
         : +add ecx, dword ptr [ebp - 4]
         : +mov eax, dword ptr [ebp + 0x20]
         : +mov al, byte ptr [ecx + eax]
0x46a078 : mov ecx, dword ptr [ebp + 0x18]
0x46a07b : mov byte ptr [ecx], al
0x46a07d : mov eax, dword ptr [ebp + 0xc] 	(spark.c:1017)
0x46a080 : -add dword ptr [ebp + 0x14], eax
         : +add eax, dword ptr [ebp + 0x14]
         : +mov dword ptr [ebp - 0x18], eax
         : +fild dword ptr [ebp - 0x18]
         : +fstp dword ptr [ebp + 0x24]
0x46a083 : inc dword ptr [ebp + 0x18] 	(spark.c:1018)
0x46a086 : inc dword ptr [ebp + 0xc] 	(spark.c:1019)
0x46a089 : add dword ptr [ebp + 0x1c], 2 	(spark.c:1020)
0x46a08d : mov eax, dword ptr [ebp + 0xc] 	(spark.c:1021)
0x46a090 : -add dword ptr [ebp + 0x14], eax
0x46a093 : -jmp -0x6a
         : +mov dword ptr [ebp - 0x1c], eax
         : +fild dword ptr [ebp - 0x1c]
         : +fadd dword ptr [ebp + 0x24]
         : +call __ftol (FUNCTION)
         : +mov dword ptr [ebp + 0x14], eax
         : +jmp -0x85 	(spark.c:1022)
0x46a098 : pop edi 	(spark.c:1023)
0x46a099 : pop esi
0x46a09a : pop ebx
0x46a09b : leave 
0x46a09c : ret 


SmokeLine is only 57.14% similar to the original, diff above
```

*AI generated. Time taken: 531s, tokens: 61,206*
