### PR TITLE
FourPointColl 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3868,35 +3868,39 @@ br_scalar FourPointColl(br_scalar* f, br_matrix4* m, br_scalar* d, br_vector3* t
     br_scalar ts;
 
     ts = ThreePointColl(f, m, d);
-    if (f[0] < 0.0 || f[1] < 0.0 || f[2] < 0.0 || ts < 0.000001) {
-        if (ts < 0.000001) {
-            j = 3;
-        } else if (f[0] < 0.0) {
-            j = 0;
-        } else if (f[1] >= 0.0) {
-            j = 2;
-        } else {
-            j = 1;
-        }
-        for (i = j; i < 3; ++i) {
-            for (l = 0; l < 4; ++l) {
-                m->m[i][l] = m->m[i + 1][l];
-            }
-            d[i] = d[i + 1];
-            tau[i] = tau[i + 1];
-            n[i] = n[i + 1];
-            d[i] = d[i + 1];
-        }
-        for (i = j; i < 3; ++i) {
-            for (l = 0; l < 3; ++l) {
-                m->m[l][i] = m->m[l][i + 1];
-            }
-        }
-        return ThreePointCollRec(f, m, d, tau, n, c);
-    } else {
+    if (f[0] >= 0.0f && f[1] >= 0.0f && f[2] >= 0.0f && ts >= 0.000001) {
         c->infinite_mass = 256;
         return ts;
     }
+    if (ts < 0.000001) {
+        i = 3;
+    } else if (f[0] < 0.0f) {
+        i = 0;
+    } else if (f[1] < 0.0f) {
+        i = 1;
+    } else {
+        i = 2;
+    }
+    for (j = i; j < 3; ++j) {
+        for (l = 0; l < 4; ++l) {
+            m->m[j][l] = m->m[j + 1][l];
+        }
+        d[j] = d[j + 1];
+        tau[j].v[0] = tau[j + 1].v[0];
+        tau[j].v[1] = tau[j + 1].v[1];
+        tau[j].v[2] = tau[j + 1].v[2];
+        n[j].v[0] = n[j + 1].v[0];
+        n[j].v[1] = n[j + 1].v[1];
+        n[j].v[2] = n[j + 1].v[2];
+        d[j] = d[j + 1];
+    }
+    for (j = i; j < 3; ++j) {
+        for (l = 0; l < 3; ++l) {
+            m->m[l][j] = m->m[l][j + 1];
+        }
+    }
+    ts = ThreePointCollRec(f, m, d, tau, n, c);
+    return ts;
 }
 
 // IDA: void __usercall MultiFindFloorInBoxM(int pNum_rays@<EAX>, br_vector3 *a@<EDX>, br_vector3 *b@<EBX>, br_vector3 *nor@<ECX>, br_scalar *d, tCar_spec *c, int *mat_ref)


### PR DESCRIPTION
## Match result

```
0x48379f: FourPointColl 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4837ab,161 +0x4559ba,171 @@
0x4837ab : push eax
0x4837ac : mov eax, dword ptr [ebp + 0xc]
0x4837af : push eax
0x4837b0 : mov eax, dword ptr [ebp + 8]
0x4837b3 : push eax
0x4837b4 : call ThreePointColl (FUNCTION)
0x4837b9 : add esp, 0xc
0x4837bc : fstp dword ptr [ebp - 8]
0x4837bf : mov eax, dword ptr [ebp + 8] 	(car.c:3871)
0x4837c2 : fld dword ptr [eax]
0x4837c4 : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x4837ca : fnstsw ax
0x4837cc : test ah, 1
0x4837cf : -jne 0x57
         : +jne 0x42
0x4837d5 : mov eax, dword ptr [ebp + 8]
0x4837d8 : fld dword ptr [eax + 4]
0x4837db : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x4837e1 : fnstsw ax
0x4837e3 : test ah, 1
0x4837e6 : -jne 0x40
         : +jne 0x2b
0x4837ec : mov eax, dword ptr [ebp + 8]
0x4837ef : fld dword ptr [eax + 8]
0x4837f2 : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x4837f8 : fnstsw ax
0x4837fa : test ah, 1
0x4837fd : -jne 0x29
         : +jne 0x14
0x483803 : fld dword ptr [ebp - 8]
0x483806 : fcomp qword ptr [1e-06 (FLOAT)]
0x48380c : fnstsw ax
0x48380e : test ah, 1
0x483811 : -jne 0x15
0x483817 : -mov eax, dword ptr [ebp + 0x1c]
0x48381a : -mov dword ptr [eax + 0xc4], 0x100
0x483824 : -fld dword ptr [ebp - 8]
0x483827 : -jmp 0x218
         : +je 0x1ce
0x48382c : fld dword ptr [ebp - 8] 	(car.c:3872)
0x48382f : fcomp qword ptr [1e-06 (FLOAT)]
0x483835 : fnstsw ax
0x483837 : test ah, 1
0x48383a : je 0xc
0x483840 : -mov dword ptr [ebp - 4], 3
         : +mov dword ptr [ebp - 0xc], 3 	(car.c:3873)
0x483847 : jmp 0x4c 	(car.c:3874)
0x48384c : mov eax, dword ptr [ebp + 8]
0x48384f : fld dword ptr [eax]
0x483851 : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x483857 : fnstsw ax
0x483859 : test ah, 1
0x48385c : je 0xc
0x483862 : -mov dword ptr [ebp - 4], 0
         : +mov dword ptr [ebp - 0xc], 0 	(car.c:3875)
0x483869 : jmp 0x2a 	(car.c:3876)
0x48386e : mov eax, dword ptr [ebp + 8]
0x483871 : fld dword ptr [eax + 4]
0x483874 : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x48387a : fnstsw ax
0x48387c : test ah, 1
0x48387f : -je 0xc
0x483885 : -mov dword ptr [ebp - 4], 1
         : +jne 0xc
         : +mov dword ptr [ebp - 0xc], 2 	(car.c:3877)
0x48388c : jmp 0x7 	(car.c:3878)
0x483891 : -mov dword ptr [ebp - 4], 2
0x483898 : -mov eax, dword ptr [ebp - 4]
0x48389b : -mov dword ptr [ebp - 0xc], eax
         : +mov dword ptr [ebp - 0xc], 1 	(car.c:3879)
         : +mov eax, dword ptr [ebp - 0xc] 	(car.c:3881)
         : +mov dword ptr [ebp - 4], eax
0x48389e : jmp 0x3
0x4838a3 : -inc dword ptr [ebp - 0xc]
0x4838a6 : -cmp dword ptr [ebp - 0xc], 3
0x4838aa : -jge 0x10c
         : +inc dword ptr [ebp - 4]
         : +cmp dword ptr [ebp - 4], 3
         : +jge 0xc0
0x4838b0 : mov dword ptr [ebp - 0x10], 0 	(car.c:3882)
0x4838b7 : jmp 0x3
0x4838bc : inc dword ptr [ebp - 0x10]
0x4838bf : cmp dword ptr [ebp - 0x10], 4
0x4838c3 : jge 0x2a
0x4838c9 : -mov eax, dword ptr [ebp - 0xc]
         : +mov eax, dword ptr [ebp - 4] 	(car.c:3883)
0x4838cc : inc eax
0x4838cd : shl eax, 4
0x4838d0 : mov ecx, dword ptr [ebp - 0x10]
0x4838d3 : lea eax, [eax + ecx*4]
0x4838d6 : mov ecx, dword ptr [ebp + 0xc]
0x4838d9 : mov edx, dword ptr [ebp - 0x10]
0x4838dc : -mov ebx, dword ptr [ebp - 0xc]
         : +mov ebx, dword ptr [ebp - 4]
0x4838df : shl ebx, 4
0x4838e2 : lea edx, [ebx + edx*4]
0x4838e5 : mov ebx, dword ptr [ebp + 0xc]
0x4838e8 : mov eax, dword ptr [eax + ecx]
0x4838eb : mov dword ptr [edx + ebx], eax
0x4838ee : jmp -0x37 	(car.c:3884)
0x4838f3 : -mov eax, dword ptr [ebp - 0xc]
         : +mov eax, dword ptr [ebp - 4] 	(car.c:3885)
0x4838f6 : mov ecx, dword ptr [ebp + 0x10]
0x4838f9 : -mov edx, dword ptr [ebp - 0xc]
         : +mov edx, dword ptr [ebp - 4]
0x4838fc : mov ebx, dword ptr [ebp + 0x10]
0x4838ff : mov eax, dword ptr [ecx + eax*4 + 4]
0x483903 : mov dword ptr [ebx + edx*4], eax
0x483906 : -mov eax, dword ptr [ebp - 0xc]
         : +mov eax, dword ptr [ebp - 4] 	(car.c:3886)
0x483909 : lea eax, [eax + eax*2 + 3]
0x48390d : -mov ecx, dword ptr [ebp + 0x14]
0x483910 : -mov edx, dword ptr [ebp - 0xc]
0x483913 : -lea edx, [edx + edx*2]
0x483916 : -mov ebx, dword ptr [ebp + 0x14]
0x483919 : -mov eax, dword ptr [ecx + eax*4]
0x48391c : -mov dword ptr [ebx + edx*4], eax
0x48391f : -mov eax, dword ptr [ebp - 0xc]
         : +shl eax, 2
         : +add eax, dword ptr [ebp + 0x14]
         : +mov ecx, dword ptr [ebp - 4]
         : +lea ecx, [ecx + ecx*2]
         : +shl ecx, 2
         : +add ecx, dword ptr [ebp + 0x14]
         : +mov edx, dword ptr [eax]
         : +mov dword ptr [ecx], edx
         : +mov edx, dword ptr [eax + 4]
         : +mov dword ptr [ecx + 4], edx
         : +mov eax, dword ptr [eax + 8]
         : +mov dword ptr [ecx + 8], eax
         : +mov eax, dword ptr [ebp - 4] 	(car.c:3887)
0x483922 : lea eax, [eax + eax*2 + 3]
0x483926 : -mov ecx, dword ptr [ebp + 0x14]
0x483929 : -mov edx, dword ptr [ebp - 0xc]
0x48392c : -lea edx, [edx + edx*2]
0x48392f : -mov ebx, dword ptr [ebp + 0x14]
0x483932 : -mov eax, dword ptr [ecx + eax*4 + 4]
0x483936 : -mov dword ptr [ebx + edx*4 + 4], eax
0x48393a : -mov eax, dword ptr [ebp - 0xc]
0x48393d : -lea eax, [eax + eax*2 + 3]
0x483941 : -mov ecx, dword ptr [ebp + 0x14]
0x483944 : -mov edx, dword ptr [ebp - 0xc]
0x483947 : -lea edx, [edx + edx*2]
0x48394a : -mov ebx, dword ptr [ebp + 0x14]
0x48394d : -mov eax, dword ptr [ecx + eax*4 + 8]
0x483951 : -mov dword ptr [ebx + edx*4 + 8], eax
0x483955 : -mov eax, dword ptr [ebp - 0xc]
0x483958 : -lea eax, [eax + eax*2 + 3]
0x48395c : -mov ecx, dword ptr [ebp + 0x18]
0x48395f : -mov edx, dword ptr [ebp - 0xc]
0x483962 : -lea edx, [edx + edx*2]
0x483965 : -mov ebx, dword ptr [ebp + 0x18]
0x483968 : -mov eax, dword ptr [ecx + eax*4]
0x48396b : -mov dword ptr [ebx + edx*4], eax
0x48396e : -mov eax, dword ptr [ebp - 0xc]
0x483971 : -lea eax, [eax + eax*2 + 3]
0x483975 : -mov ecx, dword ptr [ebp + 0x18]
0x483978 : -mov edx, dword ptr [ebp - 0xc]
0x48397b : -lea edx, [edx + edx*2]
0x48397e : -mov ebx, dword ptr [ebp + 0x18]
0x483981 : -mov eax, dword ptr [ecx + eax*4 + 4]
0x483985 : -mov dword ptr [ebx + edx*4 + 4], eax
0x483989 : -mov eax, dword ptr [ebp - 0xc]
0x48398c : -lea eax, [eax + eax*2 + 3]
0x483990 : -mov ecx, dword ptr [ebp + 0x18]
0x483993 : -mov edx, dword ptr [ebp - 0xc]
0x483996 : -lea edx, [edx + edx*2]
0x483999 : -mov ebx, dword ptr [ebp + 0x18]
0x48399c : -mov eax, dword ptr [ecx + eax*4 + 8]
0x4839a0 : -mov dword ptr [ebx + edx*4 + 8], eax
0x4839a4 : -mov eax, dword ptr [ebp - 0xc]
         : +shl eax, 2
         : +add eax, dword ptr [ebp + 0x18]
         : +mov ecx, dword ptr [ebp - 4]
         : +lea ecx, [ecx + ecx*2]
         : +shl ecx, 2
         : +add ecx, dword ptr [ebp + 0x18]
         : +mov edx, dword ptr [eax]
         : +mov dword ptr [ecx], edx
         : +mov edx, dword ptr [eax + 4]
         : +mov dword ptr [ecx + 4], edx
         : +mov eax, dword ptr [eax + 8]
         : +mov dword ptr [ecx + 8], eax
         : +mov eax, dword ptr [ebp - 4] 	(car.c:3888)
0x4839a7 : mov ecx, dword ptr [ebp + 0x10]
0x4839aa : -mov edx, dword ptr [ebp - 0xc]
         : +mov edx, dword ptr [ebp - 4]
0x4839ad : mov ebx, dword ptr [ebp + 0x10]
0x4839b0 : mov eax, dword ptr [ecx + eax*4 + 4]
0x4839b4 : mov dword ptr [ebx + edx*4], eax
0x4839b7 : -jmp -0x119
0x4839bc : -mov eax, dword ptr [ebp - 4]
0x4839bf : -mov dword ptr [ebp - 0xc], eax
         : +jmp -0xcd 	(car.c:3889)
         : +mov eax, dword ptr [ebp - 0xc] 	(car.c:3890)
         : +mov dword ptr [ebp - 4], eax
0x4839c2 : jmp 0x3
0x4839c7 : -inc dword ptr [ebp - 0xc]
0x4839ca : -cmp dword ptr [ebp - 0xc], 3
         : +inc dword ptr [ebp - 4]
         : +cmp dword ptr [ebp - 4], 3
0x4839ce : jge 0x48
0x4839d4 : mov dword ptr [ebp - 0x10], 0 	(car.c:3891)
0x4839db : jmp 0x3
0x4839e0 : inc dword ptr [ebp - 0x10]
0x4839e3 : cmp dword ptr [ebp - 0x10], 3
0x4839e7 : jge 0x2a
0x4839ed : -mov eax, dword ptr [ebp - 0xc]
         : +mov eax, dword ptr [ebp - 4] 	(car.c:3892)
0x4839f0 : mov ecx, dword ptr [ebp - 0x10]
0x4839f3 : shl ecx, 4
0x4839f6 : lea eax, [ecx + eax*4 + 4]
0x4839fa : mov ecx, dword ptr [ebp + 0xc]
         : +mov edx, dword ptr [ebp - 4]
         : +mov ebx, dword ptr [ebp - 0x10]
         : +shl ebx, 4
         : +lea edx, [ebx + edx*4]
         : +mov ebx, dword ptr [ebp + 0xc]
         : +mov eax, dword ptr [eax + ecx]
         : +mov dword ptr [edx + ebx], eax
         : +jmp -0x37 	(car.c:3893)
         : +jmp -0x55 	(car.c:3894)
         : +mov eax, dword ptr [ebp + 0x1c] 	(car.c:3895)
         : +push eax
         : +mov eax, dword ptr [ebp + 0x18]
         : +push eax
         : +mov eax, dword ptr [ebp + 0x14]
         : +push eax
         : +mov eax, dword ptr [ebp + 0x10]
         : +push eax
         : +mov eax, dword ptr [ebp + 0xc]
         : +push eax
         : +mov eax, dword ptr [ebp + 8]
         : +push eax
         : +call ThreePointCollRec (FUNCTION)
         : +add esp, 0x18
         : +jmp 0x1a
         : +jmp 0x15 	(car.c:3896)
         : +mov eax, dword ptr [ebp + 0x1c] 	(car.c:3897)
         : +mov dword ptr [eax + 0xc4], 0x100
         : +fld dword ptr [ebp - 8] 	(car.c:3898)
         : +jmp 0x0
         : +pop edi 	(car.c:3900)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


FourPointColl is only 50.29% similar to the original, diff above
```

*AI generated. Time taken: 197s, tokens: 26,880*
