### PR TITLE
DrawTheGlow 100% match

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -2181,21 +2181,24 @@ void DrawTheGlow(br_pixelmap* pRender_screen, br_pixelmap* pDepth_buffer, br_act
     br_vector3 tv;
     tU32 seed;
 
-    if (gColumn_flags) {
-        seed = rand();
-        srand(GetTotalTime());
-        for (i = 0; i < MAX_SMOKE_COLUMNS; i++) {
-            if (TEST_BIT(gColumn_flags, i) && gSmoke_column[i].colour <= 1) {
-                strength = 0.5f;
-                if (gSmoke_column[i].lifetime < 4000) {
-                    strength = gSmoke_column[i].lifetime * 0.5f / 4000.f;
-                }
-                BrVector3Set(&tv, gSmoke_column[i].pos.v[0], gSmoke_column[i].pos.v[1] + 0.02f, gSmoke_column[i].pos.v[2]);
-                SmokeCircle3D(&tv, 0.07f, strength, SRandomBetween(0.5f, 0.99f), pRender_screen, pDepth_buffer, gAcid_shade_table, pCamera);
-            }
-        }
-        srand(seed);
+    if (!gColumn_flags) {
+        return;
     }
+
+    seed = rand();
+    srand(GetTotalTime());
+    for (i = 0; i < MAX_SMOKE_COLUMNS; i++) {
+        if (!TEST_BIT(gColumn_flags, i) || gSmoke_column[i].colour > 1) {
+            continue;
+        }
+        strength = 0.5f;
+        if (gSmoke_column[i].lifetime < 4000) {
+            strength = gSmoke_column[i].lifetime * strength / 4000.f;
+        }
+        BrVector3Set(&tv, gSmoke_column[i].pos.v[0], gSmoke_column[i].pos.v[1] + 0.02, gSmoke_column[i].pos.v[2]);
+        SmokeCircle3D(&tv, 0.07f, strength, SRandomBetween(0.5f, 0.99f), pRender_screen, pDepth_buffer, gAcid_shade_table, pCamera);
+    }
+    srand(seed);
 }
 
 // IDA: void __usercall PipeInstantUnSmudge(tCar_spec *pCar@<EAX>)


### PR DESCRIPTION
## Match result

```
0x46c133: DrawTheGlow 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x46c133,77 +0x4b2f53,75 @@
0x46c133 : push ebp 	(spark.c:2178)
0x46c134 : mov ebp, esp
0x46c136 : sub esp, 0x20
0x46c139 : push ebx
0x46c13a : push esi
0x46c13b : push edi
0x46c13c : cmp dword ptr [gColumn_flags (DATA)], 0 	(spark.c:2184)
0x46c143 : -jne 0x5
0x46c149 : -jmp 0x14c
         : +je 0x14a
0x46c14e : call rand (FUNCTION) 	(spark.c:2185)
0x46c153 : mov dword ptr [ebp - 8], eax
0x46c156 : call GetTotalTime (FUNCTION) 	(spark.c:2186)
0x46c15b : push eax
0x46c15c : call srand (FUNCTION)
0x46c161 : add esp, 4
0x46c164 : mov dword ptr [ebp - 4], 0 	(spark.c:2187)
0x46c16b : jmp 0x3
0x46c170 : inc dword ptr [ebp - 4]
0x46c173 : cmp dword ptr [ebp - 4], 5
0x46c177 : -jge 0x111
         : +jge 0x10f
0x46c17d : mov eax, 1 	(spark.c:2188)
0x46c182 : mov cl, byte ptr [ebp - 4]
0x46c185 : shl eax, cl
0x46c187 : test dword ptr [gColumn_flags (DATA)], eax
0x46c18d : -je 0x1a
         : +je 0xf4
0x46c193 : mov eax, dword ptr [ebp - 4]
0x46c196 : mov ecx, eax
0x46c198 : shl eax, 3
0x46c19b : sub eax, ecx
0x46c19d : shl eax, 4
0x46c1a0 : cmp dword ptr [eax + gSmoke_column[0].colour (OFFSET)], 1
0x46c1a7 : -jle 0x5
0x46c1ad : -jmp -0x42
         : +jg 0xda
0x46c1b2 : mov dword ptr [ebp - 0x18], 0x3f000000 	(spark.c:2189)
0x46c1b9 : mov eax, dword ptr [ebp - 4] 	(spark.c:2190)
0x46c1bc : mov ecx, eax
0x46c1be : shl eax, 3
0x46c1c1 : sub eax, ecx
0x46c1c3 : shl eax, 4
0x46c1c6 : cmp dword ptr [eax + gSmoke_column[0].lifetime (OFFSET)], 0xfa0
0x46c1d0 : -jae 0x2c
         : +jae 0x2f
0x46c1d6 : mov eax, dword ptr [ebp - 4] 	(spark.c:2191)
0x46c1d9 : mov ecx, eax
0x46c1db : shl eax, 3
0x46c1de : sub eax, ecx
0x46c1e0 : shl eax, 4
0x46c1e3 : mov eax, dword ptr [eax + gSmoke_column[0].lifetime (OFFSET)]
0x46c1e9 : mov dword ptr [ebp - 0x20], eax
0x46c1ec : mov dword ptr [ebp - 0x1c], 0
0x46c1f3 : fild qword ptr [ebp - 0x20]
0x46c1f6 : -fmul dword ptr [ebp - 0x18]
         : +fmul dword ptr [0.5 (FLOAT)]
0x46c1f9 : fdiv dword ptr [4000.0 (FLOAT)]
0x46c1ff : fstp dword ptr [ebp - 0x18]
0x46c202 : mov eax, dword ptr [ebp - 4] 	(spark.c:2193)
0x46c205 : mov ecx, eax
0x46c207 : shl eax, 3
0x46c20a : sub eax, ecx
0x46c20c : shl eax, 4
0x46c20f : mov eax, dword ptr [eax + gSmoke_column[0].pos (OFFSET)]
0x46c215 : mov dword ptr [ebp - 0x14], eax
0x46c218 : mov eax, dword ptr [ebp - 4]
0x46c21b : mov ecx, eax
0x46c21d : shl eax, 3
0x46c220 : sub eax, ecx
0x46c222 : shl eax, 4
0x46c225 : fld dword ptr [eax + gSmoke_column[0].pos+4 (OFFSET)]
0x46c22b : -fadd qword ptr [0.02 (FLOAT)]
         : +fadd dword ptr [0.019999999552965164 (FLOAT)]
0x46c231 : fstp dword ptr [ebp - 0x10]
0x46c234 : mov eax, dword ptr [ebp - 4]
0x46c237 : mov ecx, eax
0x46c239 : shl eax, 3
0x46c23c : sub eax, ecx
0x46c23e : shl eax, 4
0x46c241 : mov eax, dword ptr [eax + gSmoke_column[0].pos+8 (OFFSET)]
0x46c247 : mov dword ptr [ebp - 0xc], eax
0x46c24a : mov eax, dword ptr [ebp + 0x10] 	(spark.c:2194)
0x46c24d : push eax

---
+++
@@ -0x46c26b,14 +0x4b3084,20 @@
0x46c26b : add esp, 8
0x46c26e : sub esp, 4
0x46c271 : fstp dword ptr [esp]
0x46c274 : mov eax, dword ptr [ebp - 0x18]
0x46c277 : push eax
0x46c278 : push 0x3d8f5c29
0x46c27d : lea eax, [ebp - 0x14]
0x46c280 : push eax
0x46c281 : call SmokeCircle3D (FUNCTION)
0x46c286 : add esp, 0x20
0x46c289 : -jmp -0x11e
         : +jmp -0x11c 	(spark.c:2196)
0x46c28e : mov eax, dword ptr [ebp - 8] 	(spark.c:2197)
0x46c291 : push eax
0x46c292 : call srand (FUNCTION)
         : +add esp, 4
         : +pop edi 	(spark.c:2199)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DrawTheGlow is only 88.24% similar to the original, diff above
```

*AI generated. Time taken: 408s, tokens: 43,352*
