### PR TITLE
MainGameLoop 100% match

### DIFF
--- a/src/DETHRACE/common/mainloop.c
+++ b/src/DETHRACE/common/mainloop.c
@@ -605,10 +605,13 @@ tRace_result MainGameLoop(void) {
         if (gHost_abandon_game || gProgram_state.prog_status == eProg_idling) {
             break;
         }
-        if (gNet_mode && gMap_mode
-            && ((gCurrent_net_game->type == eNet_game_type_foxy && gThis_net_player_index == gIt_or_fox)
-                || (gCurrent_net_game->type == eNet_game_type_tag && gThis_net_player_index != gIt_or_fox))) {
-            ToggleMap();
+        if (gNet_mode) {
+            if ((gCurrent_net_game->type == eNet_game_type_foxy && gThis_net_player_index == gIt_or_fox)
+                || (gCurrent_net_game->type == eNet_game_type_tag && gThis_net_player_index != gIt_or_fox)) {
+                if (gMap_mode) {
+                    ToggleMap();
+                }
+            }
         }
         ResetGrooveFlags();
         MungeEngineNoise();
@@ -619,19 +622,20 @@ tRace_result MainGameLoop(void) {
             DoPowerupPeriodics(gFrame_period);
         }
         ResetLollipopQueue();
+        MungePalette();
         if (!gAction_replay_mode) {
             MungeOpponents(gFrame_period);
             PollCarControls(gFrame_period);
         }
         PollCameraControls(camera_period);
-        if (gAction_replay_mode) {
-            DoActionReplay(gFrame_period);
-        } else {
+        if (!gAction_replay_mode) {
             ControlOurCar(gFrame_period);
             ApplyPhysicsToCars(gLast_tick_count - gRace_start, gFrame_period);
             PipeCarPositions();
             NetSendMessageStacks();
-            CheckRecoveryOfCars(gFrame_period + gLast_tick_count - gRace_start);
+            CheckRecoveryOfCars(gLast_tick_count - gRace_start + gFrame_period);
+        } else {
+            DoActionReplay(gFrame_period);
         }
         if (!gNasty_kludgey_cockpit_variable) {
             gNasty_kludgey_cockpit_variable = 1;
@@ -684,7 +688,7 @@ tRace_result MainGameLoop(void) {
             && !gPalette_fade_time
             && (gNet_mode == eNet_mode_none
                 || !gAction_replay_mode
-                || gProgram_state.current_car.car_master_actor->t.t.mat.m[3][0] < 500.0)) {
+                || gProgram_state.current_car.car_master_actor->t.t.mat.m[3][0] < 500.0f)) {
 
             EnsureRenderPalette();
             EnsurePaletteUp();
@@ -704,10 +708,10 @@ tRace_result MainGameLoop(void) {
                 AddLostTime(PDGetTotalTime() - start_menu_time);
             }
         }
-        if (gAction_replay_mode) {
-            PollActionReplayControls(gFrame_period);
-        } else {
+        if (!gAction_replay_mode) {
             CheckTimer();
+        } else {
+            PollActionReplayControls(gFrame_period);
         }
         if (!gAction_replay_mode && gKnobbled_frame_period) {
             while (GetTotalTime() - frame_start_time < gKnobbled_frame_period) {
@@ -767,10 +771,10 @@ tRace_result MainGameLoop(void) {
     } else {
         result = eRace_game_abandonned;
     }
-    if (result >= eRace_completed) {
-        gProgram_state.redo_race_index = -1;
-    } else {
+    if (result < eRace_completed) {
         gProgram_state.redo_race_index = gProgram_state.current_race_index;
+    } else {
+        gProgram_state.redo_race_index = -1;
     }
     gAbandon_game = 0;
     gSynch_race_start = 0;


### PR DESCRIPTION
## Match result

```
0x46fe77: MainGameLoop 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x46ffb1,93 +0x48cbc8,92 @@
0x46ffb1 : mov dword ptr [ebp - 0x14], eax
0x46ffb4 : call CyclePollKeys (FUNCTION) 	(mainloop.c:602)
0x46ffb9 : push 1 	(mainloop.c:603)
0x46ffbb : call CheckSystemKeys (FUNCTION)
0x46ffc0 : add esp, 4
0x46ffc3 : call NetReceiveAndProcessMessages (FUNCTION) 	(mainloop.c:604)
0x46ffc8 : cmp dword ptr [gHost_abandon_game (DATA)], 0 	(mainloop.c:605)
0x46ffcf : jne 0xd
0x46ffd5 : cmp dword ptr [gProgram_state+164 (OFFSET)], 2
0x46ffdc : jne 0x5
0x46ffe2 : -jmp 0x48b
         : +jmp 0x486 	(mainloop.c:606)
0x46ffe7 : cmp dword ptr [gNet_mode (DATA)], 0 	(mainloop.c:610)
0x46ffee : je 0x52
         : +cmp dword ptr [gMap_mode (DATA)], 0
         : +je 0x45
0x46fff4 : mov eax, dword ptr [gCurrent_net_game (DATA)]
0x46fff9 : cmp dword ptr [eax + 0x74], 6
0x46fffd : jne 0x11
0x470003 : mov eax, dword ptr [gIt_or_fox (DATA)]
0x470008 : cmp dword ptr [gThis_net_player_index (DATA)], eax
0x47000e : je 0x20
0x470014 : mov eax, dword ptr [gCurrent_net_game (DATA)]
0x470019 : cmp dword ptr [eax + 0x74], 5
0x47001d : -jne 0x23
         : +jne 0x16
0x470023 : mov eax, dword ptr [gIt_or_fox (DATA)]
0x470028 : cmp dword ptr [gThis_net_player_index (DATA)], eax
0x47002e : -je 0x12
0x470034 : -cmp dword ptr [gMap_mode (DATA)], 0
0x47003b : je 0x5
0x470041 : call ToggleMap (FUNCTION) 	(mainloop.c:611)
0x470046 : call ResetGrooveFlags (FUNCTION) 	(mainloop.c:613)
0x47004b : call MungeEngineNoise (FUNCTION) 	(mainloop.c:614)
0x470050 : call ServiceGameInRace (FUNCTION) 	(mainloop.c:615)
0x470055 : call EnterUserMessage (FUNCTION) 	(mainloop.c:616)
0x47005a : lea eax, [ebp - 0xc] 	(mainloop.c:617)
0x47005d : push eax
0x47005e : call UpdateFramePeriod (FUNCTION)
0x470063 : add esp, 4
0x470066 : cmp dword ptr [gAction_replay_mode (DATA)], 0 	(mainloop.c:618)
0x47006d : jne 0xe
0x470073 : mov eax, dword ptr [gFrame_period (DATA)] 	(mainloop.c:619)
0x470078 : push eax
0x470079 : call DoPowerupPeriodics (FUNCTION)
0x47007e : add esp, 4
0x470081 : call ResetLollipopQueue (FUNCTION) 	(mainloop.c:621)
0x470086 : -call MungePalette (FUNCTION)
0x47008b : cmp dword ptr [gAction_replay_mode (DATA)], 0 	(mainloop.c:622)
0x470092 : jne 0x1c
0x470098 : mov eax, dword ptr [gFrame_period (DATA)] 	(mainloop.c:623)
0x47009d : push eax
0x47009e : call MungeOpponents (FUNCTION)
0x4700a3 : add esp, 4
0x4700a6 : mov eax, dword ptr [gFrame_period (DATA)] 	(mainloop.c:624)
0x4700ab : push eax
0x4700ac : call PollCarControls (FUNCTION)
0x4700b1 : add esp, 4
0x4700b4 : mov eax, dword ptr [ebp - 0xc] 	(mainloop.c:626)
0x4700b7 : push eax
0x4700b8 : call PollCameraControls (FUNCTION)
0x4700bd : add esp, 4
0x4700c0 : cmp dword ptr [gAction_replay_mode (DATA)], 0 	(mainloop.c:627)
0x4700c7 : -jne 0x51
         : +je 0x13
         : +mov eax, dword ptr [gFrame_period (DATA)] 	(mainloop.c:628)
         : +push eax
         : +call DoActionReplay (FUNCTION)
         : +add esp, 4
         : +jmp 0x4c 	(mainloop.c:629)
0x4700cd : mov eax, dword ptr [gFrame_period (DATA)] 	(mainloop.c:630)
0x4700d2 : push eax
0x4700d3 : call ControlOurCar (FUNCTION)
0x4700d8 : add esp, 4
0x4700db : mov eax, dword ptr [gFrame_period (DATA)] 	(mainloop.c:631)
0x4700e0 : push eax
0x4700e1 : mov eax, dword ptr [gLast_tick_count (DATA)]
0x4700e6 : sub eax, dword ptr [gRace_start (DATA)]
0x4700ec : push eax
0x4700ed : call ApplyPhysicsToCars (FUNCTION)
0x4700f2 : add esp, 8
0x4700f5 : call PipeCarPositions (FUNCTION) 	(mainloop.c:632)
0x4700fa : call NetSendMessageStacks (FUNCTION) 	(mainloop.c:633)
0x4700ff : -mov eax, dword ptr [gLast_tick_count (DATA)]
         : +mov eax, dword ptr [gFrame_period (DATA)] 	(mainloop.c:634)
         : +add eax, dword ptr [gLast_tick_count (DATA)]
0x470104 : sub eax, dword ptr [gRace_start (DATA)]
0x47010a : -add eax, dword ptr [gFrame_period (DATA)]
0x470110 : push eax
0x470111 : call CheckRecoveryOfCars (FUNCTION)
0x470116 : -add esp, 4
0x470119 : -jmp 0xe
0x47011e : -mov eax, dword ptr [gFrame_period (DATA)]
0x470123 : -push eax
0x470124 : -call DoActionReplay (FUNCTION)
0x470129 : add esp, 4
0x47012c : cmp dword ptr [gNasty_kludgey_cockpit_variable (DATA)], 0 	(mainloop.c:636)
0x470133 : jne 0xf
0x470139 : mov dword ptr [gNasty_kludgey_cockpit_variable (DATA)], 1 	(mainloop.c:637)
0x470143 : call ToggleCockpit (FUNCTION) 	(mainloop.c:638)
0x470148 : mov eax, dword ptr [gSelf (DATA)] 	(mainloop.c:640)
0x47014d : add eax, 0x50
0x470150 : mov dword ptr [gOur_pos (DATA)], eax
0x470155 : mov eax, dword ptr [ebp - 0xc] 	(mainloop.c:641)
0x470158 : push eax

---
+++
@@ -0x4702b2,21 +0x48cec4,21 @@
0x4702b2 : cmp dword ptr [gProgram_state+164 (OFFSET)], 5
0x4702b9 : jne 0x4a
0x4702bf : cmp dword ptr [gPalette_fade_time (DATA)], 0
0x4702c6 : jne 0x3d
0x4702cc : cmp dword ptr [gNet_mode (DATA)], 0
0x4702d3 : je 0x26
0x4702d9 : cmp dword ptr [gAction_replay_mode (DATA)], 0
0x4702e0 : je 0x19
0x4702e6 : mov eax, dword ptr [gProgram_state+188 (OFFSET)]
0x4702eb : fld dword ptr [eax + 0x50]
0x4702ee : -fcomp dword ptr [500.0 (FLOAT)]
         : +fcomp qword ptr [500.0 (FLOAT)]
0x4702f4 : fnstsw ax
0x4702f6 : test ah, 1
0x4702f9 : je 0xa
0x4702ff : call EnsureRenderPalette (FUNCTION) 	(mainloop.c:689)
0x470304 : call EnsurePaletteUp (FUNCTION) 	(mainloop.c:690)
0x470309 : call DoNetGameManagement (FUNCTION) 	(mainloop.c:692)
0x47030e : push 0 	(mainloop.c:693)
0x470310 : call KeyIsDown (FUNCTION)
0x470315 : add esp, 4
0x470318 : test eax, eax

---
+++
@@ -0x470364,27 +0x48cf76,27 @@
0x470364 : push 0
0x470366 : call DoMainMenuScreen (FUNCTION)
0x47036b : add esp, 0xc
0x47036e : call GoingBackToRaceFromInterface (FUNCTION) 	(mainloop.c:703)
0x470373 : call PDGetTotalTime (FUNCTION) 	(mainloop.c:704)
0x470378 : sub eax, dword ptr [ebp - 0x1c]
0x47037b : push eax
0x47037c : call AddLostTime (FUNCTION)
0x470381 : add esp, 4
0x470384 : cmp dword ptr [gAction_replay_mode (DATA)], 0 	(mainloop.c:707)
0x47038b : -jne 0xa
0x470391 : -call CheckTimer (FUNCTION)
0x470396 : -jmp 0xe
         : +je 0x13
0x47039b : mov eax, dword ptr [gFrame_period (DATA)] 	(mainloop.c:708)
0x4703a0 : push eax
0x4703a1 : call PollActionReplayControls (FUNCTION)
0x4703a6 : add esp, 4
         : +jmp 0x5 	(mainloop.c:709)
         : +call CheckTimer (FUNCTION) 	(mainloop.c:710)
0x4703a9 : cmp dword ptr [gAction_replay_mode (DATA)], 0 	(mainloop.c:712)
0x4703b0 : jne 0x26
0x4703b6 : cmp dword ptr [gKnobbled_frame_period (DATA)], 0
0x4703bd : je 0x19
0x4703c3 : call GetTotalTime (FUNCTION) 	(mainloop.c:713)
0x4703c8 : sub eax, dword ptr [ebp - 0x14]
0x4703cb : cmp eax, dword ptr [gKnobbled_frame_period (DATA)]
0x4703d1 : jae 0x5
0x4703d7 : jmp -0x19 	(mainloop.c:715)
0x4703dc : cmp dword ptr [ebp - 0x18], 0 	(mainloop.c:717)

---
+++
@@ -0x47042a,21 +0x48d03c,21 @@
0x47042a : mov dword ptr [gProgram_state+164 (OFFSET)], 2 	(mainloop.c:724)
0x470434 : mov dword ptr [gAbandon_game (DATA)], 0 	(mainloop.c:725)
0x47043e : cmp dword ptr [gProgram_state+164 (OFFSET)], 5 	(mainloop.c:731)
0x470445 : jne 0x27
0x47044b : call MungeRaceFinished (FUNCTION)
0x470450 : test eax, eax
0x470452 : jne 0x1a
0x470458 : cmp dword ptr [gAbandon_game (DATA)], 0
0x47045f : jne 0xd
0x470465 : cmp dword ptr [gHost_abandon_game (DATA)], 0
0x47046c : -je -0x4c6
         : +je -0x4c1
0x470472 : push "JUST EXITED MAINLOOP" (STRING) 	(mainloop.c:732)
0x470477 : push 0
0x470479 : call PrintMemoryDump (FUNCTION)
0x47047e : add esp, 8
0x470481 : call FadePaletteDown (FUNCTION) 	(mainloop.c:733)
0x470486 : call ClearEntireScreen (FUNCTION) 	(mainloop.c:734)
0x47048b : call SuspendPendingFlic (FUNCTION) 	(mainloop.c:735)
0x470490 : call RevertPalette (FUNCTION) 	(mainloop.c:736)
0x470495 : cmp dword ptr [gMap_mode (DATA)], 0 	(mainloop.c:737)
0x47049c : je 0x5

---
+++
@@ -0x470567,25 +0x48d179,25 @@
0x470567 : cmp dword ptr [gRace_over_reason (DATA)], 4
0x47056e : je 0xd
0x470574 : cmp dword ptr [gRace_over_reason (DATA)], 5
0x47057b : jne 0xc
0x470581 : mov dword ptr [ebp - 4], 2 	(mainloop.c:763)
0x470588 : jmp 0x7 	(mainloop.c:764)
0x47058d : mov dword ptr [ebp - 4], 3 	(mainloop.c:765)
0x470594 : jmp 0x7 	(mainloop.c:767)
0x470599 : mov dword ptr [ebp - 4], 0 	(mainloop.c:768)
0x4705a0 : cmp dword ptr [ebp - 4], 3 	(mainloop.c:770)
0x4705a4 : -jge 0xf
         : +jl 0xf
         : +mov dword ptr [gProgram_state+124 (OFFSET)], 0xffffffff 	(mainloop.c:771)
         : +jmp 0xa 	(mainloop.c:772)
0x4705aa : mov eax, dword ptr [gProgram_state+120 (OFFSET)] 	(mainloop.c:773)
0x4705af : mov dword ptr [gProgram_state+124 (OFFSET)], eax
0x4705b4 : -jmp 0xa
0x4705b9 : -mov dword ptr [gProgram_state+124 (OFFSET)], 0xffffffff
0x4705c3 : mov dword ptr [gAbandon_game (DATA)], 0 	(mainloop.c:775)
0x4705cd : mov dword ptr [gSynch_race_start (DATA)], 0 	(mainloop.c:776)
0x4705d7 : mov dword ptr [gInitialised_grid (DATA)], 0 	(mainloop.c:777)
0x4705e1 : mov dword ptr [gHost_abandon_game (DATA)], 0 	(mainloop.c:778)
0x4705eb : call S3StopAllOutletSounds (FUNCTION) 	(mainloop.c:779)
0x4705f0 : cmp dword ptr [gTime_bonus_state (DATA)], 0 	(mainloop.c:780)
0x4705f7 : jle 0x2d
0x4705fd : mov eax, dword ptr [gProgram_state+40 (OFFSET)] 	(mainloop.c:781)
0x470602 : mov ecx, dword ptr [eax*4 + gPoints_per_second[0] (DATA)]
0x470609 : mov ebx, 0x3e8

---
+++
@@ -0x4706b8,10 +0x48d2ca,15 @@
0x4706b8 : mov eax, dword ptr [gCurrent_net_game (DATA)] 	(mainloop.c:796)
0x4706bd : mov dword ptr [eax + 0x40], 0
0x4706c4 : call WaitForNoKeys (FUNCTION) 	(mainloop.c:798)
0x4706c9 : cmp dword ptr [gNet_mode (DATA)], 0 	(mainloop.c:799)
0x4706d0 : je 0x17
0x4706d6 : cmp dword ptr [gAbandon_game (DATA)], 0
0x4706dd : je 0xa
0x4706e3 : mov dword ptr [gProgram_state+164 (OFFSET)], 2 	(mainloop.c:800)
0x4706ed : mov eax, dword ptr [ebp - 4] 	(mainloop.c:802)
0x4706f0 : jmp 0x0
         : +pop edi 	(mainloop.c:803)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


MainGameLoop is only 94.74% similar to the original, diff above
```

*AI generated. Time taken: 119s, tokens: 20,579*
