### PR TITLE
MoveAndCollideNonCar 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -1585,16 +1585,16 @@ void MoveAndCollideNonCar(tNon_car_spec* non_car, br_scalar dt) {
 
     car_info = &non_car->collision_info;
     if (car_info->water_d != 10000.f) {
-        TestAutoSpecialVolume(&non_car->collision_info);
+        TestAutoSpecialVolume(car_info);
     }
-    MungeSpecialVolume(&non_car->collision_info);
+    MungeSpecialVolume(car_info);
     if (car_info->dt >= 0.f) {
         dt = car_info->dt;
     }
     NonCarCalcForce(non_car, dt);
-    RotateCar(&non_car->collision_info, dt);
-    TranslateCar(&non_car->collision_info, dt);
-    CollideCarWithWall(&non_car->collision_info, dt);
+    RotateCar(car_info, dt);
+    TranslateCar(car_info, dt);
+    CollideCarWithWall(car_info, dt);
     BrMatrix34ApplyP(&car_info->pos, &car_info->cmpos, &car_info->car_master_actor->t.t.mat);
     BrVector3InvScale(&car_info->pos, &car_info->pos, WORLD_SCALE);
 }


### PR DESCRIPTION
## Match result

```
0x479914: MoveAndCollideNonCar 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x47991b,58 +0x44b400,58 @@
0x47991b : push esi
0x47991c : push edi
0x47991d : mov eax, dword ptr [ebp + 8] 	(car.c:1586)
0x479920 : mov dword ptr [ebp - 4], eax
0x479923 : mov eax, dword ptr [ebp - 4] 	(car.c:1587)
0x479926 : fld dword ptr [eax + 0x2a4]
0x47992c : fcomp dword ptr [10000.0 (FLOAT)]
0x479932 : fnstsw ax
0x479934 : test ah, 0x40
0x479937 : jne 0xc
0x47993d : -mov eax, dword ptr [ebp - 4]
         : +mov eax, dword ptr [ebp + 8] 	(car.c:1588)
0x479940 : push eax
0x479941 : call TestAutoSpecialVolume (FUNCTION)
0x479946 : add esp, 4
0x479949 : -mov eax, dword ptr [ebp - 4]
         : +mov eax, dword ptr [ebp + 8] 	(car.c:1590)
0x47994c : push eax
0x47994d : call MungeSpecialVolume (FUNCTION)
0x479952 : add esp, 4
0x479955 : mov eax, dword ptr [ebp - 4] 	(car.c:1591)
0x479958 : fld dword ptr [eax + 0x334]
0x47995e : fcomp dword ptr [0.0 (FLOAT)]
0x479964 : fnstsw ax
0x479966 : test ah, 1
0x479969 : jne 0xc
0x47996f : mov eax, dword ptr [ebp - 4] 	(car.c:1592)
0x479972 : mov eax, dword ptr [eax + 0x334]
0x479978 : mov dword ptr [ebp + 0xc], eax
0x47997b : mov eax, dword ptr [ebp + 0xc] 	(car.c:1594)
0x47997e : push eax
0x47997f : mov eax, dword ptr [ebp + 8]
0x479982 : push eax
0x479983 : call NonCarCalcForce (FUNCTION)
0x479988 : add esp, 8
0x47998b : mov eax, dword ptr [ebp + 0xc] 	(car.c:1595)
0x47998e : push eax
0x47998f : -mov eax, dword ptr [ebp - 4]
         : +mov eax, dword ptr [ebp + 8]
0x479992 : push eax
0x479993 : call RotateCar (FUNCTION)
0x479998 : add esp, 8
0x47999b : mov eax, dword ptr [ebp + 0xc] 	(car.c:1596)
0x47999e : push eax
0x47999f : -mov eax, dword ptr [ebp - 4]
         : +mov eax, dword ptr [ebp + 8]
0x4799a2 : push eax
0x4799a3 : call TranslateCar (FUNCTION)
0x4799a8 : add esp, 8
0x4799ab : mov eax, dword ptr [ebp + 0xc] 	(car.c:1597)
0x4799ae : push eax
0x4799af : -mov eax, dword ptr [ebp - 4]
         : +mov eax, dword ptr [ebp + 8]
0x4799b2 : push eax
0x4799b3 : call CollideCarWithWall (FUNCTION)
0x4799b8 : add esp, 8
0x4799bb : mov eax, dword ptr [ebp - 4] 	(car.c:1598)
0x4799be : mov eax, dword ptr [eax + 0xc]
0x4799c1 : add eax, 0x2c
0x4799c4 : push eax
0x4799c5 : mov eax, dword ptr [ebp - 4]
0x4799c8 : add eax, 0xd4
0x4799cd : push eax


MoveAndCollideNonCar is only 94.25% similar to the original, diff above
```

*AI generated. Time taken: 73s, tokens: 18,969*
