### PR TITLE
StopCarSmoking 100% match

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -2442,7 +2442,10 @@ void StopCarSmoking(tCar_spec* pCar) {
     int i;
 
     for (i = 0; i < MAX_SMOKE_COLUMNS; i++) {
-        if (gSmoke_column[i].car == pCar && gSmoke_column[i].lifetime > 2000) {
+        if (gSmoke_column[i].car != pCar) {
+            continue;
+        }
+        if (gSmoke_column[i].lifetime > 2000) {
             gSmoke_column[i].lifetime = 2000;
         }
     }


### PR DESCRIPTION
## Match result

```
0x46d0be: StopCarSmoking 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x46d0be,34 +0x4b3edf,38 @@
0x46d0be : push ebp 	(spark.c:2441)
0x46d0bf : mov ebp, esp
0x46d0c1 : sub esp, 4
0x46d0c4 : push ebx
0x46d0c5 : push esi
0x46d0c6 : push edi
0x46d0c7 : mov dword ptr [ebp - 4], 0 	(spark.c:2444)
0x46d0ce : jmp 0x3
0x46d0d3 : inc dword ptr [ebp - 4]
0x46d0d6 : cmp dword ptr [ebp - 4], 5
0x46d0da : -jge 0x5a
         : +jge 0x55
0x46d0e0 : mov eax, dword ptr [ebp - 4] 	(spark.c:2445)
0x46d0e3 : mov ecx, eax
0x46d0e5 : shl eax, 3
0x46d0e8 : sub eax, ecx
0x46d0ea : shl eax, 4
0x46d0ed : mov ecx, dword ptr [ebp + 8]
0x46d0f0 : cmp dword ptr [eax + gSmoke_column[0].car (DATA)], ecx
0x46d0f6 : -je 0x5
0x46d0fc : -jmp -0x2e
         : +jne 0x34
0x46d101 : mov eax, dword ptr [ebp - 4]
0x46d104 : mov ecx, eax
0x46d106 : shl eax, 3
0x46d109 : sub eax, ecx
0x46d10b : shl eax, 4
0x46d10e : cmp dword ptr [eax + gSmoke_column[0].lifetime (OFFSET)], 0x7d0
0x46d118 : jbe 0x17
0x46d11e : mov eax, dword ptr [ebp - 4] 	(spark.c:2446)
0x46d121 : mov ecx, eax
0x46d123 : shl eax, 3
0x46d126 : sub eax, ecx
0x46d128 : shl eax, 4
0x46d12b : mov dword ptr [eax + gSmoke_column[0].lifetime (OFFSET)], 0x7d0
0x46d135 : -jmp -0x67
         : +jmp -0x62 	(spark.c:2448)
         : +pop edi 	(spark.c:2449)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


StopCarSmoking is only 83.33% similar to the original, diff above
```

*AI generated. Time taken: 294s, tokens: 30,365*
