### PR TITLE
StopTyping 100% effective match

### DIFF
--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -796,11 +796,7 @@ void StopTyping(int pSlot_index) {
     int i;
 
     for (i = 0; i < gThe_length; i++) {
-        if (i < (strlen(gCurrent_typing) - 1)) {
-            ChangeCharTo(pSlot_index, i, gCurrent_typing[i]);
-        } else {
-            ChangeCharTo(pSlot_index, i, ' ');
-        }
+        ChangeCharTo(pSlot_index, i, i < strlen(gCurrent_typing) ? gCurrent_typing[i] : ' ');
     }
 }
 


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x472d51,22 +0x488086,22 @@
0x472d51 : push ebp 	(input.c:795)
0x472d52 : mov ebp, esp
0x472d54 : sub esp, 8
0x472d57 : push ebx
0x472d58 : push esi
0x472d59 : push edi
0x472d5a : mov dword ptr [ebp - 4], 0 	(input.c:798)
0x472d61 : jmp 0x3
0x472d66 : inc dword ptr [ebp - 4]
0x472d69 : -mov eax, dword ptr [gThe_length (DATA)]
0x472d6e : -cmp dword ptr [ebp - 4], eax
0x472d71 : -jge 0x4e
         : +mov eax, dword ptr [ebp - 4]
         : +cmp dword ptr [gThe_length (DATA)], eax
         : +jle 0x4e
0x472d77 : mov edi, gCurrent_typing[0] (DATA) 	(input.c:799)
0x472d7c : mov ecx, 0xffffffff
0x472d81 : sub eax, eax
0x472d83 : repne scasb al, byte ptr es:[edi]
0x472d85 : not ecx
0x472d87 : lea eax, [ecx - 1]
0x472d8a : cmp eax, dword ptr [ebp - 4]
0x472d8d : ja 0xc
0x472d93 : mov dword ptr [ebp - 8], 0x20
0x472d9a : jmp 0xd

---
+++
@@ -0x472da2,16 +0x4880d8,16 @@
0x472da2 : movsx eax, byte ptr [eax + gCurrent_typing[0] (DATA)]
0x472da9 : mov dword ptr [ebp - 8], eax
0x472dac : mov eax, dword ptr [ebp - 8]
0x472daf : push eax
0x472db0 : mov eax, dword ptr [ebp - 4]
0x472db3 : push eax
0x472db4 : mov eax, dword ptr [ebp + 8]
0x472db7 : push eax
0x472db8 : call ChangeCharTo (FUNCTION)
0x472dbd : add esp, 0xc
0x472dc0 : -jmp -0x5f
         : +jmp -0x60 	(input.c:800)
0x472dc5 : pop edi 	(input.c:801)
0x472dc6 : pop esi
0x472dc7 : pop ebx
0x472dc8 : leave 
0x472dc9 : ret 


0x472d51: StopTyping 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x472d51,39 +0x488086,44 @@
0x472d51 : push ebp 	(input.c:795)
0x472d52 : mov ebp, esp
0x472d54 : -sub esp, 8
         : +sub esp, 4
0x472d57 : push ebx
0x472d58 : push esi
0x472d59 : push edi
0x472d5a : mov dword ptr [ebp - 4], 0 	(input.c:798)
0x472d61 : jmp 0x3
0x472d66 : inc dword ptr [ebp - 4]
0x472d69 : -mov eax, dword ptr [gThe_length (DATA)]
0x472d6e : -cmp dword ptr [ebp - 4], eax
0x472d71 : -jge 0x4e
         : +mov eax, dword ptr [ebp - 4]
         : +cmp dword ptr [gThe_length (DATA)], eax
         : +jle 0x53
0x472d77 : mov edi, gCurrent_typing[0] (DATA) 	(input.c:799)
0x472d7c : mov ecx, 0xffffffff
0x472d81 : sub eax, eax
0x472d83 : repne scasb al, byte ptr es:[edi]
0x472d85 : not ecx
0x472d87 : lea eax, [ecx - 1]
         : +dec eax
0x472d8a : cmp eax, dword ptr [ebp - 4]
0x472d8d : -ja 0xc
0x472d93 : -mov dword ptr [ebp - 8], 0x20
0x472d9a : -jmp 0xd
         : +jbe 0x1f
0x472d9f : mov eax, dword ptr [ebp - 4] 	(input.c:800)
0x472da2 : -movsx eax, byte ptr [eax + gCurrent_typing[0] (DATA)]
0x472da9 : -mov dword ptr [ebp - 8], eax
0x472dac : -mov eax, dword ptr [ebp - 8]
         : +mov al, byte ptr [eax + gCurrent_typing[0] (DATA)]
0x472daf : push eax
0x472db0 : mov eax, dword ptr [ebp - 4]
0x472db3 : push eax
0x472db4 : mov eax, dword ptr [ebp + 8]
0x472db7 : push eax
0x472db8 : call ChangeCharTo (FUNCTION)
0x472dbd : add esp, 0xc
0x472dc0 : -jmp -0x5f
         : +jmp 0x12 	(input.c:801)
         : +push 0x20 	(input.c:802)
         : +mov eax, dword ptr [ebp - 4]
         : +push eax
         : +mov eax, dword ptr [ebp + 8]
         : +push eax
         : +call ChangeCharTo (FUNCTION)
         : +add esp, 0xc
         : +jmp -0x65 	(input.c:804)
0x472dc5 : pop edi 	(input.c:805)
0x472dc6 : pop esi
0x472dc7 : pop ebx
0x472dc8 : leave 
0x472dc9 : ret 


StopTyping is only 67.47% similar to the original, diff above
```

*AI generated. Time taken: 237s, tokens: 20,458*
