### PR TITLE
DoBumpiness 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -2136,12 +2136,8 @@ void DoBumpiness(tCar_spec* c, br_vector3* wheel_pos, br_vector3* norm, br_scala
     tMaterial_modifiers* mat_list;
 
     mat_list = gCurrent_race.material_modifiers;
-    tv.v[0] = c->nor[n].v[0] * d[n];
-    tv.v[1] = c->nor[n].v[1] * d[n];
-    tv.v[2] = c->nor[n].v[2] * d[n];
-    tv.v[0] += wheel_pos[n].v[0];
-    tv.v[1] += wheel_pos[n].v[1];
-    tv.v[2] += wheel_pos[n].v[2];
+    BrVector3Scale(&tv, &c->nor[n], d[n]);
+    BrVector3Accumulate(&tv, &wheel_pos[n]);
 
     x = abs((int)(512.0f * tv.v[0])) % 2048;
     y = abs((int)(512.0f * tv.v[2])) % 2048;

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -2135,8 +2135,13 @@ void DoBumpiness(tCar_spec* c, br_vector3* wheel_pos, br_vector3* norm, br_scala
     int y;
     tMaterial_modifiers* mat_list;
 
-    tv.v[0] = c->nor[n].v[0] * d[n] + wheel_pos[n].v[0];
-    tv.v[2] = c->nor[n].v[2] * d[n] + wheel_pos[n].v[2];
+    mat_list = gCurrent_race.material_modifiers;
+    tv.v[0] = c->nor[n].v[0] * d[n];
+    tv.v[1] = c->nor[n].v[1] * d[n];
+    tv.v[2] = c->nor[n].v[2] * d[n];
+    tv.v[0] += wheel_pos[n].v[0];
+    tv.v[1] += wheel_pos[n].v[1];
+    tv.v[2] += wheel_pos[n].v[2];
 
     x = abs((int)(512.0f * tv.v[0])) % 2048;
     y = abs((int)(512.0f * tv.v[2])) % 2048;
@@ -2147,16 +2152,15 @@ void DoBumpiness(tCar_spec* c, br_vector3* wheel_pos, br_vector3* norm, br_scala
     if (y > 1024) {
         y = 2048 - y;
     }
-    if (x + y <= 1024) {
-        delta = x + y;
-    } else {
+    if (x + y > 1024) {
         delta = 2048 - x - y;
+    } else {
+        delta = x + y;
     }
     delta -= 400;
     if (delta < 0) {
         delta = 0;
     }
-    mat_list = gCurrent_race.material_modifiers;
     d[n] = delta * mat_list[c->material_index[n]].bumpiness / 42400.0f * norm[n].v[1] + d[n];
 }
 


### PR DESCRIPTION
## Match result

```
0x47ede9: DoBumpiness 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x47ede9,60 +0x44d855,39 @@
0x47ede9 : push ebp 	(car.c:2131)
0x47edea : mov ebp, esp
0x47edec : sub esp, 0x20
0x47edef : push ebx
0x47edf0 : push esi
0x47edf1 : push edi
0x47edf2 : -mov eax, gCurrent_race (DATA)
0x47edf7 : -add eax, 0xfbc
0x47edfc : -mov dword ptr [ebp - 8], eax
0x47edff : mov eax, dword ptr [ebp + 0x18] 	(car.c:2138)
0x47ee02 : lea eax, [eax + eax*2]
0x47ee05 : mov ecx, dword ptr [ebp + 8]
0x47ee08 : fld dword ptr [ecx + eax*4 + 0x18c0]
0x47ee0f : mov eax, dword ptr [ebp + 0x18]
0x47ee12 : mov ecx, dword ptr [ebp + 0x14]
0x47ee15 : fmul dword ptr [ecx + eax*4]
0x47ee18 : -fstp dword ptr [ebp - 0x1c]
0x47ee1b : mov eax, dword ptr [ebp + 0x18]
0x47ee1e : lea eax, [eax + eax*2]
0x47ee21 : -mov ecx, dword ptr [ebp + 8]
0x47ee24 : -fld dword ptr [ecx + eax*4 + 0x18c4]
0x47ee2b : -mov eax, dword ptr [ebp + 0x18]
0x47ee2e : -mov ecx, dword ptr [ebp + 0x14]
0x47ee31 : -fmul dword ptr [ecx + eax*4]
0x47ee34 : -fstp dword ptr [ebp - 0x18]
         : +mov ecx, dword ptr [ebp + 0xc]
         : +fadd dword ptr [ecx + eax*4]
         : +fstp dword ptr [ebp - 0x1c]
0x47ee37 : mov eax, dword ptr [ebp + 0x18] 	(car.c:2139)
0x47ee3a : lea eax, [eax + eax*2]
0x47ee3d : mov ecx, dword ptr [ebp + 8]
0x47ee40 : fld dword ptr [ecx + eax*4 + 0x18c8]
0x47ee47 : mov eax, dword ptr [ebp + 0x18]
0x47ee4a : mov ecx, dword ptr [ebp + 0x14]
0x47ee4d : fmul dword ptr [ecx + eax*4]
0x47ee50 : -fstp dword ptr [ebp - 0x14]
0x47ee53 : mov eax, dword ptr [ebp + 0x18]
0x47ee56 : lea eax, [eax + eax*2]
0x47ee59 : mov ecx, dword ptr [ebp + 0xc]
0x47ee5c : -fld dword ptr [ecx + eax*4]
0x47ee5f : -fadd dword ptr [ebp - 0x1c]
0x47ee62 : -fstp dword ptr [ebp - 0x1c]
0x47ee65 : -mov eax, dword ptr [ebp + 0x18]
0x47ee68 : -lea eax, [eax + eax*2]
0x47ee6b : -mov ecx, dword ptr [ebp + 0xc]
0x47ee6e : -fld dword ptr [ecx + eax*4 + 4]
0x47ee72 : -fadd dword ptr [ebp - 0x18]
0x47ee75 : -fstp dword ptr [ebp - 0x18]
0x47ee78 : -mov eax, dword ptr [ebp + 0x18]
0x47ee7b : -lea eax, [eax + eax*2]
0x47ee7e : -mov ecx, dword ptr [ebp + 0xc]
0x47ee81 : -fld dword ptr [ecx + eax*4 + 8]
0x47ee85 : -fadd dword ptr [ebp - 0x14]
         : +fadd dword ptr [ecx + eax*4 + 8]
0x47ee88 : fstp dword ptr [ebp - 0x14]
0x47ee8b : fld dword ptr [ebp - 0x1c] 	(car.c:2141)
0x47ee8e : fmul dword ptr [512.0 (FLOAT)]
0x47ee94 : call __ftol (FUNCTION)
0x47ee99 : cdq 
0x47ee9a : xor eax, edx
0x47ee9c : sub eax, edx
0x47ee9e : cdq 
0x47ee9f : xor eax, edx
0x47eea1 : sub eax, edx

---
+++
@@ -0x47eee5,25 +0x44d909,50 @@
0x47eee5 : sub eax, dword ptr [ebp - 4]
0x47eee8 : mov dword ptr [ebp - 4], eax
0x47eeeb : cmp dword ptr [ebp - 0xc], 0x400 	(car.c:2147)
0x47eef2 : jle 0xb
0x47eef8 : mov eax, 0x800 	(car.c:2148)
0x47eefd : sub eax, dword ptr [ebp - 0xc]
0x47ef00 : mov dword ptr [ebp - 0xc], eax
0x47ef03 : mov eax, dword ptr [ebp - 0xc] 	(car.c:2150)
0x47ef06 : add eax, dword ptr [ebp - 4]
0x47ef09 : cmp eax, 0x400
0x47ef0e : -jle 0x13
         : +jg 0xe
         : +mov eax, dword ptr [ebp - 0xc] 	(car.c:2151)
         : +add eax, dword ptr [ebp - 4]
         : +mov dword ptr [ebp - 0x10], eax
         : +jmp 0xe 	(car.c:2152)
0x47ef14 : mov eax, 0x800 	(car.c:2153)
0x47ef19 : sub eax, dword ptr [ebp - 4]
0x47ef1c : sub eax, dword ptr [ebp - 0xc]
0x47ef1f : mov dword ptr [ebp - 0x10], eax
0x47ef22 : -jmp 0x9
0x47ef27 : -mov eax, dword ptr [ebp - 0xc]
0x47ef2a : -add eax, dword ptr [ebp - 4]
0x47ef2d : -mov dword ptr [ebp - 0x10], eax
0x47ef30 : sub dword ptr [ebp - 0x10], 0x190 	(car.c:2155)
0x47ef37 : jns 0x7 	(car.c:2156)
0x47ef3d : mov dword ptr [ebp - 0x10], 0 	(car.c:2157)
         : +mov eax, gCurrent_race (DATA) 	(car.c:2159)
         : +add eax, 0xfbc
         : +mov dword ptr [ebp - 8], eax
0x47ef44 : mov eax, dword ptr [ebp + 0x18] 	(car.c:2160)
0x47ef47 : mov ecx, dword ptr [ebp + 8]
0x47ef4a : mov eax, dword ptr [ecx + eax*4 + 0x1518]
         : +lea eax, [eax + eax*4]
         : +mov ecx, dword ptr [ebp - 8]
         : +mov edx, dword ptr [ebp - 0x10]
         : +mov dword ptr [ebp - 0x20], edx
         : +fild dword ptr [ebp - 0x20]
         : +fmul dword ptr [ecx + eax*8 + 0xc]
         : +fdiv dword ptr [42400.0 (FLOAT)]
         : +mov eax, dword ptr [ebp + 0x18]
         : +lea eax, [eax + eax*2]
         : +mov ecx, dword ptr [ebp + 0x10]
         : +fmul dword ptr [ecx + eax*4 + 4]
         : +mov eax, dword ptr [ebp + 0x18]
         : +mov ecx, dword ptr [ebp + 0x14]
         : +fadd dword ptr [ecx + eax*4]
         : +mov eax, dword ptr [ebp + 0x18]
         : +mov ecx, dword ptr [ebp + 0x14]
         : +fstp dword ptr [ecx + eax*4]
         : +pop edi 	(car.c:2161)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DoBumpiness is only 70.09% similar to the original, diff above
```

*AI generated. Time taken: 95s, tokens: 50,469*
