### PR TITLE
TwoPointColl 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3783,12 +3783,8 @@ br_scalar TwoPointColl(br_scalar* f, br_matrix4* m, br_scalar* d, br_vector3* ta
         f[1] = 0.0f;
     } else if (f[0] < 0.0f) {
         m->m[0][0] = m->m[1][1];
-        tau[0].v[0] = tau[1].v[0];
-        tau[0].v[1] = tau[1].v[1];
-        tau[0].v[2] = tau[1].v[2];
-        n[0].v[0] = n[1].v[0];
-        n[0].v[1] = n[1].v[1];
-        n[0].v[2] = n[1].v[2];
+        BrVector3Copy(&tau[0], &tau[1]);
+        BrVector3Copy(&n[0], &n[1]);
         d[0] = d[1];
         ts = SinglePointColl(f, m, d);
         f[1] = 0.0;

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3774,17 +3774,21 @@ br_scalar TwoPointColl(br_scalar* f, br_matrix4* m, br_scalar* d, br_vector3* ta
 
     ts = m->m[1][1] * m->m[0][0] - m->m[0][1] * m->m[1][0];
 
-    if (fabs(ts) >= 0.000001f) {
+    if (fabs(ts) >= 0.000001) {
         f[0] = (m->m[1][1] * d[0] - m->m[0][1] * d[1]) / ts;
-        f[1] = (m->m[1][0] * d[0] - m->m[0][0] * d[1]) / -ts;
+        f[1] = (m->m[1][0] * d[0] - m->m[0][0] * d[1]) / (-ts);
     }
-    if (f[1] < 0.0f || fabs(ts) < 0.000001f) {
+    if (f[1] < 0.0f || fabs(ts) < 0.000001) {
         ts = SinglePointColl(f, m, d);
         f[1] = 0.0f;
     } else if (f[0] < 0.0f) {
         m->m[0][0] = m->m[1][1];
-        tau[0] = tau[1];
-        n[0] = n[1];
+        tau[0].v[0] = tau[1].v[0];
+        tau[0].v[1] = tau[1].v[1];
+        tau[0].v[2] = tau[1].v[2];
+        n[0].v[0] = n[1].v[0];
+        n[0].v[1] = n[1].v[1];
+        n[0].v[2] = n[1].v[2];
         d[0] = d[1];
         ts = SinglePointColl(f, m, d);
         f[1] = 0.0;


### PR DESCRIPTION
## Match result

```
0x4832b2: TwoPointColl 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4832be,24 +0x45553e,24 @@
0x4832be : fld dword ptr [eax + 0x14]
0x4832c1 : mov eax, dword ptr [ebp + 0xc]
0x4832c4 : fmul dword ptr [eax]
0x4832c6 : mov eax, dword ptr [ebp + 0xc]
0x4832c9 : fld dword ptr [eax + 4]
0x4832cc : mov eax, dword ptr [ebp + 0xc]
0x4832cf : fmul dword ptr [eax + 0x10]
0x4832d2 : fsubp st(1)
0x4832d4 : fst dword ptr [ebp - 4]
0x4832d7 : fabs  	(car.c:3777)
0x4832d9 : -fcomp qword ptr [1e-06 (FLOAT)]
         : +fcomp qword ptr [9.999999974752427e-07 (FLOAT)]
0x4832df : fnstsw ax
0x4832e1 : test ah, 1
0x4832e4 : -jne 0x46
         : +jne 0x44
0x4832ea : mov eax, dword ptr [ebp + 0xc] 	(car.c:3778)
0x4832ed : fld dword ptr [eax + 0x14]
0x4832f0 : mov eax, dword ptr [ebp + 0x10]
0x4832f3 : fmul dword ptr [eax]
0x4832f5 : mov eax, dword ptr [ebp + 0xc]
0x4832f8 : fld dword ptr [eax + 4]
0x4832fb : mov eax, dword ptr [ebp + 0x10]
0x4832fe : fmul dword ptr [eax + 4]
0x483301 : fsubp st(1)
0x483303 : fdiv dword ptr [ebp - 4]

---
+++
@@ -0x483309,87 +0x455589,89 @@
0x483309 : fstp dword ptr [eax]
0x48330b : mov eax, dword ptr [ebp + 0xc] 	(car.c:3779)
0x48330e : fld dword ptr [eax + 0x10]
0x483311 : mov eax, dword ptr [ebp + 0x10]
0x483314 : fmul dword ptr [eax]
0x483316 : mov eax, dword ptr [ebp + 0xc]
0x483319 : fld dword ptr [eax]
0x48331b : mov eax, dword ptr [ebp + 0x10]
0x48331e : fmul dword ptr [eax + 4]
0x483321 : fsubp st(1)
0x483323 : -fld dword ptr [ebp - 4]
         : +fdiv dword ptr [ebp - 4]
0x483326 : fchs 
0x483328 : -fdivp st(1)
0x48332a : mov eax, dword ptr [ebp + 8]
0x48332d : fstp dword ptr [eax + 4]
0x483330 : mov eax, dword ptr [ebp + 8] 	(car.c:3781)
0x483333 : fld dword ptr [eax + 4]
0x483336 : fcomp dword ptr [0.0 (FLOAT)]
0x48333c : fnstsw ax
0x48333e : test ah, 1
0x483341 : jne 0x16
0x483347 : fld dword ptr [ebp - 4]
0x48334a : fabs 
0x48334c : -fcomp qword ptr [1e-06 (FLOAT)]
         : +fcomp qword ptr [9.999999974752427e-07 (FLOAT)]
0x483352 : fnstsw ax
0x483354 : test ah, 1
0x483357 : je 0x26
0x48335d : mov eax, dword ptr [ebp + 0x10] 	(car.c:3782)
0x483360 : push eax
0x483361 : mov eax, dword ptr [ebp + 0xc]
0x483364 : push eax
0x483365 : mov eax, dword ptr [ebp + 8]
0x483368 : push eax
0x483369 : call SinglePointColl (FUNCTION)
0x48336e : add esp, 0xc
0x483371 : fstp dword ptr [ebp - 4]
0x483374 : mov eax, dword ptr [ebp + 8] 	(car.c:3783)
0x483377 : mov dword ptr [eax + 4], 0
0x48337e : -jmp 0x93
         : +jmp 0x7f 	(car.c:3784)
0x483383 : mov eax, dword ptr [ebp + 8]
0x483386 : fld dword ptr [eax]
0x483388 : fcomp dword ptr [0.0 (FLOAT)]
0x48338e : fnstsw ax
0x483390 : test ah, 1
0x483393 : -je 0x7d
         : +je 0x69
0x483399 : mov eax, dword ptr [ebp + 0xc] 	(car.c:3785)
0x48339c : mov ecx, dword ptr [ebp + 0xc]
0x48339f : mov eax, dword ptr [eax + 0x14]
0x4833a2 : mov dword ptr [ecx], eax
0x4833a4 : mov eax, dword ptr [ebp + 0x14] 	(car.c:3786)
         : +add eax, 0xc
0x4833a7 : mov ecx, dword ptr [ebp + 0x14]
0x4833aa : -mov eax, dword ptr [eax + 0xc]
0x4833ad : -mov dword ptr [ecx], eax
0x4833af : -mov eax, dword ptr [ebp + 0x14]
0x4833b2 : -mov ecx, dword ptr [ebp + 0x14]
0x4833b5 : -mov eax, dword ptr [eax + 0x10]
0x4833b8 : -mov dword ptr [ecx + 4], eax
0x4833bb : -mov eax, dword ptr [ebp + 0x14]
0x4833be : -mov ecx, dword ptr [ebp + 0x14]
0x4833c1 : -mov eax, dword ptr [eax + 0x14]
         : +mov edx, dword ptr [eax]
         : +mov dword ptr [ecx], edx
         : +mov edx, dword ptr [eax + 4]
         : +mov dword ptr [ecx + 4], edx
         : +mov eax, dword ptr [eax + 8]
0x4833c4 : mov dword ptr [ecx + 8], eax
0x4833c7 : mov eax, dword ptr [ebp + 0x18] 	(car.c:3787)
         : +add eax, 0xc
0x4833ca : mov ecx, dword ptr [ebp + 0x18]
0x4833cd : -mov eax, dword ptr [eax + 0xc]
0x4833d0 : -mov dword ptr [ecx], eax
0x4833d2 : -mov eax, dword ptr [ebp + 0x18]
0x4833d5 : -mov ecx, dword ptr [ebp + 0x18]
0x4833d8 : -mov eax, dword ptr [eax + 0x10]
0x4833db : -mov dword ptr [ecx + 4], eax
0x4833de : -mov eax, dword ptr [ebp + 0x18]
0x4833e1 : -mov ecx, dword ptr [ebp + 0x18]
0x4833e4 : -mov eax, dword ptr [eax + 0x14]
         : +mov edx, dword ptr [eax]
         : +mov dword ptr [ecx], edx
         : +mov edx, dword ptr [eax + 4]
         : +mov dword ptr [ecx + 4], edx
         : +mov eax, dword ptr [eax + 8]
0x4833e7 : mov dword ptr [ecx + 8], eax
0x4833ea : mov eax, dword ptr [ebp + 0x10] 	(car.c:3788)
0x4833ed : mov ecx, dword ptr [ebp + 0x10]
0x4833f0 : mov eax, dword ptr [eax + 4]
0x4833f3 : mov dword ptr [ecx], eax
0x4833f5 : mov eax, dword ptr [ebp + 0x10] 	(car.c:3789)
0x4833f8 : push eax
0x4833f9 : mov eax, dword ptr [ebp + 0xc]
0x4833fc : push eax
0x4833fd : mov eax, dword ptr [ebp + 8]
0x483400 : push eax
0x483401 : call SinglePointColl (FUNCTION)
0x483406 : add esp, 0xc
0x483409 : fstp dword ptr [ebp - 4]
0x48340c : mov eax, dword ptr [ebp + 8] 	(car.c:3790)
         : +mov dword ptr [eax + 4], 0
         : +fld dword ptr [ebp - 4] 	(car.c:3792)
         : +fabs 
         : +jmp 0x0
         : +pop edi 	(car.c:3793)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


TwoPointColl is only 78.33% similar to the original, diff above
```

*AI generated. Time taken: 196s, tokens: 20,583*
