### PR TITLE
FindFloorInBoxBU 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -4002,10 +4002,8 @@ int FindFloorInBoxBU(br_vector3* a, br_vector3* b, br_vector3* nor, br_scalar* d
     }
     if (*d < 2.f) {
         i = gFace_list__car[j].material->identifier[0] - ('0' - 1);
-        if (i >= 0) {
-            if (i < 11) {
-                return i;
-            }
+        if (i >= 0 && i < 11) {
+            return i;
         }
     }
     return 0;

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3987,26 +3987,28 @@ int FindFloorInBoxBU(br_vector3* a, br_vector3* b, br_vector3* nor, br_scalar* d
     j = 0; // added to keep compiler happy
 #endif
     *d = 2.0;
-    for (i = c->box_face_start; i < c->box_face_end; i++) {
-        face_ref = &gFace_list__car[i];
-        if (!gEliminate_faces || SLOBYTE(face_ref->flags) >= 0) {
-            CheckSingleFace(face_ref, a, b, &nor2, &dist);
-            if (*d > dist) {
-                *d = dist;
-                j = i;
-                BrVector3Copy(nor, &nor2);
+    i = c->box_face_start;
+    face_ref = &gFace_list__car[i];
+    for (; i < c->box_face_end; i++, face_ref++) {
+        if (gEliminate_faces && (face_ref->flags & 0x80) != 0) {
+            continue;
+        }
+        CheckSingleFace(face_ref, a, b, &nor2, &dist);
+        if (*d > dist) {
+            *d = dist;
+            j = i;
+            BrVector3Copy(nor, &nor2);
+        }
+    }
+    if (*d < 2.f) {
+        i = gFace_list__car[j].material->identifier[0] - ('0' - 1);
+        if (i >= 0) {
+            if (i < 11) {
+                return i;
             }
         }
     }
-    if (*d >= 2.f) {
-        return 0;
-    }
-    i = gFace_list__car[j].material->identifier[0] - ('0' - 1);
-    if (i < 0 || i >= 11) {
-        return 0;
-    } else {
-        return i;
-    }
+    return 0;
 }
 
 // IDA: int __usercall FindFloorInBoxBU2@<EAX>(br_vector3 *a@<EAX>, br_vector3 *b@<EDX>, br_vector3 *nor@<EBX>, br_scalar *d@<ECX>, tCollision_info *c)


### PR DESCRIPTION
## Match result

```
0x483d73: FindFloorInBoxBU 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x483d74,38 +0x455f19,37 @@
0x483d74 : mov ebp, esp
0x483d76 : sub esp, 0x1c
0x483d79 : push ebx
0x483d7a : push esi
0x483d7b : push edi
0x483d7c : mov eax, dword ptr [ebp + 0x14] 	(car.c:3989)
0x483d7f : mov dword ptr [eax], 0x40000000
0x483d85 : mov eax, dword ptr [ebp + 0x18] 	(car.c:3990)
0x483d88 : mov eax, dword ptr [eax + 0x1d4]
0x483d8e : mov dword ptr [ebp - 0x18], eax
         : +jmp 0x3
         : +inc dword ptr [ebp - 0x18]
         : +mov eax, dword ptr [ebp + 0x18]
         : +mov ecx, dword ptr [ebp - 0x18]
         : +cmp dword ptr [eax + 0x1d8], ecx
         : +jle 0x89
0x483d91 : mov eax, dword ptr [ebp - 0x18] 	(car.c:3991)
0x483d94 : shl eax, 3
0x483d97 : lea eax, [eax + eax*8]
0x483d9a : add eax, gFace_list__car[0].material (DATA)
0x483d9f : mov dword ptr [ebp - 8], eax
0x483da2 : -jmp 0x7
0x483da7 : -inc dword ptr [ebp - 0x18]
0x483daa : -add dword ptr [ebp - 8], 0x48
0x483dae : -mov eax, dword ptr [ebp + 0x18]
0x483db1 : -mov ecx, dword ptr [ebp - 0x18]
0x483db4 : -cmp dword ptr [eax + 0x1d8], ecx
0x483dba : -jle 0x7b
0x483dc0 : cmp dword ptr [gEliminate_faces (DATA)], 0 	(car.c:3992)
0x483dc7 : -je 0x12
         : +je 0xf
0x483dcd : mov eax, dword ptr [ebp - 8]
0x483dd0 : -test byte ptr [eax + 0x40], 0x80
0x483dd4 : -je 0x5
0x483dda : -jmp -0x38
         : +movsx eax, byte ptr [eax + 0x40]
         : +test eax, eax
         : +jl 0x57
0x483ddf : lea eax, [ebp - 4] 	(car.c:3993)
0x483de2 : push eax
0x483de3 : lea eax, [ebp - 0x14]
0x483de6 : push eax
0x483de7 : mov eax, dword ptr [ebp + 0xc]
0x483dea : push eax
0x483deb : mov eax, dword ptr [ebp + 8]
0x483dee : push eax
0x483def : mov eax, dword ptr [ebp - 8]
0x483df2 : push eax

---
+++
@@ -0x483e19,37 +0x455fb7,40 @@
0x483e19 : mov dword ptr [ebp - 0x1c], eax
0x483e1c : mov eax, dword ptr [ebp + 0x10] 	(car.c:3997)
0x483e1f : mov ecx, dword ptr [ebp - 0x14]
0x483e22 : mov dword ptr [eax], ecx
0x483e24 : mov eax, dword ptr [ebp + 0x10]
0x483e27 : mov ecx, dword ptr [ebp - 0x10]
0x483e2a : mov dword ptr [eax + 4], ecx
0x483e2d : mov eax, dword ptr [ebp + 0x10]
0x483e30 : mov ecx, dword ptr [ebp - 0xc]
0x483e33 : mov dword ptr [eax + 8], ecx
0x483e36 : -jmp -0x94
         : +jmp -0x9e 	(car.c:4000)
0x483e3b : mov eax, dword ptr [ebp + 0x14] 	(car.c:4001)
0x483e3e : fld dword ptr [eax]
0x483e40 : fcomp dword ptr [2.0 (FLOAT)]
0x483e46 : fnstsw ax
0x483e48 : test ah, 1
0x483e4b : -je 0x35
         : +jne 0x7
         : +xor eax, eax 	(car.c:4002)
         : +jmp 0x41
0x483e51 : mov eax, dword ptr [ebp - 0x1c] 	(car.c:4004)
0x483e54 : shl eax, 3
0x483e57 : mov eax, dword ptr [eax + eax*8 + gFace_list__car[0].material (DATA)]
0x483e5e : mov eax, dword ptr [eax + 4]
0x483e61 : movsx eax, byte ptr [eax]
0x483e64 : sub eax, 0x2f
0x483e67 : mov dword ptr [ebp - 0x18], eax
0x483e6a : cmp dword ptr [ebp - 0x18], 0 	(car.c:4005)
0x483e6e : -jl 0x12
         : +jl 0xa
0x483e74 : cmp dword ptr [ebp - 0x18], 0xb
0x483e78 : -jge 0x8
         : +jl 0xc
         : +xor eax, eax 	(car.c:4006)
         : +jmp 0xd
         : +jmp 0x8 	(car.c:4007)
0x483e7e : mov eax, dword ptr [ebp - 0x18] 	(car.c:4008)
0x483e81 : -jmp 0x7
0x483e86 : -xor eax, eax
0x483e88 : jmp 0x0
0x483e8d : pop edi 	(car.c:4010)
0x483e8e : pop esi
0x483e8f : pop ebx
0x483e90 : leave 
0x483e91 : ret 


FindFloorInBoxBU is only 79.78% similar to the original, diff above
```

*AI generated. Time taken: 188s, tokens: 42,960*
