### PR TITLE
Match SmudgeCar

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -2282,6 +2282,30 @@ void PipeInstantUnSmudge(tCar_spec* pCar) {
 // IDA: void __usercall SmudgeCar(tCar_spec *pCar@<EAX>, int fire_point@<EDX>)
 // FUNCTION: CARM95 0x0046c72d
 void SmudgeCar(tCar_spec* pCar, int fire_point) {
+    struct smudge_vertex {
+        br_vector3 p;
+        br_vector2 map;
+        br_vector3 normal;
+    };
+    struct smudge_group {
+        void* stored;
+        void* faces;
+        void* face_colours;
+        void* face_user;
+        struct smudge_vertex* vertices;
+        br_colour* vertex_colours;
+        tU16* vertex_user;
+        tU16 nfaces;
+        tU16 nvertices;
+        tU16 nedges;
+    };
+    struct smudge_model {
+        int size;
+        tU32 flags;
+        tU16 ngroups;
+        br_vector3 pivot;
+        struct smudge_group* groups;
+    };
     int v;
     int j;
     int real_vertex_number;
@@ -2308,24 +2332,71 @@ void SmudgeCar(tCar_spec* pCar, int fire_point) {
     bonny = pCar->car_model_actors[pCar->car_actor_count - 1].actor;
     n = 0;
     real_vertex_number = 0;
-    if ((model->flags & BR_MODF_KEEP_ORIGINAL) != 0 || (model->flags & BR_MODF_UPDATEABLE) != 0) {
-        point = V11MODEL(model)->groups[group].position[fire_point];
-        StartPipingSession(ePipe_chunk_smudge);
-        for (group = 0; group < V11MODEL(model)->ngroups; group++) {
-            for (j = 0; j < V11MODEL(model)->groups[group].nvertices; j++) {
-                BrVector3Sub(&tv, &V11MODEL(model)->groups[group].position[j], &point);
-                ts = (.0144f - BrVector3LengthSquared(&tv) / SRandomBetween(.5f, 1.f)) / .0144f * 127.f;
+    if ((model->flags & 0x2) == 0) {
+        if ((model->flags & 0x80) == 0) {
+            return;
+        }
+    }
+    point.v[0] = ((struct smudge_model*)model->prepared)->groups[group].vertices[v].p.v[0];
+    point.v[1] = ((struct smudge_model*)model->prepared)->groups[group].vertices[v].p.v[1];
+    point.v[2] = ((struct smudge_model*)model->prepared)->groups[group].vertices[v].p.v[2];
+    StartPipingSession(ePipe_chunk_smudge);
+    for (group = 0; group < ((struct smudge_model*)model->prepared)->ngroups; group++) {
+        for (j = 0; j < ((struct smudge_model*)model->prepared)->groups[group].nvertices; j++, real_vertex_number++) {
+            BrVector3Sub(&tv, &((struct smudge_model*)model->prepared)->groups[group].vertices[j].p, &point);
+            ts = (.0144f - (tv.v[1] * tv.v[1] + tv.v[2] * tv.v[2] + tv.v[0] * tv.v[0]) / SRandomBetween(.5f, 1.f)) / .0144f * 127.f;
+            if (ts > 0.f) {
+                ts += BR_ALPHA(((struct smudge_model*)model->prepared)->groups[group].vertex_colours[j]);
+                if (ts > 255.f) {
+                    ts = 255.f;
+                }
+                if (BR_ALPHA(((struct smudge_model*)model->prepared)->groups[group].vertex_colours[j]) != (int)ts) {
+                    data[n].vertex_index = real_vertex_number;
+                    data[n].light_index = (int)ts - BR_ALPHA(((struct smudge_model*)model->prepared)->groups[group].vertex_colours[j]);
+                    ((struct smudge_model*)model->prepared)->groups[group].vertex_colours[j] = (int)ts << 24;
+                    if ((model->flags & BR_MODF_UPDATEABLE) != 0) {
+                        model->vertices[((struct smudge_model*)model->prepared)->groups[group].vertex_user[j]].index = (int)ts;
+                    }
+                    n++;
+                    if (n >= COUNT_OF(data)) {
+                        break;
+                    }
+                }
+            }
+        }
+        if (n >= COUNT_OF(data)) {
+            break;
+        }
+    }
+    if (n != 0) {
+        AddSmudgeToPipingSession(pCar->car_ID, pCar->principal_car_actor, n, data);
+        // FIXME?
+        // Added by dethrace to update gpu-buffered vertices
+        // model->flags |= BR_MODF_DETHRACE_FORCE_BUFFER_UPDATE;
+    }
+
+    n = 0;
+    real_vertex_number = 0;
+    if (actor != bonny) {
+        b_model = bonny->model;
+        BrVector3Add(&tv, &actor->t.t.translate.t, &point);
+        BrVector3Sub(&tv, &tv, &bonny->t.t.translate.t);
+        BrMatrix34TApplyV(&bonny_pos, &tv, &bonny->t.t.mat);
+        for (group = 0; group < ((struct smudge_model*)b_model->prepared)->ngroups; group++) {
+            for (j = 0; j < ((struct smudge_model*)b_model->prepared)->groups[group].nvertices; j++, real_vertex_number++) {
+                BrVector3Sub(&tv, &((struct smudge_model*)b_model->prepared)->groups[group].vertices[j].p, &bonny_pos);
+                ts = (.0144f - (tv.v[1] * tv.v[1] + tv.v[2] * tv.v[2] + tv.v[0] * tv.v[0]) / SRandomBetween(.5f, 1.f)) / .0144f * 127.f;
                 if (ts > 0.f) {
-                    ts += BR_ALPHA(V11MODEL(model)->groups[group].vertex_colours[j]);
+                    ts += BR_ALPHA(((struct smudge_model*)b_model->prepared)->groups[group].vertex_colours[j]);
                     if (ts > 255.f) {
                         ts = 255.f;
                     }
-                    if (BR_ALPHA(V11MODEL(model)->groups[group].vertex_colours[j]) != (int)ts) {
+                    if (BR_ALPHA(((struct smudge_model*)b_model->prepared)->groups[group].vertex_colours[j]) != (int)ts) {
                         data[n].vertex_index = real_vertex_number;
-                        data[n].light_index = (int)ts - BR_ALPHA(V11MODEL(model)->groups[group].vertex_colours[j]);
-                        V11MODEL(model)->groups[group].vertex_colours[j] = (int)ts << 24;
-                        if ((model->flags & BR_MODF_UPDATEABLE) != 0) {
-                            model->vertices[V11MODEL(model)->groups[group].vertex_user[j]].index = (int)ts;
+                        data[n].light_index = (int)ts - BR_ALPHA(((struct smudge_model*)b_model->prepared)->groups[group].vertex_colours[j]);
+                        ((struct smudge_model*)b_model->prepared)->groups[group].vertex_colours[j] = (int)ts << 24;
+                        if ((b_model->flags & BR_MODF_UPDATEABLE) != 0) {
+                            b_model->vertices[((struct smudge_model*)b_model->prepared)->groups[group].vertex_user[j]].index = (int)ts;
                         }
                         n++;
                         if (n >= COUNT_OF(data)) {
@@ -2333,64 +2404,19 @@ void SmudgeCar(tCar_spec* pCar, int fire_point) {
                         }
                     }
                 }
-                real_vertex_number++;
             }
             if (n >= COUNT_OF(data)) {
                 break;
             }
         }
-        if (n > 0) {
-            AddSmudgeToPipingSession(pCar->car_ID, pCar->principal_car_actor, n, data);
+        if (n != 0) {
+            AddSmudgeToPipingSession(pCar->car_ID, pCar->car_actor_count - 1, n, data);
             // FIXME?
             // Added by dethrace to update gpu-buffered vertices
-            // model->flags |= BR_MODF_DETHRACE_FORCE_BUFFER_UPDATE;
+            // b_model->flags |= BR_MODF_DETHRACE_FORCE_BUFFER_UPDATE;
         }
-
-        n = 0;
-        real_vertex_number = 0;
-        if (actor != bonny) {
-            b_model = bonny->model;
-            BrVector3Add(&tv, &actor->t.t.translate.t, &point);
-            BrVector3Accumulate(&tv, &bonny->t.t.translate.t);
-            BrMatrix34TApplyV(&bonny_pos, &tv, &bonny->t.t.mat);
-            for (group = 0; group < V11MODEL(b_model)->ngroups; group++) {
-                j = 0;
-                for (j = 0; j < V11MODEL(b_model)->groups[group].nvertices; j++) {
-                    BrVector3Sub(&tv, &V11MODEL(b_model)->groups[group].position[j], &bonny_pos);
-                    ts = (.0144f - BrVector3LengthSquared(&tv) / SRandomBetween(.5f, 1.f)) / .0144f * 127.f;
-                    if (ts > 0.f) {
-                        ts += BR_ALPHA(V11MODEL(b_model)->groups[group].vertex_colours[j]);
-                        if (ts > 255.f) {
-                            ts = 255.f;
-                        }
-                        if (BR_ALPHA(V11MODEL(b_model)->groups[group].vertex_colours[j]) != (int)ts) {
-                            data[n].vertex_index = real_vertex_number;
-                            data[n].light_index = (int)ts - BR_ALPHA(V11MODEL(b_model)->groups[group].vertex_colours[j]);
-                            V11MODEL(b_model)->groups[group].vertex_colours[j] = (int)ts << 24;
-                            if ((b_model->flags & BR_MODF_UPDATEABLE) != 0) {
-                                b_model->vertices[V11MODEL(b_model)->groups[group].vertex_user[j]].index = (int)ts;
-                            }
-                            n++;
-                            if (n >= COUNT_OF(data)) {
-                                break;
-                            }
-                        }
-                    }
-                    real_vertex_number++;
-                }
-                if (n >= COUNT_OF(data)) {
-                    break;
-                }
-            }
-            if (n > 0) {
-                AddSmudgeToPipingSession(pCar->car_ID, pCar->car_actor_count - 1, n, data);
-                // FIXME?
-                // Added by dethrace to update gpu-buffered vertices
-                // b_model->flags |= BR_MODF_DETHRACE_FORCE_BUFFER_UPDATE;
-            }
-        }
-        EndPipingSession();
     }
+    EndPipingSession();
 }
 
 // IDA: void __cdecl ResetSmokeColumns()


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x46cb9e,22 +0x4b39cc,22 @@
0x46cb9e : mov eax, dword ptr [ebp + 8]
0x46cba1 : mov eax, dword ptr [eax + 0x66c]
0x46cba7 : push eax
0x46cba8 : mov eax, dword ptr [ebp + 8]
0x46cbab : mov ax, word ptr [eax + 0x250]
0x46cbb2 : push eax
0x46cbb3 : call AddSmudgeToPipingSession (FUNCTION)
0x46cbb8 : add esp, 0x10
0x46cbbb : mov dword ptr [ebp - 0xc0], 0 	(spark.c:2378)
0x46cbc5 : mov dword ptr [ebp - 8], 0 	(spark.c:2379)
0x46cbcc : -mov eax, dword ptr [ebp - 4]
0x46cbcf : -cmp dword ptr [ebp - 0xc4], eax
         : +mov eax, dword ptr [ebp - 0xc4] 	(spark.c:2380)
         : +cmp dword ptr [ebp - 4], eax
0x46cbd5 : je 0x411
0x46cbdb : mov eax, dword ptr [ebp - 4] 	(spark.c:2381)
0x46cbde : mov eax, dword ptr [eax + 0x18]
0x46cbe1 : mov dword ptr [ebp - 0x88], eax
0x46cbe7 : mov eax, dword ptr [ebp - 0xc4] 	(spark.c:2382)
0x46cbed : fld dword ptr [eax + 0x50]
0x46cbf0 : fadd dword ptr [ebp - 0xa4]
0x46cbf6 : fstp dword ptr [ebp - 0xbc]
0x46cbfc : mov eax, dword ptr [ebp - 0xc4]
0x46cc02 : fld dword ptr [eax + 0x54]


0x46c72d: SmudgeCar 100% effective match (differs, but only in ways that don't affect behavior).

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x46c72d,19 +0x4b355b,19 @@
0x46c72d : push ebp 	(spark.c:2284)
0x46c72e : mov ebp, esp
0x46c730 : sub esp, 0xd4
0x46c736 : push ebx
0x46c737 : push esi
0x46c738 : push edi
0x46c739 : cmp dword ptr [gAusterity_mode (DATA)], 0 	(spark.c:2300)
0x46c740 : je 0x5
0x46c746 : -jmp 0x8a6
         : +jmp 0x899 	(spark.c:2301)
0x46c74b : mov eax, dword ptr [ebp + 0xc] 	(spark.c:2304)
0x46c74e : mov dword ptr [ebp - 0x90], eax
0x46c754 : mov dword ptr [ebp - 0x8c], 0 	(spark.c:2305)
0x46c75e : mov eax, dword ptr [ebp + 8] 	(spark.c:2306)
0x46c761 : mov eax, dword ptr [eax + 0x66c]
0x46c767 : shl eax, 4
0x46c76a : lea eax, [eax + eax*2]
0x46c76d : mov ecx, dword ptr [ebp + 8]
0x46c770 : mov eax, dword ptr [eax + ecx + 0x12b8]
0x46c777 : mov dword ptr [ebp - 0xc4], eax

---
+++
@@ -0x46c796,120 +0x4b35c4,107 @@
0x46c796 : lea eax, [eax + eax*2]
0x46c799 : mov ecx, dword ptr [ebp + 8]
0x46c79c : mov eax, dword ptr [eax + ecx + 0x12b8]
0x46c7a3 : mov dword ptr [ebp - 4], eax
0x46c7a6 : mov dword ptr [ebp - 0xc0], 0 	(spark.c:2309)
0x46c7b0 : mov dword ptr [ebp - 8], 0 	(spark.c:2310)
0x46c7b7 : mov eax, dword ptr [ebp - 0xc] 	(spark.c:2311)
0x46c7ba : xor ecx, ecx
0x46c7bc : mov cx, word ptr [eax + 0x20]
0x46c7c0 : test cl, 2
0x46c7c3 : -jne 0x17
         : +jne 0x12
0x46c7c9 : mov eax, dword ptr [ebp - 0xc]
0x46c7cc : xor ecx, ecx
0x46c7ce : mov cx, word ptr [eax + 0x20]
0x46c7d2 : test cl, 0x80
0x46c7d5 : -jne 0x5
0x46c7db : -jmp 0x811
         : +je 0x809
0x46c7e0 : mov eax, dword ptr [ebp - 0xc] 	(spark.c:2312)
0x46c7e3 : mov eax, dword ptr [eax + 0x4c]
0x46c7e6 : mov eax, dword ptr [eax + 0x18]
0x46c7e9 : mov ecx, dword ptr [ebp - 0x8c]
0x46c7ef : shl ecx, 2
0x46c7f2 : -lea ecx, [ecx + ecx*8]
0x46c7f5 : -mov eax, dword ptr [eax + ecx + 0x10]
0x46c7f9 : -mov ecx, dword ptr [ebp - 0x90]
0x46c7ff : -shl ecx, 5
0x46c802 : -mov eax, dword ptr [eax + ecx]
0x46c805 : -mov dword ptr [ebp - 0xa4], eax
0x46c80b : -mov eax, dword ptr [ebp - 0xc]
0x46c80e : -mov eax, dword ptr [eax + 0x4c]
0x46c811 : -mov eax, dword ptr [eax + 0x18]
0x46c814 : -mov ecx, dword ptr [ebp - 0x8c]
0x46c81a : -shl ecx, 2
0x46c81d : -lea ecx, [ecx + ecx*8]
0x46c820 : -mov eax, dword ptr [eax + ecx + 0x10]
0x46c824 : -mov ecx, dword ptr [ebp - 0x90]
0x46c82a : -shl ecx, 5
0x46c82d : -mov eax, dword ptr [eax + ecx + 4]
0x46c831 : -mov dword ptr [ebp - 0xa0], eax
0x46c837 : -mov eax, dword ptr [ebp - 0xc]
0x46c83a : -mov eax, dword ptr [eax + 0x4c]
0x46c83d : -mov eax, dword ptr [eax + 0x18]
0x46c840 : -mov ecx, dword ptr [ebp - 0x8c]
0x46c846 : -shl ecx, 2
0x46c849 : -lea ecx, [ecx + ecx*8]
0x46c84c : -mov eax, dword ptr [eax + ecx + 0x10]
0x46c850 : -mov ecx, dword ptr [ebp - 0x90]
0x46c856 : -shl ecx, 5
0x46c859 : -mov eax, dword ptr [eax + ecx + 8]
0x46c85d : -mov dword ptr [ebp - 0x9c], eax
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x1c]
         : +mov ecx, dword ptr [ebp + 0xc]
         : +lea ecx, [ecx + ecx*2]
         : +lea eax, [eax + ecx*4]
         : +lea ecx, [ebp - 0xa4]
         : +mov edx, dword ptr [eax]
         : +mov dword ptr [ecx], edx
         : +mov edx, dword ptr [eax + 4]
         : +mov dword ptr [ecx + 4], edx
         : +mov eax, dword ptr [eax + 8]
         : +mov dword ptr [ecx + 8], eax
0x46c863 : push 0x1c 	(spark.c:2313)
0x46c865 : call StartPipingSession (FUNCTION)
0x46c86a : add esp, 4
0x46c86d : mov dword ptr [ebp - 0x8c], 0 	(spark.c:2314)
0x46c877 : jmp 0x6
0x46c87c : inc dword ptr [ebp - 0x8c]
0x46c882 : mov eax, dword ptr [ebp - 0xc]
0x46c885 : mov eax, dword ptr [eax + 0x4c]
0x46c888 : xor ecx, ecx
0x46c88a : mov cx, word ptr [eax + 8]
0x46c88e : cmp ecx, dword ptr [ebp - 0x8c]
0x46c894 : -jle 0x2e9
         : +jle 0x304
0x46c89a : mov dword ptr [ebp - 0x98], 0 	(spark.c:2315)
0x46c8a4 : -jmp 0x9
         : +jmp 0x6
0x46c8a9 : inc dword ptr [ebp - 0x98]
0x46c8af : -inc dword ptr [ebp - 8]
0x46c8b2 : mov eax, dword ptr [ebp - 0xc]
0x46c8b5 : mov eax, dword ptr [eax + 0x4c]
0x46c8b8 : mov eax, dword ptr [eax + 0x18]
0x46c8bb : mov ecx, dword ptr [ebp - 0x8c]
0x46c8c1 : shl ecx, 2
0x46c8c4 : -lea ecx, [ecx + ecx*8]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
0x46c8c7 : xor edx, edx
0x46c8c9 : -mov dx, word ptr [eax + ecx + 0x1e]
         : +mov dx, word ptr [eax + ecx + 0x32]
0x46c8ce : cmp edx, dword ptr [ebp - 0x98]
0x46c8d4 : -jle 0x292
         : +jle 0x2ad
0x46c8da : mov eax, dword ptr [ebp - 0xc] 	(spark.c:2316)
0x46c8dd : mov eax, dword ptr [eax + 0x4c]
0x46c8e0 : mov eax, dword ptr [eax + 0x18]
0x46c8e3 : mov ecx, dword ptr [ebp - 0x8c]
0x46c8e9 : shl ecx, 2
0x46c8ec : -lea ecx, [ecx + ecx*8]
0x46c8ef : -mov eax, dword ptr [eax + ecx + 0x10]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x1c]
0x46c8f3 : mov ecx, dword ptr [ebp - 0x98]
0x46c8f9 : -shl ecx, 5
0x46c8fc : -fld dword ptr [eax + ecx]
         : +lea ecx, [ecx + ecx*2]
         : +fld dword ptr [eax + ecx*4]
0x46c8ff : fsub dword ptr [ebp - 0xa4]
0x46c905 : fstp dword ptr [ebp - 0xbc]
0x46c90b : mov eax, dword ptr [ebp - 0xc]
0x46c90e : mov eax, dword ptr [eax + 0x4c]
0x46c911 : mov eax, dword ptr [eax + 0x18]
0x46c914 : mov ecx, dword ptr [ebp - 0x8c]
0x46c91a : shl ecx, 2
0x46c91d : -lea ecx, [ecx + ecx*8]
0x46c920 : -mov eax, dword ptr [eax + ecx + 0x10]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x1c]
0x46c924 : mov ecx, dword ptr [ebp - 0x98]
0x46c92a : -shl ecx, 5
0x46c92d : -fld dword ptr [eax + ecx + 4]
         : +lea ecx, [ecx + ecx*2]
         : +fld dword ptr [eax + ecx*4 + 4]
0x46c931 : fsub dword ptr [ebp - 0xa0]
0x46c937 : fstp dword ptr [ebp - 0xb8]
0x46c93d : mov eax, dword ptr [ebp - 0xc]
0x46c940 : mov eax, dword ptr [eax + 0x4c]
0x46c943 : mov eax, dword ptr [eax + 0x18]
0x46c946 : mov ecx, dword ptr [ebp - 0x8c]
0x46c94c : shl ecx, 2
0x46c94f : -lea ecx, [ecx + ecx*8]
0x46c952 : -mov eax, dword ptr [eax + ecx + 0x10]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x1c]
0x46c956 : mov ecx, dword ptr [ebp - 0x98]
0x46c95c : -shl ecx, 5
0x46c95f : -fld dword ptr [eax + ecx + 8]
         : +lea ecx, [ecx + ecx*2]
         : +fld dword ptr [eax + ecx*4 + 8]
0x46c963 : fsub dword ptr [ebp - 0x9c]
0x46c969 : fstp dword ptr [ebp - 0xb4]
0x46c96f : push 0x3f800000 	(spark.c:2317)
0x46c974 : push 0x3f000000
0x46c979 : call SRandomBetween (FUNCTION)
0x46c97e : add esp, 8
0x46c981 : fld dword ptr [ebp - 0xb8]
0x46c987 : fmul dword ptr [ebp - 0xb8]
0x46c98d : fld dword ptr [ebp - 0xb4]
0x46c993 : fmul dword ptr [ebp - 0xb4]

---
+++
@@ -0x46c9a1,230 +0x4b378b,240 @@
0x46c9a1 : fmul dword ptr [ebp - 0xbc]
0x46c9a7 : faddp st(1)
0x46c9a9 : fdivrp st(1)
0x46c9ab : fsubr dword ptr [0.014399999752640724 (FLOAT)]
0x46c9b1 : fdiv dword ptr [0.014399999752640724 (FLOAT)]
0x46c9b7 : fmul dword ptr [127.0 (FLOAT)]
0x46c9bd : fcom dword ptr [0.0 (FLOAT)] 	(spark.c:2318)
0x46c9c3 : fstp dword ptr [ebp - 0x94]
0x46c9c9 : fnstsw ax
0x46c9cb : test ah, 0x41
0x46c9ce : -jne 0x193
         : +jne 0x1a2
0x46c9d4 : mov eax, dword ptr [ebp - 0xc] 	(spark.c:2319)
0x46c9d7 : mov eax, dword ptr [eax + 0x4c]
0x46c9da : mov eax, dword ptr [eax + 0x18]
0x46c9dd : mov ecx, dword ptr [ebp - 0x8c]
0x46c9e3 : shl ecx, 2
0x46c9e6 : -lea ecx, [ecx + ecx*8]
0x46c9e9 : -mov eax, dword ptr [eax + ecx + 0x14]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x28]
0x46c9ed : mov ecx, dword ptr [ebp - 0x98]
0x46c9f3 : mov eax, dword ptr [eax + ecx*4]
0x46c9f6 : shr eax, 0x18
0x46c9f9 : and eax, 0xff
0x46c9fe : mov dword ptr [ebp - 0xcc], eax
0x46ca04 : mov dword ptr [ebp - 0xc8], 0
0x46ca0e : fild qword ptr [ebp - 0xcc]
0x46ca14 : fadd dword ptr [ebp - 0x94]
0x46ca1a : fcom dword ptr [255.0 (FLOAT)] 	(spark.c:2320)
0x46ca20 : fstp dword ptr [ebp - 0x94]
0x46ca26 : fnstsw ax
0x46ca28 : test ah, 0x41
0x46ca2b : jne 0xa
0x46ca31 : mov dword ptr [ebp - 0x94], 0x437f0000 	(spark.c:2321)
0x46ca3b : mov eax, dword ptr [ebp - 0xc] 	(spark.c:2323)
0x46ca3e : mov eax, dword ptr [eax + 0x4c]
0x46ca41 : mov eax, dword ptr [eax + 0x18]
0x46ca44 : mov ecx, dword ptr [ebp - 0x8c]
0x46ca4a : shl ecx, 2
0x46ca4d : -lea ecx, [ecx + ecx*8]
0x46ca50 : -mov eax, dword ptr [eax + ecx + 0x14]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x28]
0x46ca54 : mov ecx, dword ptr [ebp - 0x98]
0x46ca5a : mov ebx, dword ptr [eax + ecx*4]
0x46ca5d : shr ebx, 0x18
0x46ca60 : and ebx, 0xff
0x46ca66 : fld dword ptr [ebp - 0x94]
0x46ca6c : call __ftol (FUNCTION)
0x46ca71 : cmp ebx, eax
0x46ca73 : -je 0xee
         : +je 0xf7
0x46ca79 : mov eax, dword ptr [ebp - 8] 	(spark.c:2324)
0x46ca7c : mov ecx, dword ptr [ebp - 0xc0]
0x46ca82 : mov word ptr [ebp + ecx*4 - 0x84], ax
0x46ca8a : fld dword ptr [ebp - 0x94] 	(spark.c:2325)
0x46ca90 : call __ftol (FUNCTION)
0x46ca95 : mov ecx, dword ptr [ebp - 0xc]
0x46ca98 : mov ecx, dword ptr [ecx + 0x4c]
0x46ca9b : mov ecx, dword ptr [ecx + 0x18]
0x46ca9e : mov edx, dword ptr [ebp - 0x8c]
0x46caa4 : shl edx, 2
0x46caa7 : -lea edx, [edx + edx*8]
0x46caaa : -mov ecx, dword ptr [ecx + edx + 0x14]
         : +lea edx, [edx + edx*2]
         : +lea edx, [edx + edx*4]
         : +mov ecx, dword ptr [ecx + edx + 0x28]
0x46caae : mov edx, dword ptr [ebp - 0x98]
0x46cab4 : mov ecx, dword ptr [ecx + edx*4]
0x46cab7 : shr ecx, 0x18
0x46caba : and ecx, 0xff
0x46cac0 : sub eax, ecx
0x46cac2 : mov ecx, dword ptr [ebp - 0xc0]
0x46cac8 : mov word ptr [ebp + ecx*4 - 0x82], ax
0x46cad0 : fld dword ptr [ebp - 0x94] 	(spark.c:2326)
0x46cad6 : call __ftol (FUNCTION)
0x46cadb : shl eax, 0x18
0x46cade : mov ecx, dword ptr [ebp - 0xc]
0x46cae1 : mov ecx, dword ptr [ecx + 0x4c]
0x46cae4 : mov ecx, dword ptr [ecx + 0x18]
0x46cae7 : mov edx, dword ptr [ebp - 0x8c]
0x46caed : shl edx, 2
0x46caf0 : -lea edx, [edx + edx*8]
0x46caf3 : -mov ecx, dword ptr [ecx + edx + 0x14]
         : +lea edx, [edx + edx*2]
         : +lea edx, [edx + edx*4]
         : +mov ecx, dword ptr [ecx + edx + 0x28]
0x46caf7 : mov edx, dword ptr [ebp - 0x98]
0x46cafd : mov dword ptr [ecx + edx*4], eax
0x46cb00 : mov eax, dword ptr [ebp - 0xc] 	(spark.c:2327)
0x46cb03 : xor ecx, ecx
0x46cb05 : mov cx, word ptr [eax + 0x20]
0x46cb09 : test cl, 0x80
0x46cb0c : -je 0x3d
         : +je 0x40
0x46cb12 : fld dword ptr [ebp - 0x94] 	(spark.c:2328)
0x46cb18 : call __ftol (FUNCTION)
0x46cb1d : mov ecx, dword ptr [ebp - 0xc]
0x46cb20 : mov ecx, dword ptr [ecx + 0x4c]
0x46cb23 : mov ecx, dword ptr [ecx + 0x18]
0x46cb26 : mov edx, dword ptr [ebp - 0x8c]
0x46cb2c : shl edx, 2
0x46cb2f : -lea edx, [edx + edx*8]
0x46cb32 : -mov ecx, dword ptr [ecx + edx + 0x18]
         : +lea edx, [edx + edx*2]
         : +lea edx, [edx + edx*4]
         : +mov ecx, dword ptr [ecx + edx + 0x2c]
0x46cb36 : mov edx, dword ptr [ebp - 0x98]
0x46cb3c : xor ebx, ebx
0x46cb3e : mov bx, word ptr [ecx + edx*2]
0x46cb42 : lea ecx, [ebx + ebx*4]
0x46cb45 : mov edx, dword ptr [ebp - 0xc]
0x46cb48 : mov edx, dword ptr [edx + 8]
0x46cb4b : mov byte ptr [edx + ecx*8 + 0x14], al
0x46cb4f : inc dword ptr [ebp - 0xc0] 	(spark.c:2330)
0x46cb55 : cmp dword ptr [ebp - 0xc0], 0x1e 	(spark.c:2331)
0x46cb5c : jl 0x5
0x46cb62 : -jmp 0x5
0x46cb67 : -jmp -0x2c3
         : +jmp 0x8 	(spark.c:2332)
         : +inc dword ptr [ebp - 8] 	(spark.c:2336)
         : +jmp -0x2de 	(spark.c:2337)
0x46cb6c : cmp dword ptr [ebp - 0xc0], 0x1e 	(spark.c:2338)
0x46cb73 : jl 0x5
0x46cb79 : jmp 0x5 	(spark.c:2339)
0x46cb7e : -jmp -0x307
         : +jmp -0x322 	(spark.c:2341)
0x46cb83 : cmp dword ptr [ebp - 0xc0], 0 	(spark.c:2342)
0x46cb8a : -je 0x2b
         : +jle 0x2b
0x46cb90 : lea eax, [ebp - 0x84] 	(spark.c:2343)
0x46cb96 : push eax
0x46cb97 : mov eax, dword ptr [ebp - 0xc0]
0x46cb9d : push eax
0x46cb9e : mov eax, dword ptr [ebp + 8]
0x46cba1 : mov eax, dword ptr [eax + 0x66c]
0x46cba7 : push eax
0x46cba8 : mov eax, dword ptr [ebp + 8]
0x46cbab : mov ax, word ptr [eax + 0x250]
0x46cbb2 : push eax
0x46cbb3 : call AddSmudgeToPipingSession (FUNCTION)
0x46cbb8 : add esp, 0x10
0x46cbbb : mov dword ptr [ebp - 0xc0], 0 	(spark.c:2349)
0x46cbc5 : mov dword ptr [ebp - 8], 0 	(spark.c:2350)
0x46cbcc : -mov eax, dword ptr [ebp - 4]
0x46cbcf : -cmp dword ptr [ebp - 0xc4], eax
0x46cbd5 : -je 0x411
         : +mov eax, dword ptr [ebp - 0xc4] 	(spark.c:2351)
         : +cmp dword ptr [ebp - 4], eax
         : +je 0x436
0x46cbdb : mov eax, dword ptr [ebp - 4] 	(spark.c:2352)
0x46cbde : mov eax, dword ptr [eax + 0x18]
0x46cbe1 : mov dword ptr [ebp - 0x88], eax
0x46cbe7 : mov eax, dword ptr [ebp - 0xc4] 	(spark.c:2353)
0x46cbed : fld dword ptr [eax + 0x50]
0x46cbf0 : fadd dword ptr [ebp - 0xa4]
0x46cbf6 : fstp dword ptr [ebp - 0xbc]
0x46cbfc : mov eax, dword ptr [ebp - 0xc4]
0x46cc02 : fld dword ptr [eax + 0x54]
0x46cc05 : fadd dword ptr [ebp - 0xa0]
0x46cc0b : fstp dword ptr [ebp - 0xb8]
0x46cc11 : mov eax, dword ptr [ebp - 0xc4]
0x46cc17 : fld dword ptr [eax + 0x58]
0x46cc1a : fadd dword ptr [ebp - 0x9c]
0x46cc20 : fstp dword ptr [ebp - 0xb4]
0x46cc26 : -fld dword ptr [ebp - 0xbc]
0x46cc2c : mov eax, dword ptr [ebp - 4] 	(spark.c:2354)
0x46cc2f : -fsub dword ptr [eax + 0x50]
         : +fld dword ptr [eax + 0x50]
         : +fadd dword ptr [ebp - 0xbc]
0x46cc32 : fstp dword ptr [ebp - 0xbc]
0x46cc38 : -fld dword ptr [ebp - 0xb8]
0x46cc3e : mov eax, dword ptr [ebp - 4]
0x46cc41 : -fsub dword ptr [eax + 0x54]
         : +fld dword ptr [eax + 0x54]
         : +fadd dword ptr [ebp - 0xb8]
0x46cc44 : fstp dword ptr [ebp - 0xb8]
0x46cc4a : -fld dword ptr [ebp - 0xb4]
0x46cc50 : mov eax, dword ptr [ebp - 4]
0x46cc53 : -fsub dword ptr [eax + 0x58]
         : +fld dword ptr [eax + 0x58]
         : +fadd dword ptr [ebp - 0xb4]
0x46cc56 : fstp dword ptr [ebp - 0xb4]
0x46cc5c : mov eax, dword ptr [ebp - 4] 	(spark.c:2355)
0x46cc5f : add eax, 0x2c
0x46cc62 : push eax
0x46cc63 : lea eax, [ebp - 0xbc]
0x46cc69 : push eax
0x46cc6a : lea eax, [ebp - 0xb0]
0x46cc70 : push eax
0x46cc71 : call BrMatrix34TApplyV (FUNCTION)
0x46cc76 : add esp, 0xc
0x46cc79 : mov dword ptr [ebp - 0x8c], 0 	(spark.c:2356)
0x46cc83 : jmp 0x6
0x46cc88 : inc dword ptr [ebp - 0x8c]
0x46cc8e : mov eax, dword ptr [ebp - 0x88]
0x46cc94 : mov eax, dword ptr [eax + 0x4c]
0x46cc97 : xor ecx, ecx
0x46cc99 : mov cx, word ptr [eax + 8]
0x46cc9d : cmp ecx, dword ptr [ebp - 0x8c]
0x46cca3 : -jle 0x30a
         : +jle 0x32f
0x46cca9 : mov dword ptr [ebp - 0x98], 0 	(spark.c:2357)
0x46ccb3 : -jmp 0x9
         : +mov dword ptr [ebp - 0x98], 0 	(spark.c:2358)
         : +jmp 0x6
0x46ccb8 : inc dword ptr [ebp - 0x98]
0x46ccbe : -inc dword ptr [ebp - 8]
0x46ccc1 : mov eax, dword ptr [ebp - 0x88]
0x46ccc7 : mov eax, dword ptr [eax + 0x4c]
0x46ccca : mov eax, dword ptr [eax + 0x18]
0x46cccd : mov ecx, dword ptr [ebp - 0x8c]
0x46ccd3 : shl ecx, 2
0x46ccd6 : -lea ecx, [ecx + ecx*8]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
0x46ccd9 : xor edx, edx
0x46ccdb : -mov dx, word ptr [eax + ecx + 0x1e]
         : +mov dx, word ptr [eax + ecx + 0x32]
0x46cce0 : cmp edx, dword ptr [ebp - 0x98]
0x46cce6 : -jle 0x2b0
         : +jle 0x2cb
0x46ccec : mov eax, dword ptr [ebp - 0x88] 	(spark.c:2359)
0x46ccf2 : mov eax, dword ptr [eax + 0x4c]
0x46ccf5 : mov eax, dword ptr [eax + 0x18]
0x46ccf8 : mov ecx, dword ptr [ebp - 0x8c]
0x46ccfe : shl ecx, 2
0x46cd01 : -lea ecx, [ecx + ecx*8]
0x46cd04 : -mov eax, dword ptr [eax + ecx + 0x10]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x1c]
0x46cd08 : mov ecx, dword ptr [ebp - 0x98]
0x46cd0e : -shl ecx, 5
0x46cd11 : -fld dword ptr [eax + ecx]
         : +lea ecx, [ecx + ecx*2]
         : +fld dword ptr [eax + ecx*4]
0x46cd14 : fsub dword ptr [ebp - 0xb0]
0x46cd1a : fstp dword ptr [ebp - 0xbc]
0x46cd20 : mov eax, dword ptr [ebp - 0x88]
0x46cd26 : mov eax, dword ptr [eax + 0x4c]
0x46cd29 : mov eax, dword ptr [eax + 0x18]
0x46cd2c : mov ecx, dword ptr [ebp - 0x8c]
0x46cd32 : shl ecx, 2
0x46cd35 : -lea ecx, [ecx + ecx*8]
0x46cd38 : -mov eax, dword ptr [eax + ecx + 0x10]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x1c]
0x46cd3c : mov ecx, dword ptr [ebp - 0x98]
0x46cd42 : -shl ecx, 5
0x46cd45 : -fld dword ptr [eax + ecx + 4]
         : +lea ecx, [ecx + ecx*2]
         : +fld dword ptr [eax + ecx*4 + 4]
0x46cd49 : fsub dword ptr [ebp - 0xac]
0x46cd4f : fstp dword ptr [ebp - 0xb8]
0x46cd55 : mov eax, dword ptr [ebp - 0x88]
0x46cd5b : mov eax, dword ptr [eax + 0x4c]
0x46cd5e : mov eax, dword ptr [eax + 0x18]
0x46cd61 : mov ecx, dword ptr [ebp - 0x8c]
0x46cd67 : shl ecx, 2
0x46cd6a : -lea ecx, [ecx + ecx*8]
0x46cd6d : -mov eax, dword ptr [eax + ecx + 0x10]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x1c]
0x46cd71 : mov ecx, dword ptr [ebp - 0x98]
0x46cd77 : -shl ecx, 5
0x46cd7a : -fld dword ptr [eax + ecx + 8]
         : +lea ecx, [ecx + ecx*2]
         : +fld dword ptr [eax + ecx*4 + 8]
0x46cd7e : fsub dword ptr [ebp - 0xa8]
0x46cd84 : fstp dword ptr [ebp - 0xb4]
0x46cd8a : push 0x3f800000 	(spark.c:2360)
0x46cd8f : push 0x3f000000
0x46cd94 : call SRandomBetween (FUNCTION)
0x46cd99 : add esp, 8
0x46cd9c : fld dword ptr [ebp - 0xb8]
0x46cda2 : fmul dword ptr [ebp - 0xb8]
0x46cda8 : fld dword ptr [ebp - 0xb4]
0x46cdae : fmul dword ptr [ebp - 0xb4]

---
+++
@@ -0x46cdbc,122 +0x4b3bcb,135 @@
0x46cdbc : fmul dword ptr [ebp - 0xbc]
0x46cdc2 : faddp st(1)
0x46cdc4 : fdivrp st(1)
0x46cdc6 : fsubr dword ptr [0.014399999752640724 (FLOAT)]
0x46cdcc : fdiv dword ptr [0.014399999752640724 (FLOAT)]
0x46cdd2 : fmul dword ptr [127.0 (FLOAT)]
0x46cdd8 : fcom dword ptr [0.0 (FLOAT)] 	(spark.c:2361)
0x46cdde : fstp dword ptr [ebp - 0x94]
0x46cde4 : fnstsw ax
0x46cde6 : test ah, 0x41
0x46cde9 : -jne 0x1a8
         : +jne 0x1b7
0x46cdef : mov eax, dword ptr [ebp - 0x88] 	(spark.c:2362)
0x46cdf5 : mov eax, dword ptr [eax + 0x4c]
0x46cdf8 : mov eax, dword ptr [eax + 0x18]
0x46cdfb : mov ecx, dword ptr [ebp - 0x8c]
0x46ce01 : shl ecx, 2
0x46ce04 : -lea ecx, [ecx + ecx*8]
0x46ce07 : -mov eax, dword ptr [eax + ecx + 0x14]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x28]
0x46ce0b : mov ecx, dword ptr [ebp - 0x98]
0x46ce11 : mov eax, dword ptr [eax + ecx*4]
0x46ce14 : shr eax, 0x18
0x46ce17 : and eax, 0xff
0x46ce1c : mov dword ptr [ebp - 0xd4], eax
0x46ce22 : mov dword ptr [ebp - 0xd0], 0
0x46ce2c : fild qword ptr [ebp - 0xd4]
0x46ce32 : fadd dword ptr [ebp - 0x94]
0x46ce38 : fcom dword ptr [255.0 (FLOAT)] 	(spark.c:2363)
0x46ce3e : fstp dword ptr [ebp - 0x94]
0x46ce44 : fnstsw ax
0x46ce46 : test ah, 0x41
0x46ce49 : jne 0xa
0x46ce4f : mov dword ptr [ebp - 0x94], 0x437f0000 	(spark.c:2364)
0x46ce59 : mov eax, dword ptr [ebp - 0x88] 	(spark.c:2366)
0x46ce5f : mov eax, dword ptr [eax + 0x4c]
0x46ce62 : mov eax, dword ptr [eax + 0x18]
0x46ce65 : mov ecx, dword ptr [ebp - 0x8c]
0x46ce6b : shl ecx, 2
0x46ce6e : -lea ecx, [ecx + ecx*8]
0x46ce71 : -mov eax, dword ptr [eax + ecx + 0x14]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x28]
0x46ce75 : mov ecx, dword ptr [ebp - 0x98]
0x46ce7b : mov ebx, dword ptr [eax + ecx*4]
0x46ce7e : shr ebx, 0x18
0x46ce81 : and ebx, 0xff
0x46ce87 : fld dword ptr [ebp - 0x94]
0x46ce8d : call __ftol (FUNCTION)
0x46ce92 : cmp ebx, eax
0x46ce94 : -je 0xfd
         : +je 0x106
