### PR TITLE
CollideCarWithWall 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -1607,8 +1607,7 @@ int CollideCarWithWall(tCollision_info* car, br_scalar dt) {
     if (gCollision_detection_on__car) {
         car->collision_flag = 0;
         while (CollCheck(car, dt)) {
-            car->collision_flag++;
-            if (car->collision_flag - 1 > 20) {
+            if (car->collision_flag++ > 20) {
                 car->collision_flag = 1;
                 BrVector3Set(&car->v, 0.f, 0.f, 0.f);
                 BrVector3Set(&car->omega, 0.f, 0.f, 0.f);


### PR DESCRIPTION
## Match result

```
0x479a2c: CollideCarWithWall 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x479a2c,38 +0x44b511,37 @@
0x479a2c : push ebp 	(car.c:1604)
0x479a2d : mov ebp, esp
0x479a2f : -sub esp, 4
0x479a32 : push ebx
0x479a33 : push esi
0x479a34 : push edi
0x479a35 : mov eax, dword ptr [ebp + 8] 	(car.c:1606)
0x479a38 : push eax
0x479a39 : call GetFacesInBox (FUNCTION)
0x479a3e : add esp, 4
0x479a41 : cmp dword ptr [gCollision_detection_on__car (DATA)], 0 	(car.c:1607)
0x479a48 : -je 0x119
         : +je 0x116
0x479a4e : mov eax, dword ptr [ebp + 8] 	(car.c:1608)
0x479a51 : mov dword ptr [eax + 0x238], 0
0x479a5b : mov eax, dword ptr [ebp + 0xc] 	(car.c:1609)
0x479a5e : push eax
0x479a5f : mov eax, dword ptr [ebp + 8]
0x479a62 : push eax
0x479a63 : call CollCheck (FUNCTION)
0x479a68 : add esp, 8
0x479a6b : test eax, eax
0x479a6d : -je 0xa7
         : +je 0xa4
         : +mov eax, dword ptr [ebp + 8] 	(car.c:1610)
         : +inc dword ptr [eax + 0x238]
0x479a73 : mov eax, dword ptr [ebp + 8] 	(car.c:1611)
0x479a76 : mov eax, dword ptr [eax + 0x238]
0x479a7c : -mov dword ptr [ebp - 4], eax
0x479a7f : -mov eax, dword ptr [ebp + 8]
0x479a82 : -inc dword ptr [eax + 0x238]
0x479a88 : -cmp dword ptr [ebp - 4], 0x14
         : +dec eax
         : +cmp eax, 0x14
0x479a8c : jle 0x57
0x479a92 : mov eax, dword ptr [ebp + 8] 	(car.c:1612)
0x479a95 : mov dword ptr [eax + 0x238], 1
0x479a9f : mov eax, dword ptr [ebp + 8] 	(car.c:1613)
0x479aa2 : mov dword ptr [eax + 0x18], 0
0x479aa9 : mov eax, dword ptr [ebp + 8]
0x479aac : mov dword ptr [eax + 0x1c], 0
0x479ab3 : mov eax, dword ptr [ebp + 8]
0x479ab6 : mov dword ptr [eax + 0x20], 0
0x479abd : mov eax, dword ptr [ebp + 8] 	(car.c:1614)

---
+++
@@ -0x479af9,21 +0x44b5d8,21 @@
0x479af9 : mov eax, dword ptr [ebp + 0xc] 	(car.c:1618)
0x479afc : push eax
0x479afd : mov eax, dword ptr [ebp + 8]
0x479b00 : push eax
0x479b01 : call TranslateCar (FUNCTION)
0x479b06 : add esp, 8
0x479b09 : mov eax, dword ptr [ebp + 8] 	(car.c:1619)
0x479b0c : push eax
0x479b0d : call GetFacesInBox (FUNCTION)
0x479b12 : add esp, 4
0x479b15 : -jmp -0xbf
         : +jmp -0xbc 	(car.c:1620)
0x479b1a : mov eax, dword ptr [ebp + 8] 	(car.c:1621)
0x479b1d : cmp dword ptr [eax + 0x238], 0
0x479b24 : je 0xe
0x479b2a : push 0 	(car.c:1622)
0x479b2c : mov eax, dword ptr [ebp + 8]
0x479b2f : push eax
0x479b30 : call CrashEarnings (FUNCTION)
0x479b35 : add esp, 8
0x479b38 : mov eax, dword ptr [ebp + 8] 	(car.c:1624)
0x479b3b : add eax, 0x3c

---
+++
@@ -0x479b49,10 +0x44b628,16 @@
0x479b49 : add eax, 0x30
0x479b4c : push eax
0x479b4d : call BrMatrix34TApplyV (FUNCTION)
0x479b52 : add esp, 0xc
0x479b55 : mov eax, dword ptr [ebp + 8] 	(car.c:1625)
0x479b58 : mov eax, dword ptr [eax + 0x238]
0x479b5e : mov ecx, dword ptr [ebp + 8]
0x479b61 : add dword ptr [ecx + 0x234], eax
0x479b67 : mov eax, dword ptr [ebp + 8] 	(car.c:1627)
0x479b6a : mov eax, dword ptr [eax + 0x238]
         : +jmp 0x0
         : +pop edi 	(car.c:1628)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


CollideCarWithWall is only 88.14% similar to the original, diff above
```

*AI generated. Time taken: 72s, tokens: 13,035*
