### PR TITLE
WaitForNoKeys 100% match

### DIFF
--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -353,9 +353,9 @@ int KeyIsDown(int pKey_index) {
 // FUNCTION: CARM95 0x0047232b
 void WaitForNoKeys(void) {
 
-    while (AnyKeyDown() || EitherMouseButtonDown()) {
+    do {
         CheckQuit();
-    }
+    } while (AnyKeyDown() || EitherMouseButtonDown());
     CheckQuit();
 }
 


### PR DESCRIPTION
## Match result

```
0x47232b: WaitForNoKeys 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x47232b,18 +0x4871db,19 @@
0x47232b : push ebp 	(input.c:354)
0x47232c : mov ebp, esp
0x47232e : push ebx
0x47232f : push esi
0x472330 : push edi
0x472331 : -call CheckQuit (FUNCTION)
0x472336 : call AnyKeyDown (FUNCTION) 	(input.c:356)
0x47233b : test eax, eax
0x47233d : -jne -0x12
         : +jne 0xd
0x472343 : call EitherMouseButtonDown (FUNCTION)
0x472348 : test eax, eax
0x47234a : -jne -0x1f
         : +je 0xa
         : +call CheckQuit (FUNCTION) 	(input.c:357)
         : +jmp -0x24 	(input.c:358)
0x472350 : call CheckQuit (FUNCTION) 	(input.c:359)
0x472355 : pop edi 	(input.c:360)
0x472356 : pop esi
0x472357 : pop ebx
0x472358 : leave 
0x472359 : ret 


WaitForNoKeys is only 81.08% similar to the original, diff above
```

*AI generated. Time taken: 61s, tokens: 8,760*
