### PR TITLE
EnableChoice 100% match

### DIFF
--- a/src/DETHRACE/common/intrface.c
+++ b/src/DETHRACE/common/intrface.c
@@ -156,7 +156,7 @@ void EnableChoice(int pChoice) {
 
     for (i = 0; i < gDisabled_count; i++) {
         if (gDisabled_choices[i] == pChoice) {
-            memmove(&gDisabled_choices[i], &gDisabled_choices[i + 1], (gDisabled_count - i - 1) * sizeof(gDisabled_choices[0]));
+            memcpy(&gDisabled_choices[i], &gDisabled_choices[i + 1], (gDisabled_count - i - 1) * sizeof(gDisabled_choices[0]));
             gDisabled_count--;
             break;
         }

--- a/src/DETHRACE/common/intrface.c
+++ b/src/DETHRACE/common/intrface.c
@@ -156,7 +156,12 @@ void EnableChoice(int pChoice) {
 
     for (i = 0; i < gDisabled_count; i++) {
         if (gDisabled_choices[i] == pChoice) {
+#ifdef DETHRACE_FIX_BUGS
+            // Use memmove because destination and source overlap
+            memmove(&gDisabled_choices[i], &gDisabled_choices[i + 1], (gDisabled_count - i - 1) * sizeof(gDisabled_choices[0]));
+#else
             memcpy(&gDisabled_choices[i], &gDisabled_choices[i + 1], (gDisabled_count - i - 1) * sizeof(gDisabled_choices[0]));
+#endif
             gDisabled_count--;
             break;
         }


### PR DESCRIPTION
## Match result

```
0x47364d: EnableChoice 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x47364e,33 +0x4888ed,35 @@
0x47364e : mov ebp, esp
0x473650 : sub esp, 4
0x473653 : push ebx
0x473654 : push esi
0x473655 : push edi
0x473656 : mov dword ptr [ebp - 4], 0 	(intrface.c:157)
0x47365d : jmp 0x3
0x473662 : inc dword ptr [ebp - 4]
0x473665 : mov eax, dword ptr [gDisabled_count (DATA)]
0x47366a : cmp dword ptr [ebp - 4], eax
0x47366d : -jge 0x54
         : +jge 0x51
0x473673 : mov eax, dword ptr [ebp - 4] 	(intrface.c:158)
0x473676 : mov ecx, dword ptr [ebp + 8]
0x473679 : cmp dword ptr [eax*4 + gDisabled_choices[0] (DATA)], ecx
0x473680 : -jne 0x3c
         : +jne 0x39
0x473686 : mov eax, dword ptr [gDisabled_count (DATA)] 	(intrface.c:159)
0x47368b : sub eax, dword ptr [ebp - 4]
0x47368e : lea eax, [eax*4 - 4]
0x473695 : -mov ecx, dword ptr [ebp - 4]
0x473698 : -mov edx, dword ptr [ebp - 4]
0x47369b : -lea edi, [edx*4 + gDisabled_choices[0] (DATA)]
0x4736a2 : -lea esi, [ecx*4 + gDisabled_choices[1] (OFFSET)]
0x4736a9 : -mov ecx, eax
0x4736ab : -shr ecx, 2
0x4736ae : -rep movsd dword ptr es:[edi], dword ptr [esi]
0x4736b0 : -mov ecx, eax
0x4736b2 : -and ecx, 3
0x4736b5 : -rep movsb byte ptr es:[edi], byte ptr [esi]
         : +push eax
         : +mov eax, dword ptr [ebp - 4]
         : +lea eax, [eax*4 + gDisabled_choices[1] (OFFSET)]
         : +push eax
         : +mov eax, dword ptr [ebp - 4]
         : +lea eax, [eax*4 + gDisabled_choices[0] (DATA)]
         : +push eax
         : +call memmove (FUNCTION)
         : +add esp, 0xc
0x4736b7 : dec dword ptr [gDisabled_count (DATA)] 	(intrface.c:160)
0x4736bd : jmp 0x5 	(intrface.c:161)
0x4736c2 : -jmp -0x65
         : +jmp -0x62 	(intrface.c:163)
0x4736c7 : pop edi 	(intrface.c:164)
0x4736c8 : pop esi
         : +pop ebx
         : +leave 
         : +ret 


EnableChoice is only 60.00% similar to the original, diff above
```

*AI generated. Time taken: 91s, tokens: 9,437*
