### PR TITLE
ChangeTextTo 100% effective match

### DIFF
--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -626,7 +626,7 @@ void ChangeTextTo(int pXcoord, int pYcoord, char* pNew_str, char* pOld_str) {
     new_type = eRT_looping_random;
 #endif
 
-    for (i = 0; !(i >= len); i++) {
+    for (i = 0; i < len; i++) {
         x_coord = gCurrent_graf_data->rolling_letter_x_pitch * i + pXcoord;
         if (len2 <= i) {
             new_char = ' ';

--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -626,11 +626,12 @@ void ChangeTextTo(int pXcoord, int pYcoord, char* pNew_str, char* pOld_str) {
     new_type = eRT_looping_random;
 #endif
 
-    for (i = 0; i < len; i++) {
-        if (i < len2) {
-            new_char = pNew_str[i];
-        } else {
+    for (i = 0; !(i >= len); i++) {
+        x_coord = gCurrent_graf_data->rolling_letter_x_pitch * i + pXcoord;
+        if (len2 <= i) {
             new_char = ' ';
+        } else {
+            new_char = pNew_str[i];
         }
         if (new_char == ROLLING_LETTER_LOOP_RANDOM) {
             new_type = eRT_looping_random;
@@ -639,14 +640,13 @@ void ChangeTextTo(int pXcoord, int pYcoord, char* pNew_str, char* pOld_str) {
         } else {
             new_type = eRT_alpha;
         }
-        x_coord = gCurrent_graf_data->rolling_letter_x_pitch * i + pXcoord;
-        for (j = 0, let = gRolling_letters; j < NBR_ROLLING_LETTERS; j++, let++) {
+        for (let = gRolling_letters, j = 0; j < NBR_ROLLING_LETTERS; j++, let++) {
             if (let->number_of_letters >= 0 && let->x_coord == x_coord && let->y_coord == pYcoord) {
                 if (new_char != ROLLING_LETTER_LOOP_RANDOM) {
                     let->letters[0] = new_char;
                 }
                 if (new_char == ' ') {
-                    let->letters[0] = ' ';
+                    let->letters[0] = new_char;
                 }
                 let->current_offset = let->number_of_letters * gCurrent_graf_data->save_slot_letter_height;
                 let->rolling_type = new_type;


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4729fc,23 +0x487a3b,23 @@
0x4729fc : mov edi, dword ptr [ebp + 0x10] 	(input.c:624)
0x4729ff : mov ecx, 0xffffffff
0x472a04 : sub eax, eax
0x472a06 : repne scasb al, byte ptr es:[edi]
0x472a08 : not ecx
0x472a0a : lea eax, [ecx - 1]
0x472a0d : mov dword ptr [ebp - 0x20], eax
0x472a10 : mov dword ptr [ebp - 0x14], 0 	(input.c:629)
0x472a17 : jmp 0x3
0x472a1c : inc dword ptr [ebp - 0x14]
0x472a1f : -mov eax, dword ptr [ebp - 0x1c]
0x472a22 : -cmp dword ptr [ebp - 0x14], eax
0x472a25 : -jge 0x127
         : +mov eax, dword ptr [ebp - 0x14]
         : +cmp dword ptr [ebp - 0x1c], eax
         : +jle 0x127
0x472a2b : mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(input.c:630)
0x472a30 : mov eax, dword ptr [eax + 0x10]
0x472a33 : imul eax, dword ptr [ebp - 0x14]
0x472a37 : add eax, dword ptr [ebp + 8]
0x472a3a : mov dword ptr [ebp - 0xc], eax
0x472a3d : mov eax, dword ptr [ebp - 0x14] 	(input.c:631)
0x472a40 : cmp dword ptr [ebp - 0x20], eax
0x472a43 : jg 0x9
0x472a49 : mov byte ptr [ebp - 0x10], 0x20 	(input.c:632)
0x472a4d : jmp 0xc 	(input.c:633)


0x4729df: ChangeTextTo 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x4729fc,54 +0x487a3b,54 @@
0x4729fc : mov edi, dword ptr [ebp + 0x10] 	(input.c:624)
0x4729ff : mov ecx, 0xffffffff
0x472a04 : sub eax, eax
0x472a06 : repne scasb al, byte ptr es:[edi]
0x472a08 : not ecx
0x472a0a : lea eax, [ecx - 1]
0x472a0d : mov dword ptr [ebp - 0x20], eax
0x472a10 : mov dword ptr [ebp - 0x14], 0 	(input.c:629)
0x472a17 : jmp 0x3
0x472a1c : inc dword ptr [ebp - 0x14]
0x472a1f : -mov eax, dword ptr [ebp - 0x1c]
0x472a22 : -cmp dword ptr [ebp - 0x14], eax
0x472a25 : -jge 0x127
0x472a2b : -mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x472a30 : -mov eax, dword ptr [eax + 0x10]
0x472a33 : -imul eax, dword ptr [ebp - 0x14]
0x472a37 : -add eax, dword ptr [ebp + 8]
0x472a3a : -mov dword ptr [ebp - 0xc], eax
         : +mov eax, dword ptr [ebp - 0x14]
         : +cmp dword ptr [ebp - 0x1c], eax
         : +jle 0x127
0x472a3d : mov eax, dword ptr [ebp - 0x14] 	(input.c:630)
0x472a40 : cmp dword ptr [ebp - 0x20], eax
0x472a43 : -jg 0x9
0x472a49 : -mov byte ptr [ebp - 0x10], 0x20
0x472a4d : -jmp 0xc
         : +jle 0x11
0x472a52 : mov eax, dword ptr [ebp - 0x14] 	(input.c:631)
0x472a55 : mov ecx, dword ptr [ebp + 0x10]
0x472a58 : mov al, byte ptr [eax + ecx]
0x472a5b : mov byte ptr [ebp - 0x10], al
         : +jmp 0x4 	(input.c:632)
         : +mov byte ptr [ebp - 0x10], 0x20 	(input.c:633)
0x472a5e : movsx eax, byte ptr [ebp - 0x10] 	(input.c:635)
0x472a62 : cmp eax, 0x60
0x472a65 : jne 0xc
0x472a6b : mov dword ptr [ebp - 8], 2 	(input.c:636)
0x472a72 : jmp 0x2d 	(input.c:637)
0x472a77 : movsx eax, byte ptr [ebp - 0x10]
0x472a7b : cmp eax, 0x30
0x472a7e : jl 0x19
0x472a84 : movsx eax, byte ptr [ebp - 0x10]
0x472a88 : cmp eax, 0x39
0x472a8b : jg 0xc
0x472a91 : mov dword ptr [ebp - 8], 1 	(input.c:638)
0x472a98 : jmp 0x7 	(input.c:639)
0x472a9d : mov dword ptr [ebp - 8], 0 	(input.c:640)
         : +mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(input.c:642)
         : +mov eax, dword ptr [eax + 0x10]
         : +imul eax, dword ptr [ebp - 0x14]
         : +add eax, dword ptr [ebp + 8]
         : +mov dword ptr [ebp - 0xc], eax
         : +mov dword ptr [ebp - 0x18], 0 	(input.c:643)
0x472aa4 : mov eax, dword ptr [gRolling_letters (DATA)]
0x472aa9 : mov dword ptr [ebp - 4], eax
0x472aac : -mov dword ptr [ebp - 0x18], 0
0x472ab3 : jmp 0x7
0x472ab8 : inc dword ptr [ebp - 0x18]
0x472abb : add dword ptr [ebp - 4], 0x38
0x472abf : cmp dword ptr [ebp - 0x18], 0x1f4
0x472ac6 : jge 0x81
0x472acc : mov eax, dword ptr [ebp - 4] 	(input.c:644)
0x472acf : cmp dword ptr [eax + 0x2c], 0
0x472ad3 : jl 0x6f
0x472ad9 : mov eax, dword ptr [ebp - 4]
0x472adc : mov ecx, dword ptr [ebp - 0xc]

---
+++
@@ -0x472af1,23 +0x487b30,22 @@
0x472af1 : jne 0x51
0x472af7 : movsx eax, byte ptr [ebp - 0x10] 	(input.c:645)
0x472afb : cmp eax, 0x60
0x472afe : je 0x9
0x472b04 : movsx eax, byte ptr [ebp - 0x10] 	(input.c:646)
0x472b08 : mov ecx, dword ptr [ebp - 4]
0x472b0b : mov dword ptr [ecx], eax
0x472b0d : movsx eax, byte ptr [ebp - 0x10] 	(input.c:648)
0x472b11 : cmp eax, 0x20
0x472b14 : jne 0x9
0x472b1a : -movsx eax, byte ptr [ebp - 0x10]
0x472b1e : -mov ecx, dword ptr [ebp - 4]
0x472b21 : -mov dword ptr [ecx], eax
         : +mov eax, dword ptr [ebp - 4] 	(input.c:649)
         : +mov dword ptr [eax], 0x20
0x472b23 : mov eax, dword ptr [ebp - 4] 	(input.c:651)
0x472b26 : mov eax, dword ptr [eax + 0x2c]
0x472b29 : mov ecx, dword ptr [gCurrent_graf_data (DATA)]
0x472b2f : imul eax, dword ptr [ecx + 0x24]
0x472b33 : mov dword ptr [ebp - 0x24], eax
0x472b36 : fild dword ptr [ebp - 0x24]
0x472b39 : mov eax, dword ptr [ebp - 4]
0x472b3c : fstp dword ptr [eax + 0x34]
0x472b3f : mov eax, dword ptr [ebp - 8] 	(input.c:652)
0x472b42 : mov ecx, dword ptr [ebp - 4]


ChangeTextTo is only 88.45% similar to the original, diff above
```

*AI generated. Time taken: 144s, tokens: 16,707*
