### PR TITLE
ChangeSelectionTo 100% match

### DIFF
--- a/src/DETHRACE/common/intrface.c
+++ b/src/DETHRACE/common/intrface.c
@@ -561,5 +561,6 @@ void ChangeSelectionTo(int pNew_choice, int pNew_mode) {
 
     last_choice = gCurrent_choice;
     gCurrent_choice = pNew_choice;
-    ChangeSelection(gSpec, &last_choice, &gCurrent_choice, (gCurrent_mode = pNew_mode), 1);
+    gCurrent_mode = pNew_mode;
+    ChangeSelection(gSpec, &last_choice, &gCurrent_choice, gCurrent_mode, 1);
 }

--- a/src/DETHRACE/common/intrface.c
+++ b/src/DETHRACE/common/intrface.c
@@ -561,6 +561,5 @@ void ChangeSelectionTo(int pNew_choice, int pNew_mode) {
 
     last_choice = gCurrent_choice;
     gCurrent_choice = pNew_choice;
-    gCurrent_mode = pNew_mode;
-    ChangeSelection(gSpec, &last_choice, &gCurrent_choice, pNew_mode, 1);
+    ChangeSelection(gSpec, &last_choice, &gCurrent_choice, (gCurrent_mode = pNew_mode), 1);
 }


### PR DESCRIPTION
## Match result

```
0x475175: ChangeSelectionTo 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x47517b,22 +0x489fd7,24 @@
0x47517b : push ebx
0x47517c : push esi
0x47517d : push edi
0x47517e : mov eax, dword ptr [gCurrent_choice (DATA)] 	(intrface.c:562)
0x475183 : mov dword ptr [ebp - 4], eax
0x475186 : mov eax, dword ptr [ebp + 8] 	(intrface.c:563)
0x475189 : mov dword ptr [gCurrent_choice (DATA)], eax
0x47518e : mov eax, dword ptr [ebp + 0xc] 	(intrface.c:564)
0x475191 : mov dword ptr [gCurrent_mode (DATA)], eax
0x475196 : push 1 	(intrface.c:565)
0x475198 : -mov eax, dword ptr [gCurrent_mode (DATA)]
         : +mov eax, dword ptr [ebp + 0xc]
0x47519d : push eax
0x47519e : push gCurrent_choice (DATA)
0x4751a3 : lea eax, [ebp - 4]
0x4751a6 : push eax
0x4751a7 : mov eax, dword ptr [gSpec (DATA)]
0x4751ac : push eax
0x4751ad : call ChangeSelection (FUNCTION)
0x4751b2 : add esp, 0x14
0x4751b5 : pop edi 	(intrface.c:566)
0x4751b6 : pop esi
0x4751b7 : pop ebx
         : +leave 
         : +ret 


ChangeSelectionTo is only 92.31% similar to the original, diff above
```

*AI generated. Time taken: 337s, tokens: 34,139*
