### PR TITLE
PositionExternalCamera 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -4975,7 +4975,7 @@ void PositionExternalCamera(tCar_spec* c, tU32 pTime) {
         if (c->car_master_actor->t.t.translate.t.v[0] > 500.0f) {
         } else {
             switch (gAction_replay_camera_mode * gAction_replay_mode) {
-            case 0:
+            case eAction_replay_standard:
                 NormalPositionExternalCamera(c, pTime);
                 break;
             case eAction_replay_action:

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -4965,23 +4965,29 @@ void PositionExternalCamera(tCar_spec* c, tU32 pTime) {
         camera_ptr->field_of_view = BrDegreeToAngle(gCamera_angle);
         old_camera_mode = -1;
     }
-    if (!gProgram_state.cockpit_on) {
+    if (gProgram_state.cockpit_on) {
+    } else {
         if (gOpponent_viewing_mode && gAction_replay_mode) {
             c = &gProgram_state.current_car;
         } else {
             c = gCar_to_view;
         }
-        if (c->car_master_actor->t.t.translate.t.v[0] <= 500.0) {
-            if (gAction_replay_mode && gAction_replay_camera_mode) {
-                if (gAction_replay_camera_mode == eAction_replay_action) {
-                    CheckDisablePlingMaterials(c);
-                    if (IncidentCam(c, pTime)) {
-                        SetPanningFieldOfView();
-                        EnablePlingMaterials();
-                        old_camera_mode = gAction_replay_camera_mode;
-                        return;
-                    }
+        if (c->car_master_actor->t.t.translate.t.v[0] > 500.0f) {
+        } else {
+            switch (gAction_replay_camera_mode * gAction_replay_mode) {
+            case 0:
+                NormalPositionExternalCamera(c, pTime);
+                break;
+            case eAction_replay_action:
+                CheckDisablePlingMaterials(c);
+                if (IncidentCam(c, pTime)) {
+                    SetPanningFieldOfView();
+                    EnablePlingMaterials();
+                    old_camera_mode = gAction_replay_camera_mode;
+                    return;
                 }
+                /* fall through */
+            default:
                 CheckDisablePlingMaterials(c);
                 SetPanningFieldOfView();
                 if (gAction_replay_camera_mode != old_camera_mode) {
@@ -4990,8 +4996,7 @@ void PositionExternalCamera(tCar_spec* c, tU32 pTime) {
                 }
                 PanningExternalCamera(c, pTime);
                 EnablePlingMaterials();
-            } else {
-                NormalPositionExternalCamera(c, pTime);
+                break;
             }
         }
     }


### PR DESCRIPTION
## Match result

```
0x48754a: PositionExternalCamera 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x48754a,13 +0x459462,13 @@
0x48754a : push ebp 	(car.c:4956)
0x48754b : mov ebp, esp
0x48754d : -sub esp, 8
         : +sub esp, 4
0x487550 : push ebx
0x487551 : push esi
0x487552 : push edi
0x487553 : mov eax, dword ptr [gCamera (DATA)] 	(car.c:4961)
0x487558 : mov eax, dword ptr [eax + 0x5c]
0x48755b : mov dword ptr [ebp - 4], eax
0x48755e : call CheckCameraHither (FUNCTION) 	(car.c:4962)
0x487563 : call AmIGettingBoredWatchingCameraSpin (FUNCTION) 	(car.c:4963)
0x487568 : cmp dword ptr [gAction_replay_mode (DATA)], 0 	(car.c:4964)
0x48756f : je 0xd

---
+++
@@ -0x48757c,68 +0x459494,61 @@
0x48757c : jne 0x2f
0x487582 : cmp dword ptr [old_camera_mode (DATA)], -1
0x487589 : je 0x22
0x48758f : fld dword ptr [gCamera_angle (DATA)] 	(car.c:4965)
0x487595 : fmul qword ptr [182.04444444444445 (FLOAT)]
0x48759b : call __ftol (FUNCTION)
0x4875a0 : mov ecx, dword ptr [ebp - 4]
0x4875a3 : mov word ptr [ecx + 6], ax
0x4875a7 : mov dword ptr [old_camera_mode (DATA)], 0xffffffff 	(car.c:4966)
0x4875b1 : cmp dword ptr [gProgram_state+80 (OFFSET)], 0 	(car.c:4968)
0x4875b8 : -je 0x5
0x4875be : -jmp 0x129
         : +jne 0x114
0x4875c3 : cmp dword ptr [gOpponent_viewing_mode (DATA)], 0 	(car.c:4969)
0x4875ca : je 0x1f
0x4875d0 : cmp dword ptr [gAction_replay_mode (DATA)], 0
0x4875d7 : je 0x12
0x4875dd : mov eax, gProgram_state (DATA) 	(car.c:4970)
0x4875e2 : add eax, 0xb0
0x4875e7 : mov dword ptr [ebp + 8], eax
0x4875ea : jmp 0x8 	(car.c:4971)
0x4875ef : mov eax, dword ptr [gCar_to_view (DATA)] 	(car.c:4972)
0x4875f4 : mov dword ptr [ebp + 8], eax
0x4875f7 : mov eax, dword ptr [ebp + 8] 	(car.c:4974)
0x4875fa : mov eax, dword ptr [eax + 0xc]
0x4875fd : fld dword ptr [eax + 0x50]
0x487600 : -fcomp dword ptr [500.0 (FLOAT)]
         : +fcomp qword ptr [500.0 (FLOAT)]
0x487606 : fnstsw ax
0x487608 : test ah, 0x41
0x48760b : -jne 0x5
0x487611 : -jmp 0xd6
0x487616 : -mov eax, dword ptr [gAction_replay_camera_mode (DATA)]
0x48761b : -imul eax, dword ptr [gAction_replay_mode (DATA)]
0x487622 : -mov dword ptr [ebp - 8], eax
0x487625 : -jmp 0xa9
0x48762a : -mov eax, dword ptr [ebp + 0xc]
0x48762d : -push eax
0x48762e : -mov eax, dword ptr [ebp + 8]
0x487631 : -push eax
0x487632 : -call NormalPositionExternalCamera (FUNCTION)
0x487637 : -add esp, 8
0x48763a : -jmp 0xad
         : +je 0xc6
         : +cmp dword ptr [gAction_replay_mode (DATA)], 0 	(car.c:4975)
         : +je 0xa9
         : +cmp dword ptr [gAction_replay_camera_mode (DATA)], 0
         : +je 0x9c
         : +cmp dword ptr [gAction_replay_camera_mode (DATA)], 2 	(car.c:4976)
         : +jne 0x3d
0x48763f : mov eax, dword ptr [ebp + 8] 	(car.c:4977)
0x487642 : push eax
0x487643 : call CheckDisablePlingMaterials (FUNCTION)
0x487648 : add esp, 4
0x48764b : mov eax, dword ptr [ebp + 0xc] 	(car.c:4978)
0x48764e : push eax
0x48764f : mov eax, dword ptr [ebp + 8]
0x487652 : push eax
0x487653 : call IncidentCam (FUNCTION)
0x487658 : add esp, 8
0x48765b : test eax, eax
0x48765d : je 0x19
0x487663 : call SetPanningFieldOfView (FUNCTION) 	(car.c:4979)
0x487668 : call EnablePlingMaterials (FUNCTION) 	(car.c:4980)
0x48766d : mov eax, dword ptr [gAction_replay_camera_mode (DATA)] 	(car.c:4981)
0x487672 : mov dword ptr [old_camera_mode (DATA)], eax
0x487677 : -jmp 0x70
         : +jmp 0x62 	(car.c:4982)
0x48767c : mov eax, dword ptr [ebp + 8] 	(car.c:4985)
0x48767f : push eax
0x487680 : call CheckDisablePlingMaterials (FUNCTION)
0x487685 : add esp, 4
0x487688 : call SetPanningFieldOfView (FUNCTION) 	(car.c:4986)
0x48768d : mov eax, dword ptr [old_camera_mode (DATA)] 	(car.c:4987)
0x487692 : cmp dword ptr [gAction_replay_camera_mode (DATA)], eax
0x487698 : je 0x16
0x48769e : mov eax, dword ptr [ebp + 8] 	(car.c:4988)
0x4876a1 : push eax

---
+++
@@ -0x4876a7,13 +0x4595b3,22 @@
0x4876a7 : add esp, 4
0x4876aa : mov eax, dword ptr [gAction_replay_camera_mode (DATA)] 	(car.c:4989)
0x4876af : mov dword ptr [old_camera_mode (DATA)], eax
0x4876b4 : mov eax, dword ptr [ebp + 0xc] 	(car.c:4991)
0x4876b7 : push eax
0x4876b8 : mov eax, dword ptr [ebp + 8]
0x4876bb : push eax
0x4876bc : call PanningExternalCamera (FUNCTION)
0x4876c1 : add esp, 8
0x4876c4 : call EnablePlingMaterials (FUNCTION) 	(car.c:4992)
0x4876c9 : -jmp 0x1e
0x4876ce : -jmp 0x19
0x4876d3 : -cmp dword ptr [ebp - 8], 0
         : +jmp 0x10 	(car.c:4993)
         : +mov eax, dword ptr [ebp + 0xc] 	(car.c:4994)
         : +push eax
         : +mov eax, dword ptr [ebp + 8]
         : +push eax
         : +call NormalPositionExternalCamera (FUNCTION)
         : +add esp, 8
         : +pop edi 	(car.c:4998)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


PositionExternalCamera is only 77.32% similar to the original, diff above
```

*AI generated. Time taken: 322s, tokens: 57,765*
