### PR TITLE
CalculateFrameRate 100% match

### DIFF
--- a/src/DETHRACE/common/mainloop.c
+++ b/src/DETHRACE/common/mainloop.c
@@ -122,6 +122,7 @@ void CalculateFrameRate(void) {
     // GLOBAL: CARM95 0x53a0ec
     static tU32 last_time;
     tU32 new_time;
+    // GLOBAL: CARM95 0x0053A128
     static int last_rates[30];
     int new_rate;
     int i;


### PR DESCRIPTION
## Match result

```
0x4706fa: CalculateFrameRate 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x470729,37 +0x48b906,37 @@
0x470729 : div ecx
0x47072b : mov dword ptr [ebp - 4], eax
0x47072e : mov eax, dword ptr [ebp - 4] 	(mainloop.c:132)
0x470731 : mov dword ptr [gFrame_rate (DATA)], eax
0x470736 : mov dword ptr [ebp - 8], 0 	(mainloop.c:133)
0x47073d : jmp 0x3
0x470742 : inc dword ptr [ebp - 8]
0x470745 : cmp dword ptr [ebp - 8], 0x1e
0x470749 : jge 0x15
0x47074f : mov eax, dword ptr [ebp - 8] 	(mainloop.c:134)
0x470752 : -mov eax, dword ptr [eax*4 + <OFFSET4>]
         : +mov eax, dword ptr [eax*4 + last_rates (DATA)]
0x470759 : add dword ptr [gFrame_rate (DATA)], eax
0x47075f : jmp -0x22 	(mainloop.c:135)
0x470764 : mov ecx, 0x1f 	(mainloop.c:136)
0x470769 : mov eax, dword ptr [gFrame_rate (DATA)]
0x47076e : cdq 
0x47076f : idiv ecx
0x470771 : mov dword ptr [gFrame_rate (DATA)], eax
0x470776 : mov dword ptr [ebp - 8], 0 	(mainloop.c:137)
0x47077d : jmp 0x3
0x470782 : inc dword ptr [ebp - 8]
0x470785 : cmp dword ptr [ebp - 8], 0x1d
0x470789 : jge 0x19
0x47078f : mov eax, dword ptr [ebp - 8] 	(mainloop.c:138)
0x470792 : -mov eax, dword ptr [eax*4 + <OFFSET5>]
         : +mov eax, dword ptr [eax*4 + last_rates+4 (OFFSET)]
0x470799 : mov ecx, dword ptr [ebp - 8]
0x47079c : -mov dword ptr [ecx*4 + <OFFSET4>], eax
         : +mov dword ptr [ecx*4 + last_rates (DATA)], eax
0x4707a3 : jmp -0x26 	(mainloop.c:139)
0x4707a8 : mov eax, dword ptr [ebp - 4] 	(mainloop.c:140)
0x4707ab : -mov dword ptr [<OFFSET6>], eax
         : +mov dword ptr [last_rates+116 (OFFSET)], eax
0x4707b0 : mov eax, dword ptr [ebp - 0xc] 	(mainloop.c:141)
0x4707b3 : mov dword ptr [last_time (DATA)], eax
0x4707b8 : pop edi 	(mainloop.c:143)
0x4707b9 : pop esi
0x4707ba : pop ebx
0x4707bb : leave 
0x4707bc : ret 


CalculateFrameRate is only 92.31% similar to the original, diff above
```

*AI generated. Time taken: 255s, tokens: 55,015*
