### PR TITLE
AdjustFlame 100% match

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -1747,7 +1747,7 @@ void AdjustFlame(int pIndex, int pFrame_count, br_scalar pScale_x, br_scalar pSc
     br_actor* actor;
 
     i = pIndex & 0xf;
-    col = &gSmoke_column[(pIndex & -16) >> 4];
+    col = &gSmoke_column[(pIndex & ~0xf) >> 4];
     col->frame_count[i] = pFrame_count;
     col->scale_x[i] = pScale_x;
     col->scale_y[i] = pScale_y;

--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -1746,14 +1746,13 @@ void AdjustFlame(int pIndex, int pFrame_count, br_scalar pScale_x, br_scalar pSc
     tSmoke_column* col;
     br_actor* actor;
 
-    i = pIndex >> 4;
-    j = pIndex & 0xf;
-    col = &gSmoke_column[i];
-    col->frame_count[j] = pFrame_count;
-    col->scale_x[j] = pScale_x;
-    col->scale_y[j] = pScale_y;
-    col->offset_x[j] = pOffset_x;
-    col->offset_z[j] = pOffset_z;
+    i = pIndex & 0xf;
+    col = &gSmoke_column[(pIndex & -16) >> 4];
+    col->frame_count[i] = pFrame_count;
+    col->scale_x[i] = pScale_x;
+    col->scale_y[i] = pScale_y;
+    col->offset_x[i] = pOffset_x;
+    col->offset_z[i] = pOffset_z;
 }
 
 // IDA: void __usercall ReplayFlame(tSmoke_column *col@<EAX>, br_actor *actor@<EDX>)


### PR DESCRIPTION
## Match result

```
0x46ad34: AdjustFlame 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x46ad34,42 +0x4b16b7,44 @@
0x46ad34 : push ebp 	(spark.c:1743)
0x46ad35 : mov ebp, esp
0x46ad37 : sub esp, 0x10
0x46ad3a : push ebx
0x46ad3b : push esi
0x46ad3c : push edi
0x46ad3d : mov eax, dword ptr [ebp + 8] 	(spark.c:1749)
0x46ad40 : -and eax, 0xf
         : +sar eax, 4
0x46ad43 : mov dword ptr [ebp - 8], eax
0x46ad46 : mov eax, dword ptr [ebp + 8] 	(spark.c:1750)
0x46ad49 : -and eax, 0xfffffff0
0x46ad4c : -sar eax, 0
         : +and eax, 0xf
         : +mov dword ptr [ebp - 0xc], eax
         : +mov eax, dword ptr [ebp - 8] 	(spark.c:1751)
0x46ad4f : mov ecx, eax
0x46ad51 : shl eax, 3
0x46ad54 : sub eax, ecx
         : +shl eax, 4
0x46ad56 : add eax, gSmoke_column[0].car (DATA)
0x46ad5b : mov dword ptr [ebp - 4], eax
0x46ad5e : mov eax, dword ptr [ebp + 0xc] 	(spark.c:1752)
0x46ad61 : -mov ecx, dword ptr [ebp - 8]
         : +mov ecx, dword ptr [ebp - 0xc]
0x46ad64 : mov edx, dword ptr [ebp - 4]
0x46ad67 : mov dword ptr [edx + ecx*4 + 0x1c], eax
0x46ad6b : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp - 0xc] 	(spark.c:1753)
0x46ad6e : mov ecx, dword ptr [ebp - 4]
0x46ad71 : mov edx, dword ptr [ebp + 0x10]
0x46ad74 : mov dword ptr [ecx + eax*4 + 0x34], edx
0x46ad78 : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp - 0xc] 	(spark.c:1754)
0x46ad7b : mov ecx, dword ptr [ebp - 4]
0x46ad7e : mov edx, dword ptr [ebp + 0x14]
0x46ad81 : mov dword ptr [ecx + eax*4 + 0x40], edx
0x46ad85 : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp - 0xc] 	(spark.c:1755)
0x46ad88 : mov ecx, dword ptr [ebp - 4]
0x46ad8b : mov edx, dword ptr [ebp + 0x18]
0x46ad8e : mov dword ptr [ecx + eax*4 + 0x4c], edx
0x46ad92 : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp - 0xc] 	(spark.c:1756)
0x46ad95 : mov ecx, dword ptr [ebp - 4]
0x46ad98 : mov edx, dword ptr [ebp + 0x1c]
0x46ad9b : mov dword ptr [ecx + eax*4 + 0x58], edx
0x46ad9f : pop edi 	(spark.c:1757)
0x46ada0 : pop esi
0x46ada1 : pop ebx
0x46ada2 : leave 
0x46ada3 : ret 


AdjustFlame is only 79.07% similar to the original, diff above
```

*AI generated. Time taken: 207s, tokens: 23,650*
