### PR TITLE
KillCursor 100% match

### DIFF
--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -876,10 +876,9 @@ void KillCursor(int pSlot_index) {
     if (gCurrent_position < gVisible_length && gCurrent_position >= 0) {
         y_coord = gLetter_y_coords[pSlot_index];
         x_coord = gCurrent_graf_data->rolling_letter_x_pitch * gCurrent_position + gLetter_x_coords[pSlot_index];
-        for (i = 0; i < NBR_ROLLING_LETTERS; i++) {
-            let = &gRolling_letters[i];
+        for (let = gRolling_letters, j = 0; j < NBR_ROLLING_LETTERS; j++, let++) {
             if (let->number_of_letters >= 0 && x_coord == let->x_coord && y_coord == let->y_coord) {
-                gRolling_letters[i].number_of_letters = -1;
+                gRolling_letters[j].number_of_letters = -1;
                 break;
             }
         }


### PR DESCRIPTION
## Match result

```
0x4734aa: KillCursor 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4734aa,53 +0x48835a,57 @@
0x4734aa : push ebp 	(input.c:868)
0x4734ab : mov ebp, esp
0x4734ad : sub esp, 0x18
0x4734b0 : push ebx
0x4734b1 : push esi
0x4734b2 : push edi
0x4734b3 : mov eax, dword ptr [gCurrent_position (DATA)] 	(input.c:876)
0x4734b8 : cmp dword ptr [gVisible_length (DATA)], eax
0x4734be : -jle 0xae
         : +jle 0xb8
0x4734c4 : cmp dword ptr [gCurrent_position (DATA)], 0
0x4734cb : -jl 0xa1
         : +jl 0xab
0x4734d1 : mov eax, dword ptr [ebp + 8] 	(input.c:877)
0x4734d4 : mov eax, dword ptr [eax*4 + gLetter_y_coords[0] (DATA)]
0x4734db : mov dword ptr [ebp - 0x18], eax
0x4734de : mov eax, dword ptr [ebp + 8] 	(input.c:878)
0x4734e1 : mov eax, dword ptr [eax*4 + gLetter_x_coords[0] (DATA)]
0x4734e8 : mov ecx, dword ptr [gCurrent_graf_data (DATA)]
0x4734ee : mov ecx, dword ptr [ecx + 0x10]
0x4734f1 : imul ecx, dword ptr [gCurrent_position (DATA)]
0x4734f8 : add eax, ecx
0x4734fa : mov dword ptr [ebp - 0xc], eax
0x4734fd : -mov eax, dword ptr [gRolling_letters (DATA)]
         : +mov dword ptr [ebp - 0x10], 0 	(input.c:879)
         : +jmp 0x3
         : +inc dword ptr [ebp - 0x10]
         : +cmp dword ptr [ebp - 0x10], 0x1f4
         : +jge 0x63
         : +mov eax, dword ptr [ebp - 0x10] 	(input.c:880)
         : +mov ecx, eax
         : +shl eax, 3
         : +sub eax, ecx
         : +shl eax, 3
         : +add eax, dword ptr [gRolling_letters (DATA)]
0x473502 : mov dword ptr [ebp - 4], eax
0x473505 : -mov dword ptr [ebp - 0x14], 0
0x47350c : -jmp 0x7
0x473511 : -inc dword ptr [ebp - 0x14]
0x473514 : -add dword ptr [ebp - 4], 0x38
0x473518 : -cmp dword ptr [ebp - 0x14], 0x1f4
0x47351f : -jge 0x4d
0x473525 : mov eax, dword ptr [ebp - 4] 	(input.c:881)
0x473528 : cmp dword ptr [eax + 0x2c], 0
0x47352c : jl 0x3b
0x473532 : mov eax, dword ptr [ebp - 4]
0x473535 : mov ecx, dword ptr [ebp - 0xc]
0x473538 : cmp dword ptr [eax + 0x24], ecx
0x47353b : jne 0x2c
0x473541 : mov eax, dword ptr [ebp - 4]
0x473544 : mov ecx, dword ptr [ebp - 0x18]
0x473547 : cmp dword ptr [eax + 0x28], ecx
0x47354a : jne 0x1d
0x473550 : -mov eax, dword ptr [ebp - 0x14]
         : +mov eax, dword ptr [ebp - 0x10] 	(input.c:882)
0x473553 : mov ecx, eax
0x473555 : shl eax, 3
0x473558 : sub eax, ecx
0x47355a : mov ecx, dword ptr [gRolling_letters (DATA)]
0x473560 : mov dword ptr [ecx + eax*8 + 0x2c], 0xffffffff
0x473568 : jmp 0x5 	(input.c:883)
0x47356d : -jmp -0x61
         : +jmp -0x73 	(input.c:885)
0x473572 : pop edi 	(input.c:887)
0x473573 : pop esi
0x473574 : pop ebx
0x473575 : leave 
0x473576 : ret 


KillCursor is only 76.36% similar to the original, diff above
```

*AI generated. Time taken: 175s, tokens: 20,153*
