### PR TITLE
ResetCarSpecialVolume 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -1452,8 +1452,7 @@ void ResetCarSpecialVolume(tCollision_info* pCar) {
     if (t < 100.0f && material != NULL) {
         mat_id = material->identifier;
         if (mat_id) {
-            id_len = strlen(mat_id);
-            if (id_len > 0 && (*mat_id == '!' || *mat_id == '#')) {
+            if (strlen(mat_id) != 0 && (*mat_id == '!' || *mat_id == '#')) {
                 new_special_volume = GetDefaultSpecialVolumeForWater();
             }
         }


### PR DESCRIPTION
## Match result

```
0x47901e: ResetCarSpecialVolume 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x47905b,36 +0x44ad3e,37 @@
0x47905b : mov eax, dword ptr [eax + 0xc]
0x47905e : add eax, 0x50
0x479061 : push eax
0x479062 : call FindFace (FUNCTION)
0x479067 : add esp, 0x14
0x47906a : call EnablePlingMaterials (FUNCTION) 	(car.c:1451)
0x47906f : fld dword ptr [ebp - 0x1c] 	(car.c:1452)
0x479072 : fcomp dword ptr [100.0 (FLOAT)]
0x479078 : fnstsw ax
0x47907a : test ah, 1
0x47907d : -je 0x5c
         : +je 0x61
0x479083 : cmp dword ptr [ebp - 0x28], 0
0x479087 : -je 0x52
         : +je 0x57
0x47908d : mov eax, dword ptr [ebp - 0x28] 	(car.c:1453)
0x479090 : mov eax, dword ptr [eax + 4]
0x479093 : mov dword ptr [ebp - 0x2c], eax
0x479096 : cmp dword ptr [ebp - 0x2c], 0 	(car.c:1454)
0x47909a : -je 0x3f
         : +je 0x44
0x4790a0 : mov edi, dword ptr [ebp - 0x2c] 	(car.c:1455)
0x4790a3 : mov ecx, 0xffffffff
0x4790a8 : sub eax, eax
0x4790aa : repne scasb al, byte ptr es:[edi]
0x4790ac : not ecx
0x4790ae : lea eax, [ecx - 1]
0x4790b1 : -test eax, eax
0x4790b3 : -je 0x26
         : +mov dword ptr [ebp - 0x24], eax
         : +cmp dword ptr [ebp - 0x24], 0 	(car.c:1456)
         : +jle 0x26
0x4790b9 : mov eax, dword ptr [ebp - 0x2c]
0x4790bc : movsx eax, byte ptr [eax]
0x4790bf : cmp eax, 0x21
0x4790c2 : je 0xf
0x4790c8 : mov eax, dword ptr [ebp - 0x2c]
0x4790cb : movsx eax, byte ptr [eax]
0x4790ce : cmp eax, 0x23
0x4790d1 : jne 0x8
0x4790d7 : call GetDefaultSpecialVolumeForWater (FUNCTION) 	(car.c:1457)
0x4790dc : mov dword ptr [ebp - 0x20], eax


ResetCarSpecialVolume is only 91.73% similar to the original, diff above
```

*AI generated. Time taken: 58s, tokens: 10,378*
