### PR TITLE
WaitForAKey 100% match

### DIFF
--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -362,16 +362,9 @@ void WaitForNoKeys(void) {
 // IDA: void __cdecl WaitForAKey()
 // FUNCTION: CARM95 0x0047235a
 void WaitForAKey(void) {
-
-    while (1) {
+    do {
         CheckQuit();
-        if (AnyKeyDown()) {
-            break;
-        }
-        if (EitherMouseButtonDown()) {
-            break;
-        }
-    }
+    } while (!AnyKeyDown() && !EitherMouseButtonDown());
     CheckQuit();
     WaitForNoKeys();
 }


### PR DESCRIPTION
## Match result

```
0x47235a: WaitForAKey 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x47235a,19 +0x48720f,22 @@
0x47235a : push ebp 	(input.c:364)
0x47235b : mov ebp, esp
0x47235d : push ebx
0x47235e : push esi
0x47235f : push edi
0x472360 : call CheckQuit (FUNCTION) 	(input.c:367)
0x472365 : call AnyKeyDown (FUNCTION) 	(input.c:368)
0x47236a : test eax, eax
0x47236c : -jne 0xd
         : +je 0x5
         : +jmp 0x17 	(input.c:369)
0x472372 : call EitherMouseButtonDown (FUNCTION) 	(input.c:371)
0x472377 : test eax, eax
0x472379 : -je -0x1f
         : +je 0x5
         : +jmp 0x5 	(input.c:372)
         : +jmp -0x2e 	(input.c:374)
0x47237f : call CheckQuit (FUNCTION) 	(input.c:375)
0x472384 : call WaitForNoKeys (FUNCTION) 	(input.c:376)
0x472389 : pop edi 	(input.c:377)
0x47238a : pop esi
0x47238b : pop ebx
0x47238c : leave 
0x47238d : ret 


WaitForAKey is only 82.93% similar to the original, diff above
```

*AI generated. Time taken: 105s*
