### PR TITLE
setrotate 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -1878,9 +1878,9 @@ void ControlCar1(tCar_spec* c, br_scalar dt) {
 void setrotate(br_vector3* wdt, br_matrix34* m) {
     br_euler e;
 
-    e.a = BR_ANGLE_RAD(wdt->v[0]);
-    e.b = BR_ANGLE_RAD(wdt->v[1]);
-    e.c = BR_ANGLE_RAD(wdt->v[2]);
+    e.a = BrRadianToAngle(wdt->v[0]);
+    e.b = BrRadianToAngle(wdt->v[1]);
+    e.c = BrRadianToAngle(wdt->v[2]);
     e.order = 0;
     BrEulerToMatrix34(m, &e);
 }


### PR DESCRIPTION
## Match result

```
0x47ae59: setrotate 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x47ae59,29 +0x44c946,29 @@
0x47ae59 : push ebp 	(car.c:1878)
0x47ae5a : mov ebp, esp
0x47ae5c : sub esp, 8
0x47ae5f : push ebx
0x47ae60 : push esi
0x47ae61 : push edi
0x47ae62 : mov eax, dword ptr [ebp + 8] 	(car.c:1881)
0x47ae65 : fld dword ptr [eax]
0x47ae67 : -fmul qword ptr [10430.378350470453 (FLOAT)]
         : +fmul dword ptr [10430.0 (FLOAT)]
0x47ae6d : call __ftol (FUNCTION)
0x47ae72 : mov word ptr [ebp - 8], ax
0x47ae76 : mov eax, dword ptr [ebp + 8] 	(car.c:1882)
0x47ae79 : fld dword ptr [eax + 4]
0x47ae7c : -fmul qword ptr [10430.378350470453 (FLOAT)]
         : +fmul dword ptr [10430.0 (FLOAT)]
0x47ae82 : call __ftol (FUNCTION)
0x47ae87 : mov word ptr [ebp - 6], ax
0x47ae8b : mov eax, dword ptr [ebp + 8] 	(car.c:1883)
0x47ae8e : fld dword ptr [eax + 8]
0x47ae91 : -fmul qword ptr [10430.378350470453 (FLOAT)]
         : +fmul dword ptr [10430.0 (FLOAT)]
0x47ae97 : call __ftol (FUNCTION)
0x47ae9c : mov word ptr [ebp - 4], ax
0x47aea0 : mov byte ptr [ebp - 2], 0 	(car.c:1884)
0x47aea4 : lea eax, [ebp - 8] 	(car.c:1885)
0x47aea7 : push eax
0x47aea8 : mov eax, dword ptr [ebp + 0xc]
0x47aeab : push eax
0x47aeac : call BrEulerToMatrix34 (FUNCTION)
0x47aeb1 : add esp, 8
0x47aeb4 : pop edi 	(car.c:1886)


setrotate is only 90.91% similar to the original, diff above
```

*AI generated. Time taken: 70s, tokens: 23,318*
