### PR TITLE
DoRLBackspace 100% match

### DIFF
--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -684,15 +684,14 @@ void DoRLBackspace(int pSlot_index) {
 
     if (gCurrent_position != 0) {
         if (strlen(gCurrent_typing) == gCurrent_position) {
-            new_len = strlen(gCurrent_typing);
+            ChangeCharTo(pSlot_index, strlen(gCurrent_typing), ' ');
         } else {
-            new_len = strlen(gCurrent_typing) - 1;
+            ChangeCharTo(pSlot_index, strlen(gCurrent_typing) - 1, ' ');
         }
-        ChangeCharTo(pSlot_index, new_len, ' ');
         new_len = strlen(gCurrent_typing) - 1;
         for (i = gCurrent_position - 1; i < new_len; i++) {
-            ChangeCharTo(pSlot_index, i, gCurrent_typing[i]);
             gCurrent_typing[i] = gCurrent_typing[i + 1];
+            ChangeCharTo(pSlot_index, i, gCurrent_typing[i]);
         }
         gCurrent_typing[new_len] = 0;
         gCurrent_position = gCurrent_position - 1;


### PR DESCRIPTION
## Match result

```
0x472fb9: DoRLBackspace 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x472fb9,47 +0x487c4b,44 @@
0x472fb9 : push ebp 	(input.c:681)
0x472fba : mov ebp, esp
0x472fbc : sub esp, 8
0x472fbf : push ebx
0x472fc0 : push esi
0x472fc1 : push edi
0x472fc2 : cmp dword ptr [gCurrent_position (DATA)], 0 	(input.c:685)
0x472fc9 : -je 0xea
         : +je 0xe4
0x472fcf : mov edi, gCurrent_typing[0] (DATA) 	(input.c:686)
0x472fd4 : mov ecx, 0xffffffff
0x472fd9 : sub eax, eax
0x472fdb : repne scasb al, byte ptr es:[edi]
0x472fdd : not ecx
0x472fdf : lea eax, [ecx - 1]
0x472fe2 : cmp eax, dword ptr [gCurrent_position (DATA)]
0x472fe8 : -jne 0x27
0x472fee : -push 0x20
         : +jne 0x1b
0x472ff0 : mov edi, gCurrent_typing[0] (DATA) 	(input.c:687)
0x472ff5 : mov ecx, 0xffffffff
0x472ffa : sub eax, eax
0x472ffc : repne scasb al, byte ptr es:[edi]
0x472ffe : not ecx
0x473000 : lea eax, [ecx - 1]
0x473003 : -push eax
0x473004 : -mov eax, dword ptr [ebp + 8]
0x473007 : -push eax
0x473008 : -call ChangeCharTo (FUNCTION)
0x47300d : -add esp, 0xc
0x473010 : -jmp 0x23
0x473015 : -push 0x20
         : +mov dword ptr [ebp - 4], eax
         : +jmp 0x17 	(input.c:688)
0x473017 : mov edi, gCurrent_typing[0] (DATA) 	(input.c:689)
0x47301c : mov ecx, 0xffffffff
0x473021 : sub eax, eax
0x473023 : repne scasb al, byte ptr es:[edi]
0x473025 : not ecx
0x473027 : lea eax, [ecx - 1]
0x47302a : dec eax
         : +mov dword ptr [ebp - 4], eax
         : +push 0x20 	(input.c:691)
         : +mov eax, dword ptr [ebp - 4]
0x47302b : push eax
0x47302c : mov eax, dword ptr [ebp + 8]
0x47302f : push eax
0x473030 : call ChangeCharTo (FUNCTION)
0x473035 : add esp, 0xc
0x473038 : mov edi, gCurrent_typing[0] (DATA) 	(input.c:692)
0x47303d : mov ecx, 0xffffffff
0x473042 : sub eax, eax
0x473044 : repne scasb al, byte ptr es:[edi]
0x473046 : not ecx

---
+++
@@ -0x47304c,29 +0x487cd8,35 @@
0x47304c : mov dword ptr [ebp - 4], eax
0x47304f : mov eax, dword ptr [gCurrent_position (DATA)] 	(input.c:693)
0x473054 : dec eax
0x473055 : mov dword ptr [ebp - 8], eax
0x473058 : jmp 0x3
0x47305d : inc dword ptr [ebp - 8]
0x473060 : mov eax, dword ptr [ebp - 8]
0x473063 : cmp dword ptr [ebp - 4], eax
0x473066 : jle 0x31
0x47306c : mov eax, dword ptr [ebp - 8] 	(input.c:694)
0x47306f : -mov al, byte ptr [eax + gCurrent_typing[1] (OFFSET)]
0x473075 : -mov ecx, dword ptr [ebp - 8]
0x473078 : -mov byte ptr [ecx + gCurrent_typing[0] (DATA)], al
0x47307e : -mov eax, dword ptr [ebp - 8]
0x473081 : mov al, byte ptr [eax + gCurrent_typing[0] (DATA)]
0x473087 : push eax
0x473088 : mov eax, dword ptr [ebp - 8]
0x47308b : push eax
0x47308c : mov eax, dword ptr [ebp + 8]
0x47308f : push eax
0x473090 : call ChangeCharTo (FUNCTION)
0x473095 : add esp, 0xc
         : +mov eax, dword ptr [ebp - 8] 	(input.c:695)
         : +mov al, byte ptr [eax + gCurrent_typing[1] (OFFSET)]
         : +mov ecx, dword ptr [ebp - 8]
         : +mov byte ptr [ecx + gCurrent_typing[0] (DATA)], al
0x473098 : jmp -0x40 	(input.c:696)
0x47309d : mov eax, dword ptr [ebp - 4] 	(input.c:697)
0x4730a0 : mov byte ptr [eax + gCurrent_typing[0] (DATA)], 0
0x4730a7 : dec dword ptr [gCurrent_position (DATA)] 	(input.c:698)
0x4730ad : mov eax, dword ptr [ebp + 8] 	(input.c:699)
0x4730b0 : push eax
0x4730b1 : call SetRollingCursor (FUNCTION)
         : +add esp, 4
         : +pop edi 	(input.c:701)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DoRLBackspace is only 80.50% similar to the original, diff above
```

*AI generated. Time taken: 193s, tokens: 19,712*
