### PR TITLE
ReplayFlame 100% match

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -1761,11 +1761,9 @@ void AdjustFlame(int pIndex, int pFrame_count, br_scalar pScale_x, br_scalar pSc
 void ReplayFlame(tSmoke_column* col, br_actor* actor) {
     int i;
 
-    for (i = 0; i < COUNT_OF(col->frame_count); i++, actor = actor->next) {
+    for (i = 0; i < COUNT_OF(col->frame_count); i++) {
         col->frame_count[i] += GetReplayRate();
-        if (col->frame_count[i] < 0 || col->frame_count[i] >= COUNT_OF(gFlame_map)) {
-            actor->type = BR_ACTOR_NONE;
-        } else {
+        if (col->frame_count[i] >= 0 && col->frame_count[i] < COUNT_OF(gFlame_map)) {
             actor->type = BR_ACTOR_MODEL;
             actor->material->colour_map = gFlame_map[col->frame_count[i]];
             BrMaterialUpdate(actor->material, BR_MATU_ALL);
@@ -1775,7 +1773,10 @@ void ReplayFlame(tSmoke_column* col, br_actor* actor) {
                 1.f);
             actor->t.t.translate.t.v[0] = col->offset_x[i];
             actor->t.t.translate.t.v[2] = col->offset_z[i];
+        } else {
+            actor->type = BR_ACTOR_NONE;
         }
+        actor = actor->next;
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x46b722: ReplayFlame 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x46b722,40 +0x4b172d,46 @@
0x46b722 : push ebp 	(spark.c:1761)
0x46b723 : mov ebp, esp
0x46b725 : sub esp, 0x10
0x46b728 : push ebx
0x46b729 : push esi
0x46b72a : push edi
0x46b72b : mov dword ptr [ebp - 4], 0 	(spark.c:1764)
0x46b732 : -jmp 0x3
         : +jmp 0xb
0x46b737 : inc dword ptr [ebp - 4]
         : +mov eax, dword ptr [ebp + 0xc]
         : +mov eax, dword ptr [eax]
         : +mov dword ptr [ebp + 0xc], eax
0x46b73a : cmp dword ptr [ebp - 4], 3
0x46b73e : -jge 0x124
         : +jge 0x11c
0x46b744 : call GetReplayRate (FUNCTION) 	(spark.c:1765)
0x46b749 : mov eax, dword ptr [ebp - 4]
0x46b74c : mov ecx, dword ptr [ebp + 8]
0x46b74f : mov eax, dword ptr [ecx + eax*4 + 0x1c]
0x46b753 : mov dword ptr [ebp - 8], eax
0x46b756 : fild dword ptr [ebp - 8]
0x46b759 : faddp st(1)
0x46b75b : call __ftol (FUNCTION)
0x46b760 : mov ecx, dword ptr [ebp - 4]
0x46b763 : mov edx, dword ptr [ebp + 8]
0x46b766 : mov dword ptr [edx + ecx*4 + 0x1c], eax
0x46b76a : mov eax, dword ptr [ebp - 4] 	(spark.c:1766)
0x46b76d : mov ecx, dword ptr [ebp + 8]
0x46b770 : cmp dword ptr [ecx + eax*4 + 0x1c], 0
0x46b775 : -jl 0xd9
         : +jl 0x11
0x46b77b : mov eax, dword ptr [ebp - 4]
0x46b77e : mov ecx, dword ptr [ebp + 8]
0x46b781 : cmp dword ptr [ecx + eax*4 + 0x1c], 0x14
0x46b786 : -jge 0xc8
         : +jl 0xc
         : +mov eax, dword ptr [ebp + 0xc] 	(spark.c:1767)
         : +mov byte ptr [eax + 0x12], 0
         : +jmp 0xc3 	(spark.c:1768)
0x46b78c : mov eax, dword ptr [ebp + 0xc] 	(spark.c:1769)
0x46b78f : mov byte ptr [eax + 0x12], 1
0x46b793 : mov eax, dword ptr [ebp - 4] 	(spark.c:1770)
0x46b796 : mov ecx, dword ptr [ebp + 8]
0x46b799 : mov eax, dword ptr [ecx + eax*4 + 0x1c]
0x46b79d : mov eax, dword ptr [eax*4 + gFlame_map[0] (DATA)]
0x46b7a4 : mov ecx, dword ptr [ebp + 0xc]
0x46b7a7 : mov ecx, dword ptr [ecx + 0x1c]
0x46b7aa : mov dword ptr [ecx + 0x40], eax
0x46b7ad : push 0x7fff 	(spark.c:1771)

---
+++
@@ -0x46b82f,22 +0x4b184e,16 @@
0x46b82f : mov eax, dword ptr [ebp - 4] 	(spark.c:1776)
0x46b832 : mov ecx, dword ptr [ebp + 8]
0x46b835 : mov edx, dword ptr [ebp + 0xc]
0x46b838 : mov eax, dword ptr [ecx + eax*4 + 0x4c]
0x46b83c : mov dword ptr [edx + 0x50], eax
0x46b83f : mov eax, dword ptr [ebp - 4] 	(spark.c:1777)
0x46b842 : mov ecx, dword ptr [ebp + 8]
0x46b845 : mov edx, dword ptr [ebp + 0xc]
0x46b848 : mov eax, dword ptr [ecx + eax*4 + 0x58]
0x46b84c : mov dword ptr [edx + 0x58], eax
0x46b84f : -jmp 0x7
0x46b854 : -mov eax, dword ptr [ebp + 0xc]
0x46b857 : -mov byte ptr [eax + 0x12], 0
0x46b85b : -mov eax, dword ptr [ebp + 0xc]
0x46b85e : -mov eax, dword ptr [eax]
0x46b860 : -mov dword ptr [ebp + 0xc], eax
0x46b863 : jmp -0x131 	(spark.c:1779)
0x46b868 : pop edi 	(spark.c:1780)
0x46b869 : pop esi
0x46b86a : pop ebx
0x46b86b : leave 
0x46b86c : ret 


ReplayFlame is only 89.90% similar to the original, diff above
```

*AI generated. Time taken: 102s, tokens: 27,302*
