### PR TITLE
RememberSafePosition 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -870,7 +870,8 @@ void RememberSafePosition(tCar_spec* car, tU32 pTime) {
     for (j = 0; j < 5; j++) {
         BrVector3Sub(&r, &car->car_master_actor->t.t.translate.t, (br_vector3*)car->last_safe_positions[j].m[3]);
 
-        if (BrVector3LengthSquared(&r) < 8.4015961f) {
+        ts = BrVector3LengthSquared(&r);
+        if (ts < 8.4015961f) {
             return;
         }
     }


### PR DESCRIPTION
## Match result

```
0x4771a2: RememberSafePosition 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4771a2,43 +0x448802,43 @@
0x4771a2 : push ebp 	(car.c:840)
0x4771a3 : mov ebp, esp
0x4771a5 : sub esp, 0x14
0x4771a8 : push ebx
0x4771a9 : push esi
0x4771aa : push edi
0x4771ab : mov eax, dword ptr [ebp + 8] 	(car.c:847)
0x4771ae : cmp dword ptr [eax + 4], 0
0x4771b2 : je 0x5
0x4771b8 : -jmp 0x271
         : +jmp 0x26e 	(car.c:848)
0x4771bd : mov eax, dword ptr [ebp + 0xc] 	(car.c:850)
0x4771c0 : add dword ptr [time_count (DATA)], eax
0x4771c6 : cmp dword ptr [time_count (DATA)], 0x1388 	(car.c:851)
0x4771d0 : jae 0x5
0x4771d6 : -jmp 0x253
         : +jmp 0x250 	(car.c:852)
0x4771db : mov dword ptr [time_count (DATA)], 0xfa0 	(car.c:854)
0x4771e5 : mov dword ptr [ebp - 0x14], 0 	(car.c:855)
0x4771ec : jmp 0x3
0x4771f1 : inc dword ptr [ebp - 0x14]
0x4771f4 : cmp dword ptr [ebp - 0x14], 4
0x4771f8 : jge 0x35
0x4771fe : mov eax, dword ptr [ebp - 0x14] 	(car.c:856)
0x477201 : and eax, 0xfffffffe
0x477204 : sar eax, 0
0x477207 : mov ecx, dword ptr [ebp + 8]
0x47720a : fld dword ptr [ecx + eax*2 + 0x14c0]
0x477211 : mov eax, dword ptr [ebp - 0x14]
0x477214 : mov ecx, dword ptr [ebp + 8]
0x477217 : fcomp dword ptr [ecx + eax*4 + 0x1508]
0x47721e : fnstsw ax
0x477220 : test ah, 0x41
0x477223 : je 0x5
0x477229 : -jmp 0x200
         : +jmp 0x1fd 	(car.c:857)
0x47722e : jmp -0x42 	(car.c:859)
0x477233 : mov eax, dword ptr [ebp + 8] 	(car.c:864)
0x477236 : cmp dword ptr [eax + 0x22c], 0
0x47723d : je 0x1d
0x477243 : mov eax, dword ptr [ebp + 8]
0x477246 : mov eax, dword ptr [eax + 0x22c]
0x47724c : fld dword ptr [eax + 0x78]
0x47724f : fcomp qword ptr [1.0 (FLOAT)]
0x477255 : fnstsw ax
0x477257 : test ah, 0x40

---
+++
@@ -0x4772c3,34 +0x448923,34 @@
0x4772c3 : test ah, 1
0x4772c6 : jne 0x24
0x4772cc : mov eax, dword ptr [ebp + 8]
0x4772cf : mov eax, dword ptr [eax + 0x1524]
0x4772d5 : lea eax, [eax + eax*4]
0x4772d8 : fld dword ptr [eax*8 + gCurrent_race+4032 (OFFSET)]
0x4772df : fcomp qword ptr [0.1 (FLOAT)]
0x4772e5 : fnstsw ax
0x4772e7 : test ah, 1
0x4772ea : je 0x5
0x4772f0 : -jmp 0x139
         : +jmp 0x136 	(car.c:865)
0x4772f5 : mov eax, dword ptr [ebp + 8] 	(car.c:867)
0x4772f8 : mov eax, dword ptr [eax + 0xc]
0x4772fb : fld dword ptr [eax + 0x3c]
0x4772fe : fcomp dword ptr [0.800000011920929 (FLOAT)]
0x477304 : fnstsw ax
0x477306 : test ah, 1
0x477309 : je 0x5
0x47730f : -jmp 0x11a
         : +jmp 0x117 	(car.c:868)
0x477314 : mov dword ptr [ebp - 0x14], 0 	(car.c:870)
0x47731b : jmp 0x3
0x477320 : inc dword ptr [ebp - 0x14]
0x477323 : cmp dword ptr [ebp - 0x14], 5
0x477327 : -jge 0x91
         : +jge 0x8e
0x47732d : mov eax, dword ptr [ebp + 8] 	(car.c:871)
0x477330 : mov eax, dword ptr [eax + 0xc]
0x477333 : fld dword ptr [eax + 0x50]
0x477336 : mov eax, dword ptr [ebp - 0x14]
0x477339 : shl eax, 4
0x47733c : lea eax, [eax + eax*2]
0x47733f : mov ecx, dword ptr [ebp + 8]
0x477342 : fsub dword ptr [eax + ecx + 0x13d4]
0x477349 : fstp dword ptr [ebp - 0xc]
0x47734c : mov eax, dword ptr [ebp + 8]

---
+++
@@ -0x477380,27 +0x4489e0,26 @@
0x477380 : fsub dword ptr [eax + ecx + 0x13dc]
0x477387 : fstp dword ptr [ebp - 4]
0x47738a : fld dword ptr [ebp - 8] 	(car.c:873)
0x47738d : fmul dword ptr [ebp - 8]
0x477390 : fld dword ptr [ebp - 4]
0x477393 : fmul dword ptr [ebp - 4]
0x477396 : faddp st(1)
0x477398 : fld dword ptr [ebp - 0xc]
0x47739b : fmul dword ptr [ebp - 0xc]
0x47739e : faddp st(1)
0x4773a0 : -fcom dword ptr [8.401596069335938 (FLOAT)]
0x4773a6 : -fstp dword ptr [ebp - 0x10]
         : +fcomp dword ptr [8.401596069335938 (FLOAT)]
0x4773a9 : fnstsw ax
0x4773ab : test ah, 1
0x4773ae : je 0x5
0x4773b4 : jmp 0x75 	(car.c:874)
0x4773b9 : -jmp -0x9e
         : +jmp -0x9b 	(car.c:876)
0x4773be : mov dword ptr [ebp - 0x14], 3 	(car.c:877)
0x4773c5 : jmp 0x3
0x4773ca : dec dword ptr [ebp - 0x14]
0x4773cd : cmp dword ptr [ebp - 0x14], 0
0x4773d1 : jle 0x32
0x4773d7 : mov eax, dword ptr [ebp - 0x14] 	(car.c:878)
0x4773da : dec eax
0x4773db : shl eax, 4
0x4773de : lea eax, [eax + eax*2]
0x4773e1 : add eax, dword ptr [ebp + 8]

---
+++
@@ -0x47740f,10 +0x448a6c,13 @@
0x47740f : add eax, 0x2c
0x477412 : push eax
0x477413 : mov eax, dword ptr [ebp + 8]
0x477416 : add eax, 0x13b0
0x47741b : push eax
0x47741c : call BrMatrix34Copy (FUNCTION)
0x477421 : add esp, 8
0x477424 : mov dword ptr [time_count (DATA)], 0 	(car.c:881)
0x47742e : pop edi 	(car.c:882)
0x47742f : pop esi
         : +pop ebx
         : +leave 
         : +ret 


RememberSafePosition is only 93.98% similar to the original, diff above
```

*AI generated. Time taken: 59s, tokens: 10,394*
