### PR TITLE
ToggleInfo 100% match

### DIFF
--- a/src/DETHRACE/common/mainloop.c
+++ b/src/DETHRACE/common/mainloop.c
@@ -98,20 +98,21 @@ int gLast_credit_headup__mainloop; // suffix added to avoid duplicate symbol
 // FUNCTION: CARM95 0x0046fd00
 void ToggleInfo(void) {
 
-    if (gProgram_state.game_completed) {
-        if (KeyIsDown(KEYMAP_CONTROL_ANY)) {
-            gAR_fudge_headups = !gAR_fudge_headups;
-        } else {
-            gInfo_on = !gInfo_on;
-            if (gInfo_on) {
+    if (!gProgram_state.game_completed) {
+        return;
+    }
+    if (KeyIsDown(KEYMAP_CONTROL_ANY)) {
+        gAR_fudge_headups = !gAR_fudge_headups;
+    } else {
+        gInfo_on = !gInfo_on;
+        if (gInfo_on) {
 #ifdef DETHRACE_3DFX_PATCH
-                if (PDKeyDown(KEY_SHIFT_ANY)) {
-                    gInfo_mode = (gInfo_mode + 1) % 3;
-                }
-#else
-                gInfo_mode = PDKeyDown(KEY_SHIFT_ANY);
-#endif
+            if (PDKeyDown(KEY_SHIFT_ANY)) {
+                gInfo_mode = (gInfo_mode + 1) % 3;
             }
+#else
+            gInfo_mode = PDKeyDown(KEY_SHIFT_ANY);
+#endif
         }
     }
 }


### PR DESCRIPTION
## Match result

```
0x46fd00: ToggleInfo 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x46fd00,18 +0x48b840,17 @@
0x46fd00 : push ebp 	(mainloop.c:99)
0x46fd01 : mov ebp, esp
0x46fd03 : push ebx
0x46fd04 : push esi
0x46fd05 : push edi
0x46fd06 : cmp dword ptr [gProgram_state+132 (OFFSET)], 0 	(mainloop.c:101)
0x46fd0d : -jne 0x5
0x46fd13 : -jmp 0x7f
         : +je 0x7f
0x46fd18 : push 7 	(mainloop.c:102)
0x46fd1a : call KeyIsDown (FUNCTION)
0x46fd1f : add esp, 4
0x46fd22 : test eax, eax
0x46fd24 : je 0x2b
0x46fd2a : cmp dword ptr [gAR_fudge_headups (DATA)], 0 	(mainloop.c:103)
0x46fd31 : jne 0xf
0x46fd37 : mov dword ptr [gAR_fudge_headups (DATA)], 1
0x46fd41 : jmp 0xa
0x46fd46 : mov dword ptr [gAR_fudge_headups (DATA)], 0

---
+++
@@ -0x46fd5c,10 +0x48b897,15 @@
0x46fd5c : jne 0xf
0x46fd62 : mov dword ptr [gInfo_on (DATA)], 1
0x46fd6c : jmp 0xa
0x46fd71 : mov dword ptr [gInfo_on (DATA)], 0
0x46fd7b : cmp dword ptr [gInfo_on (DATA)], 0 	(mainloop.c:106)
0x46fd82 : je 0xf
0x46fd88 : push 0 	(mainloop.c:112)
0x46fd8a : call PDKeyDown (FUNCTION)
0x46fd8f : add esp, 4
0x46fd92 : mov dword ptr [gInfo_mode (DATA)], eax
         : +pop edi 	(mainloop.c:117)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


ToggleInfo is only 87.50% similar to the original, diff above
```

*AI generated. Time taken: 81s, tokens: 12,423*
