### PR TITLE
ThreePointColl 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3807,9 +3807,12 @@ br_scalar ThreePointColl(br_scalar* f, br_matrix4* m, br_scalar* d) {
     br_scalar ts;
 
     BrMatrix4Copy(&mc, m);
-    memset(&mc.m[2][3], 0, 16);
-    mc.m[1][3] = 0.0f;
-    mc.m[0][3] = 0.0f;
+    mc.m[2][3] = 0.0f;
+    mc.m[1][3] = mc.m[2][3];
+    mc.m[0][3] = mc.m[1][3];
+    mc.m[3][2] = mc.m[0][3];
+    mc.m[3][1] = mc.m[3][2];
+    mc.m[3][0] = mc.m[3][1];
     mc.m[3][3] = 1.0f;
     ts = DrMatrix4Inverse(&mi, &mc);
     BrMatrix4TApply((br_vector4*)f, (br_vector4*)d, &mi);


### PR DESCRIPTION
## Match result

```
0x4836f1: ThreePointColl 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4836f4,31 +0x4556b2,27 @@
0x4836f4 : sub esp, 0x84
0x4836fa : push ebx
0x4836fb : push esi
0x4836fc : push edi
0x4836fd : mov eax, dword ptr [ebp + 0xc] 	(car.c:3809)
0x483700 : push eax
0x483701 : lea eax, [ebp - 0x84]
0x483707 : push eax
0x483708 : call BrMatrix4Copy (FUNCTION)
0x48370d : add esp, 8
0x483710 : -mov dword ptr [ebp - 0x58], 0
0x483717 : -mov eax, dword ptr [ebp - 0x58]
0x48371a : -mov dword ptr [ebp - 0x68], eax
0x48371d : -mov eax, dword ptr [ebp - 0x68]
0x483720 : -mov dword ptr [ebp - 0x78], eax
0x483723 : -mov eax, dword ptr [ebp - 0x78]
0x483726 : -mov dword ptr [ebp - 0x4c], eax
0x483729 : -mov eax, dword ptr [ebp - 0x4c]
0x48372c : -mov dword ptr [ebp - 0x50], eax
0x48372f : -mov eax, dword ptr [ebp - 0x50]
0x483732 : -mov dword ptr [ebp - 0x54], eax
         : +lea eax, [ebp - 0x58] 	(car.c:3810)
         : +mov dword ptr [eax], 0
         : +mov dword ptr [eax + 4], 0
         : +mov dword ptr [eax + 8], 0
         : +mov dword ptr [eax + 0xc], 0
         : +mov dword ptr [ebp - 0x68], 0 	(car.c:3811)
         : +mov dword ptr [ebp - 0x78], 0 	(car.c:3812)
0x483735 : mov dword ptr [ebp - 0x48], 0x3f800000 	(car.c:3813)
0x48373c : lea eax, [ebp - 0x84] 	(car.c:3814)
0x483742 : push eax
0x483743 : lea eax, [ebp - 0x40]
0x483746 : push eax
0x483747 : call DrMatrix4Inverse (FUNCTION)
0x48374c : add esp, 8
0x48374f : fstp dword ptr [ebp - 0x44]
0x483752 : lea eax, [ebp - 0x40] 	(car.c:3815)
0x483755 : push eax


ThreePointColl is only 80.85% similar to the original, diff above
```

*AI generated. Time taken: 87s, tokens: 10,757*
