### PR TITLE
RenderSplashes 100% match

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -2803,11 +2803,12 @@ void RenderSplashes(void) {
     int i;
 
     for (i = 0; i < COUNT_OF(gSplash); i++) {
-        if (TEST_BIT(gSplash_flags, i)) {
-            BrActorRelink(gNon_track_actor, gSplash[i].actor);
-            BrZbSceneRenderAdd(gSplash[i].actor);
-            BrActorRelink(gDont_render_actor, gSplash[i].actor);
+        if (!TEST_BIT(gSplash_flags, i)) {
+            continue;
         }
+        BrActorRelink(gNon_track_actor, gSplash[i].actor);
+        BrZbSceneRenderAdd(gSplash[i].actor);
+        BrActorRelink(gDont_render_actor, gSplash[i].actor);
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x46ea05: RenderSplashes 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x46ea05,27 +0x4b57bf,26 @@
0x46ea05 : push ebp 	(spark.c:2802)
0x46ea06 : mov ebp, esp
0x46ea08 : sub esp, 4
0x46ea0b : push ebx
0x46ea0c : push esi
0x46ea0d : push edi
0x46ea0e : mov dword ptr [ebp - 4], 0 	(spark.c:2805)
0x46ea15 : jmp 0x3
0x46ea1a : inc dword ptr [ebp - 4]
0x46ea1d : cmp dword ptr [ebp - 4], 0x20
0x46ea21 : -jge 0x7a
         : +jge 0x75
0x46ea27 : mov eax, 1 	(spark.c:2806)
0x46ea2c : mov cl, byte ptr [ebp - 4]
0x46ea2f : shl eax, cl
0x46ea31 : test dword ptr [gSplash_flags (DATA)], eax
0x46ea37 : -jne 0x5
0x46ea3d : -jmp -0x28
         : +je 0x5a
0x46ea42 : mov eax, dword ptr [ebp - 4] 	(spark.c:2807)
0x46ea45 : mov ecx, eax
0x46ea47 : shl eax, 3
0x46ea4a : sub eax, ecx
0x46ea4c : mov eax, dword ptr [eax*4 + gSplash[0].actor (DATA)]
0x46ea53 : push eax
0x46ea54 : mov eax, dword ptr [gNon_track_actor (DATA)]
0x46ea59 : push eax
0x46ea5a : call BrActorRelink (FUNCTION)
0x46ea5f : add esp, 8

---
+++
@@ -0x46ea7c,11 +0x4b5831,16 @@
0x46ea7c : mov eax, dword ptr [ebp - 4] 	(spark.c:2809)
0x46ea7f : mov ecx, eax
0x46ea81 : shl eax, 3
0x46ea84 : sub eax, ecx
0x46ea86 : mov eax, dword ptr [eax*4 + gSplash[0].actor (DATA)]
0x46ea8d : push eax
0x46ea8e : mov eax, dword ptr [gDont_render_actor (DATA)]
0x46ea93 : push eax
0x46ea94 : call BrActorRelink (FUNCTION)
0x46ea99 : add esp, 8
0x46ea9c : -jmp -0x87
         : +jmp -0x82 	(spark.c:2811)
         : +pop edi 	(spark.c:2812)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


RenderSplashes is only 87.50% similar to the original, diff above
```

*AI generated. Time taken: 67s, tokens: 11,032*
