### PR TITLE
Match PipeInstantUnSmudge

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -2214,66 +2214,86 @@ void PipeInstantUnSmudge(tCar_spec* pCar) {
     int v;
     int group;
     tSmudged_vertex data[1000];
+    struct old_v11group {
+        void* stored;
+        void* faces;
+        br_colour* face_colours;
+        br_uint_16* face_user;
+        void* vertices;
+        br_colour* vertex_colours;
+        br_uint_16* vertex_user;
+        br_uint_16 nfaces;
+        br_uint_16 nvertices;
+        br_uint_16 nedges;
+    };
+    struct old_v11model {
+        br_size_t size;
+        br_uint_32 flags;
+        br_uint_16 ngroups;
+        br_vector3 pivot;
+        struct old_v11group* groups;
+    };
 
-    if (!gAction_replay_mode) {
+    if (gAction_replay_mode) {
         return;
     }
     actor = pCar->car_model_actors[pCar->principal_car_actor].actor;
     model = actor->model;
     bonny = pCar->car_model_actors[pCar->car_actor_count - 1].actor;
     n = 0;
-    if ((model->flags & BR_MODF_KEEP_ORIGINAL) != 0 || (model->flags & BR_MODF_UPDATEABLE) != 0) {
-        StartPipingSession(ePipe_chunk_smudge);
+    if ((model->flags & BR_MODF_KEEP_ORIGINAL) == 0) {
+        if ((model->flags & BR_MODF_UPDATEABLE) == 0) {
+            return;
+        }
+    }
+    StartPipingSession(ePipe_chunk_smudge);
+    j = 0;
+    for (group = 0; group < ((struct old_v11model*)model->prepared)->ngroups; group++) {
+        for (v = 0; v < ((struct old_v11model*)model->prepared)->groups[group].nvertices; v++, j++) {
+            if (BR_ALPHA(((struct old_v11model*)model->prepared)->groups[group].vertex_colours[v])) {
+                data[n].vertex_index = j;
+                data[n].light_index = -BR_ALPHA(((struct old_v11model*)model->prepared)->groups[group].vertex_colours[v]);
+                n += 1;
+                ((struct old_v11model*)model->prepared)->groups[group].vertex_colours[v] = 0;
+                if ((model->flags & BR_MODF_UPDATEABLE) != 0) {
+                    model->vertices[((struct old_v11model*)model->prepared)->groups[group].vertex_user[v]].index = 0;
+                }
+                if (n >= COUNT_OF(data)) {
+                    group = ((struct old_v11model*)model->prepared)->ngroups;
+                    break;
+                }
+            }
+        }
+    }
+    if (n != 0) {
+        AddSmudgeToPipingSession(pCar->car_ID, pCar->principal_car_actor, n, data);
+    }
+    if (bonny != actor) {
+        b_model = bonny->model;
+        n = 0;
         j = 0;
-        for (group = 0; group < V11MODEL(model)->ngroups; group++) {
-            for (v = 0; v < V11MODEL(model)->groups[group].nvertices; v++) {
-                if ((V11MODEL(model)->groups[group].vertex_colours[v] >> 24) != 0) {
+        for (group = 0; group < ((struct old_v11model*)b_model->prepared)->ngroups; group++) {
+            for (v = 0; v < ((struct old_v11model*)b_model->prepared)->groups[group].nvertices; v++, j++) {
+                if (BR_ALPHA(((struct old_v11model*)b_model->prepared)->groups[group].vertex_colours[v])) {
                     data[n].vertex_index = j;
-                    data[n].light_index = -(V11MODEL(model)->groups[group].vertex_colours[v] >> 24);
+                    data[n].light_index = -((struct old_v11model*)b_model->prepared)->groups[group].nvertices;
                     n += 1;
-                    V11MODEL(model)->groups[group].vertex_colours[v] = 0;
-                    if ((model->flags & 0x80) != 0) {
-                        model->vertices[V11MODEL(model)->groups[group].vertex_user[v]].index = 0;
+                    ((struct old_v11model*)b_model->prepared)->groups[group].vertex_colours[v] = 0;
+                    if ((b_model->flags & BR_MODF_UPDATEABLE) != 0) {
+                        b_model->vertices[((struct old_v11model*)b_model->prepared)->groups[group].vertex_user[v]].index = 0;
                     }
                     if (n >= COUNT_OF(data)) {
-                        group = V11MODEL(model)->ngroups;
+                        group = ((struct old_v11model*)b_model->prepared)->groups[group].nvertices;
                         break;
                     }
                 }
-                j += 1;
             }
         }
         if (n != 0) {
-            AddSmudgeToPipingSession(pCar->car_ID, pCar->principal_car_actor, n, data);
+            AddSmudgeToPipingSession(pCar->car_ID, pCar->car_actor_count - 1, n, data);
         }
-        if (bonny != actor) {
-            b_model = bonny->model;
-            n = 0;
-            j = 0;
-            for (group = 0; group < V11MODEL(b_model)->ngroups; group++) {
-                for (v = 0; v < V11MODEL(b_model)->groups[group].nvertices; v++) {
-                    if ((V11MODEL(b_model)->groups[group].vertex_colours[v] >> 24) != 0) {
-                        data[n].vertex_index = j;
-                        data[n].light_index = -V11MODEL(b_model)->groups[group].nvertices;
-                        n += 1;
-                        V11MODEL(b_model)->groups[group].vertex_colours[v] = 0;
-                        if ((b_model->flags & BR_MODF_UPDATEABLE) != 0) {
-                            b_model->vertices[V11MODEL(b_model)->groups[group].vertex_user[v]].index = 0;
-                        }
-                        if (n >= COUNT_OF(data)) {
-                            group = V11MODEL(b_model)->groups[group].nvertices;
-                            break;
-                        }
-                    }
-                    j += 1;
-                }
-            }
-            if (n != 0) {
-                AddSmudgeToPipingSession(pCar->car_ID, pCar->car_actor_count - 1, n, data);
-            }
-        }
-        EndPipingSession();
     }
+    EndPipingSession();
 }
 
 // IDA: void __usercall SmudgeCar(tCar_spec *pCar@<EAX>, int fire_point@<EDX>)


### PR DESCRIPTION
## Match result

```
0x46c29f: PipeInstantUnSmudge 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x46c29f,19 +0x4b309b,19 @@
0x46c29f : push ebp 	(spark.c:2207)
0x46c2a0 : mov ebp, esp
0x46c2a2 : sub esp, 0xfc0
0x46c2a8 : push ebx
0x46c2a9 : push esi
0x46c2aa : push edi
0x46c2ab : cmp dword ptr [gAction_replay_mode (DATA)], 0 	(spark.c:2218)
0x46c2b2 : -je 0x5
0x46c2b8 : -jmp 0x46b
         : +jne 0x5
         : +jmp 0x496 	(spark.c:2219)
0x46c2bd : mov eax, dword ptr [ebp + 8] 	(spark.c:2221)
0x46c2c0 : mov eax, dword ptr [eax + 0x66c]
0x46c2c6 : shl eax, 4
0x46c2c9 : lea eax, [eax + eax*2]
0x46c2cc : mov ecx, dword ptr [ebp + 8]
0x46c2cf : mov eax, dword ptr [eax + ecx + 0x12b8]
0x46c2d6 : mov dword ptr [ebp - 0xfc0], eax
0x46c2dc : mov eax, dword ptr [ebp - 0xfc0] 	(spark.c:2222)
0x46c2e2 : mov eax, dword ptr [eax + 0x18]
0x46c2e5 : mov dword ptr [ebp - 8], eax

---
+++
@@ -0x46c2f2,236 +0x4b30ee,249 @@
0x46c2f2 : shl eax, 4
0x46c2f5 : lea eax, [eax + eax*2]
0x46c2f8 : mov ecx, dword ptr [ebp + 8]
0x46c2fb : mov eax, dword ptr [eax + ecx + 0x12b8]
0x46c302 : mov dword ptr [ebp - 4], eax
0x46c305 : mov dword ptr [ebp - 0xfbc], 0 	(spark.c:2224)
0x46c30f : mov eax, dword ptr [ebp - 8] 	(spark.c:2225)
0x46c312 : xor ecx, ecx
0x46c314 : mov cx, word ptr [eax + 0x20]
0x46c318 : test cl, 2
0x46c31b : -jne 0x17
         : +jne 0x12
0x46c321 : mov eax, dword ptr [ebp - 8]
0x46c324 : xor ecx, ecx
0x46c326 : mov cx, word ptr [eax + 0x20]
0x46c32a : test cl, 0x80
0x46c32d : -jne 0x5
0x46c333 : -jmp 0x3f0
         : +je 0x420
0x46c338 : push 0x1c 	(spark.c:2226)
0x46c33a : call StartPipingSession (FUNCTION)
0x46c33f : add esp, 4
0x46c342 : mov dword ptr [ebp - 0xfb8], 0 	(spark.c:2227)
0x46c34c : mov dword ptr [ebp - 0xfb0], 0 	(spark.c:2228)
0x46c356 : jmp 0x6
0x46c35b : inc dword ptr [ebp - 0xfb0]
0x46c361 : mov eax, dword ptr [ebp - 8]
0x46c364 : mov eax, dword ptr [eax + 0x4c]
0x46c367 : xor ecx, ecx
0x46c369 : mov cx, word ptr [eax + 8]
0x46c36d : cmp ecx, dword ptr [ebp - 0xfb0]
0x46c373 : -jle 0x160
         : +jle 0x174
0x46c379 : mov dword ptr [ebp - 0xfb4], 0 	(spark.c:2229)
0x46c383 : -jmp 0xc
         : +jmp 0x6
0x46c388 : inc dword ptr [ebp - 0xfb4]
0x46c38e : -inc dword ptr [ebp - 0xfb8]
0x46c394 : mov eax, dword ptr [ebp - 8]
0x46c397 : mov eax, dword ptr [eax + 0x4c]
0x46c39a : mov eax, dword ptr [eax + 0x18]
0x46c39d : mov ecx, dword ptr [ebp - 0xfb0]
0x46c3a3 : shl ecx, 2
0x46c3a6 : -lea ecx, [ecx + ecx*8]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
0x46c3a9 : xor edx, edx
0x46c3ab : -mov dx, word ptr [eax + ecx + 0x1e]
         : +mov dx, word ptr [eax + ecx + 0x32]
0x46c3b0 : cmp edx, dword ptr [ebp - 0xfb4]
0x46c3b6 : -jle 0x118
         : +jle 0x12f
0x46c3bc : mov eax, dword ptr [ebp - 8] 	(spark.c:2230)
0x46c3bf : mov eax, dword ptr [eax + 0x4c]
0x46c3c2 : mov eax, dword ptr [eax + 0x18]
0x46c3c5 : mov ecx, dword ptr [ebp - 0xfb0]
0x46c3cb : shl ecx, 2
0x46c3ce : -lea ecx, [ecx + ecx*8]
0x46c3d1 : -mov eax, dword ptr [eax + ecx + 0x14]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x28]
0x46c3d5 : mov ecx, dword ptr [ebp - 0xfb4]
0x46c3db : mov eax, dword ptr [eax + ecx*4]
0x46c3de : -shr eax, 0x18
0x46c3e1 : -test al, al
0x46c3e3 : -je 0xe6
         : +and eax, 0xff000000
         : +xor ecx, ecx
         : +and ecx, 0xff000000
         : +cmp eax, ecx
         : +je 0xea
0x46c3e9 : mov eax, dword ptr [ebp - 0xfb8] 	(spark.c:2231)
0x46c3ef : mov ecx, dword ptr [ebp - 0xfbc]
0x46c3f5 : mov word ptr [ebp + ecx*4 - 0xfa8], ax
0x46c3fd : mov eax, dword ptr [ebp - 8] 	(spark.c:2232)
0x46c400 : mov eax, dword ptr [eax + 0x4c]
0x46c403 : mov eax, dword ptr [eax + 0x18]
0x46c406 : mov ecx, dword ptr [ebp - 0xfb0]
0x46c40c : shl ecx, 2
0x46c40f : -lea ecx, [ecx + ecx*8]
0x46c412 : -mov eax, dword ptr [eax + ecx + 0x14]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x28]
0x46c416 : mov ecx, dword ptr [ebp - 0xfb4]
0x46c41c : mov eax, dword ptr [eax + ecx*4]
0x46c41f : shr eax, 0x18
0x46c422 : -and eax, 0xff
0x46c427 : neg eax
0x46c429 : mov ecx, dword ptr [ebp - 0xfbc]
0x46c42f : mov word ptr [ebp + ecx*4 - 0xfa6], ax
0x46c437 : inc dword ptr [ebp - 0xfbc] 	(spark.c:2233)
0x46c43d : mov eax, dword ptr [ebp - 8] 	(spark.c:2234)
0x46c440 : mov eax, dword ptr [eax + 0x4c]
0x46c443 : mov eax, dword ptr [eax + 0x18]
0x46c446 : mov ecx, dword ptr [ebp - 0xfb0]
0x46c44c : shl ecx, 2
0x46c44f : -lea ecx, [ecx + ecx*8]
0x46c452 : -mov eax, dword ptr [eax + ecx + 0x14]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x28]
0x46c456 : mov ecx, dword ptr [ebp - 0xfb4]
0x46c45c : mov dword ptr [eax + ecx*4], 0
0x46c463 : mov eax, dword ptr [ebp - 8] 	(spark.c:2235)
0x46c466 : xor ecx, ecx
0x46c468 : mov cx, word ptr [eax + 0x20]
0x46c46c : test cl, 0x80
0x46c46f : -je 0x33
         : +je 0x36
0x46c475 : mov eax, dword ptr [ebp - 8] 	(spark.c:2236)
0x46c478 : mov eax, dword ptr [eax + 0x4c]
0x46c47b : mov eax, dword ptr [eax + 0x18]
0x46c47e : mov ecx, dword ptr [ebp - 0xfb0]
0x46c484 : shl ecx, 2
0x46c487 : -lea ecx, [ecx + ecx*8]
0x46c48a : -mov eax, dword ptr [eax + ecx + 0x18]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x2c]
0x46c48e : mov ecx, dword ptr [ebp - 0xfb4]
0x46c494 : xor edx, edx
0x46c496 : mov dx, word ptr [eax + ecx*2]
0x46c49a : lea eax, [edx + edx*4]
0x46c49d : mov ecx, dword ptr [ebp - 8]
0x46c4a0 : mov ecx, dword ptr [ecx + 8]
0x46c4a3 : mov byte ptr [ecx + eax*8 + 0x14], 0
0x46c4a8 : cmp dword ptr [ebp - 0xfbc], 0x3e8 	(spark.c:2238)
0x46c4b2 : jl 0x17
0x46c4b8 : mov eax, dword ptr [ebp - 8] 	(spark.c:2239)
0x46c4bb : mov eax, dword ptr [eax + 0x4c]
0x46c4be : xor ecx, ecx
0x46c4c0 : mov cx, word ptr [eax + 8]
0x46c4c4 : mov dword ptr [ebp - 0xfb0], ecx
0x46c4ca : -jmp 0x5
0x46c4cf : -jmp -0x14c
0x46c4d4 : -jmp -0x17e
         : +jmp 0xb 	(spark.c:2240)
         : +inc dword ptr [ebp - 0xfb8] 	(spark.c:2243)
         : +jmp -0x160 	(spark.c:2244)
         : +jmp -0x192 	(spark.c:2245)
0x46c4d9 : cmp dword ptr [ebp - 0xfbc], 0 	(spark.c:2246)
0x46c4e0 : je 0x2b
0x46c4e6 : lea eax, [ebp - 0xfa8] 	(spark.c:2247)
0x46c4ec : push eax
0x46c4ed : mov eax, dword ptr [ebp - 0xfbc]
0x46c4f3 : push eax
0x46c4f4 : mov eax, dword ptr [ebp + 8]
0x46c4f7 : mov eax, dword ptr [eax + 0x66c]
0x46c4fd : push eax
0x46c4fe : mov eax, dword ptr [ebp + 8]
0x46c501 : mov ax, word ptr [eax + 0x250]
0x46c508 : push eax
0x46c509 : call AddSmudgeToPipingSession (FUNCTION)
0x46c50e : add esp, 0x10
0x46c511 : mov eax, dword ptr [ebp - 0xfc0] 	(spark.c:2249)
0x46c517 : cmp dword ptr [ebp - 4], eax
0x46c51a : -je 0x203
         : +je 0x21f
0x46c520 : mov eax, dword ptr [ebp - 4] 	(spark.c:2250)
0x46c523 : mov eax, dword ptr [eax + 0x18]
0x46c526 : mov dword ptr [ebp - 0xfac], eax
0x46c52c : mov dword ptr [ebp - 0xfbc], 0 	(spark.c:2251)
0x46c536 : mov dword ptr [ebp - 0xfb8], 0 	(spark.c:2252)
0x46c540 : mov dword ptr [ebp - 0xfb0], 0 	(spark.c:2253)
0x46c54a : jmp 0x6
0x46c54f : inc dword ptr [ebp - 0xfb0]
0x46c555 : mov eax, dword ptr [ebp - 0xfac]
0x46c55b : mov eax, dword ptr [eax + 0x4c]
0x46c55e : xor ecx, ecx
0x46c560 : mov cx, word ptr [eax + 8]
0x46c564 : cmp ecx, dword ptr [ebp - 0xfb0]
0x46c56a : -jle 0x17a
         : +jle 0x196
0x46c570 : mov dword ptr [ebp - 0xfb4], 0 	(spark.c:2254)
0x46c57a : -jmp 0xc
         : +jmp 0x6
0x46c57f : inc dword ptr [ebp - 0xfb4]
0x46c585 : -inc dword ptr [ebp - 0xfb8]
0x46c58b : mov eax, dword ptr [ebp - 0xfac]
0x46c591 : mov eax, dword ptr [eax + 0x4c]
0x46c594 : mov eax, dword ptr [eax + 0x18]
0x46c597 : mov ecx, dword ptr [ebp - 0xfb0]
0x46c59d : shl ecx, 2
0x46c5a0 : -lea ecx, [ecx + ecx*8]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
0x46c5a3 : xor edx, edx
0x46c5a5 : -mov dx, word ptr [eax + ecx + 0x1e]
         : +mov dx, word ptr [eax + ecx + 0x32]
0x46c5aa : cmp edx, dword ptr [ebp - 0xfb4]
0x46c5b0 : -jle 0x12f
         : +jle 0x14e
0x46c5b6 : mov eax, dword ptr [ebp - 0xfac] 	(spark.c:2255)
0x46c5bc : mov eax, dword ptr [eax + 0x4c]
0x46c5bf : mov eax, dword ptr [eax + 0x18]
0x46c5c2 : mov ecx, dword ptr [ebp - 0xfb0]
0x46c5c8 : shl ecx, 2
0x46c5cb : -lea ecx, [ecx + ecx*8]
0x46c5ce : -mov eax, dword ptr [eax + ecx + 0x14]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x28]
0x46c5d2 : mov ecx, dword ptr [ebp - 0xfb4]
0x46c5d8 : mov eax, dword ptr [eax + ecx*4]
0x46c5db : -shr eax, 0x18
0x46c5de : -test al, al
0x46c5e0 : -je 0xfa
         : +and eax, 0xff000000
         : +xor ecx, ecx
         : +and ecx, 0xff000000
         : +cmp eax, ecx
         : +je 0x106
0x46c5e6 : mov eax, dword ptr [ebp - 0xfb8] 	(spark.c:2256)
0x46c5ec : mov ecx, dword ptr [ebp - 0xfbc]
0x46c5f2 : mov word ptr [ebp + ecx*4 - 0xfa8], ax
0x46c5fa : mov eax, dword ptr [ebp - 0xfac] 	(spark.c:2257)
0x46c600 : mov eax, dword ptr [eax + 0x4c]
0x46c603 : mov eax, dword ptr [eax + 0x18]
0x46c606 : mov ecx, dword ptr [ebp - 0xfb0]
0x46c60c : shl ecx, 2
0x46c60f : -lea ecx, [ecx + ecx*8]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
0x46c612 : xor edx, edx
0x46c614 : -mov dx, word ptr [eax + ecx + 0x1e]
         : +mov dx, word ptr [eax + ecx + 0x32]
0x46c619 : neg edx
0x46c61b : mov eax, dword ptr [ebp - 0xfbc]
0x46c621 : mov word ptr [ebp + eax*4 - 0xfa6], dx
0x46c629 : inc dword ptr [ebp - 0xfbc] 	(spark.c:2258)
0x46c62f : mov eax, dword ptr [ebp - 0xfac] 	(spark.c:2259)
0x46c635 : mov eax, dword ptr [eax + 0x4c]
0x46c638 : mov eax, dword ptr [eax + 0x18]
0x46c63b : mov ecx, dword ptr [ebp - 0xfb0]
0x46c641 : shl ecx, 2
0x46c644 : -lea ecx, [ecx + ecx*8]
0x46c647 : -mov eax, dword ptr [eax + ecx + 0x14]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x28]
0x46c64b : mov ecx, dword ptr [ebp - 0xfb4]
0x46c651 : mov dword ptr [eax + ecx*4], 0
0x46c658 : mov eax, dword ptr [ebp - 0xfac] 	(spark.c:2260)
0x46c65e : xor ecx, ecx
0x46c660 : mov cx, word ptr [eax + 0x20]
0x46c664 : test cl, 0x80
0x46c667 : -je 0x39
         : +je 0x3c
0x46c66d : mov eax, dword ptr [ebp - 0xfac] 	(spark.c:2261)
0x46c673 : mov eax, dword ptr [eax + 0x4c]
0x46c676 : mov eax, dword ptr [eax + 0x18]
0x46c679 : mov ecx, dword ptr [ebp - 0xfb0]
0x46c67f : shl ecx, 2
0x46c682 : -lea ecx, [ecx + ecx*8]
0x46c685 : -mov eax, dword ptr [eax + ecx + 0x18]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x2c]
0x46c689 : mov ecx, dword ptr [ebp - 0xfb4]
0x46c68f : xor edx, edx
0x46c691 : mov dx, word ptr [eax + ecx*2]
0x46c695 : lea eax, [edx + edx*4]
0x46c698 : mov ecx, dword ptr [ebp - 0xfac]
0x46c69e : mov ecx, dword ptr [ecx + 8]
0x46c6a1 : mov byte ptr [ecx + eax*8 + 0x14], 0
0x46c6a6 : cmp dword ptr [ebp - 0xfbc], 0x3e8 	(spark.c:2263)
0x46c6b0 : -jl 0x2a
         : +jl 0x2d
0x46c6b6 : mov eax, dword ptr [ebp - 0xfac] 	(spark.c:2264)
0x46c6bc : mov eax, dword ptr [eax + 0x4c]
0x46c6bf : mov eax, dword ptr [eax + 0x18]
0x46c6c2 : mov ecx, dword ptr [ebp - 0xfb0]
0x46c6c8 : shl ecx, 2
0x46c6cb : -lea ecx, [ecx + ecx*8]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
0x46c6ce : xor edx, edx
0x46c6d0 : -mov dx, word ptr [eax + ecx + 0x1e]
         : +mov dx, word ptr [eax + ecx + 0x32]
0x46c6d5 : mov dword ptr [ebp - 0xfb0], edx
0x46c6db : -jmp 0x5
0x46c6e0 : -jmp -0x166
0x46c6e5 : -jmp -0x19b
         : +jmp 0xb 	(spark.c:2265)
         : +inc dword ptr [ebp - 0xfb8] 	(spark.c:2268)
         : +jmp -0x182 	(spark.c:2269)
         : +jmp -0x1b7 	(spark.c:2270)
0x46c6ea : cmp dword ptr [ebp - 0xfbc], 0 	(spark.c:2271)
0x46c6f1 : je 0x2c
0x46c6f7 : lea eax, [ebp - 0xfa8] 	(spark.c:2272)
0x46c6fd : push eax
0x46c6fe : mov eax, dword ptr [ebp - 0xfbc]
0x46c704 : push eax
0x46c705 : mov eax, dword ptr [ebp + 8]
0x46c708 : mov eax, dword ptr [eax + 0x664]
0x46c70e : dec eax
0x46c70f : push eax


PipeInstantUnSmudge is only 78.77% similar to the original, diff above
```

*AI generated. Time taken: 783s, tokens: 164,816*
