### PR TITLE
StartTyping 100% match

### DIFF
--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -820,8 +820,8 @@ void StartTyping(int pSlot_index, char* pText, int pVisible_length) {
 
     gThe_length = pVisible_length;
     strcpy(gCurrent_typing, pText);
-    gVisible_length = pVisible_length;
     gCurrent_position = strlen(gCurrent_typing);
+    gVisible_length = pVisible_length;
     SetRollingCursor(pSlot_index);
 }
 


### PR DESCRIPTION
## Match result

```
0x472e42: StartTyping 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x472e5e,28 +0x488198,28 @@
0x472e5e : sub edi, ecx
0x472e60 : mov eax, ecx
0x472e62 : mov edx, edi
0x472e64 : mov edi, gCurrent_typing[0] (DATA)
0x472e69 : mov esi, edx
0x472e6b : shr ecx, 2
0x472e6e : rep movsd dword ptr es:[edi], dword ptr [esi]
0x472e70 : mov ecx, eax
0x472e72 : and ecx, 3
0x472e75 : rep movsb byte ptr es:[edi], byte ptr [esi]
         : +mov eax, dword ptr [ebp + 0x10] 	(input.c:823)
         : +mov dword ptr [gVisible_length (DATA)], eax
0x472e77 : mov edi, gCurrent_typing[0] (DATA) 	(input.c:824)
0x472e7c : mov ecx, 0xffffffff
0x472e81 : sub eax, eax
0x472e83 : repne scasb al, byte ptr es:[edi]
0x472e85 : not ecx
0x472e87 : lea eax, [ecx - 1]
0x472e8a : mov dword ptr [gCurrent_position (DATA)], eax
0x472e8f : -mov eax, dword ptr [ebp + 0x10]
0x472e92 : -mov dword ptr [gVisible_length (DATA)], eax
0x472e97 : mov eax, dword ptr [ebp + 8] 	(input.c:825)
0x472e9a : push eax
0x472e9b : call SetRollingCursor (FUNCTION)
0x472ea0 : add esp, 4
0x472ea3 : pop edi 	(input.c:826)
0x472ea4 : pop esi
0x472ea5 : pop ebx
0x472ea6 : leave 
0x472ea7 : ret 


StartTyping is only 95.00% similar to the original, diff above
```

*AI generated. Time taken: 57s, tokens: 6,935*
