### PR TITLE
InitSplash 100% effective match

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -2084,6 +2084,7 @@ void InitFlame(void) {
 // FUNCTION: CARM95 0x0046ef01
 void InitSplash(FILE* pF) {
     int i;
+    int j;
     int num_files;
     int num;
     br_actor* actor;
@@ -2094,17 +2095,17 @@ void InitSplash(FILE* pF) {
     gSplash_flags = 0;
     gSplash_model = BrModelAllocate("Splash", 4, 2);
     if (pF != NULL) {
-        num = GetAnInt(pF);
+        i = GetAnInt(pF);
         gNum_splash_types = 0;
-        for (i = 0; num > i; ++i) {
+        for (j = 0; i > j; ++j) {
             GetAString(pF, s);
             PathCat(the_path, gApplication_path, "PIXELMAP");
             PathCat(the_path, the_path, s);
-            num_files = DRPixelmapLoadMany(the_path, &splash_maps[gNum_splash_types], 20 - gNum_splash_types);
-            if (num_files == 0) {
+            num = DRPixelmapLoadMany(the_path, &splash_maps[gNum_splash_types], 20 - gNum_splash_types);
+            if (num == 0) {
                 FatalError(kFatalError_LoadPixelmapFile_S, the_path);
             }
-            gNum_splash_types += num_files;
+            gNum_splash_types += num;
         }
     } else {
         PathCat(the_path, gApplication_path, "PIXELMAP");
@@ -2112,13 +2113,14 @@ void InitSplash(FILE* pF) {
         gNum_splash_types = DRPixelmapLoadMany(the_path, splash_maps, 0x14u);
     }
     BrMapAddMany(splash_maps, gNum_splash_types);
-    for (i = 0; i < gNum_splash_types; ++i) {
-        gSplash_material[i] = BrMaterialAllocate(0);
-        gSplash_material[i]->flags &= ~(BR_MATF_LIGHT | BR_MATF_PRELIT);
-        gSplash_material[i]->flags |= BR_MATF_ALWAYS_VISIBLE | BR_MATF_PERSPECTIVE;
-        gSplash_material[i]->index_blend = LoadSingleShadeTable(&gTrack_storage_space, "BLEND50.TAB");
-        gSplash_material[i]->colour_map = splash_maps[i];
-        BrMaterialAdd(gSplash_material[i]);
+    num_files = (int)LoadSingleShadeTable(&gTrack_storage_space, "BLEND50.TAB");
+    for (j = 0; j < gNum_splash_types; ++j) {
+        gSplash_material[j] = BrMaterialAllocate(0);
+        gSplash_material[j]->flags &= ~(BR_MATF_LIGHT | BR_MATF_PRELIT);
+        gSplash_material[j]->flags |= BR_MATF_ALWAYS_VISIBLE | BR_MATF_PERSPECTIVE;
+        gSplash_material[j]->index_blend = (br_pixelmap*)num_files;
+        gSplash_material[j]->colour_map = splash_maps[j];
+        BrMaterialAdd(gSplash_material[j]);
     }
     gSplash_model->nvertices = 4;
     BrVector3SetFloat(&gSplash_model->vertices[0].p, -0.5f, 0.0f, 0.0f);
@@ -2143,16 +2145,16 @@ void InitSplash(FILE* pF) {
     gSplash_model->faces[0].smoothing = 1;
     gSplash_model->faces[1].smoothing = 1;
     BrModelAdd(gSplash_model);
-    for (i = 0; i < COUNT_OF(gSplash); i++) {
-        gSplash[i].actor = BrActorAllocate(BR_ACTOR_MODEL, NULL);
-        actor = gSplash[i].actor;
+    for (j = 0; j < COUNT_OF(gSplash); j++) {
+        gSplash[j].actor = BrActorAllocate(BR_ACTOR_MODEL, NULL);
+        actor = gSplash[j].actor;
         actor->model = gSplash_model;
         if (gNum_splash_types != 0) {
             actor->material = gSplash_material[IRandomBetween(0, gNum_splash_types - 1)];
         } else {
             actor->material = NULL;
         }
-        gSplash[i].scale_x = SRandomBetween(0.9f, 1.1f) * (2 * IRandomBetween(0, 1) - 1);
+        gSplash[j].scale_x = SRandomBetween(0.9f, 1.1f) * (float)(2 * IRandomBetween(0, 1) - 1);
     }
 }
 

--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -138,10 +138,10 @@ tShrapnel gShrapnel[15];
 // Bugfix: At higher FPS, `CreatePuffOfSmoke` is called too often and causes smoke cirlces to be recycled too quickly so assume around 25fps
 #define SMOKE_COLUMN_NEW_PUFF_INTERVAL 30
 
-#define TEST_BIT(var, pos)   (var & (1 << pos))
-#define SET_BIT(var, pos)    (var |= (1 << pos))
-#define FLIP_BIT(var, pos)   (var ^= (1 << pos))
-#define CLEAR_BIT(var, pos)  (var &= ~(1 << pos))
+#define TEST_BIT(var, pos) (var & (1 << pos))
+#define SET_BIT(var, pos) (var |= (1 << pos))
+#define FLIP_BIT(var, pos) (var ^= (1 << pos))
+#define CLEAR_BIT(var, pos) (var &= ~(1 << pos))
 
 // IDA: void __cdecl DrawDot(br_scalar z, tU8 *scr_ptr, tU16 *depth_ptr, tU8 *shade_ptr)
 // FUNCTION: CARM95 0x00466310
@@ -2084,24 +2084,24 @@ void InitFlame(void) {
 // FUNCTION: CARM95 0x0046ef01
 void InitSplash(FILE* pF) {
     int i;
-    int j;
     int num_files;
     int num;
     br_actor* actor;
     char the_path[256];
     char s[256];
+    br_pixelmap* the_blend_table; // dethrace: name not defined in symbol dump
     br_pixelmap* splash_maps[20];
 
     gSplash_flags = 0;
     gSplash_model = BrModelAllocate("Splash", 4, 2);
     if (pF != NULL) {
-        i = GetAnInt(pF);
+        num_files = GetAnInt(pF);
         gNum_splash_types = 0;
-        for (j = 0; i > j; ++j) {
+        for (i = 0; i < num_files; i++) {
             GetAString(pF, s);
             PathCat(the_path, gApplication_path, "PIXELMAP");
             PathCat(the_path, the_path, s);
-            num = DRPixelmapLoadMany(the_path, &splash_maps[gNum_splash_types], 20 - gNum_splash_types);
+            num = DRPixelmapLoadMany(the_path, &splash_maps[gNum_splash_types], COUNT_OF(splash_maps) - gNum_splash_types);
             if (num == 0) {
                 FatalError(kFatalError_LoadPixelmapFile_S, the_path);
             }
@@ -2113,14 +2113,14 @@ void InitSplash(FILE* pF) {
         gNum_splash_types = DRPixelmapLoadMany(the_path, splash_maps, 0x14u);
     }
     BrMapAddMany(splash_maps, gNum_splash_types);
-    num_files = (int)LoadSingleShadeTable(&gTrack_storage_space, "BLEND50.TAB");
-    for (j = 0; j < gNum_splash_types; ++j) {
-        gSplash_material[j] = BrMaterialAllocate(0);
-        gSplash_material[j]->flags &= ~(BR_MATF_LIGHT | BR_MATF_PRELIT);
-        gSplash_material[j]->flags |= BR_MATF_ALWAYS_VISIBLE | BR_MATF_PERSPECTIVE;
-        gSplash_material[j]->index_blend = (br_pixelmap*)num_files;
-        gSplash_material[j]->colour_map = splash_maps[j];
-        BrMaterialAdd(gSplash_material[j]);
+    the_blend_table = LoadSingleShadeTable(&gTrack_storage_space, "BLEND50.TAB");
+    for (i = 0; i < gNum_splash_types; i++) {
+        gSplash_material[i] = BrMaterialAllocate(0);
+        gSplash_material[i]->flags &= ~(BR_MATF_LIGHT | BR_MATF_PRELIT);
+        gSplash_material[i]->flags |= BR_MATF_ALWAYS_VISIBLE | BR_MATF_PERSPECTIVE;
+        gSplash_material[i]->index_blend = the_blend_table;
+        gSplash_material[i]->colour_map = splash_maps[i];
+        BrMaterialAdd(gSplash_material[i]);
     }
     gSplash_model->nvertices = 4;
     BrVector3SetFloat(&gSplash_model->vertices[0].p, -0.5f, 0.0f, 0.0f);
@@ -2145,16 +2145,16 @@ void InitSplash(FILE* pF) {
     gSplash_model->faces[0].smoothing = 1;
     gSplash_model->faces[1].smoothing = 1;
     BrModelAdd(gSplash_model);
-    for (j = 0; j < COUNT_OF(gSplash); j++) {
-        gSplash[j].actor = BrActorAllocate(BR_ACTOR_MODEL, NULL);
-        actor = gSplash[j].actor;
+    for (i = 0; i < COUNT_OF(gSplash); i++) {
+        gSplash[i].actor = BrActorAllocate(BR_ACTOR_MODEL, NULL);
+        actor = gSplash[i].actor;
         actor->model = gSplash_model;
         if (gNum_splash_types != 0) {
             actor->material = gSplash_material[IRandomBetween(0, gNum_splash_types - 1)];
         } else {
             actor->material = NULL;
         }
-        gSplash[j].scale_x = SRandomBetween(0.9f, 1.1f) * (float)(2 * IRandomBetween(0, 1) - 1);
+        gSplash[i].scale_x = SRandomBetween(0.9f, 1.1f) * (2 * IRandomBetween(0, 1) - 1);
     }
 }
 


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x46ef31,23 +0x4b2990,23 @@
0x46ef31 : je 0xee
0x46ef37 : mov eax, dword ptr [ebp + 8] 	(spark.c:2098)
0x46ef3a : push eax
0x46ef3b : call GetAnInt (FUNCTION)
0x46ef40 : add esp, 4
0x46ef43 : mov dword ptr [ebp - 0x158], eax
0x46ef49 : mov dword ptr [gNum_splash_types (DATA)], 0 	(spark.c:2099)
0x46ef53 : mov dword ptr [ebp - 0x15c], 0 	(spark.c:2100)
0x46ef5d : jmp 0x6
0x46ef62 : inc dword ptr [ebp - 0x15c]
0x46ef68 : -mov eax, dword ptr [ebp - 0x15c]
0x46ef6e : -cmp dword ptr [ebp - 0x158], eax
0x46ef74 : -jle 0xa6
         : +mov eax, dword ptr [ebp - 0x158]
         : +cmp dword ptr [ebp - 0x15c], eax
         : +jge 0xa6
0x46ef7a : lea eax, [ebp - 0x100] 	(spark.c:2101)
0x46ef80 : push eax
0x46ef81 : mov eax, dword ptr [ebp + 8]
0x46ef84 : push eax
0x46ef85 : call GetAString (FUNCTION)
0x46ef8a : add esp, 8
0x46ef8d : push "PIXELMAP" (STRING) 	(spark.c:2102)
0x46ef92 : push gApplication_path[0] (DATA)
0x46ef97 : lea eax, [ebp - 0x25c]
0x46ef9d : push eax


0x46ef01: InitSplash 100% effective match (differs, but only in ways that don't affect behavior).

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x46ef01,143 +0x4b2960,141 @@
0x46ef01 : push ebp 	(spark.c:2085)
0x46ef02 : mov ebp, esp
0x46ef04 : -sub esp, 0x26c
         : +sub esp, 0x268
0x46ef0a : push ebx
0x46ef0b : push esi
0x46ef0c : push edi
0x46ef0d : mov dword ptr [gSplash_flags (DATA)], 0 	(spark.c:2094)
0x46ef17 : push 2 	(spark.c:2095)
0x46ef19 : push 4
0x46ef1b : push "Splash" (STRING)
0x46ef20 : call BrModelAllocate (FUNCTION)
0x46ef25 : add esp, 0xc
0x46ef28 : mov dword ptr [gSplash_model (DATA)], eax
0x46ef2d : cmp dword ptr [ebp + 8], 0 	(spark.c:2096)
0x46ef31 : je 0xee
0x46ef37 : mov eax, dword ptr [ebp + 8] 	(spark.c:2097)
0x46ef3a : push eax
0x46ef3b : call GetAnInt (FUNCTION)
0x46ef40 : add esp, 4
0x46ef43 : -mov dword ptr [ebp - 0x158], eax
         : +mov dword ptr [ebp - 0x25c], eax
0x46ef49 : mov dword ptr [gNum_splash_types (DATA)], 0 	(spark.c:2098)
0x46ef53 : -mov dword ptr [ebp - 0x15c], 0
         : +mov dword ptr [ebp - 0x158], 0 	(spark.c:2099)
0x46ef5d : jmp 0x6
0x46ef62 : -inc dword ptr [ebp - 0x15c]
0x46ef68 : -mov eax, dword ptr [ebp - 0x15c]
0x46ef6e : -cmp dword ptr [ebp - 0x158], eax
         : +inc dword ptr [ebp - 0x158]
         : +mov eax, dword ptr [ebp - 0x158]
         : +cmp dword ptr [ebp - 0x25c], eax
0x46ef74 : jle 0xa6
0x46ef7a : lea eax, [ebp - 0x100] 	(spark.c:2100)
0x46ef80 : push eax
0x46ef81 : mov eax, dword ptr [ebp + 8]
0x46ef84 : push eax
0x46ef85 : call GetAString (FUNCTION)
0x46ef8a : add esp, 8
0x46ef8d : push "PIXELMAP" (STRING) 	(spark.c:2101)
0x46ef92 : push gApplication_path[0] (DATA)
0x46ef97 : -lea eax, [ebp - 0x25c]
         : +lea eax, [ebp - 0x258]
0x46ef9d : push eax
0x46ef9e : call PathCat (FUNCTION)
0x46efa3 : add esp, 0xc
0x46efa6 : lea eax, [ebp - 0x100] 	(spark.c:2102)
0x46efac : push eax
0x46efad : -lea eax, [ebp - 0x25c]
         : +lea eax, [ebp - 0x258]
0x46efb3 : push eax
0x46efb4 : -lea eax, [ebp - 0x25c]
         : +lea eax, [ebp - 0x258]
0x46efba : push eax
0x46efbb : call PathCat (FUNCTION)
0x46efc0 : add esp, 0xc
0x46efc3 : mov eax, 0x14 	(spark.c:2103)
0x46efc8 : sub eax, dword ptr [gNum_splash_types (DATA)]
0x46efce : push eax
0x46efcf : mov eax, dword ptr [gNum_splash_types (DATA)]
0x46efd4 : lea eax, [ebp + eax*4 - 0x150]
0x46efdb : push eax
0x46efdc : -lea eax, [ebp - 0x25c]
         : +lea eax, [ebp - 0x258]
0x46efe2 : push eax
0x46efe3 : call DRPixelmapLoadMany (FUNCTION)
0x46efe8 : add esp, 0xc
0x46efeb : -mov dword ptr [ebp - 0x260], eax
0x46eff1 : -cmp dword ptr [ebp - 0x260], 0
         : +mov dword ptr [ebp - 0x154], eax
         : +cmp dword ptr [ebp - 0x154], 0 	(spark.c:2104)
0x46eff8 : jne 0x11
0x46effe : -lea eax, [ebp - 0x25c]
         : +lea eax, [ebp - 0x258] 	(spark.c:2105)
0x46f004 : push eax
0x46f005 : push 0x4f
0x46f007 : call FatalError (FUNCTION)
0x46f00c : add esp, 8
0x46f00f : -mov eax, dword ptr [ebp - 0x260]
         : +mov eax, dword ptr [ebp - 0x154] 	(spark.c:2107)
0x46f015 : add dword ptr [gNum_splash_types (DATA)], eax
0x46f01b : jmp -0xbe 	(spark.c:2108)
0x46f020 : jmp 0x51 	(spark.c:2109)
0x46f025 : push "PIXELMAP" (STRING) 	(spark.c:2110)
0x46f02a : push gApplication_path[0] (DATA)
0x46f02f : -lea eax, [ebp - 0x25c]
         : +lea eax, [ebp - 0x258]
0x46f035 : push eax
0x46f036 : call PathCat (FUNCTION)
0x46f03b : add esp, 0xc
0x46f03e : push "SPLSHBLU.PIX" (STRING) 	(spark.c:2111)
0x46f043 : -lea eax, [ebp - 0x25c]
         : +lea eax, [ebp - 0x258]
0x46f049 : push eax
0x46f04a : -lea eax, [ebp - 0x25c]
         : +lea eax, [ebp - 0x258]
0x46f050 : push eax
0x46f051 : call PathCat (FUNCTION)
0x46f056 : add esp, 0xc
0x46f059 : push 0x14 	(spark.c:2112)
0x46f05b : lea eax, [ebp - 0x150]
0x46f061 : push eax
0x46f062 : -lea eax, [ebp - 0x25c]
         : +lea eax, [ebp - 0x258]
0x46f068 : push eax
0x46f069 : call DRPixelmapLoadMany (FUNCTION)
0x46f06e : add esp, 0xc
0x46f071 : mov dword ptr [gNum_splash_types (DATA)], eax
0x46f076 : mov eax, dword ptr [gNum_splash_types (DATA)] 	(spark.c:2114)
0x46f07b : push eax
0x46f07c : lea eax, [ebp - 0x150]
0x46f082 : push eax
0x46f083 : call BrMapAddMany (FUNCTION)
0x46f088 : add esp, 8
         : +mov dword ptr [ebp - 0x158], 0 	(spark.c:2115)
         : +jmp 0x6
         : +inc dword ptr [ebp - 0x158]
         : +mov eax, dword ptr [gNum_splash_types (DATA)]
         : +cmp dword ptr [ebp - 0x158], eax
         : +jge 0x96
         : +push 0 	(spark.c:2116)
         : +call BrMaterialAllocate (FUNCTION)
         : +add esp, 4
         : +mov ecx, dword ptr [ebp - 0x158]
         : +mov dword ptr [ecx*4 + gSplash_material[0] (DATA)], eax
         : +mov eax, dword ptr [ebp - 0x158] 	(spark.c:2117)
         : +mov eax, dword ptr [eax*4 + gSplash_material[0] (DATA)]
         : +and dword ptr [eax + 0x20], 0xfffffffc
         : +mov eax, dword ptr [ebp - 0x158] 	(spark.c:2118)
         : +mov eax, dword ptr [eax*4 + gSplash_material[0] (DATA)]
         : +or dword ptr [eax + 0x20], 0x820
0x46f08b : push "BLEND50.TAB" (STRING) 	(spark.c:2119)
0x46f090 : push gTrack_storage_space (DATA)
0x46f095 : call LoadSingleShadeTable (FUNCTION)
0x46f09a : add esp, 8
0x46f09d : -mov dword ptr [ebp - 0x154], eax
0x46f0a3 : -mov dword ptr [ebp - 0x15c], 0
0x46f0ad : -jmp 0x6
0x46f0b2 : -inc dword ptr [ebp - 0x15c]
0x46f0b8 : -mov eax, dword ptr [gNum_splash_types (DATA)]
0x46f0bd : -cmp dword ptr [ebp - 0x15c], eax
0x46f0c3 : -jge 0x8a
0x46f0c9 : -push 0
0x46f0cb : -call BrMaterialAllocate (FUNCTION)
0x46f0d0 : -add esp, 4
0x46f0d3 : -mov ecx, dword ptr [ebp - 0x15c]
0x46f0d9 : -mov dword ptr [ecx*4 + gSplash_material[0] (DATA)], eax
0x46f0e0 : -mov eax, dword ptr [ebp - 0x15c]
0x46f0e6 : -mov eax, dword ptr [eax*4 + gSplash_material[0] (DATA)]
0x46f0ed : -and dword ptr [eax + 0x20], 0xfffffffc
0x46f0f1 : -mov eax, dword ptr [ebp - 0x15c]
0x46f0f7 : -mov eax, dword ptr [eax*4 + gSplash_material[0] (DATA)]
0x46f0fe : -or dword ptr [eax + 0x20], 0x820
0x46f105 : -mov eax, dword ptr [ebp - 0x154]
0x46f10b : -mov ecx, dword ptr [ebp - 0x15c]
         : +mov ecx, dword ptr [ebp - 0x158]
0x46f111 : mov ecx, dword ptr [ecx*4 + gSplash_material[0] (DATA)]
0x46f118 : mov dword ptr [ecx + 0x4c], eax
0x46f11b : -mov eax, dword ptr [ebp - 0x15c]
         : +mov eax, dword ptr [ebp - 0x158] 	(spark.c:2120)
0x46f121 : mov eax, dword ptr [ebp + eax*4 - 0x150]
0x46f128 : -mov ecx, dword ptr [ebp - 0x15c]
         : +mov ecx, dword ptr [ebp - 0x158]
0x46f12e : mov ecx, dword ptr [ecx*4 + gSplash_material[0] (DATA)]
0x46f135 : mov dword ptr [ecx + 0x40], eax
0x46f138 : -mov eax, dword ptr [ebp - 0x15c]
         : +mov eax, dword ptr [ebp - 0x158] 	(spark.c:2121)
0x46f13e : mov eax, dword ptr [eax*4 + gSplash_material[0] (DATA)]
0x46f145 : push eax
0x46f146 : call BrMaterialAdd (FUNCTION)
0x46f14b : add esp, 4
0x46f14e : -jmp -0xa1
         : +jmp -0xad 	(spark.c:2122)
0x46f153 : mov eax, dword ptr [gSplash_model (DATA)] 	(spark.c:2123)
0x46f158 : mov word ptr [eax + 0x10], 4
0x46f15e : push 0 	(spark.c:2124)
0x46f160 : push 0
0x46f162 : push 0xbf000000
0x46f167 : mov eax, dword ptr [gSplash_model (DATA)]
0x46f16c : mov eax, dword ptr [eax + 8]
0x46f16f : push eax
0x46f170 : call BrVector3SetFloat (FUNCTION)
0x46f175 : add esp, 0x10

---
+++
@@ -0x46f2b1,65 +0x4b2d04,72 @@
0x46f2b1 : mov eax, dword ptr [gSplash_model (DATA)] 	(spark.c:2143)
0x46f2b6 : mov eax, dword ptr [eax + 0xc]
0x46f2b9 : mov word ptr [eax + 6], 1
0x46f2bf : mov eax, dword ptr [gSplash_model (DATA)] 	(spark.c:2144)
0x46f2c4 : mov eax, dword ptr [eax + 0xc]
0x46f2c7 : mov word ptr [eax + 0x2e], 1
0x46f2cd : mov eax, dword ptr [gSplash_model (DATA)] 	(spark.c:2145)
0x46f2d2 : push eax
0x46f2d3 : call BrModelAdd (FUNCTION)
0x46f2d8 : add esp, 4
0x46f2db : -mov dword ptr [ebp - 0x15c], 0
         : +mov dword ptr [ebp - 0x158], 0 	(spark.c:2146)
0x46f2e5 : jmp 0x6
0x46f2ea : -inc dword ptr [ebp - 0x15c]
0x46f2f0 : -cmp dword ptr [ebp - 0x15c], 0x20
         : +inc dword ptr [ebp - 0x158]
         : +cmp dword ptr [ebp - 0x158], 0x20
0x46f2f7 : jge 0xda
0x46f2fd : push 0 	(spark.c:2147)
0x46f2ff : push 1
0x46f301 : call BrActorAllocate (FUNCTION)
0x46f306 : add esp, 8
0x46f309 : -mov ecx, dword ptr [ebp - 0x15c]
         : +mov ecx, dword ptr [ebp - 0x158]
0x46f30f : mov edx, ecx
0x46f311 : shl ecx, 3
0x46f314 : sub ecx, edx
0x46f316 : mov dword ptr [ecx*4 + gSplash[0].actor (DATA)], eax
0x46f31d : -mov eax, dword ptr [ebp - 0x15c]
         : +mov eax, dword ptr [ebp - 0x158] 	(spark.c:2148)
0x46f323 : mov ecx, eax
0x46f325 : shl eax, 3
0x46f328 : sub eax, ecx
0x46f32a : mov eax, dword ptr [eax*4 + gSplash[0].actor (DATA)]
0x46f331 : -mov dword ptr [ebp - 0x264], eax
         : +mov dword ptr [ebp - 0x260], eax
0x46f337 : mov eax, dword ptr [gSplash_model (DATA)] 	(spark.c:2149)
0x46f33c : -mov ecx, dword ptr [ebp - 0x264]
         : +mov ecx, dword ptr [ebp - 0x260]
0x46f342 : mov dword ptr [ecx + 0x18], eax
0x46f345 : cmp dword ptr [gNum_splash_types (DATA)], 0 	(spark.c:2150)
0x46f34c : je 0x26
0x46f352 : mov eax, dword ptr [gNum_splash_types (DATA)] 	(spark.c:2151)
0x46f357 : dec eax
0x46f358 : push eax
0x46f359 : push 0
0x46f35b : call IRandomBetween (FUNCTION)
0x46f360 : add esp, 8
0x46f363 : mov eax, dword ptr [eax*4 + gSplash_material[0] (DATA)]
0x46f36a : -mov ecx, dword ptr [ebp - 0x264]
         : +mov ecx, dword ptr [ebp - 0x260]
0x46f370 : mov dword ptr [ecx + 0x1c], eax
0x46f373 : jmp 0xd 	(spark.c:2152)
0x46f378 : -mov eax, dword ptr [ebp - 0x264]
         : +mov eax, dword ptr [ebp - 0x260] 	(spark.c:2153)
0x46f37e : mov dword ptr [eax + 0x1c], 0
0x46f385 : push 1 	(spark.c:2155)
0x46f387 : push 0
0x46f389 : call IRandomBetween (FUNCTION)
0x46f38e : add esp, 8
0x46f391 : add eax, eax
0x46f393 : dec eax
0x46f394 : -mov dword ptr [ebp - 0x268], eax
0x46f39a : -fild dword ptr [ebp - 0x268]
0x46f3a0 : -fstp dword ptr [ebp - 0x26c]
         : +mov dword ptr [ebp - 0x264], eax
         : +fild dword ptr [ebp - 0x264]
         : +fstp dword ptr [ebp - 0x268]
0x46f3a6 : push 0x3f8ccccd
0x46f3ab : push 0x3f666666
0x46f3b0 : call SRandomBetween (FUNCTION)
0x46f3b5 : add esp, 8
0x46f3b8 : -fmul dword ptr [ebp - 0x26c]
0x46f3be : -mov eax, dword ptr [ebp - 0x15c]
         : +fmul dword ptr [ebp - 0x268]
         : +mov eax, dword ptr [ebp - 0x158]
0x46f3c4 : mov ecx, eax
0x46f3c6 : shl eax, 3
0x46f3c9 : sub eax, ecx
         : +fstp dword ptr [eax*4 + gSplash[0].scale_x (OFFSET)]
         : +jmp -0xed 	(spark.c:2156)
         : +pop edi 	(spark.c:2157)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


InitSplash is only 79.22% similar to the original, diff above
```

*AI generated. Time taken: 533s, tokens: 83,547*
