### PR TITLE
DrawSomeText 100% match

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -2517,6 +2517,16 @@ void DrawSomeText2(tDR_font* pFont) {
 // IDA: void __cdecl DrawSomeText()
 // FUNCTION: CARM95 0x00485d80
 void DrawSomeText(void) {
+#ifdef DETHRACE_FIX_BUGS
+    // Font test present in DOS version, but disabled by default
+    DrawSomeText2(&gFonts[kFont_ORANGHED]);
+    DrawSomeText2(&gFonts[kFont_BLUEHEAD]);
+    DrawSomeText2(&gFonts[kFont_GREENHED]);
+    DrawSomeText2(&gFonts[kFont_MEDIUMHD]);
+    DrawSomeText2(&gFonts[kFont_NEWHITE]);
+    DrawSomeText2(&gFonts[kFont_NEWRED]);
+    DrawSomeText2(&gFonts[kFont_NEWBIGGR]);
+#endif
 }
 
 // IDA: void __cdecl SaySorryYouLittleBastard()

--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -2517,13 +2517,6 @@ void DrawSomeText2(tDR_font* pFont) {
 // IDA: void __cdecl DrawSomeText()
 // FUNCTION: CARM95 0x00485d80
 void DrawSomeText(void) {
-    DrawSomeText2(&gFonts[kFont_ORANGHED]);
-    DrawSomeText2(&gFonts[kFont_BLUEHEAD]);
-    DrawSomeText2(&gFonts[kFont_GREENHED]);
-    DrawSomeText2(&gFonts[kFont_MEDIUMHD]);
-    DrawSomeText2(&gFonts[kFont_NEWHITE]);
-    DrawSomeText2(&gFonts[kFont_NEWRED]);
-    DrawSomeText2(&gFonts[kFont_NEWBIGGR]);
 }
 
 // IDA: void __cdecl SaySorryYouLittleBastard()


### PR DESCRIPTION
## Match result

```
0x485d80: DrawSomeText 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x485d80,10 +0x469763,45 @@
0x485d80 : push ebp 	(controls.c:2519)
0x485d81 : mov ebp, esp
0x485d83 : push ebx
0x485d84 : push esi
0x485d85 : push edi
         : +mov eax, gFonts[0].images (DATA) 	(controls.c:2520)
         : +add eax, 0x39c
         : +push eax
         : +call DrawSomeText2 (FUNCTION)
         : +add esp, 4
         : +mov eax, gFonts[0].images (DATA) 	(controls.c:2521)
         : +add eax, 0x738
         : +push eax
         : +call DrawSomeText2 (FUNCTION)
         : +add esp, 4
         : +mov eax, gFonts[0].images (DATA) 	(controls.c:2522)
         : +add eax, 0xad4
         : +push eax
         : +call DrawSomeText2 (FUNCTION)
         : +add esp, 4
         : +mov eax, gFonts[0].images (DATA) 	(controls.c:2523)
         : +add eax, 0xe70
         : +push eax
         : +call DrawSomeText2 (FUNCTION)
         : +add esp, 4
         : +mov eax, gFonts[0].images (DATA) 	(controls.c:2524)
         : +add eax, 0x15a8
         : +push eax
         : +call DrawSomeText2 (FUNCTION)
         : +add esp, 4
         : +mov eax, gFonts[0].images (DATA) 	(controls.c:2525)
         : +add eax, 0x1944
         : +push eax
         : +call DrawSomeText2 (FUNCTION)
         : +add esp, 4
         : +mov eax, gFonts[0].images (DATA) 	(controls.c:2526)
         : +add eax, 0x1ce0
         : +push eax
         : +call DrawSomeText2 (FUNCTION)
         : +add esp, 4
0x485d86 : pop edi 	(controls.c:2527)
0x485d87 : pop esi
0x485d88 : pop ebx
0x485d89 : leave 
0x485d8a : ret 


DrawSomeText is only 36.36% similar to the original, diff above
```

*AI generated. Time taken: 59s, tokens: 9,142*
