### PR TITLE
Match DoSmokeColumn

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -1843,12 +1843,17 @@ void FlameAnimate(int c, br_vector3* pPos, tU32 pTime) {
 // IDA: void __usercall DoSmokeColumn(int i@<EAX>, tU32 pTime@<EDX>, br_vector3 *pRet_car_pos@<EBX>)
 // FUNCTION: CARM95 0x0046b86d
 void DoSmokeColumn(int i, tU32 pTime, br_vector3* pRet_car_pos) {
+    typedef struct tSmoke_vertex {
+        br_vector3 p;
+        char padding[20];
+    } tSmoke_vertex;
     tCar_spec* c;
     br_actor* actor;
     br_actor* bonny;
     int group;
 
     c = gSmoke_column[i].car;
+    group = 0;
     if (c->car_master_actor->t.t.mat.m[1][1] > 0.1f) {
         gSmoke_column[i].upright = 1;
     }
@@ -1858,12 +1863,14 @@ void DoSmokeColumn(int i, tU32 pTime, br_vector3* pRet_car_pos) {
     actor = c->car_model_actors[c->principal_car_actor].actor;
     bonny = c->car_model_actors[c->car_actor_count - 1].actor;
 
-    BrVector3Add(pRet_car_pos, &V11MODEL(actor->model)->groups[0].position[gSmoke_column[i].vertex_index], &actor->t.t.translate.t);
+    pRet_car_pos->v[0] = ((tSmoke_vertex*)*(void**)((char*)V11MODEL(actor->model)->groups + group * 36 + 0x10))[gSmoke_column[i].vertex_index].p.v[0] + actor->t.t.translate.t.v[0];
+    pRet_car_pos->v[1] = ((tSmoke_vertex*)*(void**)((char*)V11MODEL(actor->model)->groups + group * 36 + 0x10))[gSmoke_column[i].vertex_index].p.v[1] + actor->t.t.translate.t.v[1];
+    pRet_car_pos->v[2] = ((tSmoke_vertex*)*(void**)((char*)V11MODEL(actor->model)->groups + group * 36 + 0x10))[gSmoke_column[i].vertex_index].p.v[2] + actor->t.t.translate.t.v[2];
     if (gProgram_state.cockpit_on && c->driver == eDriver_local_human) {
-        if (c->driver_z_offset + 0.2f <= pRet_car_pos->v[2]) {
-            pRet_car_pos->v[1] -= -0.07f;
+        if (c->driver_z_offset + 0.2 > pRet_car_pos->v[2]) {
+            BrMatrix34ApplyP(pRet_car_pos, &((tSmoke_vertex*)*(void**)((char*)V11MODEL(actor->model)->groups + group * 36 + 0x10))[gSmoke_column[i].vertex_index].p, &bonny->t.t.mat);
         } else {
-            BrMatrix34ApplyP(pRet_car_pos, &V11MODEL(actor->model)->groups[0].position[gSmoke_column[i].vertex_index], &bonny->t.t.mat);
+            pRet_car_pos->v[1] -= 0.07;
         }
     }
     if (!gSmoke_column[i].upright) {


### PR DESCRIPTION
## Match result

```
0x46b86d: DoSmokeColumn 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x46b873,21 +0x4b1c05,20 @@
0x46b873 : push ebx
0x46b874 : push esi
0x46b875 : push edi
0x46b876 : mov eax, dword ptr [ebp + 8] 	(spark.c:1851)
0x46b879 : mov ecx, eax
0x46b87b : shl eax, 3
0x46b87e : sub eax, ecx
0x46b880 : shl eax, 4
0x46b883 : mov eax, dword ptr [eax + gSmoke_column[0].car (DATA)]
0x46b889 : mov dword ptr [ebp - 8], eax
0x46b88c : -mov dword ptr [ebp - 0xc], 0
0x46b893 : mov eax, dword ptr [ebp - 8] 	(spark.c:1852)
0x46b896 : mov eax, dword ptr [eax + 0xc]
0x46b899 : fld dword ptr [eax + 0x3c]
0x46b89c : fcomp dword ptr [0.10000000149011612 (FLOAT)]
0x46b8a2 : fnstsw ax
0x46b8a4 : test ah, 0x41
0x46b8a7 : jne 0x17
0x46b8ad : mov eax, dword ptr [ebp + 8] 	(spark.c:1853)
0x46b8b0 : mov ecx, eax
0x46b8b2 : shl eax, 3

---
+++
@@ -0x46b91a,119 +0x4b1ca5,107 @@
0x46b91a : dec eax
0x46b91b : shl eax, 4
0x46b91e : lea eax, [eax + eax*2]
0x46b921 : mov ecx, dword ptr [ebp - 8]
0x46b924 : mov eax, dword ptr [eax + ecx + 0x12b8]
0x46b92b : mov dword ptr [ebp - 4], eax
0x46b92e : mov eax, dword ptr [ebp - 0x10] 	(spark.c:1861)
0x46b931 : mov eax, dword ptr [eax + 0x18]
0x46b934 : mov eax, dword ptr [eax + 0x4c]
0x46b937 : mov eax, dword ptr [eax + 0x18]
0x46b93a : -mov ecx, dword ptr [ebp - 0xc]
0x46b93d : -shl ecx, 2
0x46b940 : -lea ecx, [ecx + ecx*8]
0x46b943 : -mov eax, dword ptr [eax + ecx + 0x10]
         : +mov eax, dword ptr [eax + 0x1c]
0x46b947 : mov ecx, dword ptr [ebp + 8]
0x46b94a : mov edx, ecx
0x46b94c : shl ecx, 3
0x46b94f : sub ecx, edx
0x46b951 : shl ecx, 4
0x46b954 : mov ecx, dword ptr [ecx + gSmoke_column[0].vertex_index (OFFSET)]
0x46b95a : -shl ecx, 5
0x46b95d : -fld dword ptr [eax + ecx]
         : +lea ecx, [ecx + ecx*2]
         : +fld dword ptr [eax + ecx*4]
0x46b960 : mov eax, dword ptr [ebp - 0x10]
0x46b963 : fadd dword ptr [eax + 0x50]
0x46b966 : mov eax, dword ptr [ebp + 0x10]
0x46b969 : fstp dword ptr [eax]
0x46b96b : mov eax, dword ptr [ebp - 0x10]
0x46b96e : mov eax, dword ptr [eax + 0x18]
0x46b971 : mov eax, dword ptr [eax + 0x4c]
0x46b974 : mov eax, dword ptr [eax + 0x18]
0x46b977 : -mov ecx, dword ptr [ebp - 0xc]
0x46b97a : -shl ecx, 2
0x46b97d : -lea ecx, [ecx + ecx*8]
0x46b980 : -mov eax, dword ptr [eax + ecx + 0x10]
         : +mov eax, dword ptr [eax + 0x1c]
0x46b984 : mov ecx, dword ptr [ebp + 8]
0x46b987 : mov edx, ecx
0x46b989 : shl ecx, 3
0x46b98c : sub ecx, edx
0x46b98e : shl ecx, 4
0x46b991 : mov ecx, dword ptr [ecx + gSmoke_column[0].vertex_index (OFFSET)]
0x46b997 : -shl ecx, 5
0x46b99a : -fld dword ptr [eax + ecx + 4]
         : +lea ecx, [ecx + ecx*2]
         : +fld dword ptr [eax + ecx*4 + 4]
0x46b99e : mov eax, dword ptr [ebp - 0x10]
0x46b9a1 : fadd dword ptr [eax + 0x54]
0x46b9a4 : mov eax, dword ptr [ebp + 0x10]
0x46b9a7 : fstp dword ptr [eax + 4]
0x46b9aa : mov eax, dword ptr [ebp - 0x10]
0x46b9ad : mov eax, dword ptr [eax + 0x18]
0x46b9b0 : mov eax, dword ptr [eax + 0x4c]
0x46b9b3 : mov eax, dword ptr [eax + 0x18]
0x46b9b6 : -mov ecx, dword ptr [ebp - 0xc]
0x46b9b9 : -shl ecx, 2
0x46b9bc : -lea ecx, [ecx + ecx*8]
0x46b9bf : -mov eax, dword ptr [eax + ecx + 0x10]
         : +mov eax, dword ptr [eax + 0x1c]
0x46b9c3 : mov ecx, dword ptr [ebp + 8]
0x46b9c6 : mov edx, ecx
0x46b9c8 : shl ecx, 3
0x46b9cb : sub ecx, edx
0x46b9cd : shl ecx, 4
0x46b9d0 : mov ecx, dword ptr [ecx + gSmoke_column[0].vertex_index (OFFSET)]
0x46b9d6 : -shl ecx, 5
0x46b9d9 : -fld dword ptr [eax + ecx + 8]
         : +lea ecx, [ecx + ecx*2]
         : +fld dword ptr [eax + ecx*4 + 8]
0x46b9dd : mov eax, dword ptr [ebp - 0x10]
0x46b9e0 : fadd dword ptr [eax + 0x58]
0x46b9e3 : mov eax, dword ptr [ebp + 0x10]
0x46b9e6 : fstp dword ptr [eax + 8]
0x46b9e9 : cmp dword ptr [gProgram_state+80 (OFFSET)], 0 	(spark.c:1862)
0x46b9f0 : -je 0x89
         : +je 0x80
0x46b9f6 : mov eax, dword ptr [ebp - 8]
0x46b9f9 : cmp dword ptr [eax + 8], 4
0x46b9fd : -jne 0x7c
         : +jne 0x73
0x46ba03 : mov eax, dword ptr [ebp - 8] 	(spark.c:1863)
0x46ba06 : fld dword ptr [eax + 0x6f4]
0x46ba0c : -fadd qword ptr [0.2 (FLOAT)]
         : +fadd dword ptr [0.20000000298023224 (FLOAT)]
0x46ba12 : mov eax, dword ptr [ebp + 0x10]
0x46ba15 : fcomp dword ptr [eax + 8]
0x46ba18 : fnstsw ax
0x46ba1a : test ah, 0x41
0x46ba1d : -jne 0x4a
         : +je 0x17
         : +mov eax, dword ptr [ebp + 0x10] 	(spark.c:1864)
         : +fld dword ptr [eax + 4]
         : +fsub dword ptr [-0.07000000029802322 (FLOAT)]
         : +mov eax, dword ptr [ebp + 0x10]
         : +fstp dword ptr [eax + 4]
         : +jmp 0x3c 	(spark.c:1865)
0x46ba23 : mov eax, dword ptr [ebp - 4] 	(spark.c:1866)
0x46ba26 : add eax, 0x2c
0x46ba29 : push eax
0x46ba2a : mov eax, dword ptr [ebp - 0x10]
0x46ba2d : mov eax, dword ptr [eax + 0x18]
0x46ba30 : mov eax, dword ptr [eax + 0x4c]
0x46ba33 : mov eax, dword ptr [eax + 0x18]
0x46ba36 : -mov ecx, dword ptr [ebp - 0xc]
0x46ba39 : -shl ecx, 2
0x46ba3c : -lea ecx, [ecx + ecx*8]
0x46ba3f : -mov eax, dword ptr [eax + ecx + 0x10]
         : +mov eax, dword ptr [eax + 0x1c]
0x46ba43 : mov ecx, dword ptr [ebp + 8]
0x46ba46 : mov edx, ecx
0x46ba48 : shl ecx, 3
0x46ba4b : sub ecx, edx
0x46ba4d : shl ecx, 4
0x46ba50 : mov ecx, dword ptr [ecx + gSmoke_column[0].vertex_index (OFFSET)]
0x46ba56 : -shl ecx, 5
0x46ba59 : -add eax, ecx
         : +lea ecx, [ecx + ecx*2]
         : +lea eax, [eax + ecx*4]
0x46ba5b : push eax
0x46ba5c : mov eax, dword ptr [ebp + 0x10]
0x46ba5f : push eax
0x46ba60 : call BrMatrix34ApplyP (FUNCTION)
0x46ba65 : add esp, 0xc
0x46ba68 : -jmp 0x12
0x46ba6d : -mov eax, dword ptr [ebp + 0x10]
0x46ba70 : -fld dword ptr [eax + 4]
0x46ba73 : -fsub qword ptr [0.07 (FLOAT)]
0x46ba79 : -mov eax, dword ptr [ebp + 0x10]
0x46ba7c : -fstp dword ptr [eax + 4]
0x46ba7f : mov eax, dword ptr [ebp + 8] 	(spark.c:1869)
0x46ba82 : mov ecx, eax
0x46ba84 : shl eax, 3
0x46ba87 : sub eax, ecx
0x46ba89 : shl eax, 4
0x46ba8c : cmp dword ptr [eax + gSmoke_column[0].upright (OFFSET)], 0
0x46ba93 : jne 0x15
0x46ba99 : mov eax, dword ptr [ebp - 8] 	(spark.c:1870)
0x46ba9c : fld dword ptr [eax + 0x100]
0x46baa2 : fdiv dword ptr [6.900000095367432 (FLOAT)]

---
+++
@@ -0x46babf,10 +0x4b1e23,27 @@
0x46babf : mov ecx, eax
0x46bac1 : shl eax, 3
0x46bac4 : sub eax, ecx
0x46bac6 : shl eax, 4
0x46bac9 : add eax, gSmoke_column[0].car (DATA)
0x46bace : add eax, 0x28
0x46bad1 : push eax
0x46bad2 : call BrMatrix34ApplyP (FUNCTION)
0x46bad7 : add esp, 0xc
0x46bada : mov eax, dword ptr [ebp + 8] 	(spark.c:1873)
         : +mov ecx, eax
         : +shl eax, 3
         : +sub eax, ecx
         : +shl eax, 4
         : +fld dword ptr [eax + gSmoke_column[0].pos+4 (OFFSET)]
         : +fsub dword ptr [0.029999999329447746 (FLOAT)]
         : +mov eax, dword ptr [ebp + 8]
         : +mov ecx, eax
         : +shl eax, 3
         : +sub eax, ecx
         : +shl eax, 4
         : +fstp dword ptr [eax + gSmoke_column[0].pos+4 (OFFSET)]
         : +pop edi 	(spark.c:1874)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DoSmokeColumn is only 80.42% similar to the original, diff above
```

*AI generated. Time taken: 352s, tokens: 106,648*
