### PR TITLE
MultiFindFloorInBoxBU 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3939,9 +3939,7 @@ void MultiFindFloorInBoxBU(int pNum_rays, br_vector3* a, br_vector3* b, br_vecto
         for (l = 0; l < pNum_rays; ++l) {
             if (d[l] > dist[l]) {
                 d[l] = dist[l];
-                nor[l].v[0] = nor2.v[0];
-                nor[l].v[1] = nor2.v[1];
-                nor[l].v[2] = nor2.v[2];
+                BrVector3Copy(&nor[l], &nor2);
                 j = *gFace_list__car[i].material->identifier - 47;
                 if (j >= 0 && j < 11) {
                     mat_ref[l] = j;

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3931,18 +3931,20 @@ void MultiFindFloorInBoxBU(int pNum_rays, br_vector3* a, br_vector3* b, br_vecto
     br_scalar dist[4];
     tFace_ref* face_ref;
 
-    for (i = c->box_face_start; i < c->box_face_end; i++) {
-        face_ref = &gFace_list__car[i];
-        if (!gEliminate_faces || (face_ref->flags & 0x80) == 0x0) {
-            MultiRayCheckSingleFace(pNum_rays, face_ref, a, b, &nor2, dist);
-            for (j = 0; j < pNum_rays; ++j) {
-                if (d[j] > dist[j]) {
-                    d[j] = dist[j];
-                    nor[j] = nor2;
-                    l = *gFace_list__car[i].material->identifier - 47;
-                    if (l >= 0 && l < 11) {
-                        mat_ref[j] = l;
-                    }
+    for (i = c->box_face_start, face_ref = &gFace_list__car[i]; i < c->box_face_end; i++, face_ref++) {
+        if (gEliminate_faces && (face_ref->flags & 0x80) != 0x0) {
+            continue;
+        }
+        MultiRayCheckSingleFace(pNum_rays, face_ref, a, b, &nor2, dist);
+        for (l = 0; l < pNum_rays; ++l) {
+            if (d[l] > dist[l]) {
+                d[l] = dist[l];
+                nor[l].v[0] = nor2.v[0];
+                nor[l].v[1] = nor2.v[1];
+                nor[l].v[2] = nor2.v[2];
+                j = *gFace_list__car[i].material->identifier - 47;
+                if (j >= 0 && j < 11) {
+                    mat_ref[l] = j;
                 }
             }
         }


### PR DESCRIPTION
## Match result

```
0x483b2a: MultiFindFloorInBoxBU 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x483b2a,86 +0x455ce8,91 @@
0x483b2a : push ebp 	(car.c:3926)
0x483b2b : mov ebp, esp
0x483b2d : sub esp, 0x2c
0x483b30 : push ebx
0x483b31 : push esi
0x483b32 : push edi
0x483b33 : mov eax, dword ptr [ebp + 0x1c] 	(car.c:3934)
0x483b36 : mov eax, dword ptr [eax + 0x1d4]
0x483b3c : mov dword ptr [ebp - 0x24], eax
         : +jmp 0x3
         : +inc dword ptr [ebp - 0x24]
         : +mov eax, dword ptr [ebp + 0x1c]
         : +mov ecx, dword ptr [ebp - 0x24]
         : +cmp dword ptr [eax + 0x1d8], ecx
         : +jle 0xf3
0x483b3f : mov eax, dword ptr [ebp - 0x24] 	(car.c:3935)
0x483b42 : shl eax, 3
0x483b45 : lea eax, [eax + eax*8]
0x483b48 : add eax, gFace_list__car[0].material (DATA)
0x483b4d : mov dword ptr [ebp - 0x14], eax
0x483b50 : -jmp 0x7
0x483b55 : -inc dword ptr [ebp - 0x24]
0x483b58 : -add dword ptr [ebp - 0x14], 0x48
0x483b5c : -mov eax, dword ptr [ebp + 0x1c]
0x483b5f : -mov ecx, dword ptr [ebp - 0x24]
0x483b62 : -cmp dword ptr [eax + 0x1d8], ecx
0x483b68 : -jle 0xf7
0x483b6e : cmp dword ptr [gEliminate_faces (DATA)], 0 	(car.c:3936)
0x483b75 : -je 0x12
         : +je 0xd
0x483b7b : mov eax, dword ptr [ebp - 0x14]
0x483b7e : test byte ptr [eax + 0x40], 0x80
0x483b82 : -je 0x5
0x483b88 : -jmp -0x38
         : +jne 0xc3
0x483b8d : lea eax, [ebp - 0x10] 	(car.c:3937)
0x483b90 : push eax
0x483b91 : lea eax, [ebp - 0x20]
0x483b94 : push eax
0x483b95 : mov eax, dword ptr [ebp + 0x10]
0x483b98 : push eax
0x483b99 : mov eax, dword ptr [ebp + 0xc]
0x483b9c : push eax
0x483b9d : mov eax, dword ptr [ebp - 0x14]
0x483ba0 : push eax
0x483ba1 : mov eax, dword ptr [ebp + 8]
0x483ba4 : push eax
0x483ba5 : call MultiRayCheckSingleFace (FUNCTION)
0x483baa : add esp, 0x18
0x483bad : -mov dword ptr [ebp - 0x2c], 0
         : +mov dword ptr [ebp - 0x28], 0 	(car.c:3938)
0x483bb4 : jmp 0x3
0x483bb9 : -inc dword ptr [ebp - 0x2c]
         : +inc dword ptr [ebp - 0x28]
0x483bbc : mov eax, dword ptr [ebp + 8]
0x483bbf : -cmp dword ptr [ebp - 0x2c], eax
0x483bc2 : -jge 0x98
0x483bc8 : -mov eax, dword ptr [ebp - 0x2c]
         : +cmp dword ptr [ebp - 0x28], eax
         : +jge 0x88
         : +mov eax, dword ptr [ebp - 0x28] 	(car.c:3939)
0x483bcb : mov ecx, dword ptr [ebp + 0x18]
0x483bce : fld dword ptr [ecx + eax*4]
0x483bd1 : -mov eax, dword ptr [ebp - 0x2c]
         : +mov eax, dword ptr [ebp - 0x28]
0x483bd4 : fcomp dword ptr [ebp + eax*4 - 0x10]
0x483bd8 : fnstsw ax
0x483bda : test ah, 0x41
0x483bdd : -jne 0x78
0x483be3 : -mov eax, dword ptr [ebp - 0x2c]
0x483be6 : -mov ecx, dword ptr [ebp - 0x2c]
         : +jne 0x68
         : +mov eax, dword ptr [ebp - 0x28] 	(car.c:3940)
         : +mov ecx, dword ptr [ebp - 0x28]
0x483be9 : mov edx, dword ptr [ebp + 0x18]
0x483bec : mov eax, dword ptr [ebp + eax*4 - 0x10]
0x483bf0 : mov dword ptr [edx + ecx*4], eax
0x483bf3 : -mov eax, dword ptr [ebp - 0x2c]
0x483bf6 : -lea eax, [eax + eax*2]
0x483bf9 : -mov ecx, dword ptr [ebp + 0x14]
0x483bfc : -mov edx, dword ptr [ebp - 0x20]
0x483bff : -mov dword ptr [ecx + eax*4], edx
0x483c02 : -mov eax, dword ptr [ebp - 0x2c]
0x483c05 : -lea eax, [eax + eax*2]
0x483c08 : -mov ecx, dword ptr [ebp + 0x14]
0x483c0b : -mov edx, dword ptr [ebp - 0x1c]
0x483c0e : -mov dword ptr [ecx + eax*4 + 4], edx
0x483c12 : -mov eax, dword ptr [ebp - 0x2c]
0x483c15 : -lea eax, [eax + eax*2]
0x483c18 : -mov ecx, dword ptr [ebp + 0x14]
0x483c1b : -mov edx, dword ptr [ebp - 0x18]
0x483c1e : -mov dword ptr [ecx + eax*4 + 8], edx
         : +lea eax, [ebp - 0x20] 	(car.c:3941)
         : +mov ecx, dword ptr [ebp - 0x28]
         : +lea ecx, [ecx + ecx*2]
         : +shl ecx, 2
         : +add ecx, dword ptr [ebp + 0x14]
         : +mov edx, dword ptr [eax]
         : +mov dword ptr [ecx], edx
         : +mov edx, dword ptr [eax + 4]
         : +mov dword ptr [ecx + 4], edx
         : +mov eax, dword ptr [eax + 8]
         : +mov dword ptr [ecx + 8], eax
0x483c22 : mov eax, dword ptr [ebp - 0x24] 	(car.c:3942)
0x483c25 : shl eax, 3
0x483c28 : mov eax, dword ptr [eax + eax*8 + gFace_list__car[0].material (DATA)]
0x483c2f : mov eax, dword ptr [eax + 4]
0x483c32 : movsx eax, byte ptr [eax]
0x483c35 : sub eax, 0x2f
0x483c38 : -mov dword ptr [ebp - 0x28], eax
0x483c3b : -cmp dword ptr [ebp - 0x28], 0
         : +mov dword ptr [ebp - 0x2c], eax
         : +cmp dword ptr [ebp - 0x2c], 0 	(car.c:3943)
0x483c3f : jl 0x16
0x483c45 : -cmp dword ptr [ebp - 0x28], 0xb
         : +cmp dword ptr [ebp - 0x2c], 0xb
0x483c49 : jge 0xc
         : +mov eax, dword ptr [ebp - 0x2c] 	(car.c:3944)
         : +mov ecx, dword ptr [ebp - 0x28]
         : +mov edx, dword ptr [ebp + 0x20]
         : +mov dword ptr [edx + ecx*4], eax
         : +jmp -0x97 	(car.c:3947)
         : +jmp -0x108 	(car.c:3949)
         : +pop edi 	(car.c:3950)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


MultiFindFloorInBoxBU is only 55.37% similar to the original, diff above
```

*AI generated. Time taken: 199s, tokens: 42,662*
