### PR TITLE
GetBoundsEdge 100% effective match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -4304,9 +4304,9 @@ int GetBoundsEdge(br_vector3* pos, br_vector3* edge, br_bounds* pB, int plane1, 
 
     d1 = (plane1 - 1) & 3;
     d2 = (plane2 - 1) & 3;
-    BrVector3Sub(&n, b, a);
-    BrVector3Sub(&p, c, a);
-    BrVector3Cross(&q, &n, &p);
+    BrVector3Sub(&p, b, a);
+    BrVector3Sub(&q, c, a);
+    BrVector3Cross(&n, &p, &q);
     if ((plane1 & 4) != 0) {
         pos->v[d1] = pB->min.v[d1];
     } else {
@@ -4324,7 +4324,7 @@ int GetBoundsEdge(br_vector3* pos, br_vector3* edge, br_bounds* pB, int plane1, 
     if ((flag & 1) != 0) {
         pos->v[d3] = (c->v[d3] + b->v[d3]) / 2.f;
     } else {
-        pos->v[d3] = a->v[d3] - ((pos->v[d2] - a->v[d2]) * q.v[d2] + (pos->v[d1] - a->v[d1]) * q.v[d1]) / q.v[d3];
+        pos->v[d3] = a->v[d3] - ((pos->v[d2] - a->v[d2]) * n.v[d2] + (pos->v[d1] - a->v[d1]) * n.v[d1]) / n.v[d3];
     }
     return 1;
 }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x485574,36 +0x45771c,36 @@
0x485574 : mov eax, dword ptr [ebp + 0x24]
0x485577 : fld dword ptr [eax + 4]
0x48557a : mov eax, dword ptr [ebp + 0x1c]
0x48557d : fsub dword ptr [eax + 4]
0x485580 : fstp dword ptr [ebp - 0x14]
0x485583 : mov eax, dword ptr [ebp + 0x24]
0x485586 : fld dword ptr [eax + 8]
0x485589 : mov eax, dword ptr [ebp + 0x1c]
0x48558c : fsub dword ptr [eax + 8]
0x48558f : fstp dword ptr [ebp - 0x10]
0x485592 : -fld dword ptr [ebp - 0x10]
0x485595 : -fmul dword ptr [ebp - 8]
         : +fld dword ptr [ebp - 8] 	(car.c:4309)
         : +fmul dword ptr [ebp - 0x10]
0x485598 : fld dword ptr [ebp - 0x14]
0x48559b : fmul dword ptr [ebp - 4]
0x48559e : fsubp st(1)
0x4855a0 : fstp dword ptr [ebp - 0x30]
0x4855a3 : -fld dword ptr [ebp - 4]
0x4855a6 : -fmul dword ptr [ebp - 0x18]
0x4855a9 : -fld dword ptr [ebp - 0x10]
0x4855ac : -fmul dword ptr [ebp - 0xc]
         : +fld dword ptr [ebp - 0x18]
         : +fmul dword ptr [ebp - 4]
         : +fld dword ptr [ebp - 0xc]
         : +fmul dword ptr [ebp - 0x10]
0x4855af : fsubp st(1)
0x4855b1 : fstp dword ptr [ebp - 0x2c]
0x4855b4 : -fld dword ptr [ebp - 0x14]
0x4855b7 : -fmul dword ptr [ebp - 0xc]
0x4855ba : -fld dword ptr [ebp - 8]
0x4855bd : -fmul dword ptr [ebp - 0x18]
         : +fld dword ptr [ebp - 0xc]
         : +fmul dword ptr [ebp - 0x14]
         : +fld dword ptr [ebp - 0x18]
         : +fmul dword ptr [ebp - 8]
0x4855c0 : fsubp st(1)
0x4855c2 : fstp dword ptr [ebp - 0x28]
0x4855c5 : test byte ptr [ebp + 0x14], 4 	(car.c:4310)
0x4855c9 : je 0x17
0x4855cf : mov eax, dword ptr [ebp - 0x1c] 	(car.c:4311)
0x4855d2 : mov ecx, dword ptr [ebp + 0x10]
0x4855d5 : mov edx, dword ptr [ebp - 0x1c]
0x4855d8 : mov ebx, dword ptr [ebp + 8]
0x4855db : mov eax, dword ptr [ecx + eax*4]
0x4855de : mov dword ptr [ebx + edx*4], eax


0x48551f: GetBoundsEdge 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x48552c,64 +0x4576d4,64 @@
0x48552c : and eax, 3
0x48552f : mov dword ptr [ebp - 0x1c], eax
0x485532 : mov eax, dword ptr [ebp + 0x18] 	(car.c:4306)
0x485535 : dec eax
0x485536 : and eax, 3
0x485539 : mov dword ptr [ebp - 0x20], eax
0x48553c : mov eax, dword ptr [ebp + 0x20] 	(car.c:4307)
0x48553f : fld dword ptr [eax]
0x485541 : mov eax, dword ptr [ebp + 0x1c]
0x485544 : fsub dword ptr [eax]
0x485546 : -fstp dword ptr [ebp - 0xc]
         : +fstp dword ptr [ebp - 0x30]
0x485549 : mov eax, dword ptr [ebp + 0x20]
0x48554c : fld dword ptr [eax + 4]
0x48554f : mov eax, dword ptr [ebp + 0x1c]
0x485552 : fsub dword ptr [eax + 4]
0x485555 : -fstp dword ptr [ebp - 8]
         : +fstp dword ptr [ebp - 0x2c]
0x485558 : mov eax, dword ptr [ebp + 0x20]
0x48555b : fld dword ptr [eax + 8]
0x48555e : mov eax, dword ptr [ebp + 0x1c]
0x485561 : fsub dword ptr [eax + 8]
0x485564 : -fstp dword ptr [ebp - 4]
         : +fstp dword ptr [ebp - 0x28]
0x485567 : mov eax, dword ptr [ebp + 0x24] 	(car.c:4308)
0x48556a : fld dword ptr [eax]
0x48556c : mov eax, dword ptr [ebp + 0x1c]
0x48556f : fsub dword ptr [eax]
0x485571 : -fstp dword ptr [ebp - 0x18]
         : +fstp dword ptr [ebp - 0xc]
0x485574 : mov eax, dword ptr [ebp + 0x24]
0x485577 : fld dword ptr [eax + 4]
0x48557a : mov eax, dword ptr [ebp + 0x1c]
0x48557d : fsub dword ptr [eax + 4]
0x485580 : -fstp dword ptr [ebp - 0x14]
         : +fstp dword ptr [ebp - 8]
0x485583 : mov eax, dword ptr [ebp + 0x24]
0x485586 : fld dword ptr [eax + 8]
0x485589 : mov eax, dword ptr [ebp + 0x1c]
0x48558c : fsub dword ptr [eax + 8]
0x48558f : -fstp dword ptr [ebp - 0x10]
0x485592 : -fld dword ptr [ebp - 0x10]
         : +fstp dword ptr [ebp - 4]
         : +fld dword ptr [ebp - 0x2c] 	(car.c:4309)
         : +fmul dword ptr [ebp - 4]
         : +fld dword ptr [ebp - 0x28]
0x485595 : fmul dword ptr [ebp - 8]
0x485598 : -fld dword ptr [ebp - 0x14]
         : +fsubp st(1)
         : +fstp dword ptr [ebp - 0x18]
         : +fld dword ptr [ebp - 0x28]
         : +fmul dword ptr [ebp - 0xc]
         : +fld dword ptr [ebp - 0x30]
0x48559b : fmul dword ptr [ebp - 4]
0x48559e : fsubp st(1)
0x4855a0 : -fstp dword ptr [ebp - 0x30]
0x4855a3 : -fld dword ptr [ebp - 4]
0x4855a6 : -fmul dword ptr [ebp - 0x18]
0x4855a9 : -fld dword ptr [ebp - 0x10]
         : +fstp dword ptr [ebp - 0x14]
         : +fld dword ptr [ebp - 0x30]
         : +fmul dword ptr [ebp - 8]
         : +fld dword ptr [ebp - 0x2c]
0x4855ac : fmul dword ptr [ebp - 0xc]
0x4855af : fsubp st(1)
0x4855b1 : -fstp dword ptr [ebp - 0x2c]
0x4855b4 : -fld dword ptr [ebp - 0x14]
0x4855b7 : -fmul dword ptr [ebp - 0xc]
0x4855ba : -fld dword ptr [ebp - 8]
0x4855bd : -fmul dword ptr [ebp - 0x18]
0x4855c0 : -fsubp st(1)
0x4855c2 : -fstp dword ptr [ebp - 0x28]
         : +fstp dword ptr [ebp - 0x10]
0x4855c5 : test byte ptr [ebp + 0x14], 4 	(car.c:4310)
0x4855c9 : je 0x17
0x4855cf : mov eax, dword ptr [ebp - 0x1c] 	(car.c:4311)
0x4855d2 : mov ecx, dword ptr [ebp + 0x10]
0x4855d5 : mov edx, dword ptr [ebp - 0x1c]
0x4855d8 : mov ebx, dword ptr [ebp + 8]
0x4855db : mov eax, dword ptr [ecx + eax*4]
0x4855de : mov dword ptr [ebx + edx*4], eax
0x4855e1 : jmp 0x13 	(car.c:4312)
0x4855e6 : mov eax, dword ptr [ebp - 0x1c] 	(car.c:4313)

---
+++
@@ -0x485687,32 +0x45782f,32 @@
0x485687 : mov ecx, dword ptr [ebp + 8]
0x48568a : fstp dword ptr [ecx + eax*4]
0x48568d : jmp 0x4d 	(car.c:4326)
0x485692 : mov eax, dword ptr [ebp - 0x20] 	(car.c:4327)
0x485695 : mov ecx, dword ptr [ebp + 8]
0x485698 : fld dword ptr [ecx + eax*4]
0x48569b : mov eax, dword ptr [ebp - 0x20]
0x48569e : mov ecx, dword ptr [ebp + 0x1c]
0x4856a1 : fsub dword ptr [ecx + eax*4]
0x4856a4 : mov eax, dword ptr [ebp - 0x20]
0x4856a7 : -fmul dword ptr [ebp + eax*4 - 0x30]
         : +fmul dword ptr [ebp + eax*4 - 0x18]
0x4856ab : mov eax, dword ptr [ebp - 0x1c]
0x4856ae : mov ecx, dword ptr [ebp + 8]
0x4856b1 : fld dword ptr [ecx + eax*4]
0x4856b4 : mov eax, dword ptr [ebp - 0x1c]
0x4856b7 : mov ecx, dword ptr [ebp + 0x1c]
0x4856ba : fsub dword ptr [ecx + eax*4]
0x4856bd : mov eax, dword ptr [ebp - 0x1c]
0x4856c0 : -fmul dword ptr [ebp + eax*4 - 0x30]
         : +fmul dword ptr [ebp + eax*4 - 0x18]
0x4856c4 : faddp st(1)
0x4856c6 : mov eax, dword ptr [ebp - 0x24]
0x4856c9 : -fdiv dword ptr [ebp + eax*4 - 0x30]
         : +fdiv dword ptr [ebp + eax*4 - 0x18]
0x4856cd : mov eax, dword ptr [ebp - 0x24]
0x4856d0 : mov ecx, dword ptr [ebp + 0x1c]
0x4856d3 : fsubr dword ptr [ecx + eax*4]
0x4856d6 : mov eax, dword ptr [ebp - 0x24]
0x4856d9 : mov ecx, dword ptr [ebp + 8]
0x4856dc : fstp dword ptr [ecx + eax*4]
0x4856df : mov eax, 1 	(car.c:4329)
0x4856e4 : jmp 0x0
0x4856e9 : pop edi 	(car.c:4330)
0x4856ea : pop esi


GetBoundsEdge is only 85.33% similar to the original, diff above
```

*AI generated. Time taken: 69s, tokens: 26,207*
