### PR TITLE
ControlCar2 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -1661,26 +1661,26 @@ void ControlCar2(tCar_spec* c, br_scalar dt) {
         c->acc_force = 7.f * c->M;
     }
     if (c->keys.dec) {
-        c->acc_force = -7.f * c->M;
+        c->acc_force = -(7.f * c->M);
     }
     if (c->keys.left) {
         if (c->turn_speed < 0.f) {
             c->turn_speed = 0.f;
         }
-        if (c->curvature >= 0.f) {
-            c->turn_speed += dt / 0.04f * (0.05f / (5.f + BrVector3Length(&c->v)) / 2.f);
+        if (c->curvature < 0.f) {
+            c->turn_speed += 0.01 * dt / 0.04 / 2.0;
         } else {
-            c->turn_speed += 0.01f * dt / 0.04f / 2.f;
+            c->turn_speed += dt / 0.04f * (0.05f / (5.f + BrVector3Length(&c->v))) / 2.f;
         }
     }
     if (c->keys.right) {
         if (c->turn_speed > 0.f) {
             c->turn_speed = 0.f;
         }
-        if (c->curvature <= 0.f) {
-            c->turn_speed -= dt / 0.04f * (0.05f / (5.f + BrVector3Length(&c->v)) / 2.f);
+        if (c->curvature > 0.f) {
+            c->turn_speed -= 0.01 * dt / 0.04 / 2.0;
         } else {
-            c->turn_speed -= 0.01f * dt / 0.04f / 2.f;
+            c->turn_speed -= dt / 0.04f * (0.05f / (5.f + BrVector3Length(&c->v))) / 2.f;
         }
     }
     if (!c->keys.left && !c->keys.right) {


### PR DESCRIPTION
## Match result

```
0x479c6d: ControlCar2 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x479c8e,75 +0x44b773,74 @@
0x479c8e : je 0x18
0x479c94 : mov eax, dword ptr [ebp + 8] 	(car.c:1661)
0x479c97 : fld dword ptr [eax + 0xc0]
0x479c9d : fmul dword ptr [7.0 (FLOAT)]
0x479ca3 : mov eax, dword ptr [ebp + 8]
0x479ca6 : fstp dword ptr [eax + 0x155c]
0x479cac : mov eax, dword ptr [ebp + 8] 	(car.c:1663)
0x479caf : mov eax, dword ptr [eax + 0x1574]
0x479cb5 : shr eax, 0x13
0x479cb8 : test al, 1
0x479cba : -je 0x1a
         : +je 0x18
0x479cc0 : mov eax, dword ptr [ebp + 8] 	(car.c:1664)
0x479cc3 : fld dword ptr [eax + 0xc0]
0x479cc9 : -fmul dword ptr [7.0 (FLOAT)]
0x479ccf : -fchs 
         : +fmul dword ptr [-7.0 (FLOAT)]
0x479cd1 : mov eax, dword ptr [ebp + 8]
0x479cd4 : fstp dword ptr [eax + 0x155c]
0x479cda : mov eax, dword ptr [ebp + 8] 	(car.c:1666)
0x479cdd : mov eax, dword ptr [eax + 0x1574]
0x479ce3 : shr eax, 0x10
0x479ce6 : test al, 1
0x479ce8 : je 0xc9
0x479cee : mov eax, dword ptr [ebp + 8] 	(car.c:1667)
0x479cf1 : fld dword ptr [eax + 0x1504]
0x479cf7 : fcomp dword ptr [0.0 (FLOAT)]
0x479cfd : fnstsw ax
0x479cff : test ah, 1
0x479d02 : je 0xd
0x479d08 : mov eax, dword ptr [ebp + 8] 	(car.c:1668)
0x479d0b : mov dword ptr [eax + 0x1504], 0
0x479d15 : mov eax, dword ptr [ebp + 8] 	(car.c:1670)
0x479d18 : fld dword ptr [eax + 0x14fc]
0x479d1e : fcomp dword ptr [0.0 (FLOAT)]
0x479d24 : fnstsw ax
0x479d26 : test ah, 1
0x479d29 : -je 0x2c
0x479d2f : -fld dword ptr [ebp + 0xc]
0x479d32 : -fmul qword ptr [0.01 (FLOAT)]
0x479d38 : -fdiv qword ptr [0.04 (FLOAT)]
0x479d3e : -fdiv qword ptr [2.0 (FLOAT)]
0x479d44 : -mov eax, dword ptr [ebp + 8]
0x479d47 : -fadd dword ptr [eax + 0x1504]
0x479d4d : -mov eax, dword ptr [ebp + 8]
0x479d50 : -fstp dword ptr [eax + 0x1504]
0x479d56 : -jmp 0x5c
         : +jne 0x61
0x479d5b : mov eax, dword ptr [ebp + 8] 	(car.c:1671)
0x479d5e : fld dword ptr [eax + 0x20]
0x479d61 : mov eax, dword ptr [ebp + 8]
0x479d64 : fmul dword ptr [eax + 0x20]
0x479d67 : mov eax, dword ptr [ebp + 8]
0x479d6a : fld dword ptr [eax + 0x1c]
0x479d6d : mov eax, dword ptr [ebp + 8]
0x479d70 : fmul dword ptr [eax + 0x1c]
0x479d73 : faddp st(1)
0x479d75 : mov eax, dword ptr [ebp + 8]
0x479d78 : fld dword ptr [eax + 0x18]
0x479d7b : mov eax, dword ptr [ebp + 8]
0x479d7e : fmul dword ptr [eax + 0x18]
0x479d81 : faddp st(1)
0x479d83 : call __CIsqrt (FUNCTION)
0x479d88 : fadd dword ptr [5.0 (FLOAT)]
0x479d8e : fdivr dword ptr [0.05000000074505806 (FLOAT)]
         : +fdiv dword ptr [2.0 (FLOAT)]
0x479d94 : fld dword ptr [ebp + 0xc]
0x479d97 : fdiv dword ptr [0.03999999910593033 (FLOAT)]
0x479d9d : fmulp st(1)
         : +mov eax, dword ptr [ebp + 8]
         : +fadd dword ptr [eax + 0x1504]
         : +mov eax, dword ptr [ebp + 8]
         : +fstp dword ptr [eax + 0x1504]
         : +jmp 0x27 	(car.c:1672)
         : +fld dword ptr [ebp + 0xc] 	(car.c:1673)
         : +fmul dword ptr [0.009999999776482582 (FLOAT)]
         : +fdiv dword ptr [0.03999999910593033 (FLOAT)]
0x479d9f : fdiv dword ptr [2.0 (FLOAT)]
0x479da5 : mov eax, dword ptr [ebp + 8]
0x479da8 : fadd dword ptr [eax + 0x1504]
0x479dae : mov eax, dword ptr [ebp + 8]
0x479db1 : fstp dword ptr [eax + 0x1504]
0x479db7 : mov eax, dword ptr [ebp + 8] 	(car.c:1676)
0x479dba : mov eax, dword ptr [eax + 0x1574]
0x479dc0 : shr eax, 0x11
0x479dc3 : test al, 1
0x479dc5 : je 0xc9

---
+++
@@ -0x479dda,50 +0x44b8bd,50 @@
0x479dda : fnstsw ax
0x479ddc : test ah, 0x41
0x479ddf : jne 0xd
0x479de5 : mov eax, dword ptr [ebp + 8] 	(car.c:1678)
0x479de8 : mov dword ptr [eax + 0x1504], 0
0x479df2 : mov eax, dword ptr [ebp + 8] 	(car.c:1680)
0x479df5 : fld dword ptr [eax + 0x14fc]
0x479dfb : fcomp dword ptr [0.0 (FLOAT)]
0x479e01 : fnstsw ax
0x479e03 : test ah, 0x41
0x479e06 : -jne 0x2c
0x479e0c : -fld dword ptr [ebp + 0xc]
0x479e0f : -fmul qword ptr [0.01 (FLOAT)]
0x479e15 : -fdiv qword ptr [0.04 (FLOAT)]
0x479e1b : -fdiv qword ptr [2.0 (FLOAT)]
0x479e21 : -mov eax, dword ptr [ebp + 8]
0x479e24 : -fsubr dword ptr [eax + 0x1504]
0x479e2a : -mov eax, dword ptr [ebp + 8]
0x479e2d : -fstp dword ptr [eax + 0x1504]
0x479e33 : -jmp 0x5c
         : +je 0x61
0x479e38 : mov eax, dword ptr [ebp + 8] 	(car.c:1681)
0x479e3b : fld dword ptr [eax + 0x20]
0x479e3e : mov eax, dword ptr [ebp + 8]
0x479e41 : fmul dword ptr [eax + 0x20]
0x479e44 : mov eax, dword ptr [ebp + 8]
0x479e47 : fld dword ptr [eax + 0x1c]
0x479e4a : mov eax, dword ptr [ebp + 8]
0x479e4d : fmul dword ptr [eax + 0x1c]
0x479e50 : faddp st(1)
0x479e52 : mov eax, dword ptr [ebp + 8]
0x479e55 : fld dword ptr [eax + 0x18]
0x479e58 : mov eax, dword ptr [ebp + 8]
0x479e5b : fmul dword ptr [eax + 0x18]
0x479e5e : faddp st(1)
0x479e60 : call __CIsqrt (FUNCTION)
0x479e65 : fadd dword ptr [5.0 (FLOAT)]
0x479e6b : fdivr dword ptr [0.05000000074505806 (FLOAT)]
         : +fdiv dword ptr [2.0 (FLOAT)]
0x479e71 : fld dword ptr [ebp + 0xc]
0x479e74 : fdiv dword ptr [0.03999999910593033 (FLOAT)]
0x479e7a : fmulp st(1)
         : +mov eax, dword ptr [ebp + 8]
         : +fsubr dword ptr [eax + 0x1504]
         : +mov eax, dword ptr [ebp + 8]
         : +fstp dword ptr [eax + 0x1504]
         : +jmp 0x27 	(car.c:1682)
         : +fld dword ptr [ebp + 0xc] 	(car.c:1683)
         : +fmul dword ptr [0.009999999776482582 (FLOAT)]
         : +fdiv dword ptr [0.03999999910593033 (FLOAT)]
0x479e7c : fdiv dword ptr [2.0 (FLOAT)]
0x479e82 : mov eax, dword ptr [ebp + 8]
0x479e85 : fsubr dword ptr [eax + 0x1504]
0x479e8b : mov eax, dword ptr [ebp + 8]
0x479e8e : fstp dword ptr [eax + 0x1504]
0x479e94 : mov eax, dword ptr [ebp + 8] 	(car.c:1686)
0x479e97 : mov eax, dword ptr [eax + 0x1574]
0x479e9d : shr eax, 0x10
0x479ea0 : test al, 1
0x479ea2 : jne 0x21

---
+++
@@ -0x479f29,10 +0x44ba0c,12 @@
0x479f29 : test ah, 0x41
0x479f2c : jne 0x14
0x479f32 : mov eax, dword ptr [ebp + 8] 	(car.c:1694)
0x479f35 : fld dword ptr [eax + 0x1500]
0x479f3b : fchs 
0x479f3d : mov eax, dword ptr [ebp + 8]
0x479f40 : fstp dword ptr [eax + 0x14fc]
0x479f46 : pop edi 	(car.c:1696)
0x479f47 : pop esi
0x479f48 : pop ebx
         : +leave 
         : +ret 


ControlCar2 is only 86.91% similar to the original, diff above
```

*AI generated. Time taken: 178s, tokens: 32,964*
