### PR TITLE
GetTypedName 100% match

### DIFF
--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -855,11 +855,11 @@ void SetSlotXY(int pSlot_index, int pX_coord, int pY_coord) {
 // FUNCTION: CARM95 0x00473434
 void GetTypedName(char* pDestn, int pMax_length) {
 
-    if (strlen(gCurrent_typing) <= pMax_length) {
-        strcpy(pDestn, gCurrent_typing);
-    } else {
+    if (strlen(gCurrent_typing) > pMax_length) {
         memcpy(pDestn, gCurrent_typing, pMax_length);
         pDestn[pMax_length] = 0;
+    } else {
+        strcpy(pDestn, gCurrent_typing);
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x473434: GetTypedName 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x473437,44 +0x4882e7,44 @@
0x473437 : push ebx
0x473438 : push esi
0x473439 : push edi
0x47343a : mov edi, gCurrent_typing[0] (DATA) 	(input.c:858)
0x47343f : mov ecx, 0xffffffff
0x473444 : sub eax, eax
0x473446 : repne scasb al, byte ptr es:[edi]
0x473448 : not ecx
0x47344a : lea eax, [ecx - 1]
0x47344d : cmp eax, dword ptr [ebp + 0xc]
0x473450 : -jbe 0x28
0x473456 : -mov eax, dword ptr [ebp + 0xc]
0x473459 : -mov esi, gCurrent_typing[0] (DATA)
0x47345e : -mov edi, dword ptr [ebp + 8]
0x473461 : -mov ecx, eax
0x473463 : -shr ecx, 2
0x473466 : -rep movsd dword ptr es:[edi], dword ptr [esi]
0x473468 : -mov ecx, eax
0x47346a : -and ecx, 3
0x47346d : -rep movsb byte ptr es:[edi], byte ptr [esi]
0x47346f : -mov eax, dword ptr [ebp + 0xc]
0x473472 : -mov ecx, dword ptr [ebp + 8]
0x473475 : -mov byte ptr [eax + ecx], 0
0x473479 : -jmp 0x27
         : +ja 0x2c
0x47347e : mov edi, gCurrent_typing[0] (DATA) 	(input.c:859)
0x473483 : mov ecx, 0xffffffff
0x473488 : sub eax, eax
0x47348a : repne scasb al, byte ptr es:[edi]
0x47348c : not ecx
0x47348e : sub edi, ecx
0x473490 : mov eax, ecx
0x473492 : mov edx, edi
0x473494 : mov edi, dword ptr [ebp + 8]
0x473497 : mov esi, edx
0x473499 : shr ecx, 2
0x47349c : rep movsd dword ptr es:[edi], dword ptr [esi]
0x47349e : mov ecx, eax
0x4734a0 : and ecx, 3
0x4734a3 : rep movsb byte ptr es:[edi], byte ptr [esi]
         : +jmp 0x23 	(input.c:860)
         : +mov eax, dword ptr [ebp + 0xc] 	(input.c:861)
         : +mov esi, gCurrent_typing[0] (DATA)
         : +mov edi, dword ptr [ebp + 8]
         : +mov ecx, eax
         : +shr ecx, 2
         : +rep movsd dword ptr es:[edi], dword ptr [esi]
         : +mov ecx, eax
         : +and ecx, 3
         : +rep movsb byte ptr es:[edi], byte ptr [esi]
         : +mov eax, dword ptr [ebp + 0xc] 	(input.c:862)
         : +mov ecx, dword ptr [ebp + 8]
         : +mov byte ptr [eax + ecx], 0
0x4734a5 : pop edi 	(input.c:864)
0x4734a6 : pop esi
0x4734a7 : pop ebx
0x4734a8 : leave 
0x4734a9 : ret 


GetTypedName is only 69.57% similar to the original, diff above
```

*AI generated. Time taken: 68s, tokens: 32,904*