0x46ce9a : mov eax, dword ptr [ebp - 8] 	(spark.c:2367)
0x46ce9d : mov ecx, dword ptr [ebp - 0xc0]
0x46cea3 : mov word ptr [ebp + ecx*4 - 0x84], ax
0x46ceab : fld dword ptr [ebp - 0x94] 	(spark.c:2368)
0x46ceb1 : call __ftol (FUNCTION)
0x46ceb6 : mov ecx, dword ptr [ebp - 0x88]
0x46cebc : mov ecx, dword ptr [ecx + 0x4c]
0x46cebf : mov ecx, dword ptr [ecx + 0x18]
0x46cec2 : mov edx, dword ptr [ebp - 0x8c]
0x46cec8 : shl edx, 2
0x46cecb : -lea edx, [edx + edx*8]
0x46cece : -mov ecx, dword ptr [ecx + edx + 0x14]
         : +lea edx, [edx + edx*2]
         : +lea edx, [edx + edx*4]
         : +mov ecx, dword ptr [ecx + edx + 0x28]
0x46ced2 : mov edx, dword ptr [ebp - 0x98]
0x46ced8 : mov ecx, dword ptr [ecx + edx*4]
0x46cedb : shr ecx, 0x18
0x46cede : and ecx, 0xff
0x46cee4 : sub eax, ecx
0x46cee6 : mov ecx, dword ptr [ebp - 0xc0]
0x46ceec : mov word ptr [ebp + ecx*4 - 0x82], ax
0x46cef4 : fld dword ptr [ebp - 0x94] 	(spark.c:2369)
0x46cefa : call __ftol (FUNCTION)
0x46ceff : shl eax, 0x18
0x46cf02 : mov ecx, dword ptr [ebp - 0x88]
0x46cf08 : mov ecx, dword ptr [ecx + 0x4c]
0x46cf0b : mov ecx, dword ptr [ecx + 0x18]
0x46cf0e : mov edx, dword ptr [ebp - 0x8c]
0x46cf14 : shl edx, 2
0x46cf17 : -lea edx, [edx + edx*8]
0x46cf1a : -mov ecx, dword ptr [ecx + edx + 0x14]
         : +lea edx, [edx + edx*2]
         : +lea edx, [edx + edx*4]
         : +mov ecx, dword ptr [ecx + edx + 0x28]
