### PR TITLE
RotateCarFirstOrder 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -1956,7 +1956,7 @@ void RotateCarFirstOrder(tCollision_info* c, br_scalar dt) {
     br_scalar e2;
     static br_scalar max_rad;
 
-    rad_rate = BrVector3Length(&c->omega);
+    rad_rate = sqrt(c->omega.v[1] * c->omega.v[1] + c->omega.v[2] * c->omega.v[2] + c->omega.v[0] * c->omega.v[0]);
     rad = rad_rate * dt;
 
     if (rad < .0001) {


### PR DESCRIPTION
## Match result

```
0x47b073: RotateCarFirstOrder 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x47b073,24 +0x44cdb6,24 @@
0x47b073 : push ebp 	(car.c:1948)
0x47b074 : mov ebp, esp
0x47b076 : sub esp, 0x64
0x47b079 : push ebx
0x47b07a : push esi
0x47b07b : push edi
0x47b07c : mov eax, dword ptr [ebp + 8] 	(car.c:1959)
         : +fld dword ptr [eax + 0xb0]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 0xb0]
         : +mov eax, dword ptr [ebp + 8]
0x47b07f : fld dword ptr [eax + 0xac]
0x47b085 : mov eax, dword ptr [ebp + 8]
0x47b088 : fmul dword ptr [eax + 0xac]
0x47b08e : -mov eax, dword ptr [ebp + 8]
0x47b091 : -fld dword ptr [eax + 0xb0]
0x47b097 : -mov eax, dword ptr [ebp + 8]
0x47b09a : -fmul dword ptr [eax + 0xb0]
0x47b0a0 : faddp st(1)
0x47b0a2 : mov eax, dword ptr [ebp + 8]
0x47b0a5 : fld dword ptr [eax + 0xa8]
0x47b0ab : mov eax, dword ptr [ebp + 8]
0x47b0ae : fmul dword ptr [eax + 0xa8]
0x47b0b4 : faddp st(1)
0x47b0b6 : call __CIsqrt (FUNCTION)
0x47b0bb : fst dword ptr [ebp - 0x28]
0x47b0be : fmul dword ptr [ebp + 0xc] 	(car.c:1960)
0x47b0c1 : fcom qword ptr [0.0001 (FLOAT)] 	(car.c:1962)


RotateCarFirstOrder is only 97.01% similar to the original, diff above
```

*AI generated. Time taken: 120s, tokens: 12,399*
