### PR TITLE
DoRLDelete 100% match

### DIFF
--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -706,10 +706,10 @@ void DoRLDelete(int pSlot_index) {
     int i;
     int new_len;
 
-    if (gCurrent_position <= ((int)strlen(gCurrent_typing) - 1)) {
+    if (gCurrent_position < strlen(gCurrent_typing) - 1) {
+        ChangeCharTo(pSlot_index, strlen(gCurrent_typing) - 1, ' ');
         new_len = strlen(gCurrent_typing) - 1;
-        ChangeCharTo(pSlot_index, new_len, ' ');
-        for (i = gCurrent_position; i < new_len; i++) {
+        for (i = gCurrent_position; new_len > i; i++) {
             gCurrent_typing[i] = gCurrent_typing[i + 1];
             ChangeCharTo(pSlot_index, i, gCurrent_typing[i]);
         }


### PR DESCRIPTION
## Match result

```
0x4730be: DoRLDelete 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4730c5,55 +0x487d4b,58 @@
0x4730c5 : push esi
0x4730c6 : push edi
0x4730c7 : mov edi, gCurrent_typing[0] (DATA) 	(input.c:709)
0x4730cc : mov ecx, 0xffffffff
0x4730d1 : sub eax, eax
0x4730d3 : repne scasb al, byte ptr es:[edi]
0x4730d5 : not ecx
0x4730d7 : lea eax, [ecx - 1]
0x4730da : dec eax
0x4730db : cmp eax, dword ptr [gCurrent_position (DATA)]
0x4730e1 : -jbe 0x9d
0x4730e7 : -push 0x20
0x4730e9 : -mov edi, gCurrent_typing[0] (DATA)
0x4730ee : -mov ecx, 0xffffffff
0x4730f3 : -sub eax, eax
0x4730f5 : -repne scasb al, byte ptr es:[edi]
0x4730f7 : -not ecx
0x4730f9 : -lea eax, [ecx - 1]
0x4730fc : -dec eax
0x4730fd : -push eax
0x4730fe : -mov eax, dword ptr [ebp + 8]
0x473101 : -push eax
0x473102 : -call ChangeCharTo (FUNCTION)
0x473107 : -add esp, 0xc
         : +jl 0x8c
0x47310a : mov edi, gCurrent_typing[0] (DATA) 	(input.c:710)
0x47310f : mov ecx, 0xffffffff
0x473114 : sub eax, eax
0x473116 : repne scasb al, byte ptr es:[edi]
0x473118 : not ecx
0x47311a : lea eax, [ecx - 1]
0x47311d : dec eax
0x47311e : mov dword ptr [ebp - 4], eax
         : +push 0x20 	(input.c:711)
         : +mov eax, dword ptr [ebp - 4]
         : +push eax
         : +mov eax, dword ptr [ebp + 8]
         : +push eax
         : +call ChangeCharTo (FUNCTION)
         : +add esp, 0xc
0x473121 : mov eax, dword ptr [gCurrent_position (DATA)] 	(input.c:712)
0x473126 : mov dword ptr [ebp - 8], eax
0x473129 : jmp 0x3
0x47312e : inc dword ptr [ebp - 8]
0x473131 : -mov eax, dword ptr [ebp - 8]
0x473134 : -cmp dword ptr [ebp - 4], eax
0x473137 : -jle 0x31
         : +mov eax, dword ptr [ebp - 4]
         : +cmp dword ptr [ebp - 8], eax
         : +jge 0x31
0x47313d : mov eax, dword ptr [ebp - 8] 	(input.c:713)
0x473140 : mov al, byte ptr [eax + gCurrent_typing[1] (OFFSET)]
0x473146 : mov ecx, dword ptr [ebp - 8]
0x473149 : mov byte ptr [ecx + gCurrent_typing[0] (DATA)], al
0x47314f : mov eax, dword ptr [ebp - 8] 	(input.c:714)
0x473152 : mov al, byte ptr [eax + gCurrent_typing[0] (DATA)]
0x473158 : push eax
0x473159 : mov eax, dword ptr [ebp - 8]
0x47315c : push eax
0x47315d : mov eax, dword ptr [ebp + 8]
0x473160 : push eax
0x473161 : call ChangeCharTo (FUNCTION)
0x473166 : add esp, 0xc
0x473169 : jmp -0x40 	(input.c:715)
0x47316e : mov eax, dword ptr [ebp - 4] 	(input.c:716)
0x473171 : mov byte ptr [eax + gCurrent_typing[0] (DATA)], 0
         : +mov eax, dword ptr [ebp + 8] 	(input.c:717)
         : +push eax
         : +call SetRollingCursor (FUNCTION)
         : +add esp, 4
         : +pop edi 	(input.c:719)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DoRLDelete is only 69.42% similar to the original, diff above
```

*AI generated. Time taken: 133s, tokens: 12,659*
