### PR TITLE
ScrapeNoise 100% effective match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3385,16 +3385,11 @@ void ScrapeNoise(br_scalar vel, br_vector3* position, int material) {
     br_vector3 velocity;
     br_vector3 position_in_br;
 
-    vol = vel * 7.0;
+    vol = vel * 7.0f;
     if (gCurrent_race.material_modifiers[material].scrape_noise_index == -1) {
         return;
     }
-    if ((scrape_tag && DRS3SoundStillPlaying(scrape_tag)) || vol <= 30) {
-        if (last_scrape_vol < vol) {
-            DRS3ChangeVolume(scrape_tag, vol);
-            last_scrape_vol = vol;
-        }
-    } else {
+    if ((!scrape_tag || !DRS3SoundStillPlaying(scrape_tag)) && vol > 30) {
         BrVector3Set(&velocity, 0.f, 0.f, 0.f);
         scrape_tag = DRS3StartSound3D(
             gCar_outlet,
@@ -3405,6 +3400,9 @@ void ScrapeNoise(br_scalar vel, br_vector3* position, int material) {
             vol,
             IRandomBetween(49152, 81920),
             0x10000);
+        last_scrape_vol = vol;
+    } else if (vol > last_scrape_vol) {
+        DRS3ChangeVolume(scrape_tag, vol);
         last_scrape_vol = vol;
     }
 }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x482077,21 +0x4541bb,21 @@
0x482077 : push esi
0x482078 : push edi
0x482079 : fld dword ptr [ebp + 8] 	(car.c:3388)
0x48207c : fmul dword ptr [7.0 (FLOAT)]
0x482082 : call __ftol (FUNCTION)
0x482087 : mov dword ptr [ebp - 4], eax
0x48208a : mov eax, dword ptr [ebp + 0x10] 	(car.c:3389)
0x48208d : lea eax, [eax + eax*4]
0x482090 : cmp dword ptr [eax*8 + gCurrent_race+4052 (OFFSET)], -1
0x482098 : jne 0x5
0x48209e : -jmp 0xc5
         : +jmp 0xc4 	(car.c:3390)
0x4820a3 : cmp dword ptr [scrape_tag (DATA)], 0 	(car.c:3392)
0x4820aa : je 0x16
0x4820b0 : mov eax, dword ptr [scrape_tag (DATA)]
0x4820b5 : push eax
0x4820b6 : call DRS3SoundStillPlaying (FUNCTION)
0x4820bb : add esp, 4
0x4820be : test eax, eax
0x4820c0 : jne 0x79
0x4820c6 : cmp dword ptr [ebp - 4], 0x1e
0x4820ca : jle 0x6f

---
+++
@@ -0x482114,26 +0x454258,27 @@
0x482114 : add esp, 8
0x482117 : mov eax, dword ptr [eax*4 + gMetal_scrape_sound_id__car[0] (DATA)]
0x48211e : push eax
0x48211f : mov eax, dword ptr [gCar_outlet (DATA)]
0x482124 : push eax
0x482125 : call DRS3StartSound3D (FUNCTION)
0x48212a : add esp, 0x20
0x48212d : mov dword ptr [scrape_tag (DATA)], eax
0x482132 : mov eax, dword ptr [ebp - 4] 	(car.c:3403)
0x482135 : mov dword ptr [last_scrape_vol (DATA)], eax
0x48213a : -jmp 0x29
0x48213f : -mov eax, dword ptr [ebp - 4]
0x482142 : -cmp dword ptr [last_scrape_vol (DATA)], eax
0x482148 : -jge 0x1a
         : +jmp 0x28 	(car.c:3404)
         : +mov eax, dword ptr [last_scrape_vol (DATA)]
         : +cmp dword ptr [ebp - 4], eax
         : +jle 0x1a
0x48214e : mov eax, dword ptr [ebp - 4] 	(car.c:3405)
0x482151 : push eax
0x482152 : mov eax, dword ptr [scrape_tag (DATA)]
0x482157 : push eax
0x482158 : call DRS3ChangeVolume (FUNCTION)
0x48215d : add esp, 8
0x482160 : mov eax, dword ptr [ebp - 4] 	(car.c:3406)
0x482163 : mov dword ptr [last_scrape_vol (DATA)], eax
0x482168 : pop edi 	(car.c:3408)
0x482169 : pop esi
0x48216a : pop ebx
0x48216b : leave 
         : +ret 


0x482070: ScrapeNoise 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x482070,35 +0x4541b4,47 @@
0x482070 : push ebp 	(car.c:3379)
0x482071 : mov ebp, esp
0x482073 : sub esp, 0x1c
0x482076 : push ebx
0x482077 : push esi
0x482078 : push edi
0x482079 : fld dword ptr [ebp + 8] 	(car.c:3388)
0x48207c : -fmul dword ptr [7.0 (FLOAT)]
         : +fmul qword ptr [7.0 (FLOAT)]
0x482082 : call __ftol (FUNCTION)
0x482087 : mov dword ptr [ebp - 4], eax
0x48208a : mov eax, dword ptr [ebp + 0x10] 	(car.c:3389)
0x48208d : lea eax, [eax + eax*4]
0x482090 : cmp dword ptr [eax*8 + gCurrent_race+4052 (OFFSET)], -1
0x482098 : jne 0x5
0x48209e : -jmp 0xc5
         : +jmp 0xc4 	(car.c:3390)
0x4820a3 : cmp dword ptr [scrape_tag (DATA)], 0 	(car.c:3392)
0x4820aa : je 0x16
0x4820b0 : mov eax, dword ptr [scrape_tag (DATA)]
0x4820b5 : push eax
0x4820b6 : call DRS3SoundStillPlaying (FUNCTION)
0x4820bb : add esp, 4
0x4820be : test eax, eax
0x4820c0 : -jne 0x79
         : +jne 0xa
0x4820c6 : cmp dword ptr [ebp - 4], 0x1e
0x4820ca : -jle 0x6f
         : +jg 0x2d
         : +mov eax, dword ptr [last_scrape_vol (DATA)] 	(car.c:3393)
         : +cmp dword ptr [ebp - 4], eax
         : +jle 0x1a
         : +mov eax, dword ptr [ebp - 4] 	(car.c:3394)
         : +push eax
         : +mov eax, dword ptr [scrape_tag (DATA)]
         : +push eax
         : +call DRS3ChangeVolume (FUNCTION)
         : +add esp, 8
         : +mov eax, dword ptr [ebp - 4] 	(car.c:3395)
         : +mov dword ptr [last_scrape_vol (DATA)], eax
         : +jmp 0x6a 	(car.c:3397)
0x4820d0 : mov dword ptr [ebp - 0x1c], 0 	(car.c:3398)
0x4820d7 : mov dword ptr [ebp - 0x18], 0
0x4820de : mov dword ptr [ebp - 0x14], 0
0x4820e5 : push 0x10000 	(car.c:3407)
0x4820ea : push 0x14000
0x4820ef : push 0xc000
0x4820f4 : call IRandomBetween (FUNCTION)
0x4820f9 : add esp, 8
0x4820fc : push eax
0x4820fd : mov eax, dword ptr [ebp - 4]

---
+++
@@ -0x482114,26 +0x454285,15 @@
0x482114 : add esp, 8
0x482117 : mov eax, dword ptr [eax*4 + gMetal_scrape_sound_id__car[0] (DATA)]
0x48211e : push eax
0x48211f : mov eax, dword ptr [gCar_outlet (DATA)]
0x482124 : push eax
0x482125 : call DRS3StartSound3D (FUNCTION)
0x48212a : add esp, 0x20
0x48212d : mov dword ptr [scrape_tag (DATA)], eax
0x482132 : mov eax, dword ptr [ebp - 4] 	(car.c:3408)
0x482135 : mov dword ptr [last_scrape_vol (DATA)], eax
0x48213a : -jmp 0x29
0x48213f : -mov eax, dword ptr [ebp - 4]
0x482142 : -cmp dword ptr [last_scrape_vol (DATA)], eax
0x482148 : -jge 0x1a
0x48214e : -mov eax, dword ptr [ebp - 4]
0x482151 : -push eax
0x482152 : -mov eax, dword ptr [scrape_tag (DATA)]
0x482157 : -push eax
0x482158 : -call DRS3ChangeVolume (FUNCTION)
0x48215d : -add esp, 8
0x482160 : -mov eax, dword ptr [ebp - 4]
0x482163 : -mov dword ptr [last_scrape_vol (DATA)], eax
0x482168 : pop edi 	(car.c:3410)
0x482169 : pop esi
0x48216a : pop ebx
0x48216b : leave 
         : +ret 


ScrapeNoise is only 76.60% similar to the original, diff above
```

*AI generated. Time taken: 97s, tokens: 10,974*
