### PR TITLE
DoRLTypeLetter 100% effective match

### DIFF
--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -758,36 +758,37 @@ void DoRLTypeLetter(int pChar, int pSlot_index) {
     int new_len;
 
     // v2 = pSlot_index;
-    if (pChar >= 32) {
-        if (gInsert_mode) {
-            new_len = strlen(gCurrent_typing) + 1;
-            if (new_len > 100) {
-                new_len = 100;
-                DoErrorInterface(kMiscString_FIXED_THAT_YOU_TWISTED_BASTARD);
-            }
-            for (i = new_len - 1; i > gCurrent_position; i--) {
-                gCurrent_typing[i] = gCurrent_typing[i - 1];
-                ChangeCharTo(pSlot_index, i, gCurrent_typing[i]);
-            }
-        } else if (strlen(gCurrent_typing) == gCurrent_position) {
-            new_len = strlen(gCurrent_typing) + 1;
-        } else {
-            new_len = strlen(gCurrent_typing);
-        }
+    if (pChar < 32) {
+        return;
+    }
+    if (gInsert_mode) {
+        new_len = strlen(gCurrent_typing) + 1;
         if (new_len > 100) {
             new_len = 100;
             DoErrorInterface(kMiscString_FIXED_THAT_YOU_TWISTED_BASTARD);
         }
-
-        gCurrent_typing[new_len] = 0;
-        if (new_len - 1 < gCurrent_position) {
-            gCurrent_position = new_len - 1;
+        for (i = new_len - 1; i > gCurrent_position; i--) {
+            gCurrent_typing[i] = gCurrent_typing[i - 1];
+            ChangeCharTo(pSlot_index, i, gCurrent_typing[i]);
         }
-        gCurrent_typing[gCurrent_position] = pChar;
-        ChangeCharTo(pSlot_index, gCurrent_position, pChar);
-        gCurrent_position++;
-        SetRollingCursor(pSlot_index);
+    } else if (strlen(gCurrent_typing) == gCurrent_position) {
+        new_len = strlen(gCurrent_typing) + 1;
+    } else {
+        new_len = strlen(gCurrent_typing);
     }
+    if (new_len > 100) {
+        new_len = 100;
+        DoErrorInterface(kMiscString_FIXED_THAT_YOU_TWISTED_BASTARD);
+    }
+
+    gCurrent_typing[new_len] = 0;
+    if (new_len - 1 < gCurrent_position) {
+        gCurrent_position = new_len - 1;
+    }
+    gCurrent_typing[gCurrent_position] = pChar;
+    ChangeCharTo(pSlot_index, gCurrent_position, pChar);
+    gCurrent_position++;
+    SetRollingCursor(pSlot_index);
 }
 
 // IDA: void __usercall StopTyping(int pSlot_index@<EAX>)


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4732a2,55 +0x487f17,55 @@
0x4732a2 : push ebp 	(input.c:756)
0x4732a3 : mov ebp, esp
0x4732a5 : sub esp, 8
0x4732a8 : push ebx
0x4732a9 : push esi
0x4732aa : push edi
0x4732ab : cmp dword ptr [ebp + 8], 0x20 	(input.c:761)
0x4732af : jge 0x5
0x4732b5 : -jmp 0x150
         : +jmp 0x151 	(input.c:762)
0x4732ba : cmp dword ptr [gInsert_mode (DATA)], 0 	(input.c:764)
0x4732c1 : -je 0x81
         : +je 0x82
0x4732c7 : mov edi, gCurrent_typing[0] (DATA) 	(input.c:765)
0x4732cc : mov ecx, 0xffffffff
0x4732d1 : sub eax, eax
0x4732d3 : repne scasb al, byte ptr es:[edi]
0x4732d5 : not ecx
0x4732d7 : mov dword ptr [ebp - 4], ecx
0x4732da : cmp dword ptr [ebp - 4], 0x64 	(input.c:766)
0x4732de : jle 0x11
0x4732e4 : mov dword ptr [ebp - 4], 0x64 	(input.c:767)
0x4732eb : push -1 	(input.c:768)
0x4732ed : call DoErrorInterface (FUNCTION)
0x4732f2 : add esp, 4
0x4732f5 : mov eax, dword ptr [ebp - 4] 	(input.c:770)
0x4732f8 : dec eax
0x4732f9 : mov dword ptr [ebp - 8], eax
0x4732fc : jmp 0x3
0x473301 : dec dword ptr [ebp - 8]
0x473304 : -mov eax, dword ptr [gCurrent_position (DATA)]
0x473309 : -cmp dword ptr [ebp - 8], eax
0x47330c : -jle 0x31
         : +mov eax, dword ptr [ebp - 8]
         : +cmp dword ptr [gCurrent_position (DATA)], eax
         : +jge 0x31
0x473312 : mov eax, dword ptr [ebp - 8] 	(input.c:771)
0x473315 : mov al, byte ptr [eax + <OFFSET5>]
0x47331b : mov ecx, dword ptr [ebp - 8]
0x47331e : mov byte ptr [ecx + gCurrent_typing[0] (DATA)], al
0x473324 : mov eax, dword ptr [ebp - 8] 	(input.c:772)
0x473327 : mov al, byte ptr [eax + gCurrent_typing[0] (DATA)]
0x47332d : push eax
0x47332e : mov eax, dword ptr [ebp - 8]
0x473331 : push eax
0x473332 : mov eax, dword ptr [ebp + 0xc]
0x473335 : push eax
0x473336 : call ChangeCharTo (FUNCTION)
0x47333b : add esp, 0xc
0x47333e : -jmp -0x42
         : +jmp -0x43 	(input.c:773)
0x473343 : jmp 0x4d 	(input.c:774)
0x473348 : mov edi, gCurrent_typing[0] (DATA)
0x47334d : mov ecx, 0xffffffff
0x473352 : sub eax, eax
0x473354 : repne scasb al, byte ptr es:[edi]
0x473356 : not ecx
0x473358 : lea eax, [ecx - 1]
0x47335b : cmp eax, dword ptr [gCurrent_position (DATA)]
0x473361 : jne 0x18
0x473367 : mov edi, gCurrent_typing[0] (DATA) 	(input.c:775)


0x4732a2: DoRLTypeLetter 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x4732a2,55 +0x487f17,54 @@
0x4732a2 : push ebp 	(input.c:756)
0x4732a3 : mov ebp, esp
0x4732a5 : sub esp, 8
0x4732a8 : push ebx
0x4732a9 : push esi
0x4732aa : push edi
0x4732ab : cmp dword ptr [ebp + 8], 0x20 	(input.c:761)
0x4732af : -jge 0x5
0x4732b5 : -jmp 0x150
         : +jl 0x151
0x4732ba : cmp dword ptr [gInsert_mode (DATA)], 0 	(input.c:762)
0x4732c1 : -je 0x81
         : +je 0x82
0x4732c7 : mov edi, gCurrent_typing[0] (DATA) 	(input.c:763)
0x4732cc : mov ecx, 0xffffffff
0x4732d1 : sub eax, eax
0x4732d3 : repne scasb al, byte ptr es:[edi]
0x4732d5 : not ecx
0x4732d7 : mov dword ptr [ebp - 4], ecx
0x4732da : cmp dword ptr [ebp - 4], 0x64 	(input.c:764)
0x4732de : jle 0x11
0x4732e4 : mov dword ptr [ebp - 4], 0x64 	(input.c:765)
0x4732eb : push -1 	(input.c:766)
0x4732ed : call DoErrorInterface (FUNCTION)
0x4732f2 : add esp, 4
0x4732f5 : mov eax, dword ptr [ebp - 4] 	(input.c:768)
0x4732f8 : dec eax
0x4732f9 : mov dword ptr [ebp - 8], eax
0x4732fc : jmp 0x3
0x473301 : dec dword ptr [ebp - 8]
0x473304 : -mov eax, dword ptr [gCurrent_position (DATA)]
0x473309 : -cmp dword ptr [ebp - 8], eax
0x47330c : -jle 0x31
         : +mov eax, dword ptr [ebp - 8]
         : +cmp dword ptr [gCurrent_position (DATA)], eax
         : +jge 0x31
0x473312 : mov eax, dword ptr [ebp - 8] 	(input.c:769)
0x473315 : mov al, byte ptr [eax + <OFFSET5>]
0x47331b : mov ecx, dword ptr [ebp - 8]
0x47331e : mov byte ptr [ecx + gCurrent_typing[0] (DATA)], al
0x473324 : mov eax, dword ptr [ebp - 8] 	(input.c:770)
0x473327 : mov al, byte ptr [eax + gCurrent_typing[0] (DATA)]
0x47332d : push eax
0x47332e : mov eax, dword ptr [ebp - 8]
0x473331 : push eax
0x473332 : mov eax, dword ptr [ebp + 0xc]
0x473335 : push eax
0x473336 : call ChangeCharTo (FUNCTION)
0x47333b : add esp, 0xc
0x47333e : -jmp -0x42
         : +jmp -0x43 	(input.c:771)
0x473343 : jmp 0x4d 	(input.c:772)
0x473348 : mov edi, gCurrent_typing[0] (DATA)
0x47334d : mov ecx, 0xffffffff
0x473352 : sub eax, eax
0x473354 : repne scasb al, byte ptr es:[edi]
0x473356 : not ecx
0x473358 : lea eax, [ecx - 1]
0x47335b : cmp eax, dword ptr [gCurrent_position (DATA)]
0x473361 : jne 0x18
0x473367 : mov edi, gCurrent_typing[0] (DATA) 	(input.c:773)

---
+++
@@ -0x4733ec,10 +0x48805d,14 @@
0x4733ec : mov eax, dword ptr [ebp + 0xc]
0x4733ef : push eax
0x4733f0 : call ChangeCharTo (FUNCTION)
0x4733f5 : add esp, 0xc
0x4733f8 : inc dword ptr [gCurrent_position (DATA)] 	(input.c:788)
0x4733fe : mov eax, dword ptr [ebp + 0xc] 	(input.c:789)
0x473401 : push eax
0x473402 : call SetRollingCursor (FUNCTION)
0x473407 : add esp, 4
0x47340a : pop edi 	(input.c:791)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DoRLTypeLetter is only 91.63% similar to the original, diff above
```

*AI generated. Time taken: 409s, tokens: 50,026*
