### PR TITLE
ViewNetPlayer 100% effective match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -4810,7 +4810,8 @@ void AmIGettingBoredWatchingCameraSpin(void) {
 // FUNCTION: CARM95 0x004870d8
 void ViewNetPlayer(void) {
 
-    if (gOpponent_viewing_mode) {
+    if (!gOpponent_viewing_mode) {
+    } else {
         if (gProgram_state.cockpit_on) {
             ToggleCockpit();
         }
@@ -4818,10 +4819,10 @@ void ViewNetPlayer(void) {
         if (gNumber_of_net_players <= gNet_player_to_view_index) {
             gNet_player_to_view_index = -1;
         }
-        if (gNet_player_to_view_index < 0) {
-            gCar_to_view = GetRaceLeader();
-        } else {
+        if (gNet_player_to_view_index >= 0) {
             gCar_to_view = gNet_players[gNet_player_to_view_index].car;
+        } else {
+            gCar_to_view = GetRaceLeader();
         }
         gCamera_yaw = 0;
         InitialiseExternalCamera();


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4870db,23 +0x458f71,23 @@
0x4870db : push ebx
0x4870dc : push esi
0x4870dd : push edi
0x4870de : cmp dword ptr [gOpponent_viewing_mode (DATA)], 0 	(car.c:4813)
0x4870e5 : jne 0x5
0x4870eb : jmp 0x84 	(car.c:4814)
0x4870f0 : cmp dword ptr [gProgram_state+80 (OFFSET)], 0 	(car.c:4815)
0x4870f7 : je 0x5
0x4870fd : call ToggleCockpit (FUNCTION) 	(car.c:4816)
0x487102 : inc dword ptr [gNet_player_to_view_index (DATA)] 	(car.c:4818)
0x487108 : -mov eax, dword ptr [gNet_player_to_view_index (DATA)]
0x48710d : -cmp dword ptr [gNumber_of_net_players (DATA)], eax
0x487113 : -jg 0xa
         : +mov eax, dword ptr [gNumber_of_net_players (DATA)] 	(car.c:4819)
         : +cmp dword ptr [gNet_player_to_view_index (DATA)], eax
         : +jl 0xa
0x487119 : mov dword ptr [gNet_player_to_view_index (DATA)], 0xffffffff 	(car.c:4820)
0x487123 : cmp dword ptr [gNet_player_to_view_index (DATA)], 0 	(car.c:4822)
0x48712a : jl 0x19
0x487130 : mov eax, dword ptr [gNet_player_to_view_index (DATA)] 	(car.c:4823)
0x487135 : shl eax, 6
0x487138 : mov eax, dword ptr [eax + eax*2 + gNet_players[0].car (OFFSET)]
0x48713f : mov dword ptr [gCar_to_view (DATA)], eax
0x487144 : jmp 0xa 	(car.c:4824)
0x487149 : call GetRaceLeader (FUNCTION) 	(car.c:4825)
0x48714e : mov dword ptr [gCar_to_view (DATA)], eax


0x4870d8: ViewNetPlayer 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x4870d8,32 +0x458f6e,36 @@
0x4870d8 : push ebp 	(car.c:4811)
0x4870d9 : mov ebp, esp
0x4870db : push ebx
0x4870dc : push esi
0x4870dd : push edi
0x4870de : cmp dword ptr [gOpponent_viewing_mode (DATA)], 0 	(car.c:4813)
0x4870e5 : -jne 0x5
0x4870eb : -jmp 0x84
         : +je 0x84
0x4870f0 : cmp dword ptr [gProgram_state+80 (OFFSET)], 0 	(car.c:4814)
0x4870f7 : je 0x5
0x4870fd : call ToggleCockpit (FUNCTION) 	(car.c:4815)
0x487102 : inc dword ptr [gNet_player_to_view_index (DATA)] 	(car.c:4817)
0x487108 : -mov eax, dword ptr [gNet_player_to_view_index (DATA)]
0x48710d : -cmp dword ptr [gNumber_of_net_players (DATA)], eax
0x487113 : -jg 0xa
         : +mov eax, dword ptr [gNumber_of_net_players (DATA)] 	(car.c:4818)
         : +cmp dword ptr [gNet_player_to_view_index (DATA)], eax
         : +jl 0xa
0x487119 : mov dword ptr [gNet_player_to_view_index (DATA)], 0xffffffff 	(car.c:4819)
0x487123 : cmp dword ptr [gNet_player_to_view_index (DATA)], 0 	(car.c:4821)
0x48712a : -jl 0x19
         : +jge 0xf
         : +call GetRaceLeader (FUNCTION) 	(car.c:4822)
         : +mov dword ptr [gCar_to_view (DATA)], eax
         : +jmp 0x14 	(car.c:4823)
0x487130 : mov eax, dword ptr [gNet_player_to_view_index (DATA)] 	(car.c:4824)
0x487135 : shl eax, 6
0x487138 : mov eax, dword ptr [eax + eax*2 + gNet_players[0].car (OFFSET)]
0x48713f : -mov dword ptr [gCar_to_view (DATA)], eax
0x487144 : -jmp 0xa
0x487149 : -call GetRaceLeader (FUNCTION)
0x48714e : mov dword ptr [gCar_to_view (DATA)], eax
0x487153 : mov word ptr [gCamera_yaw (DATA)], 0 	(car.c:4826)
0x48715c : call InitialiseExternalCamera (FUNCTION) 	(car.c:4827)
0x487161 : push 0xc8 	(car.c:4828)
0x487166 : mov eax, dword ptr [gCar_to_view (DATA)]
0x48716b : push eax
0x48716c : call PositionExternalCamera (FUNCTION)
0x487171 : add esp, 8
         : +pop edi 	(car.c:4830)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


ViewNetPlayer is only 67.65% similar to the original, diff above
```

*AI generated. Time taken: 231s, tokens: 20,841*
