### PR TITLE
SimpleRotate 100% effective match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -1983,10 +1983,11 @@ void SimpleRotate(tCollision_info* c, br_scalar dt) {
 
     rad_rate = BrVector3Length(&c->omega);
     BrVector3InvScale(&axis, &c->omega, rad_rate);
-    rad = rad_rate * dt;
-    if (rad >= 0.0001) {
-        BrMatrix34PreRotate(&c->car_master_actor->t.t.mat, BrRadianToAngle(rad), &axis);
+    rad = dt * rad_rate;
+    if (rad < 0.0001) {
+        return;
     }
+    BrMatrix34PreRotate(&c->car_master_actor->t.t.mat, BrRadianToAngle(rad), &axis);
 }
 
 // IDA: void __usercall RotateCar(tCollision_info *c@<EAX>, br_scalar dt)


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x47b290,22 +0x44cfd3,22 @@
0x47b290 : fdiv dword ptr [ebp - 0x14]
0x47b293 : fstp dword ptr [ebp - 0xc]
0x47b296 : mov eax, dword ptr [ebp + 8]
0x47b299 : fld dword ptr [eax + 0xac]
0x47b29f : fdiv dword ptr [ebp - 0x14]
0x47b2a2 : fstp dword ptr [ebp - 8]
0x47b2a5 : mov eax, dword ptr [ebp + 8]
0x47b2a8 : fld dword ptr [eax + 0xb0]
0x47b2ae : fdiv dword ptr [ebp - 0x14]
0x47b2b1 : fstp dword ptr [ebp - 4]
0x47b2b4 : -fld dword ptr [ebp - 0x14]
0x47b2b7 : -fmul dword ptr [ebp + 0xc]
         : +fld dword ptr [ebp + 0xc] 	(car.c:1986)
         : +fmul dword ptr [ebp - 0x14]
0x47b2ba : fcom qword ptr [0.0001 (FLOAT)] 	(car.c:1987)
0x47b2c0 : fstp dword ptr [ebp - 0x10]
0x47b2c3 : fnstsw ax
0x47b2c5 : test ah, 1
0x47b2c8 : je 0x5
0x47b2ce : jmp 0x25 	(car.c:1988)
0x47b2d3 : lea eax, [ebp - 0xc] 	(car.c:1990)
0x47b2d6 : push eax
0x47b2d7 : fld dword ptr [ebp - 0x10]
0x47b2da : fmul qword ptr [10430.378350470453 (FLOAT)]


0x47b23c: SimpleRotate 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x47b290,30 +0x44cfd3,34 @@
0x47b290 : fdiv dword ptr [ebp - 0x14]
0x47b293 : fstp dword ptr [ebp - 0xc]
0x47b296 : mov eax, dword ptr [ebp + 8]
0x47b299 : fld dword ptr [eax + 0xac]
0x47b29f : fdiv dword ptr [ebp - 0x14]
0x47b2a2 : fstp dword ptr [ebp - 8]
0x47b2a5 : mov eax, dword ptr [ebp + 8]
0x47b2a8 : fld dword ptr [eax + 0xb0]
0x47b2ae : fdiv dword ptr [ebp - 0x14]
0x47b2b1 : fstp dword ptr [ebp - 4]
0x47b2b4 : -fld dword ptr [ebp - 0x14]
0x47b2b7 : -fmul dword ptr [ebp + 0xc]
         : +fld dword ptr [ebp + 0xc] 	(car.c:1986)
         : +fmul dword ptr [ebp - 0x14]
0x47b2ba : fcom qword ptr [0.0001 (FLOAT)] 	(car.c:1987)
0x47b2c0 : fstp dword ptr [ebp - 0x10]
0x47b2c3 : fnstsw ax
0x47b2c5 : test ah, 1
0x47b2c8 : -je 0x5
0x47b2ce : -jmp 0x25
         : +jne 0x25
0x47b2d3 : lea eax, [ebp - 0xc] 	(car.c:1988)
0x47b2d6 : push eax
0x47b2d7 : fld dword ptr [ebp - 0x10]
0x47b2da : fmul qword ptr [10430.378350470453 (FLOAT)]
0x47b2e0 : call __ftol (FUNCTION)
0x47b2e5 : push eax
0x47b2e6 : mov eax, dword ptr [ebp + 8]
0x47b2e9 : mov eax, dword ptr [eax + 0xc]
0x47b2ec : add eax, 0x2c
0x47b2ef : push eax
0x47b2f0 : call BrMatrix34PreRotate (FUNCTION)
0x47b2f5 : add esp, 0xc
         : +pop edi 	(car.c:1990)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


SimpleRotate is only 89.29% similar to the original, diff above
```

*AI generated. Time taken: 62s, tokens: 8,264*
