### PR TITLE
ControlCar3 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -1703,10 +1703,10 @@ void ControlCar3(tCar_spec* c, br_scalar dt) {
         if (c->turn_speed < 0.f) {
             c->turn_speed = 0.f;
         }
-        if (c->curvature >= 0.f && c->omega.v[1] >= 0.f) {
-            c->turn_speed += dt / 0.04f * (0.05f / (5.f + BrVector3Length(&c->v)) / 2.f) * 0.75f;
+        if (c->curvature < 0.f || c->omega.v[1] < 0.f) {
+            c->turn_speed += 0.01 * dt / 0.04 / 2.0 * 3.0;
         } else {
-            c->turn_speed += 0.01f * dt / 0.04f / 2.f * 3.f;
+            c->turn_speed += dt / 0.04f * (0.05f / (5.f + BrVector3Length(&c->v))) / 2.f * 0.75;
         }
     }
 
@@ -1714,10 +1714,10 @@ void ControlCar3(tCar_spec* c, br_scalar dt) {
         if (c->turn_speed > 0.f) {
             c->turn_speed = 0.f;
         }
-        if (c->curvature <= 0.f && c->omega.v[1] <= 0.f) {
-            c->turn_speed -= dt / 0.04f * (0.05f / (5.f + BrVector3Length(&c->v)) / 2.f) * 0.75f;
+        if (c->curvature > 0.f || c->omega.v[1] > 0.f) {
+            c->turn_speed -= 0.01 * dt / 0.04 / 2.0 * 3.0;
         } else {
-            c->turn_speed -= 0.01f * dt / 0.04f / 2.f * 3.f;
+            c->turn_speed -= dt / 0.04f * (0.05f / (5.f + BrVector3Length(&c->v))) / 2.f * 0.75;
         }
     }
     if (!c->keys.left && !c->keys.right) {


### PR DESCRIPTION
## Match result

```
0x479f4b: ControlCar3 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x479f74,59 +0x44ba57,59 @@
0x479f74 : fnstsw ax
0x479f76 : test ah, 1
0x479f79 : je 0xd
0x479f7f : mov eax, dword ptr [ebp + 8] 	(car.c:1704)
0x479f82 : mov dword ptr [eax + 0x1504], 0
0x479f8c : mov eax, dword ptr [ebp + 8] 	(car.c:1706)
0x479f8f : fld dword ptr [eax + 0x14fc]
0x479f95 : fcomp dword ptr [0.0 (FLOAT)]
0x479f9b : fnstsw ax
0x479f9d : test ah, 1
0x479fa0 : -jne 0x1a
         : +jne 0x81
0x479fa6 : mov eax, dword ptr [ebp + 8]
0x479fa9 : fld dword ptr [eax + 0xac]
0x479faf : fcomp dword ptr [0.0 (FLOAT)]
0x479fb5 : fnstsw ax
0x479fb7 : test ah, 1
0x479fba : -je 0x32
0x479fc0 : -fld dword ptr [ebp + 0xc]
0x479fc3 : -fmul qword ptr [0.01 (FLOAT)]
0x479fc9 : -fdiv qword ptr [0.04 (FLOAT)]
0x479fcf : -fdiv qword ptr [2.0 (FLOAT)]
0x479fd5 : -fmul qword ptr [3.0 (FLOAT)]
0x479fdb : -mov eax, dword ptr [ebp + 8]
0x479fde : -fadd dword ptr [eax + 0x1504]
0x479fe4 : -mov eax, dword ptr [ebp + 8]
0x479fe7 : -fstp dword ptr [eax + 0x1504]
0x479fed : -jmp 0x62
         : +jne 0x67
0x479ff2 : mov eax, dword ptr [ebp + 8] 	(car.c:1707)
0x479ff5 : fld dword ptr [eax + 0x1c]
0x479ff8 : mov eax, dword ptr [ebp + 8]
0x479ffb : fmul dword ptr [eax + 0x1c]
0x479ffe : mov eax, dword ptr [ebp + 8]
0x47a001 : fld dword ptr [eax + 0x20]
0x47a004 : mov eax, dword ptr [ebp + 8]
0x47a007 : fmul dword ptr [eax + 0x20]
0x47a00a : faddp st(1)
0x47a00c : mov eax, dword ptr [ebp + 8]
0x47a00f : fld dword ptr [eax + 0x18]
0x47a012 : mov eax, dword ptr [ebp + 8]
0x47a015 : fmul dword ptr [eax + 0x18]
0x47a018 : faddp st(1)
0x47a01a : call __CIsqrt (FUNCTION)
0x47a01f : fadd dword ptr [5.0 (FLOAT)]
0x47a025 : fdivr dword ptr [0.05000000074505806 (FLOAT)]
         : +fdiv dword ptr [2.0 (FLOAT)]
0x47a02b : fld dword ptr [ebp + 0xc]
0x47a02e : fdiv dword ptr [0.03999999910593033 (FLOAT)]
0x47a034 : fmulp st(1)
         : +fmul dword ptr [0.75 (FLOAT)]
         : +mov eax, dword ptr [ebp + 8]
         : +fadd dword ptr [eax + 0x1504]
         : +mov eax, dword ptr [ebp + 8]
         : +fstp dword ptr [eax + 0x1504]
         : +jmp 0x2d 	(car.c:1708)
         : +fld dword ptr [ebp + 0xc] 	(car.c:1709)
         : +fmul dword ptr [0.009999999776482582 (FLOAT)]
         : +fdiv dword ptr [0.03999999910593033 (FLOAT)]
0x47a036 : fdiv dword ptr [2.0 (FLOAT)]
0x47a03c : -fmul qword ptr [0.75 (FLOAT)]
         : +fmul dword ptr [3.0 (FLOAT)]
0x47a042 : mov eax, dword ptr [ebp + 8]
0x47a045 : fadd dword ptr [eax + 0x1504]
0x47a04b : mov eax, dword ptr [ebp + 8]
0x47a04e : fstp dword ptr [eax + 0x1504]
0x47a054 : mov eax, dword ptr [ebp + 8] 	(car.c:1713)
0x47a057 : mov eax, dword ptr [eax + 0x1574]
0x47a05d : shr eax, 0x11
0x47a060 : test al, 1
0x47a062 : je 0xef
0x47a068 : mov eax, dword ptr [ebp + 8] 	(car.c:1714)

---
+++
@@ -0x47a077,59 +0x44bb5a,59 @@
0x47a077 : fnstsw ax
0x47a079 : test ah, 0x41
0x47a07c : jne 0xd
0x47a082 : mov eax, dword ptr [ebp + 8] 	(car.c:1715)
0x47a085 : mov dword ptr [eax + 0x1504], 0
0x47a08f : mov eax, dword ptr [ebp + 8] 	(car.c:1717)
0x47a092 : fld dword ptr [eax + 0x14fc]
0x47a098 : fcomp dword ptr [0.0 (FLOAT)]
0x47a09e : fnstsw ax
0x47a0a0 : test ah, 0x41
0x47a0a3 : -je 0x1a
         : +je 0x81
0x47a0a9 : mov eax, dword ptr [ebp + 8]
0x47a0ac : fld dword ptr [eax + 0xac]
0x47a0b2 : fcomp dword ptr [0.0 (FLOAT)]
0x47a0b8 : fnstsw ax
0x47a0ba : test ah, 0x41
0x47a0bd : -jne 0x32
0x47a0c3 : -fld dword ptr [ebp + 0xc]
0x47a0c6 : -fmul qword ptr [0.01 (FLOAT)]
0x47a0cc : -fdiv qword ptr [0.04 (FLOAT)]
0x47a0d2 : -fdiv qword ptr [2.0 (FLOAT)]
0x47a0d8 : -fmul qword ptr [3.0 (FLOAT)]
0x47a0de : -mov eax, dword ptr [ebp + 8]
0x47a0e1 : -fsubr dword ptr [eax + 0x1504]
0x47a0e7 : -mov eax, dword ptr [ebp + 8]
0x47a0ea : -fstp dword ptr [eax + 0x1504]
0x47a0f0 : -jmp 0x62
         : +je 0x67
0x47a0f5 : mov eax, dword ptr [ebp + 8] 	(car.c:1718)
0x47a0f8 : fld dword ptr [eax + 0x1c]
0x47a0fb : mov eax, dword ptr [ebp + 8]
0x47a0fe : fmul dword ptr [eax + 0x1c]
0x47a101 : mov eax, dword ptr [ebp + 8]
0x47a104 : fld dword ptr [eax + 0x20]
0x47a107 : mov eax, dword ptr [ebp + 8]
0x47a10a : fmul dword ptr [eax + 0x20]
0x47a10d : faddp st(1)
0x47a10f : mov eax, dword ptr [ebp + 8]
0x47a112 : fld dword ptr [eax + 0x18]
0x47a115 : mov eax, dword ptr [ebp + 8]
0x47a118 : fmul dword ptr [eax + 0x18]
0x47a11b : faddp st(1)
0x47a11d : call __CIsqrt (FUNCTION)
0x47a122 : fadd dword ptr [5.0 (FLOAT)]
0x47a128 : fdivr dword ptr [0.05000000074505806 (FLOAT)]
         : +fdiv dword ptr [2.0 (FLOAT)]
0x47a12e : fld dword ptr [ebp + 0xc]
0x47a131 : fdiv dword ptr [0.03999999910593033 (FLOAT)]
0x47a137 : fmulp st(1)
         : +fmul dword ptr [0.75 (FLOAT)]
         : +mov eax, dword ptr [ebp + 8]
         : +fsubr dword ptr [eax + 0x1504]
         : +mov eax, dword ptr [ebp + 8]
         : +fstp dword ptr [eax + 0x1504]
         : +jmp 0x2d 	(car.c:1719)
         : +fld dword ptr [ebp + 0xc] 	(car.c:1720)
         : +fmul dword ptr [0.009999999776482582 (FLOAT)]
         : +fdiv dword ptr [0.03999999910593033 (FLOAT)]
0x47a139 : fdiv dword ptr [2.0 (FLOAT)]
0x47a13f : -fmul qword ptr [0.75 (FLOAT)]
         : +fmul dword ptr [3.0 (FLOAT)]
0x47a145 : mov eax, dword ptr [ebp + 8]
0x47a148 : fsubr dword ptr [eax + 0x1504]
0x47a14e : mov eax, dword ptr [ebp + 8]
0x47a151 : fstp dword ptr [eax + 0x1504]
0x47a157 : mov eax, dword ptr [ebp + 8] 	(car.c:1723)
0x47a15a : mov eax, dword ptr [eax + 0x1574]
0x47a160 : shr eax, 0x10
0x47a163 : test al, 1
0x47a165 : jne 0x21
0x47a16b : mov eax, dword ptr [ebp + 8]


ControlCar3 is only 85.06% similar to the original, diff above
```

*AI generated. Time taken: 136s, tokens: 19,690*