0x46cf1e : mov edx, dword ptr [ebp - 0x98]
0x46cf24 : mov dword ptr [ecx + edx*4], eax
0x46cf27 : mov eax, dword ptr [ebp - 0x88] 	(spark.c:2370)
0x46cf2d : xor ecx, ecx
0x46cf2f : mov cx, word ptr [eax + 0x20]
0x46cf33 : test cl, 0x80
0x46cf36 : -je 0x43
         : +je 0x46
0x46cf3c : fld dword ptr [ebp - 0x94] 	(spark.c:2371)
0x46cf42 : call __ftol (FUNCTION)
0x46cf47 : mov ecx, dword ptr [ebp - 0x88]
0x46cf4d : mov ecx, dword ptr [ecx + 0x4c]
0x46cf50 : mov ecx, dword ptr [ecx + 0x18]
0x46cf53 : mov edx, dword ptr [ebp - 0x8c]
0x46cf59 : shl edx, 2
0x46cf5c : -lea edx, [edx + edx*8]
0x46cf5f : -mov ecx, dword ptr [ecx + edx + 0x18]
         : +lea edx, [edx + edx*2]
         : +lea edx, [edx + edx*4]
         : +mov ecx, dword ptr [ecx + edx + 0x2c]
0x46cf63 : mov edx, dword ptr [ebp - 0x98]
0x46cf69 : xor ebx, ebx
0x46cf6b : mov bx, word ptr [ecx + edx*2]
0x46cf6f : lea ecx, [ebx + ebx*4]
0x46cf72 : mov edx, dword ptr [ebp - 0x88]
0x46cf78 : mov edx, dword ptr [edx + 8]
0x46cf7b : mov byte ptr [edx + ecx*8 + 0x14], al
0x46cf7f : inc dword ptr [ebp - 0xc0] 	(spark.c:2373)
0x46cf85 : cmp dword ptr [ebp - 0xc0], 0x1e 	(spark.c:2374)
0x46cf8c : jl 0x5
0x46cf92 : -jmp 0x5
0x46cf97 : -jmp -0x2e4
         : +jmp 0x8 	(spark.c:2375)
         : +inc dword ptr [ebp - 8] 	(spark.c:2379)
         : +jmp -0x2ff 	(spark.c:2380)
