### PR TITLE
CalcEngineForce 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -1029,13 +1029,12 @@ void CalcEngineForce(tCar_spec* c, br_scalar dt) {
     }
     if (c->brake_force != 0.0f) {
         c->revs = c->target_revs;
-    } else {
-        if (c->revs - 1.0f > c->target_revs || c->revs + 1.0f < c->target_revs) {
-            ts = (c->torque * dt / 0.0002) + (c->revs - c->target_revs);
-            ts2 = (1.0 / (c->speed_revs_ratio * c->M) / (float)c->gear + 1.0 / (c->force_torque_ratio * 0.0002) * (double)c->gear) * dt;
-            c->acc_force += ts / ts2;
-        }
+    } else if (c->revs - 1.0f > c->target_revs || c->revs + 1.0f < c->target_revs) {
+        ts = (c->torque * dt / 0.0002) + (c->revs - c->target_revs);
+        ts2 = (1.0 / (c->speed_revs_ratio * c->M) / (float)c->gear + 1.0 / (c->force_torque_ratio * 0.0002) * (double)c->gear) * dt;
+        c->acc_force += ts / ts2;
     }
+    return;
 }
 
 // IDA: void __usercall PrepareCars(tU32 pFrame_start_time@<EAX>)


### PR DESCRIPTION
## Match result

```
0x477433: CalcEngineForce 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x477973,21 +0x449464,21 @@
0x477973 : mov eax, dword ptr [ebp + 8]
0x477976 : fadd dword ptr [eax + 0x1554]
0x47797c : mov eax, dword ptr [ebp + 8]
0x47797f : fstp dword ptr [eax + 0x1564]
0x477985 : jmp 0xd 	(car.c:1018)
0x47798a : mov eax, dword ptr [ebp + 8] 	(car.c:1019)
0x47798d : mov dword ptr [eax + 0x1564], 0
0x477997 : mov eax, dword ptr [ebp + 8] 	(car.c:1021)
0x47799a : cmp dword ptr [eax + 0x15e8], 0
0x4779a1 : jne 0x5
0x4779a7 : -jmp 0x160
         : +jmp 0x15b 	(car.c:1022)
0x4779ac : mov eax, dword ptr [ebp + 8] 	(car.c:1024)
0x4779af : fld dword ptr [eax + 0x15f8]
0x4779b5 : mov eax, dword ptr [ebp + 8]
0x4779b8 : fmul dword ptr [eax + 0x1560]
0x4779be : mov eax, dword ptr [ebp + 8]
0x4779c1 : mov eax, dword ptr [eax + 0x15e8]
0x4779c7 : mov dword ptr [ebp - 0x2c], eax
0x4779ca : fild dword ptr [ebp - 0x2c]
0x4779cd : fdivp st(1)
0x4779cf : mov eax, dword ptr [ebp + 8]

---
+++
@@ -0x477ae5,11 +0x4495d6,15 @@
0x477ae5 : fild dword ptr [ebp - 0x34]
0x477ae8 : fmulp st(1)
0x477aea : faddp st(1)
0x477aec : fmul dword ptr [ebp + 0xc]
0x477aef : fst dword ptr [ebp - 0x18]
0x477af2 : fdivr dword ptr [ebp - 8] 	(car.c:1036)
0x477af5 : mov eax, dword ptr [ebp + 8]
0x477af8 : fadd dword ptr [eax + 0x155c]
0x477afe : mov eax, dword ptr [ebp + 8]
0x477b01 : fstp dword ptr [eax + 0x155c]
0x477b07 : -jmp 0x0
         : +pop edi 	(car.c:1039)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


CalcEngineForce is only 99.01% similar to the original, diff above
```

*AI generated. Time taken: 185s, tokens: 18,301*
