### PR TITLE
GetRaceLeader 100% effective match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -4739,16 +4739,15 @@ tCar_spec* GetRaceLeader(void) {
     int score;
     tCar_spec* car;
 
+    score = gNet_players[0].last_score_index;
+    car = gNet_players[0].car;
     if ((gCurrent_net_game->type == eNet_game_type_foxy || gCurrent_net_game->type == eNet_game_type_tag) && gIt_or_fox >= 0 && gIt_or_fox < gNumber_of_net_players) {
-        car = gNet_players[gIt_or_fox].car;
-    } else {
-        car = gNet_players[0].car;
-        score = gNet_players[0].last_score_index;
-        for (i = 1; i < gNumber_of_net_players; i++) {
-            if (score > gNet_players[i].last_score_index) {
-                score = gNet_players[i].last_score_index;
-                car = gNet_players[i].car;
-            }
+        return gNet_players[gIt_or_fox].car;
+    }
+    for (i = 1; i < gNumber_of_net_players; i++) {
+        if (score > gNet_players[i].last_score_index) {
+            score = gNet_players[i].last_score_index;
+            car = gNet_players[i].car;
         }
     }
     return car;


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x48718a,43 +0x458bf8,44 @@
0x48718a : mov eax, dword ptr [gNet_players[0].car (OFFSET)] 	(car.c:4743)
0x48718f : mov dword ptr [ebp - 0xc], eax
0x487192 : mov eax, dword ptr [gCurrent_net_game (DATA)] 	(car.c:4744)
0x487197 : cmp dword ptr [eax + 0x74], 6
0x48719b : je 0xf
0x4871a1 : mov eax, dword ptr [gCurrent_net_game (DATA)]
0x4871a6 : cmp dword ptr [eax + 0x74], 5
0x4871aa : jne 0x32
0x4871b0 : cmp dword ptr [gIt_or_fox (DATA)], 0
0x4871b7 : jl 0x25
0x4871bd : -mov eax, dword ptr [gIt_or_fox (DATA)]
0x4871c2 : -cmp dword ptr [gNumber_of_net_players (DATA)], eax
0x4871c8 : -jle 0x14
         : +mov eax, dword ptr [gNumber_of_net_players (DATA)]
         : +cmp dword ptr [gIt_or_fox (DATA)], eax
         : +jge 0x14
0x4871ce : mov eax, dword ptr [gIt_or_fox (DATA)] 	(car.c:4745)
0x4871d3 : shl eax, 6
0x4871d6 : mov eax, dword ptr [eax + eax*2 + gNet_players[0].car (OFFSET)]
0x4871dd : -jmp 0x61
         : +jmp 0x60
0x4871e2 : mov dword ptr [ebp - 8], 1 	(car.c:4747)
0x4871e9 : jmp 0x3
0x4871ee : inc dword ptr [ebp - 8]
0x4871f1 : -mov eax, dword ptr [ebp - 8]
0x4871f4 : -cmp dword ptr [gNumber_of_net_players (DATA)], eax
0x4871fa : -jle 0x3b
         : +mov eax, dword ptr [gNumber_of_net_players (DATA)]
         : +cmp dword ptr [ebp - 8], eax
         : +jge 0x3b
0x487200 : mov eax, dword ptr [ebp - 8] 	(car.c:4748)
0x487203 : shl eax, 6
0x487206 : mov ecx, dword ptr [ebp - 4]
0x487209 : cmp dword ptr [eax + eax*2 + gNet_players[0].last_score_index (OFFSET)], ecx
0x487210 : jge 0x20
0x487216 : mov eax, dword ptr [ebp - 8] 	(car.c:4749)
0x487219 : shl eax, 6
0x48721c : mov eax, dword ptr [eax + eax*2 + gNet_players[0].last_score_index (OFFSET)]
0x487223 : mov dword ptr [ebp - 4], eax
0x487226 : mov eax, dword ptr [ebp - 8] 	(car.c:4750)
0x487229 : shl eax, 6
0x48722c : mov eax, dword ptr [eax + eax*2 + gNet_players[0].car (OFFSET)]
0x487233 : mov dword ptr [ebp - 0xc], eax
0x487236 : -jmp -0x4d
         : +jmp -0x4c 	(car.c:4752)
0x48723b : mov eax, dword ptr [ebp - 0xc] 	(car.c:4753)
0x48723e : jmp 0x0
0x487243 : pop edi 	(car.c:4754)
0x487244 : pop esi
0x487245 : pop ebx
0x487246 : leave 
         : +ret 


0x487179: GetRaceLeader 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x487179,52 +0x458be7,53 @@
0x487179 : push ebp 	(car.c:4737)
0x48717a : mov ebp, esp
0x48717c : sub esp, 0xc
0x48717f : push ebx
0x487180 : push esi
0x487181 : push edi
0x487182 : -mov eax, dword ptr [gNet_players[0].last_score_index (OFFSET)]
0x487187 : -mov dword ptr [ebp - 4], eax
0x48718a : -mov eax, dword ptr [gNet_players[0].car (OFFSET)]
0x48718f : -mov dword ptr [ebp - 0xc], eax
0x487192 : mov eax, dword ptr [gCurrent_net_game (DATA)] 	(car.c:4742)
0x487197 : cmp dword ptr [eax + 0x74], 6
0x48719b : je 0xf
0x4871a1 : mov eax, dword ptr [gCurrent_net_game (DATA)]
0x4871a6 : cmp dword ptr [eax + 0x74], 5
0x4871aa : -jne 0x32
         : +jne 0x35
0x4871b0 : cmp dword ptr [gIt_or_fox (DATA)], 0
0x4871b7 : -jl 0x25
0x4871bd : -mov eax, dword ptr [gIt_or_fox (DATA)]
0x4871c2 : -cmp dword ptr [gNumber_of_net_players (DATA)], eax
0x4871c8 : -jle 0x14
         : +jl 0x28
         : +mov eax, dword ptr [gNumber_of_net_players (DATA)]
         : +cmp dword ptr [gIt_or_fox (DATA)], eax
         : +jge 0x17
0x4871ce : mov eax, dword ptr [gIt_or_fox (DATA)] 	(car.c:4743)
0x4871d3 : shl eax, 6
0x4871d6 : mov eax, dword ptr [eax + eax*2 + gNet_players[0].car (OFFSET)]
0x4871dd : -jmp 0x61
         : +mov dword ptr [ebp - 0xc], eax
         : +jmp 0x68 	(car.c:4744)
         : +mov eax, dword ptr [gNet_players[0].car (OFFSET)] 	(car.c:4745)
         : +mov dword ptr [ebp - 0xc], eax
         : +mov eax, dword ptr [gNet_players[0].last_score_index (OFFSET)] 	(car.c:4746)
         : +mov dword ptr [ebp - 4], eax
0x4871e2 : mov dword ptr [ebp - 8], 1 	(car.c:4747)
0x4871e9 : jmp 0x3
0x4871ee : inc dword ptr [ebp - 8]
0x4871f1 : -mov eax, dword ptr [ebp - 8]
0x4871f4 : -cmp dword ptr [gNumber_of_net_players (DATA)], eax
0x4871fa : -jle 0x3b
         : +mov eax, dword ptr [gNumber_of_net_players (DATA)]
         : +cmp dword ptr [ebp - 8], eax
         : +jge 0x3b
0x487200 : mov eax, dword ptr [ebp - 8] 	(car.c:4748)
0x487203 : shl eax, 6
0x487206 : mov ecx, dword ptr [ebp - 4]
0x487209 : cmp dword ptr [eax + eax*2 + gNet_players[0].last_score_index (OFFSET)], ecx
0x487210 : jge 0x20
0x487216 : mov eax, dword ptr [ebp - 8] 	(car.c:4749)
0x487219 : shl eax, 6
0x48721c : mov eax, dword ptr [eax + eax*2 + gNet_players[0].last_score_index (OFFSET)]
0x487223 : mov dword ptr [ebp - 4], eax
0x487226 : mov eax, dword ptr [ebp - 8] 	(car.c:4750)
0x487229 : shl eax, 6
0x48722c : mov eax, dword ptr [eax + eax*2 + gNet_players[0].car (OFFSET)]
0x487233 : mov dword ptr [ebp - 0xc], eax
0x487236 : -jmp -0x4d
         : +jmp -0x4c 	(car.c:4752)
0x48723b : mov eax, dword ptr [ebp - 0xc] 	(car.c:4754)
0x48723e : jmp 0x0
0x487243 : pop edi 	(car.c:4755)
0x487244 : pop esi
0x487245 : pop ebx
0x487246 : leave 
0x487247 : ret 


GetRaceLeader is only 72.38% similar to the original, diff above
```

*AI generated. Time taken: 114s, tokens: 18,839*
