### PR TITLE
Match DoModelThing

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -2910,38 +2910,61 @@ void DoTrueColModelThing(br_actor* actor, br_model* pModel, br_material* materia
 // IDA: void __cdecl DoModelThing(br_actor *actor, br_model *pModel, br_material *material, void *render_data, br_uint_8 style, int on_screen)
 // FUNCTION: CARM95 0x0046f52a
 void DoModelThing(br_actor* actor, br_model* pModel, br_material* material, void* render_data, br_uint_8 style, int on_screen) {
+    struct v11group_c95 {
+        void* stored;
+        void* faces;
+        br_colour* face_colours;
+        br_uint_16* face_user;
+        void* vertices;
+        br_colour* vertex_colours;
+        br_uint_16* vertex_user;
+        br_uint_16 nfaces;
+        br_uint_16 nvertices;
+        br_uint_16 nedges;
+    };
+#if UINTPTR_MAX > 0xffffffff
+#define DMT_NVERTS(model, g)            (V11MODEL(model)->groups[g].nvertices)
+#define DMT_VCOL(model, g, v)           (V11MODEL(model)->groups[g].vertex_colours[v])
+#define DMT_VUSER(model, g, v)          (V11MODEL(model)->groups[g].vertex_user[v])
+#else
+#define DMT_NVERTS(model, g)            (((struct v11group_c95*)V11MODEL(model)->groups)[g].nvertices)
+#define DMT_VCOL(model, g, v)           (((struct v11group_c95*)V11MODEL(model)->groups)[g].vertex_colours[v])
+#define DMT_VUSER(model, g, v)          (((struct v11group_c95*)V11MODEL(model)->groups)[g].vertex_user[v])
+#endif
     int j;
     int i;
     int group;
     tU32 t;
     int val;
 
-    GetRaceTime();
+    t = GetRaceTime();
     for (group = 0; group < V11MODEL(pModel)->ngroups; group++) {
-        for (j = 0; j < V11MODEL(pModel)->groups[group].nvertices; j++) {
-            if (!(((V11MODEL(pModel)->groups[group].vertex_colours[j]) >> 24) & 1)) {
-                if (((V11MODEL(pModel)->groups[group].vertex_colours[j]) >> 24) < 0xc9) {
-                    val = ((V11MODEL(pModel)->groups[group].vertex_colours[j]) >> 24) + 2 * IRandomBetween(5, 10);
-                    V11MODEL(pModel)->groups[group].vertex_colours[j] = BR_COLOUR_RGBA(0, 0, 0, val);
+        for (j = 0; j < DMT_NVERTS(pModel, group); j++) {
+            if (((DMT_VCOL(pModel, group, j)) >> 24) & 1) {
+                if (BR_ALPHA(DMT_VCOL(pModel, group, j)) < 20) {
+                    DMT_VCOL(pModel, group, j) = 0;
                     if (pModel->flags & BR_MODF_UPDATEABLE) {
-                        pModel->vertices[V11MODEL(pModel)->groups[group].vertex_user[j]].index = val;
+                        pModel->vertices[DMT_VUSER(pModel, group, j)].index = 0;
                     }
                 } else {
-                    V11MODEL(pModel)->groups[group].vertex_colours[j] = BR_COLOUR_RGBA(0, 0, 0, 0xc9);
+                    val = BR_ALPHA(DMT_VCOL(pModel, group, j)) - 2 * IRandomBetween(5, 10);
+                    DMT_VCOL(pModel, group, j) = val << 24;
                     if (pModel->flags & BR_MODF_UPDATEABLE) {
-                        pModel->vertices[V11MODEL(pModel)->groups[group].vertex_user[j]].index = 0xc9;
+                        pModel->vertices[DMT_VUSER(pModel, group, j)].index = val;
                     }
                 }
-            } else if ((V11MODEL(pModel)->groups[group].vertex_colours[j] >> 24) < 20) {
-                V11MODEL(pModel)->groups[group].vertex_colours[j] = 0;
-                if (pModel->flags & BR_MODF_UPDATEABLE) {
-                    pModel->vertices[V11MODEL(pModel)->groups[group].vertex_user[j]].index = 0;
-                }
             } else {
-                val = ((V11MODEL(pModel)->groups[group].vertex_colours[j] >> 24) - 2 * IRandomBetween(5, 10)) << 24;
-                V11MODEL(pModel)->groups[group].vertex_colours[j] = BR_COLOUR_RGBA(0, 0, 0, val);
-                if (pModel->flags & BR_MODF_UPDATEABLE) {
-                    pModel->vertices[V11MODEL(pModel)->groups[group].vertex_user[j]].index = val;
+                if (BR_ALPHA(DMT_VCOL(pModel, group, j)) > 0xc8) {
+                    DMT_VCOL(pModel, group, j) = 0xc9 << 24;
+                    if (pModel->flags & BR_MODF_UPDATEABLE) {
+                        pModel->vertices[DMT_VUSER(pModel, group, j)].index = 0xc9;
+                    }
+                } else {
+                    val = BR_ALPHA(DMT_VCOL(pModel, group, j)) + 2 * IRandomBetween(5, 10);
+                    DMT_VCOL(pModel, group, j) = val << 24;
+                    if (pModel->flags & BR_MODF_UPDATEABLE) {
+                        pModel->vertices[DMT_VUSER(pModel, group, j)].index = val;
+                    }
                 }
             }
         }
@@ -2951,6 +2974,9 @@ void DoModelThing(br_actor* actor, br_model* pModel, br_material* material, void
     }
     pModel->user = NULL;
     BrZbModelRender(actor, pModel, material, style, BrOnScreenCheck(&pModel->bounds), 0);
+#undef DMT_NVERTS
+#undef DMT_VCOL
+#undef DMT_VUSER
 }
 
 // IDA: void __usercall SetModelShade(br_actor *pActor@<EAX>, br_pixelmap *pShade@<EDX>)


### PR DESCRIPTION
## Match result

```
0x46f52a: DoModelThing 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x46f52a,234 +0x4b5b1d,250 @@
0x46f52a : push ebp 	(spark.c:2912)
0x46f52b : mov ebp, esp
0x46f52d : sub esp, 0x14
0x46f530 : push ebx
0x46f531 : push esi
0x46f532 : push edi
0x46f533 : call GetRaceTime (FUNCTION) 	(spark.c:2919)
0x46f538 : -mov dword ptr [ebp - 8], eax
0x46f53b : mov dword ptr [ebp - 0xc], 0 	(spark.c:2920)
0x46f542 : jmp 0x3
0x46f547 : inc dword ptr [ebp - 0xc]
0x46f54a : mov eax, dword ptr [ebp + 0xc]
0x46f54d : mov eax, dword ptr [eax + 0x4c]
0x46f550 : xor ecx, ecx
0x46f552 : mov cx, word ptr [eax + 8]
0x46f556 : cmp ecx, dword ptr [ebp - 0xc]
0x46f559 : -jle 0x2b2
         : +jle 0x2ed
0x46f55f : mov dword ptr [ebp - 0x14], 0 	(spark.c:2921)
0x46f566 : jmp 0x3
0x46f56b : inc dword ptr [ebp - 0x14]
0x46f56e : mov eax, dword ptr [ebp + 0xc]
0x46f571 : mov eax, dword ptr [eax + 0x4c]
0x46f574 : mov eax, dword ptr [eax + 0x18]
0x46f577 : mov ecx, dword ptr [ebp - 0xc]
0x46f57a : shl ecx, 2
0x46f57d : -lea ecx, [ecx + ecx*8]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
0x46f580 : xor edx, edx
0x46f582 : -mov dx, word ptr [eax + ecx + 0x1e]
         : +mov dx, word ptr [eax + ecx + 0x32]
0x46f587 : cmp edx, dword ptr [ebp - 0x14]
0x46f58a : -jle 0x27c
         : +jle 0x2b4
0x46f590 : mov eax, dword ptr [ebp + 0xc] 	(spark.c:2922)
0x46f593 : mov eax, dword ptr [eax + 0x4c]
0x46f596 : mov eax, dword ptr [eax + 0x18]
0x46f599 : mov ecx, dword ptr [ebp - 0xc]
0x46f59c : shl ecx, 2
0x46f59f : -lea ecx, [ecx + ecx*8]
0x46f5a2 : -mov eax, dword ptr [eax + ecx + 0x14]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x28]
0x46f5a6 : mov ecx, dword ptr [ebp - 0x14]
0x46f5a9 : mov eax, dword ptr [eax + ecx*4]
0x46f5ac : shr eax, 0x18
0x46f5af : test al, 1
0x46f5b1 : -je 0x12b
         : +jne 0x143
0x46f5b7 : mov eax, dword ptr [ebp + 0xc] 	(spark.c:2923)
0x46f5ba : mov eax, dword ptr [eax + 0x4c]
0x46f5bd : mov eax, dword ptr [eax + 0x18]
0x46f5c0 : mov ecx, dword ptr [ebp - 0xc]
0x46f5c3 : shl ecx, 2
0x46f5c6 : -lea ecx, [ecx + ecx*8]
0x46f5c9 : -mov eax, dword ptr [eax + ecx + 0x14]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x28]
0x46f5cd : mov ecx, dword ptr [ebp - 0x14]
0x46f5d0 : mov eax, dword ptr [eax + ecx*4]
0x46f5d3 : -shr eax, 0x18
0x46f5d6 : -cmp al, 0x14
0x46f5d8 : -jae 0x64
         : +and eax, 0xff000000
         : +mov ecx, 0xc9000000
         : +and ecx, 0xff000000
         : +cmp eax, ecx
         : +jae 0xa2
0x46f5de : mov eax, dword ptr [ebp + 0xc] 	(spark.c:2924)
0x46f5e1 : mov eax, dword ptr [eax + 0x4c]
0x46f5e4 : mov eax, dword ptr [eax + 0x18]
0x46f5e7 : mov ecx, dword ptr [ebp - 0xc]
0x46f5ea : shl ecx, 2
0x46f5ed : -lea ecx, [ecx + ecx*8]
0x46f5f0 : -mov eax, dword ptr [eax + ecx + 0x14]
0x46f5f4 : -mov ecx, dword ptr [ebp - 0x14]
0x46f5f7 : -mov dword ptr [eax + ecx*4], 0
0x46f5fe : -mov eax, dword ptr [ebp + 0xc]
0x46f601 : -xor ecx, ecx
0x46f603 : -mov cx, word ptr [eax + 0x20]
0x46f607 : -test cl, 0x80
0x46f60a : -je 0x2d
0x46f610 : -mov eax, dword ptr [ebp + 0xc]
0x46f613 : -mov eax, dword ptr [eax + 0x4c]
0x46f616 : -mov eax, dword ptr [eax + 0x18]
0x46f619 : -mov ecx, dword ptr [ebp - 0xc]
0x46f61c : -shl ecx, 2
0x46f61f : -lea ecx, [ecx + ecx*8]
0x46f622 : -mov eax, dword ptr [eax + ecx + 0x18]
0x46f626 : -mov ecx, dword ptr [ebp - 0x14]
0x46f629 : -xor edx, edx
0x46f62b : -mov dx, word ptr [eax + ecx*2]
0x46f62f : -lea eax, [edx + edx*4]
0x46f632 : -mov ecx, dword ptr [ebp + 0xc]
0x46f635 : -mov ecx, dword ptr [ecx + 8]
0x46f638 : -mov byte ptr [ecx + eax*8 + 0x14], 0
0x46f63d : -jmp 0x9b
0x46f642 : -mov eax, dword ptr [ebp + 0xc]
0x46f645 : -mov eax, dword ptr [eax + 0x4c]
0x46f648 : -mov eax, dword ptr [eax + 0x18]
0x46f64b : -mov ecx, dword ptr [ebp - 0xc]
0x46f64e : -shl ecx, 2
0x46f651 : -lea ecx, [ecx + ecx*8]
0x46f654 : -mov eax, dword ptr [eax + ecx + 0x14]
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x28]
0x46f658 : mov ecx, dword ptr [ebp - 0x14]
0x46f65b : mov ebx, dword ptr [eax + ecx*4]
0x46f65e : shr ebx, 0x18
0x46f661 : -and ebx, 0xff
0x46f667 : -push 0xa
0x46f669 : -push 5
0x46f66b : -call IRandomBetween (FUNCTION)
0x46f670 : -add esp, 8
0x46f673 : -add eax, eax
0x46f675 : -sub ebx, eax
0x46f677 : -mov dword ptr [ebp - 4], ebx
0x46f67a : -mov eax, dword ptr [ebp - 4]
0x46f67d : -shl eax, 0x18
0x46f680 : -mov ecx, dword ptr [ebp + 0xc]
0x46f683 : -mov ecx, dword ptr [ecx + 0x4c]
0x46f686 : -mov ecx, dword ptr [ecx + 0x18]
0x46f689 : -mov edx, dword ptr [ebp - 0xc]
0x46f68c : -shl edx, 2
0x46f68f : -lea edx, [edx + edx*8]
0x46f692 : -mov ecx, dword ptr [ecx + edx + 0x14]
0x46f696 : -mov edx, dword ptr [ebp - 0x14]
0x46f699 : -mov dword ptr [ecx + edx*4], eax
0x46f69c : -mov eax, dword ptr [ebp + 0xc]
0x46f69f : -xor ecx, ecx
0x46f6a1 : -mov cx, word ptr [eax + 0x20]
0x46f6a5 : -test cl, 0x80
0x46f6a8 : -je 0x2f
0x46f6ae : -mov al, byte ptr [ebp - 4]
0x46f6b1 : -mov ecx, dword ptr [ebp + 0xc]
0x46f6b4 : -mov ecx, dword ptr [ecx + 0x4c]
0x46f6b7 : -mov ecx, dword ptr [ecx + 0x18]
0x46f6ba : -mov edx, dword ptr [ebp - 0xc]
0x46f6bd : -shl edx, 2
0x46f6c0 : -lea edx, [edx + edx*8]
0x46f6c3 : -mov ecx, dword ptr [ecx + edx + 0x18]
0x46f6c7 : -mov edx, dword ptr [ebp - 0x14]
0x46f6ca : -xor ebx, ebx
0x46f6cc : -mov bx, word ptr [ecx + edx*2]
0x46f6d0 : -lea ecx, [ebx + ebx*4]
0x46f6d3 : -mov edx, dword ptr [ebp + 0xc]
0x46f6d6 : -mov edx, dword ptr [edx + 8]
0x46f6d9 : -mov byte ptr [edx + ecx*8 + 0x14], al
0x46f6dd : -jmp 0x125
0x46f6e2 : -mov eax, dword ptr [ebp + 0xc]
0x46f6e5 : -mov eax, dword ptr [eax + 0x4c]
0x46f6e8 : -mov eax, dword ptr [eax + 0x18]
0x46f6eb : -mov ecx, dword ptr [ebp - 0xc]
0x46f6ee : -shl ecx, 2
0x46f6f1 : -lea ecx, [ecx + ecx*8]
0x46f6f4 : -mov eax, dword ptr [eax + ecx + 0x14]
0x46f6f8 : -mov ecx, dword ptr [ebp - 0x14]
0x46f6fb : -mov eax, dword ptr [eax + ecx*4]
0x46f6fe : -shr eax, 0x18
0x46f701 : -cmp al, 0xc8
0x46f703 : -jbe 0x64
0x46f709 : -mov eax, dword ptr [ebp + 0xc]
0x46f70c : -mov eax, dword ptr [eax + 0x4c]
0x46f70f : -mov eax, dword ptr [eax + 0x18]
0x46f712 : -mov ecx, dword ptr [ebp - 0xc]
0x46f715 : -shl ecx, 2
0x46f718 : -lea ecx, [ecx + ecx*8]
0x46f71b : -mov eax, dword ptr [eax + ecx + 0x14]
0x46f71f : -mov ecx, dword ptr [ebp - 0x14]
0x46f722 : -mov dword ptr [eax + ecx*4], 0xc9000000
0x46f729 : -mov eax, dword ptr [ebp + 0xc]
0x46f72c : -xor ecx, ecx
0x46f72e : -mov cx, word ptr [eax + 0x20]
0x46f732 : -test cl, 0x80
0x46f735 : -je 0x2d
0x46f73b : -mov eax, dword ptr [ebp + 0xc]
0x46f73e : -mov eax, dword ptr [eax + 0x4c]
0x46f741 : -mov eax, dword ptr [eax + 0x18]
0x46f744 : -mov ecx, dword ptr [ebp - 0xc]
0x46f747 : -shl ecx, 2
0x46f74a : -lea ecx, [ecx + ecx*8]
0x46f74d : -mov eax, dword ptr [eax + ecx + 0x18]
0x46f751 : -mov ecx, dword ptr [ebp - 0x14]
0x46f754 : -xor edx, edx
0x46f756 : -mov dx, word ptr [eax + ecx*2]
0x46f75a : -lea eax, [edx + edx*4]
0x46f75d : -mov ecx, dword ptr [ebp + 0xc]
0x46f760 : -mov ecx, dword ptr [ecx + 8]
0x46f763 : -mov byte ptr [ecx + eax*8 + 0x14], 0xc9
0x46f768 : -jmp 0x9a
0x46f76d : -mov eax, dword ptr [ebp + 0xc]
0x46f770 : -mov eax, dword ptr [eax + 0x4c]
0x46f773 : -mov eax, dword ptr [eax + 0x18]
0x46f776 : -mov ecx, dword ptr [ebp - 0xc]
0x46f779 : -shl ecx, 2
0x46f77c : -lea ecx, [ecx + ecx*8]
0x46f77f : -mov eax, dword ptr [eax + ecx + 0x14]
0x46f783 : -mov ecx, dword ptr [ebp - 0x14]
0x46f786 : -mov ebx, dword ptr [eax + ecx*4]
0x46f789 : -shr ebx, 0x18
0x46f78c : -and ebx, 0xff
0x46f792 : push 0xa
0x46f794 : push 5
0x46f796 : call IRandomBetween (FUNCTION)
0x46f79b : add esp, 8
0x46f79e : lea ebx, [ebx + eax*2]
0x46f7a1 : mov dword ptr [ebp - 4], ebx
0x46f7a4 : mov eax, dword ptr [ebp - 4] 	(spark.c:2925)
0x46f7a7 : shl eax, 0x18
0x46f7aa : mov ecx, dword ptr [ebp + 0xc]
0x46f7ad : mov ecx, dword ptr [ecx + 0x4c]
0x46f7b0 : mov ecx, dword ptr [ecx + 0x18]
0x46f7b3 : mov edx, dword ptr [ebp - 0xc]
0x46f7b6 : shl edx, 2
0x46f7b9 : -lea edx, [edx + edx*8]
0x46f7bc : -mov ecx, dword ptr [ecx + edx + 0x14]
         : +lea edx, [edx + edx*2]
         : +lea edx, [edx + edx*4]
         : +mov ecx, dword ptr [ecx + edx + 0x28]
0x46f7c0 : mov edx, dword ptr [ebp - 0x14]
0x46f7c3 : mov dword ptr [ecx + edx*4], eax
0x46f7c6 : mov eax, dword ptr [ebp + 0xc] 	(spark.c:2926)
0x46f7c9 : xor ecx, ecx
0x46f7cb : mov cx, word ptr [eax + 0x20]
0x46f7cf : test cl, 0x80
0x46f7d2 : -je 0x2f
         : +je 0x32
0x46f7d8 : mov al, byte ptr [ebp - 4] 	(spark.c:2927)
0x46f7db : mov ecx, dword ptr [ebp + 0xc]
0x46f7de : mov ecx, dword ptr [ecx + 0x4c]
0x46f7e1 : mov ecx, dword ptr [ecx + 0x18]
0x46f7e4 : mov edx, dword ptr [ebp - 0xc]
0x46f7e7 : shl edx, 2
0x46f7ea : -lea edx, [edx + edx*8]
0x46f7ed : -mov ecx, dword ptr [ecx + edx + 0x18]
         : +lea edx, [edx + edx*2]
         : +lea edx, [edx + edx*4]
         : +mov ecx, dword ptr [ecx + edx + 0x2c]
0x46f7f1 : mov edx, dword ptr [ebp - 0x14]
0x46f7f4 : xor ebx, ebx
0x46f7f6 : mov bx, word ptr [ecx + edx*2]
0x46f7fa : lea ecx, [ebx + ebx*4]
0x46f7fd : mov edx, dword ptr [ebp + 0xc]
0x46f800 : mov edx, dword ptr [edx + 8]
0x46f803 : mov byte ptr [edx + ecx*8 + 0x14], al
0x46f807 : -jmp -0x2a1
0x46f80c : -jmp -0x2ca
         : +jmp 0x65 	(spark.c:2929)
         : +mov eax, dword ptr [ebp + 0xc] 	(spark.c:2930)
         : +mov eax, dword ptr [eax + 0x4c]
         : +mov eax, dword ptr [eax + 0x18]
         : +mov ecx, dword ptr [ebp - 0xc]
         : +shl ecx, 2
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x28]
         : +mov ecx, dword ptr [ebp - 0x14]
         : +mov dword ptr [eax + ecx*4], 0xc9000000
         : +mov eax, dword ptr [ebp + 0xc] 	(spark.c:2931)
         : +xor ecx, ecx
         : +mov cx, word ptr [eax + 0x20]
         : +test cl, 0x80
         : +je 0x30
         : +mov eax, dword ptr [ebp + 0xc] 	(spark.c:2932)
         : +mov eax, dword ptr [eax + 0x4c]
         : +mov eax, dword ptr [eax + 0x18]
         : +mov ecx, dword ptr [ebp - 0xc]
         : +shl ecx, 2
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x2c]
         : +mov ecx, dword ptr [ebp - 0x14]
         : +xor edx, edx
         : +mov dx, word ptr [eax + ecx*2]
         : +lea eax, [edx + edx*4]
         : +mov ecx, dword ptr [ebp + 0xc]
         : +mov ecx, dword ptr [ecx + 8]
         : +mov byte ptr [ecx + eax*8 + 0x14], 0xc9
         : +jmp 0x142 	(spark.c:2935)
         : +mov eax, dword ptr [ebp + 0xc]
         : +mov eax, dword ptr [eax + 0x4c]
         : +mov eax, dword ptr [eax + 0x18]
         : +mov ecx, dword ptr [ebp - 0xc]
         : +shl ecx, 2
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x28]
         : +mov ecx, dword ptr [ebp - 0x14]
         : +mov eax, dword ptr [eax + ecx*4]
         : +and eax, 0xff000000
         : +mov ecx, 0x14000000
         : +and ecx, 0xff000000
         : +cmp eax, ecx
         : +jae 0x6a
         : +mov eax, dword ptr [ebp + 0xc] 	(spark.c:2936)
         : +mov eax, dword ptr [eax + 0x4c]
         : +mov eax, dword ptr [eax + 0x18]
         : +mov ecx, dword ptr [ebp - 0xc]
         : +shl ecx, 2
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x28]
         : +mov ecx, dword ptr [ebp - 0x14]
         : +mov dword ptr [eax + ecx*4], 0
         : +mov eax, dword ptr [ebp + 0xc] 	(spark.c:2937)
         : +xor ecx, ecx
         : +mov cx, word ptr [eax + 0x20]
         : +test cl, 0x80
         : +je 0x30
         : +mov eax, dword ptr [ebp + 0xc] 	(spark.c:2938)
         : +mov eax, dword ptr [eax + 0x4c]
         : +mov eax, dword ptr [eax + 0x18]
         : +mov ecx, dword ptr [ebp - 0xc]
         : +shl ecx, 2
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x2c]
         : +mov ecx, dword ptr [ebp - 0x14]
         : +xor edx, edx
         : +mov dx, word ptr [eax + ecx*2]
         : +lea eax, [edx + edx*4]
         : +mov ecx, dword ptr [ebp + 0xc]
         : +mov ecx, dword ptr [ecx + 8]
         : +mov byte ptr [ecx + eax*8 + 0x14], 0
         : +jmp 0xa1 	(spark.c:2940)
         : +mov eax, dword ptr [ebp + 0xc] 	(spark.c:2941)
         : +mov eax, dword ptr [eax + 0x4c]
         : +mov eax, dword ptr [eax + 0x18]
         : +mov ecx, dword ptr [ebp - 0xc]
         : +shl ecx, 2
         : +lea ecx, [ecx + ecx*2]
         : +lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [eax + ecx + 0x28]
         : +mov ecx, dword ptr [ebp - 0x14]
         : +mov ebx, dword ptr [eax + ecx*4]
         : +shr ebx, 0x18
         : +push 0xa
         : +push 5
         : +call IRandomBetween (FUNCTION)
         : +add esp, 8
         : +add eax, eax
         : +sub ebx, eax
         : +shl ebx, 0x18
         : +mov dword ptr [ebp - 4], ebx
         : +mov eax, dword ptr [ebp - 4] 	(spark.c:2942)
         : +shl eax, 0x18
         : +mov ecx, dword ptr [ebp + 0xc]
         : +mov ecx, dword ptr [ecx + 0x4c]
         : +mov ecx, dword ptr [ecx + 0x18]
         : +mov edx, dword ptr [ebp - 0xc]
         : +shl edx, 2
         : +lea edx, [edx + edx*2]
         : +lea edx, [edx + edx*4]
         : +mov ecx, dword ptr [ecx + edx + 0x28]
         : +mov edx, dword ptr [ebp - 0x14]
         : +mov dword ptr [ecx + edx*4], eax
         : +mov eax, dword ptr [ebp + 0xc] 	(spark.c:2943)
         : +xor ecx, ecx
         : +mov cx, word ptr [eax + 0x20]
         : +test cl, 0x80
         : +je 0x32
         : +mov al, byte ptr [ebp - 4] 	(spark.c:2944)
         : +mov ecx, dword ptr [ebp + 0xc]
         : +mov ecx, dword ptr [ecx + 0x4c]
         : +mov ecx, dword ptr [ecx + 0x18]
         : +mov edx, dword ptr [ebp - 0xc]
         : +shl edx, 2
         : +lea edx, [edx + edx*2]
         : +lea edx, [edx + edx*4]
         : +mov ecx, dword ptr [ecx + edx + 0x2c]
         : +mov edx, dword ptr [ebp - 0x14]
         : +xor ebx, ebx
         : +mov bx, word ptr [ecx + edx*2]
         : +lea ecx, [ebx + ebx*4]
         : +mov edx, dword ptr [ebp + 0xc]
         : +mov edx, dword ptr [edx + 8]
         : +mov byte ptr [edx + ecx*8 + 0x14], al
         : +jmp -0x2dc 	(spark.c:2947)
         : +jmp -0x305 	(spark.c:2948)
0x46f811 : mov eax, dword ptr [ebp + 0xc] 	(spark.c:2949)
0x46f814 : xor ecx, ecx
0x46f816 : mov cx, word ptr [eax + 0x20]
0x46f81a : test cl, 0x80
0x46f81d : je 0x1b
0x46f823 : mov eax, dword ptr [ebp + 0xc]
0x46f826 : cmp dword ptr [eax + 0x28], 0
0x46f82a : je 0xe
0x46f830 : push 1 	(spark.c:2950)
0x46f832 : mov eax, dword ptr [ebp + 0xc]


DoModelThing is only 43.87% similar to the original, diff above
```

*AI generated. Time taken: 985s, tokens: 198,739*
