### PR TITLE
CrushBoundingBox 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3677,54 +3677,54 @@ void CrushBoundingBox(tCar_spec* c, int crush_only) {
         return;
     }
     actor = c->car_model_actors[c->principal_car_actor].actor;
-    max.v[0] = c->wpos[2].v[2] - c->non_driven_wheels_circum / 6.2f;
-    min.v[0] = c->driven_wheels_circum / 6.2f + c->wpos[0].v[2];
-    max.v[0] /= WORLD_SCALE;
-    min.v[0] /= WORLD_SCALE;
+    min.v[2] = c->wpos[2].v[2] - c->non_driven_wheels_circum / 6.2f;
+    max.v[2] = c->driven_wheels_circum / 6.2f + c->wpos[0].v[2];
+    min.v[2] /= 6.9;
+    max.v[2] /= 6.9;
     for (i = 0; i < actor->model->nvertices; i++) {
-        if (actor->model->vertices[i].p.v[2] < max.v[0]) {
-            max.v[0] = actor->model->vertices[i].p.v[2];
+        if (actor->model->vertices[i].p.v[2] < min.v[2]) {
+            min.v[2] = actor->model->vertices[i].p.v[2];
         }
-        if (actor->model->vertices[i].p.v[2] > min.v[0]) {
-            min.v[0] = actor->model->vertices[i].p.v[2];
+        if (actor->model->vertices[i].p.v[2] > max.v[2]) {
+            max.v[2] = actor->model->vertices[i].p.v[2];
         }
     }
-    max.v[0] *= WORLD_SCALE;
-    min.v[0] *= WORLD_SCALE;
+    min.v[2] *= 6.9;
+    max.v[2] *= 6.9;
     if (crush_only) {
-        if (c->bounds[1].min.v[2] > max.v[0]) {
-            max.v[0] = c->bounds[1].min.v[2];
+        if (c->bounds[1].min.v[2] > min.v[2]) {
+            min.v[2] = c->bounds[1].min.v[2];
         }
-        if (c->bounds[1].max.v[2] < min.v[0]) {
-            min.v[0] = c->bounds[1].max.v[2];
+        if (c->bounds[1].max.v[2] < max.v[2]) {
+            max.v[2] = c->bounds[1].max.v[2];
         }
     } else {
-        if (c->max_bounds[1].min.v[2] > max.v[0]) {
-            max.v[0] = c->max_bounds[1].min.v[2];
+        if (c->max_bounds[1].min.v[2] > min.v[2]) {
+            min.v[2] = c->max_bounds[1].min.v[2];
         }
-        if (c->max_bounds[1].max.v[2] < min.v[0]) {
-            min.v[0] = c->max_bounds[1].max.v[2];
+        if (c->max_bounds[1].max.v[2] < max.v[2]) {
+            max.v[2] = c->max_bounds[1].max.v[2];
         }
     }
-    c->bounds[1].min.v[2] = max.v[0];
-    c->bounds[1].max.v[2] = min.v[0];
+    c->bounds[1].min.v[2] = min.v[2];
+    c->bounds[1].max.v[2] = max.v[2];
     for (i = 0; i < c->extra_point_num; i++) {
-        if (c->max_bounds[1].max.v[2] + 0.01f >= c->original_extra_points_z[i] && c->max_bounds[1].min.v[2] - 0.01f <= c->original_extra_points_z[i]) {
-            if (c->original_extra_points_z[i] > min.v[0]) {
-                c->extra_points[i].v[2] = min.v[0];
-            } else if (c->original_extra_points_z[i] >= max.v[0]) {
-                c->extra_points[i].v[2] = c->original_extra_points_z[i];
-            } else {
-                c->extra_points[i].v[2] = max.v[0];
-            }
-            if (c->extra_points[i].v[2] > min.v[0]) {
-                c->extra_points[i].v[2] = min.v[0];
-            }
-            if (c->extra_points[i].v[2] < max.v[0]) {
-                c->extra_points[i].v[2] = max.v[0];
-            }
-        } else {
+        if (c->max_bounds[1].max.v[2] + 0.01 < c->original_extra_points_z[i] || c->max_bounds[1].min.v[2] - 0.01 > c->original_extra_points_z[i]) {
             c->extra_points[i].v[2] = c->original_extra_points_z[i];
+        } else {
+            if (c->original_extra_points_z[i] > max.v[2]) {
+                c->extra_points[i].v[2] = max.v[2];
+            } else if (c->original_extra_points_z[i] < min.v[2]) {
+                c->extra_points[i].v[2] = min.v[2];
+            } else {
+                c->extra_points[i].v[2] = c->original_extra_points_z[i];
+            }
+            if (c->extra_points[i].v[2] > max.v[2]) {
+                c->extra_points[i].v[2] = max.v[2];
+            }
+            if (c->extra_points[i].v[2] < min.v[2]) {
+                c->extra_points[i].v[2] = min.v[2];
+            }
         }
     }
 }

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3679,8 +3679,8 @@ void CrushBoundingBox(tCar_spec* c, int crush_only) {
     actor = c->car_model_actors[c->principal_car_actor].actor;
     min.v[2] = c->wpos[2].v[2] - c->non_driven_wheels_circum / 6.2f;
     max.v[2] = c->driven_wheels_circum / 6.2f + c->wpos[0].v[2];
-    min.v[2] /= 6.9;
-    max.v[2] /= 6.9;
+    min.v[2] /= WORLD_SCALE_D;
+    max.v[2] /= WORLD_SCALE_D;
     for (i = 0; i < actor->model->nvertices; i++) {
         if (actor->model->vertices[i].p.v[2] < min.v[2]) {
             min.v[2] = actor->model->vertices[i].p.v[2];
@@ -3689,8 +3689,8 @@ void CrushBoundingBox(tCar_spec* c, int crush_only) {
             max.v[2] = actor->model->vertices[i].p.v[2];
         }
     }
-    min.v[2] *= 6.9;
-    max.v[2] *= 6.9;
+    min.v[2] *= WORLD_SCALE_D;
+    max.v[2] *= WORLD_SCALE_D;
     if (crush_only) {
         if (c->bounds[1].min.v[2] > min.v[2]) {
             min.v[2] = c->bounds[1].min.v[2];


### PR DESCRIPTION
## Match result

```
0x482dee: CrushBoundingBox 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x482e0f,216 +0x455029,216 @@
0x482e0f : shl eax, 4
0x482e12 : lea eax, [eax + eax*2]
0x482e15 : mov ecx, dword ptr [ebp + 8]
0x482e18 : mov eax, dword ptr [eax + ecx + 0x12b8]
0x482e1f : mov dword ptr [ebp - 0x20], eax
0x482e22 : mov eax, dword ptr [ebp + 8] 	(car.c:3680)
0x482e25 : fld dword ptr [eax + 0x72c]
0x482e2b : fdiv dword ptr [6.199999809265137 (FLOAT)]
0x482e31 : mov eax, dword ptr [ebp + 8]
0x482e34 : fsubr dword ptr [eax + 0x14ec]
0x482e3a : -fstp dword ptr [ebp - 0x14]
         : +fstp dword ptr [ebp - 0xc]
0x482e3d : mov eax, dword ptr [ebp + 8] 	(car.c:3681)
0x482e40 : fld dword ptr [eax + 0x728]
0x482e46 : fdiv dword ptr [6.199999809265137 (FLOAT)]
0x482e4c : mov eax, dword ptr [ebp + 8]
0x482e4f : fadd dword ptr [eax + 0x14d4]
0x482e55 : -fstp dword ptr [ebp - 4]
0x482e58 : -fld dword ptr [ebp - 0x14]
0x482e5b : -fdiv qword ptr [6.9 (FLOAT)]
0x482e61 : -fstp dword ptr [ebp - 0x14]
0x482e64 : -fld dword ptr [ebp - 4]
0x482e67 : -fdiv qword ptr [6.9 (FLOAT)]
0x482e6d : -fstp dword ptr [ebp - 4]
         : +fstp dword ptr [ebp - 0x1c]
         : +fld dword ptr [ebp - 0xc] 	(car.c:3682)
         : +fdiv dword ptr [6.900000095367432 (FLOAT)]
         : +fstp dword ptr [ebp - 0xc]
         : +fld dword ptr [ebp - 0x1c] 	(car.c:3683)
         : +fdiv dword ptr [6.900000095367432 (FLOAT)]
         : +fstp dword ptr [ebp - 0x1c]
0x482e70 : mov dword ptr [ebp - 0x10], 0 	(car.c:3684)
0x482e77 : jmp 0x3
0x482e7c : inc dword ptr [ebp - 0x10]
0x482e7f : mov eax, dword ptr [ebp - 0x20]
0x482e82 : mov eax, dword ptr [eax + 0x18]
0x482e85 : xor ecx, ecx
0x482e87 : mov cx, word ptr [eax + 0x10]
0x482e8b : cmp ecx, dword ptr [ebp - 0x10]
0x482e8e : jle 0x73
0x482e94 : mov eax, dword ptr [ebp - 0x20] 	(car.c:3685)
0x482e97 : mov eax, dword ptr [eax + 0x18]
0x482e9a : mov eax, dword ptr [eax + 8]
0x482e9d : mov ecx, dword ptr [ebp - 0x10]
0x482ea0 : lea ecx, [ecx + ecx*4]
0x482ea3 : fld dword ptr [eax + ecx*8 + 8]
0x482ea7 : -fcomp dword ptr [ebp - 0x14]
         : +fcomp dword ptr [ebp - 0xc]
0x482eaa : fnstsw ax
0x482eac : test ah, 1
0x482eaf : je 0x16
0x482eb5 : mov eax, dword ptr [ebp - 0x20] 	(car.c:3686)
0x482eb8 : mov eax, dword ptr [eax + 0x18]
0x482ebb : mov eax, dword ptr [eax + 8]
0x482ebe : mov ecx, dword ptr [ebp - 0x10]
0x482ec1 : lea ecx, [ecx + ecx*4]
0x482ec4 : mov eax, dword ptr [eax + ecx*8 + 8]
0x482ec8 : -mov dword ptr [ebp - 0x14], eax
         : +mov dword ptr [ebp - 0xc], eax
0x482ecb : mov eax, dword ptr [ebp - 0x20] 	(car.c:3688)
0x482ece : mov eax, dword ptr [eax + 0x18]
0x482ed1 : mov eax, dword ptr [eax + 8]
0x482ed4 : mov ecx, dword ptr [ebp - 0x10]
0x482ed7 : lea ecx, [ecx + ecx*4]
0x482eda : fld dword ptr [eax + ecx*8 + 8]
0x482ede : -fcomp dword ptr [ebp - 4]
         : +fcomp dword ptr [ebp - 0x1c]
0x482ee1 : fnstsw ax
0x482ee3 : test ah, 0x41
0x482ee6 : jne 0x16
0x482eec : mov eax, dword ptr [ebp - 0x20] 	(car.c:3689)
0x482eef : mov eax, dword ptr [eax + 0x18]
0x482ef2 : mov eax, dword ptr [eax + 8]
0x482ef5 : mov ecx, dword ptr [ebp - 0x10]
0x482ef8 : lea ecx, [ecx + ecx*4]
0x482efb : mov eax, dword ptr [eax + ecx*8 + 8]
0x482eff : -mov dword ptr [ebp - 4], eax
         : +mov dword ptr [ebp - 0x1c], eax
0x482f02 : jmp -0x8b 	(car.c:3691)
0x482f07 : -fld dword ptr [ebp - 0x14]
0x482f0a : -fmul qword ptr [6.9 (FLOAT)]
0x482f10 : -fstp dword ptr [ebp - 0x14]
0x482f13 : -fld dword ptr [ebp - 4]
0x482f16 : -fmul qword ptr [6.9 (FLOAT)]
0x482f1c : -fstp dword ptr [ebp - 4]
         : +fld dword ptr [ebp - 0xc] 	(car.c:3692)
         : +fmul dword ptr [6.900000095367432 (FLOAT)]
         : +fstp dword ptr [ebp - 0xc]
         : +fld dword ptr [ebp - 0x1c] 	(car.c:3693)
         : +fmul dword ptr [6.900000095367432 (FLOAT)]
         : +fstp dword ptr [ebp - 0x1c]
0x482f1f : cmp dword ptr [ebp + 0xc], 0 	(car.c:3694)
0x482f23 : je 0x4b
0x482f29 : mov eax, dword ptr [ebp + 8] 	(car.c:3695)
0x482f2c : fld dword ptr [eax + 0x104]
0x482f32 : -fcomp dword ptr [ebp - 0x14]
         : +fcomp dword ptr [ebp - 0xc]
0x482f35 : fnstsw ax
0x482f37 : test ah, 0x41
0x482f3a : jne 0xc
0x482f40 : mov eax, dword ptr [ebp + 8] 	(car.c:3696)
0x482f43 : mov eax, dword ptr [eax + 0x104]
0x482f49 : -mov dword ptr [ebp - 0x14], eax
         : +mov dword ptr [ebp - 0xc], eax
0x482f4c : mov eax, dword ptr [ebp + 8] 	(car.c:3698)
0x482f4f : fld dword ptr [eax + 0x110]
0x482f55 : -fcomp dword ptr [ebp - 4]
         : +fcomp dword ptr [ebp - 0x1c]
0x482f58 : fnstsw ax
0x482f5a : test ah, 1
0x482f5d : je 0xc
0x482f63 : mov eax, dword ptr [ebp + 8] 	(car.c:3699)
0x482f66 : mov eax, dword ptr [eax + 0x110]
0x482f6c : -mov dword ptr [ebp - 4], eax
         : +mov dword ptr [ebp - 0x1c], eax
0x482f6f : jmp 0x46 	(car.c:3701)
0x482f74 : mov eax, dword ptr [ebp + 8] 	(car.c:3702)
0x482f77 : fld dword ptr [eax + 0x14c]
0x482f7d : -fcomp dword ptr [ebp - 0x14]
         : +fcomp dword ptr [ebp - 0xc]
0x482f80 : fnstsw ax
0x482f82 : test ah, 0x41
0x482f85 : jne 0xc
0x482f8b : mov eax, dword ptr [ebp + 8] 	(car.c:3703)
0x482f8e : mov eax, dword ptr [eax + 0x14c]
0x482f94 : -mov dword ptr [ebp - 0x14], eax
         : +mov dword ptr [ebp - 0xc], eax
0x482f97 : mov eax, dword ptr [ebp + 8] 	(car.c:3705)
0x482f9a : fld dword ptr [eax + 0x158]
0x482fa0 : -fcomp dword ptr [ebp - 4]
         : +fcomp dword ptr [ebp - 0x1c]
0x482fa3 : fnstsw ax
0x482fa5 : test ah, 1
0x482fa8 : je 0xc
0x482fae : mov eax, dword ptr [ebp + 8] 	(car.c:3706)
0x482fb1 : mov eax, dword ptr [eax + 0x158]
0x482fb7 : -mov dword ptr [ebp - 4], eax
         : +mov dword ptr [ebp - 0x1c], eax
0x482fba : mov eax, dword ptr [ebp + 8] 	(car.c:3709)
0x482fbd : -mov ecx, dword ptr [ebp - 0x14]
         : +mov ecx, dword ptr [ebp - 0xc]
0x482fc0 : mov dword ptr [eax + 0x104], ecx
0x482fc6 : mov eax, dword ptr [ebp + 8] 	(car.c:3710)
0x482fc9 : -mov ecx, dword ptr [ebp - 4]
         : +mov ecx, dword ptr [ebp - 0x1c]
0x482fcc : mov dword ptr [eax + 0x110], ecx
0x482fd2 : mov dword ptr [ebp - 0x10], 0 	(car.c:3711)
0x482fd9 : jmp 0x3
0x482fde : inc dword ptr [ebp - 0x10]
0x482fe1 : mov eax, dword ptr [ebp + 8]
0x482fe4 : mov ecx, dword ptr [ebp - 0x10]
0x482fe7 : cmp dword ptr [eax + 0xe0], ecx
0x482fed : jle 0x15a
0x482ff3 : mov eax, dword ptr [ebp + 8] 	(car.c:3712)
0x482ff6 : fld dword ptr [eax + 0x158]
0x482ffc : -fadd qword ptr [0.01 (FLOAT)]
         : +fadd dword ptr [0.009999999776482582 (FLOAT)]
0x483002 : mov eax, dword ptr [ebp - 0x10]
0x483005 : mov ecx, dword ptr [ebp + 8]
0x483008 : fcomp dword ptr [ecx + eax*4 + 0x1a4]
0x48300f : fnstsw ax
0x483011 : test ah, 1
0x483014 : -jne 0x27
         : +jne 0x111
0x48301a : mov eax, dword ptr [ebp + 8]
0x48301d : fld dword ptr [eax + 0x14c]
0x483023 : -fsub qword ptr [0.01 (FLOAT)]
         : +fsub dword ptr [0.009999999776482582 (FLOAT)]
0x483029 : mov eax, dword ptr [ebp - 0x10]
0x48302c : mov ecx, dword ptr [ebp + 8]
0x48302f : fcomp dword ptr [ecx + eax*4 + 0x1a4]
0x483036 : fnstsw ax
0x483038 : test ah, 0x41
         : +je 0xea
         : +mov eax, dword ptr [ebp - 0x10] 	(car.c:3713)
         : +mov ecx, dword ptr [ebp + 8]
         : +fld dword ptr [ecx + eax*4 + 0x1a4]
         : +fcomp dword ptr [ebp - 0x1c]
         : +fnstsw ax
         : +test ah, 0x41
         : +jne 0x18
         : +mov eax, dword ptr [ebp - 0x10] 	(car.c:3714)
         : +lea eax, [eax + eax*2]
         : +mov ecx, dword ptr [ebp + 8]
         : +mov edx, dword ptr [ebp - 0x1c]
         : +mov dword ptr [ecx + eax*4 + 0x164], edx
         : +jmp 0x50 	(car.c:3715)
         : +mov eax, dword ptr [ebp - 0x10]
         : +mov ecx, dword ptr [ebp + 8]
         : +fld dword ptr [ecx + eax*4 + 0x1a4]
         : +fcomp dword ptr [ebp - 0xc]
         : +fnstsw ax
         : +test ah, 1
0x48303b : jne 0x22
0x483041 : mov eax, dword ptr [ebp - 0x10] 	(car.c:3716)
0x483044 : mov ecx, dword ptr [ebp + 8]
0x483047 : mov edx, dword ptr [ebp - 0x10]
0x48304a : lea edx, [edx + edx*2]
0x48304d : mov ebx, dword ptr [ebp + 8]
0x483050 : mov eax, dword ptr [ecx + eax*4 + 0x1a4]
0x483057 : mov dword ptr [ebx + edx*4 + 0x164], eax
0x48305e : -jmp 0xe5
0x483063 : -mov eax, dword ptr [ebp - 0x10]
0x483066 : -mov ecx, dword ptr [ebp + 8]
0x483069 : -fld dword ptr [ecx + eax*4 + 0x1a4]
0x483070 : -fcomp dword ptr [ebp - 4]
0x483073 : -fnstsw ax
0x483075 : -test ah, 0x41
0x483078 : -jne 0x18
         : +jmp 0x13 	(car.c:3717)
0x48307e : mov eax, dword ptr [ebp - 0x10] 	(car.c:3718)
0x483081 : lea eax, [eax + eax*2]
0x483084 : mov ecx, dword ptr [ebp + 8]
0x483087 : -mov edx, dword ptr [ebp - 4]
         : +mov edx, dword ptr [ebp - 0xc]
0x48308a : mov dword ptr [ecx + eax*4 + 0x164], edx
0x483091 : -jmp 0x50
0x483096 : -mov eax, dword ptr [ebp - 0x10]
0x483099 : -mov ecx, dword ptr [ebp + 8]
0x48309c : -fld dword ptr [ecx + eax*4 + 0x1a4]
0x4830a3 : -fcomp dword ptr [ebp - 0x14]
0x4830a6 : -fnstsw ax
0x4830a8 : -test ah, 1
0x4830ab : -je 0x18
0x4830b1 : mov eax, dword ptr [ebp - 0x10] 	(car.c:3720)
0x4830b4 : lea eax, [eax + eax*2]
0x4830b7 : mov ecx, dword ptr [ebp + 8]
0x4830ba : -mov edx, dword ptr [ebp - 0x14]
         : +fld dword ptr [ecx + eax*4 + 0x164]
         : +fcomp dword ptr [ebp - 0x1c]
         : +fnstsw ax
         : +test ah, 0x41
         : +jne 0x13
         : +mov eax, dword ptr [ebp - 0x10] 	(car.c:3721)
         : +lea eax, [eax + eax*2]
         : +mov ecx, dword ptr [ebp + 8]
         : +mov edx, dword ptr [ebp - 0x1c]
         : +mov dword ptr [ecx + eax*4 + 0x164], edx
         : +mov eax, dword ptr [ebp - 0x10] 	(car.c:3723)
         : +lea eax, [eax + eax*2]
         : +mov ecx, dword ptr [ebp + 8]
         : +fld dword ptr [ecx + eax*4 + 0x164]
         : +fcomp dword ptr [ebp - 0xc]
         : +fnstsw ax
         : +test ah, 1
         : +je 0x13
         : +mov eax, dword ptr [ebp - 0x10] 	(car.c:3724)
         : +lea eax, [eax + eax*2]
         : +mov ecx, dword ptr [ebp + 8]
         : +mov edx, dword ptr [ebp - 0xc]
0x4830bd : mov dword ptr [ecx + eax*4 + 0x164], edx
0x4830c4 : jmp 0x1d 	(car.c:3726)
0x4830c9 : mov eax, dword ptr [ebp - 0x10] 	(car.c:3727)
0x4830cc : mov ecx, dword ptr [ebp + 8]
0x4830cf : mov edx, dword ptr [ebp - 0x10]
0x4830d2 : lea edx, [edx + edx*2]
0x4830d5 : mov ebx, dword ptr [ebp + 8]
0x4830d8 : mov eax, dword ptr [ecx + eax*4 + 0x1a4]
0x4830df : mov dword ptr [ebx + edx*4 + 0x164], eax
0x4830e6 : -mov eax, dword ptr [ebp - 0x10]
0x4830e9 : -lea eax, [eax + eax*2]
0x4830ec : -mov ecx, dword ptr [ebp + 8]
0x4830ef : -fld dword ptr [ecx + eax*4 + 0x164]
0x4830f6 : -fcomp dword ptr [ebp - 4]
0x4830f9 : -fnstsw ax
0x4830fb : -test ah, 0x41
0x4830fe : -jne 0x13
0x483104 : -mov eax, dword ptr [ebp - 0x10]
0x483107 : -lea eax, [eax + eax*2]
0x48310a : -mov ecx, dword ptr [ebp + 8]
0x48310d : -mov edx, dword ptr [ebp - 4]
0x483110 : -mov dword ptr [ecx + eax*4 + 0x164], edx
0x483117 : -mov eax, dword ptr [ebp - 0x10]
0x48311a : -lea eax, [eax + eax*2]
0x48311d : -mov ecx, dword ptr [ebp + 8]
0x483120 : -fld dword ptr [ecx + eax*4 + 0x164]
0x483127 : -fcomp dword ptr [ebp - 0x14]
0x48312a : -fnstsw ax
0x48312c : -test ah, 1
0x48312f : -je 0x13
0x483135 : -mov eax, dword ptr [ebp - 0x10]
0x483138 : -lea eax, [eax + eax*2]
0x48313b : -mov ecx, dword ptr [ebp + 8]
0x48313e : -mov edx, dword ptr [ebp - 0x14]
0x483141 : -mov dword ptr [ecx + eax*4 + 0x164], edx
0x483148 : jmp -0x16f 	(car.c:3729)
0x48314d : pop edi 	(car.c:3730)
0x48314e : pop esi
0x48314f : pop ebx
0x483150 : leave 
0x483151 : ret 


CrushBoundingBox is only 66.96% similar to the original, diff above
```

*AI generated. Time taken: 241s, tokens: 34,217*
