### PR TITLE
MungeSpecialVolume 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -1412,23 +1412,27 @@ void MungeSpecialVolume(tCollision_info* pCar) {
     tCar_spec* car;
 
     new_special_volume = FindSpecialVolume(&pCar->pos, pCar->last_special_volume);
-    if (pCar->auto_special_volume != NULL && (new_special_volume == NULL || new_special_volume->gravity_multiplier == 1.f)) {
-        if (pCar->water_d == 10000.f && pCar->water_depth_factor != 1.f) {
-            pCar->auto_special_volume = NULL;
+    car = (tCar_spec*)pCar;
+    if (((tCollision_info*)car)->auto_special_volume != NULL && (new_special_volume == NULL || new_special_volume->gravity_multiplier == 1.f)) {
+        if (((tCollision_info*)car)->water_d == 10000.f && pCar->water_depth_factor != 1.f) {
+            ((tCollision_info*)car)->auto_special_volume = NULL;
         } else {
-            new_special_volume = pCar->auto_special_volume;
+            new_special_volume = ((tCollision_info*)car)->auto_special_volume;
         }
     }
-    if (pCar->last_special_volume != new_special_volume && pCar->driver == eDriver_local_human) {
-        if (pCar->last_special_volume != NULL && pCar->last_special_volume->exit_noise >= 0 && (new_special_volume == NULL || pCar->last_special_volume->exit_noise != new_special_volume->exit_noise)) {
-            DRS3StartSound(gCar_outlet, pCar->last_special_volume->exit_noise);
+    if (((tCollision_info*)car)->last_special_volume != new_special_volume && ((tCollision_info*)car)->driver == eDriver_local_human) {
+        if (((tCollision_info*)car)->last_special_volume != NULL && ((tCollision_info*)car)->last_special_volume->exit_noise >= 0
+            && (new_special_volume == NULL || ((tCollision_info*)car)->last_special_volume->exit_noise != new_special_volume->exit_noise)) {
+            DRS3StartSound(gCar_outlet, ((tCollision_info*)car)->last_special_volume->exit_noise);
         }
-        if (new_special_volume != NULL && new_special_volume->entry_noise >= 0 && (pCar->last_special_volume == NULL || pCar->last_special_volume->entry_noise != new_special_volume->entry_noise)) {
+        if (new_special_volume != NULL && new_special_volume->entry_noise >= 0
+            && (((tCollision_info*)car)->last_special_volume == NULL || ((tCollision_info*)car)->last_special_volume->entry_noise != new_special_volume->entry_noise)) {
             DRS3StartSound(gCar_outlet, new_special_volume->entry_noise);
         }
     }
     pCar->last_special_volume = new_special_volume;
-    if (new_special_volume != NULL && pCar->num_smoke_columns != 0 && pCar->last_special_volume != NULL && pCar->last_special_volume->gravity_multiplier < 1.f) {
+    if (new_special_volume != NULL && pCar->num_smoke_columns != 0 && pCar->last_special_volume != NULL
+        && pCar->last_special_volume->gravity_multiplier < 1.f) {
         StopCarSmoking((tCar_spec*)pCar);
     }
 }

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -1413,20 +1413,20 @@ void MungeSpecialVolume(tCollision_info* pCar) {
 
     new_special_volume = FindSpecialVolume(&pCar->pos, pCar->last_special_volume);
     car = (tCar_spec*)pCar;
-    if (((tCollision_info*)car)->auto_special_volume != NULL && (new_special_volume == NULL || new_special_volume->gravity_multiplier == 1.f)) {
+    if (car->auto_special_volume != NULL && (new_special_volume == NULL || new_special_volume->gravity_multiplier == 1.f)) {
         if (((tCollision_info*)car)->water_d == 10000.f && pCar->water_depth_factor != 1.f) {
-            ((tCollision_info*)car)->auto_special_volume = NULL;
+            car->auto_special_volume = NULL;
         } else {
-            new_special_volume = ((tCollision_info*)car)->auto_special_volume;
+            new_special_volume = car->auto_special_volume;
         }
     }
-    if (((tCollision_info*)car)->last_special_volume != new_special_volume && ((tCollision_info*)car)->driver == eDriver_local_human) {
-        if (((tCollision_info*)car)->last_special_volume != NULL && ((tCollision_info*)car)->last_special_volume->exit_noise >= 0
-            && (new_special_volume == NULL || ((tCollision_info*)car)->last_special_volume->exit_noise != new_special_volume->exit_noise)) {
-            DRS3StartSound(gCar_outlet, ((tCollision_info*)car)->last_special_volume->exit_noise);
+    if (car->last_special_volume != new_special_volume && car->driver == eDriver_local_human) {
+        if (car->last_special_volume != NULL && car->last_special_volume->exit_noise >= 0
+            && (new_special_volume == NULL || car->last_special_volume->exit_noise != new_special_volume->exit_noise)) {
+            DRS3StartSound(gCar_outlet, car->last_special_volume->exit_noise);
         }
         if (new_special_volume != NULL && new_special_volume->entry_noise >= 0
-            && (((tCollision_info*)car)->last_special_volume == NULL || ((tCollision_info*)car)->last_special_volume->entry_noise != new_special_volume->entry_noise)) {
+            && (car->last_special_volume == NULL || car->last_special_volume->entry_noise != new_special_volume->entry_noise)) {
             DRS3StartSound(gCar_outlet, new_special_volume->entry_noise);
         }
     }

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -1419,7 +1419,7 @@ void MungeSpecialVolume(tCollision_info* pCar) {
     new_special_volume = FindSpecialVolume(&pCar->pos, pCar->last_special_volume);
     car = (tCar_spec*)pCar;
     if (car->auto_special_volume != NULL && (new_special_volume == NULL || new_special_volume->gravity_multiplier == 1.f)) {
-        if (((tCollision_info*)car)->water_d == 10000.f && pCar->water_depth_factor != 1.f) {
+        if (car->water_d == 10000.f && pCar->water_depth_factor != 1.f) {
             car->auto_special_volume = NULL;
         } else {
             new_special_volume = car->auto_special_volume;


### PR DESCRIPTION
## Match result

```
0x4792d0: MungeSpecialVolume 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4792d9,89 +0x44ab0d,87 @@
0x4792d9 : mov eax, dword ptr [ebp + 8] 	(car.c:1414)
0x4792dc : mov eax, dword ptr [eax + 0x22c]
0x4792e2 : push eax
0x4792e3 : mov eax, dword ptr [ebp + 8]
0x4792e6 : add eax, 0x9c
0x4792eb : push eax
0x4792ec : call FindSpecialVolume (FUNCTION)
0x4792f1 : add esp, 8
0x4792f4 : mov dword ptr [ebp - 4], eax
0x4792f7 : mov eax, dword ptr [ebp + 8] 	(car.c:1415)
0x4792fa : -mov dword ptr [ebp - 8], eax
0x4792fd : -mov eax, dword ptr [ebp - 8]
0x479300 : cmp dword ptr [eax + 0x230], 0
0x479307 : je 0x73
0x47930d : cmp dword ptr [ebp - 4], 0
0x479311 : je 0x17
0x479317 : mov eax, dword ptr [ebp - 4]
0x47931a : fld dword ptr [eax + 0x78]
0x47931d : fcomp dword ptr [1.0 (FLOAT)]
0x479323 : fnstsw ax
0x479325 : test ah, 0x40
0x479328 : je 0x52
0x47932e : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp + 8] 	(car.c:1416)
0x479331 : fld dword ptr [eax + 0x2a4]
0x479337 : fcomp dword ptr [10000.0 (FLOAT)]
0x47933d : fnstsw ax
0x47933f : test ah, 0x40
0x479342 : je 0x2c
0x479348 : mov eax, dword ptr [ebp + 8]
0x47934b : fld dword ptr [eax + 0x2a8]
0x479351 : fcomp dword ptr [1.0 (FLOAT)]
0x479357 : fnstsw ax
0x479359 : test ah, 0x40
0x47935c : jne 0x12
0x479362 : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp + 8] 	(car.c:1417)
0x479365 : mov dword ptr [eax + 0x230], 0
0x47936f : jmp 0xc 	(car.c:1418)
0x479374 : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp + 8] 	(car.c:1419)
0x479377 : mov eax, dword ptr [eax + 0x230]
0x47937d : mov dword ptr [ebp - 4], eax
0x479380 : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp + 8] 	(car.c:1422)
0x479383 : mov ecx, dword ptr [ebp - 4]
0x479386 : cmp dword ptr [eax + 0x22c], ecx
0x47938c : je 0xd9
0x479392 : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp + 8]
0x479395 : cmp dword ptr [eax + 8], 4
0x479399 : jne 0xcc
0x47939f : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp + 8] 	(car.c:1423)
0x4793a2 : cmp dword ptr [eax + 0x22c], 0
0x4793a9 : je 0x5c
0x4793af : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp + 8]
0x4793b2 : mov eax, dword ptr [eax + 0x22c]
0x4793b8 : cmp dword ptr [eax + 0x98], 0
0x4793bf : jl 0x46
0x4793c5 : cmp dword ptr [ebp - 4], 0
0x4793c9 : je 0x1e
0x4793cf : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp + 8]
0x4793d2 : mov eax, dword ptr [eax + 0x22c]
0x4793d8 : mov ecx, dword ptr [ebp - 4]
0x4793db : mov ecx, dword ptr [ecx + 0x98]
0x4793e1 : cmp dword ptr [eax + 0x98], ecx
0x4793e7 : je 0x1e
0x4793ed : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp + 8] 	(car.c:1424)
0x4793f0 : mov eax, dword ptr [eax + 0x22c]
0x4793f6 : mov eax, dword ptr [eax + 0x98]
0x4793fc : push eax
0x4793fd : mov eax, dword ptr [gCar_outlet (DATA)]
0x479402 : push eax
0x479403 : call DRS3StartSound (FUNCTION)
0x479408 : add esp, 8
0x47940b : cmp dword ptr [ebp - 4], 0 	(car.c:1426)
0x47940f : je 0x56
0x479415 : mov eax, dword ptr [ebp - 4]
0x479418 : cmp dword ptr [eax + 0x94], 0
0x47941f : jl 0x46
0x479425 : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp + 8]
0x479428 : cmp dword ptr [eax + 0x22c], 0
0x47942f : je 0x1e
0x479435 : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp + 8]
0x479438 : mov eax, dword ptr [eax + 0x22c]
0x47943e : mov ecx, dword ptr [ebp - 4]
0x479441 : mov ecx, dword ptr [ecx + 0x94]
0x479447 : cmp dword ptr [eax + 0x94], ecx
0x47944d : je 0x18
0x479453 : mov eax, dword ptr [ebp - 4] 	(car.c:1427)
0x479456 : mov eax, dword ptr [eax + 0x94]
0x47945c : push eax
0x47945d : mov eax, dword ptr [gCar_outlet (DATA)]
0x479462 : push eax

---
+++
@@ -0x4794a5,10 +0x44acd3,16 @@
0x4794a5 : mov eax, dword ptr [ebp + 8]
0x4794a8 : mov eax, dword ptr [eax + 0x22c]
0x4794ae : fld dword ptr [eax + 0x78]
0x4794b1 : fcomp dword ptr [1.0 (FLOAT)]
0x4794b7 : fnstsw ax
0x4794b9 : test ah, 1
0x4794bc : je 0xc
0x4794c2 : mov eax, dword ptr [ebp + 8] 	(car.c:1432)
0x4794c5 : push eax
0x4794c6 : call StopCarSmoking (FUNCTION)
         : +add esp, 4
         : +pop edi 	(car.c:1434)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


MungeSpecialVolume is only 87.70% similar to the original, diff above
```

*AI generated. Time taken: 131s, tokens: 13,536*
