### PR TITLE
MoveAndCollideCar 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -1546,31 +1546,35 @@ void MoveAndCollideCar(tCar_spec* car, br_scalar dt) {
     tCollision_info* car_info;
     int wheel;
 
+    car_info = (tCollision_info*)car;
     if (car->dt >= 0.f) {
         dt = car->dt;
     }
-    if (dt != 0.f && (!gCar_flying || &gProgram_state.current_car != car)) {
-        car_info = (tCollision_info*)car;
-        car->new_skidding = 0;
-        if (car->water_d != 10000.0f) {
-            TestAutoSpecialVolume(car_info);
-        }
-        MungeSpecialVolume(car_info);
-        if (car->driver <= eDriver_oppo) {
-            CalcForce(car, dt);
-        } else {
-            CalcEngineForce(car, dt);
-            CalcForce(car, dt);
-            DoRevs(car, dt);
-        }
-        RotateCar(car_info, dt);
-        TranslateCar(car_info, dt);
-        CollideCarWithWall(car_info, dt);
-        BrMatrix34ApplyP(&car->pos, &car->cmpos, &car->car_master_actor->t.t.mat);
-        BrVector3InvScale(&car->pos, &car->pos, WORLD_SCALE);
-        for (wheel = 0; wheel < 4; wheel++) {
-            SkidMark(car, wheel);
-        }
+    if (dt == 0.f) {
+        return;
+    }
+    if (gCar_flying && &gProgram_state.current_car == car) {
+        return;
+    }
+    car->new_skidding = 0;
+    if (car->water_d != 10000.0f) {
+        TestAutoSpecialVolume(car_info);
+    }
+    MungeSpecialVolume(car_info);
+    if (car->driver >= 3) {
+        CalcEngineForce(car, dt);
+        CalcForce(car, dt);
+        DoRevs(car, dt);
+    } else {
+        CalcForce(car, dt);
+    }
+    RotateCar(car_info, dt);
+    TranslateCar(car_info, dt);
+    CollideCarWithWall(car_info, dt);
+    BrMatrix34ApplyP(&car->pos, &car->cmpos, &car->car_master_actor->t.t.mat);
+    BrVector3InvScale(&car->pos, &car->pos, WORLD_SCALE);
+    for (wheel = 0; wheel < 4; wheel++) {
+        SkidMark(car, wheel);
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4790fd: MoveAndCollideCar 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4790fd,83 +0x44b226,81 @@
0x4790fd : push ebp 	(car.c:1545)
0x4790fe : mov ebp, esp
0x479100 : sub esp, 8
0x479103 : push ebx
0x479104 : push esi
0x479105 : push edi
0x479106 : -mov eax, dword ptr [ebp + 8]
0x479109 : -mov dword ptr [ebp - 4], eax
0x47910c : mov eax, dword ptr [ebp + 8] 	(car.c:1549)
0x47910f : fld dword ptr [eax + 0x334]
0x479115 : fcomp dword ptr [0.0 (FLOAT)]
0x47911b : fnstsw ax
0x47911d : test ah, 1
0x479120 : jne 0xc
0x479126 : mov eax, dword ptr [ebp + 8] 	(car.c:1550)
0x479129 : mov eax, dword ptr [eax + 0x334]
0x47912f : mov dword ptr [ebp + 0xc], eax
0x479132 : fld dword ptr [ebp + 0xc] 	(car.c:1552)
0x479135 : fcomp dword ptr [0.0 (FLOAT)]
0x47913b : fnstsw ax
0x47913d : test ah, 0x40
0x479140 : -je 0x5
0x479146 : -jmp 0x180
         : +jne 0x181
0x47914b : cmp dword ptr [gCar_flying (DATA)], 0
0x479152 : -je 0x18
         : +je 0x13
0x479158 : mov eax, gProgram_state (DATA)
0x47915d : add eax, 0xb0
0x479162 : cmp eax, dword ptr [ebp + 8]
0x479165 : -jne 0x5
0x47916b : -jmp 0x15b
         : +je 0x161
         : +mov eax, dword ptr [ebp + 8] 	(car.c:1553)
         : +mov dword ptr [ebp - 4], eax
0x479170 : mov eax, dword ptr [ebp + 8] 	(car.c:1554)
0x479173 : mov dword ptr [eax + 0x1820], 0
0x47917d : mov eax, dword ptr [ebp + 8] 	(car.c:1555)
0x479180 : fld dword ptr [eax + 0x2a4]
0x479186 : fcomp dword ptr [10000.0 (FLOAT)]
0x47918c : fnstsw ax
0x47918e : test ah, 0x40
0x479191 : jne 0xc
0x479197 : mov eax, dword ptr [ebp - 4] 	(car.c:1556)
0x47919a : push eax
0x47919b : call TestAutoSpecialVolume (FUNCTION)
0x4791a0 : add esp, 4
0x4791a3 : mov eax, dword ptr [ebp - 4] 	(car.c:1558)
0x4791a6 : push eax
0x4791a7 : call MungeSpecialVolume (FUNCTION)
0x4791ac : add esp, 4
0x4791af : mov eax, dword ptr [ebp + 8] 	(car.c:1559)
0x4791b2 : -cmp dword ptr [eax + 8], 3
0x4791b6 : -jl 0x35
         : +cmp dword ptr [eax + 8], 2
         : +jg 0x15
         : +mov eax, dword ptr [ebp + 0xc] 	(car.c:1560)
         : +push eax
         : +mov eax, dword ptr [ebp + 8]
         : +push eax
         : +call CalcForce (FUNCTION)
         : +add esp, 8
         : +jmp 0x30 	(car.c:1561)
0x4791bc : mov eax, dword ptr [ebp + 0xc] 	(car.c:1562)
0x4791bf : push eax
0x4791c0 : mov eax, dword ptr [ebp + 8]
0x4791c3 : push eax
0x4791c4 : call CalcEngineForce (FUNCTION)
0x4791c9 : add esp, 8
0x4791cc : mov eax, dword ptr [ebp + 0xc] 	(car.c:1563)
0x4791cf : push eax
0x4791d0 : mov eax, dword ptr [ebp + 8]
0x4791d3 : push eax
0x4791d4 : call CalcForce (FUNCTION)
0x4791d9 : add esp, 8
0x4791dc : mov eax, dword ptr [ebp + 0xc] 	(car.c:1564)
0x4791df : push eax
0x4791e0 : mov eax, dword ptr [ebp + 8]
0x4791e3 : push eax
0x4791e4 : call DoRevs (FUNCTION)
0x4791e9 : -add esp, 8
0x4791ec : -jmp 0x10
0x4791f1 : -mov eax, dword ptr [ebp + 0xc]
0x4791f4 : -push eax
0x4791f5 : -mov eax, dword ptr [ebp + 8]
0x4791f8 : -push eax
0x4791f9 : -call CalcForce (FUNCTION)
0x4791fe : add esp, 8
0x479201 : mov eax, dword ptr [ebp + 0xc] 	(car.c:1566)
0x479204 : push eax
0x479205 : mov eax, dword ptr [ebp - 4]
0x479208 : push eax
0x479209 : call RotateCar (FUNCTION)
0x47920e : add esp, 8
0x479211 : mov eax, dword ptr [ebp + 0xc] 	(car.c:1567)
0x479214 : push eax
0x479215 : mov eax, dword ptr [ebp - 4]

---
+++
@@ -0x4792a4,10 +0x44b3c3,16 @@
0x4792a4 : jmp 0x3
0x4792a9 : inc dword ptr [ebp - 8]
0x4792ac : cmp dword ptr [ebp - 8], 4
0x4792b0 : jge 0x15
0x4792b6 : mov eax, dword ptr [ebp - 8] 	(car.c:1572)
0x4792b9 : push eax
0x4792ba : mov eax, dword ptr [ebp + 8]
0x4792bd : push eax
0x4792be : call SkidMark (FUNCTION)
0x4792c3 : add esp, 8
         : +jmp -0x22 	(car.c:1573)
         : +pop edi 	(car.c:1575)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


MoveAndCollideCar is only 86.36% similar to the original, diff above
```

*AI generated. Time taken: 479s, tokens: 72,984*