0x46cf9c : cmp dword ptr [ebp - 0xc0], 0x1e 	(spark.c:2381)
0x46cfa3 : jl 0x5
0x46cfa9 : jmp 0x5 	(spark.c:2382)
0x46cfae : -jmp -0x32b
         : +jmp -0x350 	(spark.c:2384)
0x46cfb3 : cmp dword ptr [ebp - 0xc0], 0 	(spark.c:2385)
0x46cfba : -je 0x2c
         : +jle 0x2c
0x46cfc0 : lea eax, [ebp - 0x84] 	(spark.c:2386)
0x46cfc6 : push eax
0x46cfc7 : mov eax, dword ptr [ebp - 0xc0]
0x46cfcd : push eax
0x46cfce : mov eax, dword ptr [ebp + 8]
0x46cfd1 : mov eax, dword ptr [eax + 0x664]
0x46cfd7 : dec eax
0x46cfd8 : push eax
0x46cfd9 : mov eax, dword ptr [ebp + 8]
0x46cfdc : mov ax, word ptr [eax + 0x250]
0x46cfe3 : push eax
0x46cfe4 : call AddSmudgeToPipingSession (FUNCTION)
         : +add esp, 0x10
         : +call EndPipingSession (FUNCTION) 	(spark.c:2392)
         : +pop edi 	(spark.c:2394)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


SmudgeCar is only 77.12% similar to the original, diff above
```

*AI generated. Time taken: 563s, tokens: 148,877*
