### PR TITLE
AmIGettingBoredWatchingCameraSpin 100% effective match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -4775,7 +4775,8 @@ void AmIGettingBoredWatchingCameraSpin(void) {
     } else if (time_of_death == 0) {
         time_of_death = GetRaceTime();
     } else {
-        if (GetRaceTime() >= time_of_death + 10000) {
+        if (GetRaceTime() < time_of_death + 10000) {
+        } else {
             if (gOpponent_viewing_mode == 0) {
                 gOpponent_viewing_mode = 1;
                 gNet_player_to_view_index = -2;
@@ -4785,19 +4786,27 @@ void AmIGettingBoredWatchingCameraSpin(void) {
                 gNet_player_to_view_index = -2;
                 ViewNetPlayer();
             }
-            if (gNet_player_to_view_index < 0 && gCar_to_view != GetRaceLeader()) {
-                gNet_player_to_view_index = -2;
-                ViewNetPlayer();
+            if (gNet_player_to_view_index < 0) {
+                car = GetRaceLeader();
+                if (gCar_to_view != car) {
+                    gNet_player_to_view_index = -2;
+                    ViewNetPlayer();
+                }
             }
             if ((GetRaceTime() > headup_timer + 1000 || headup_timer > GetRaceTime()) && gRace_over_reason == eRace_not_over_yet) {
                 strcpy(s, GetMiscString(kMiscString_WATCHING));
                 strcat(s, " ");
-                if (gNet_player_to_view_index >= 0) {
-                    strcat(s, gNet_players[gNet_player_to_view_index].player_name);
-                } else if (gCurrent_net_game->type == eNet_game_type_tag) {
-                    strcat(s, GetMiscString(kMiscString_QUOTE_IT_QUOTE));
+                if (gNet_player_to_view_index < 0) {
+                    switch (gCurrent_net_game->type) {
+                    case eNet_game_type_tag:
+                        strcat(s, GetMiscString(kMiscString_QUOTE_IT_QUOTE));
+                        break;
+                    default:
+                        strcat(s, GetMiscString(kMiscString_RACE_LEADER));
+                        break;
+                    }
                 } else {
-                    strcat(s, GetMiscString(kMiscString_RACE_LEADER));
+                    strcat(s, gNet_players[gNet_player_to_view_index].player_name);
                 }
                 headup_timer = GetRaceTime();
                 NewTextHeadupSlot(eHeadupSlot_fancies, 0, 500, -kFont_MEDIUMHD, s);


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x48778d,23 +0x458d54,23 @@
0x48778d : mov ecx, dword ptr [time_of_death (DATA)]
0x487793 : add ecx, 0x2710
0x487799 : cmp eax, ecx
0x48779b : jae 0x5
0x4877a1 : jmp 0x22d 	(car.c:4779)
0x4877a6 : cmp dword ptr [gOpponent_viewing_mode (DATA)], 0 	(car.c:4780)
0x4877ad : jne 0x19
0x4877b3 : mov dword ptr [gOpponent_viewing_mode (DATA)], 1 	(car.c:4781)
0x4877bd : mov dword ptr [gNet_player_to_view_index (DATA)], 0xfffffffe 	(car.c:4782)
0x4877c7 : call ViewNetPlayer (FUNCTION) 	(car.c:4783)
0x4877cc : -mov eax, dword ptr [gNet_player_to_view_index (DATA)]
0x4877d1 : -cmp dword ptr [gNumber_of_net_players (DATA)], eax
0x4877d7 : -jg 0xf
         : +mov eax, dword ptr [gNumber_of_net_players (DATA)] 	(car.c:4785)
         : +cmp dword ptr [gNet_player_to_view_index (DATA)], eax
         : +jl 0xf
0x4877dd : mov dword ptr [gNet_player_to_view_index (DATA)], 0xfffffffe 	(car.c:4786)
0x4877e7 : call ViewNetPlayer (FUNCTION) 	(car.c:4787)
0x4877ec : cmp dword ptr [gNet_player_to_view_index (DATA)], 0 	(car.c:4789)
0x4877f3 : jge 0x2c
0x4877f9 : call GetRaceLeader (FUNCTION) 	(car.c:4790)
0x4877fe : mov dword ptr [ebp - 0x104], eax
0x487804 : mov eax, dword ptr [ebp - 0x104] 	(car.c:4791)
0x48780a : cmp dword ptr [gCar_to_view (DATA)], eax
0x487810 : je 0xf
0x487816 : mov dword ptr [gNet_player_to_view_index (DATA)], 0xfffffffe 	(car.c:4792)


0x4876f1: AmIGettingBoredWatchingCameraSpin 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x4876f1,74 +0x458cb8,71 @@
0x4876f1 : push ebp 	(car.c:4759)
0x4876f2 : mov ebp, esp
0x4876f4 : -sub esp, 0x108
         : +sub esp, 0x104
0x4876fa : push ebx
0x4876fb : push esi
0x4876fc : push edi
0x4876fd : cmp dword ptr [gNet_mode (DATA)], 0 	(car.c:4770)
0x487704 : je 0x2d
0x48770a : mov eax, dword ptr [gCurrent_net_game (DATA)]
0x48770f : cmp dword ptr [eax + 0x74], 4
0x487713 : je 0x2d
0x487719 : mov eax, dword ptr [gCurrent_net_game (DATA)]
0x48771e : cmp dword ptr [eax + 0x74], 5
0x487722 : je 0x1e
0x487728 : mov eax, dword ptr [gCurrent_net_game (DATA)]
0x48772d : cmp dword ptr [eax + 0x74], 0
0x487731 : je 0xf
0x487737 : mov dword ptr [gOpponent_viewing_mode (DATA)], 0 	(car.c:4771)
0x487741 : -jmp 0x28d
         : +jmp 0x25c 	(car.c:4772)
0x487746 : cmp dword ptr [gRace_finished (DATA)], 0
0x48774d : jne 0x19
0x487753 : mov dword ptr [time_of_death (DATA)], 0 	(car.c:4773)
0x48775d : mov dword ptr [gOpponent_viewing_mode (DATA)], 0 	(car.c:4774)
0x487767 : -jmp 0x267
         : +jmp 0x236 	(car.c:4775)
0x48776c : cmp dword ptr [time_of_death (DATA)], 0
0x487773 : jne 0xf
0x487779 : call GetRaceTime (FUNCTION) 	(car.c:4776)
0x48777e : mov dword ptr [time_of_death (DATA)], eax
0x487783 : -jmp 0x24b
         : +jmp 0x21a 	(car.c:4777)
0x487788 : call GetRaceTime (FUNCTION) 	(car.c:4778)
0x48778d : mov ecx, dword ptr [time_of_death (DATA)]
0x487793 : add ecx, 0x2710
0x487799 : cmp eax, ecx
0x48779b : -jae 0x5
0x4877a1 : -jmp 0x22d
         : +jb 0x201
0x4877a6 : cmp dword ptr [gOpponent_viewing_mode (DATA)], 0 	(car.c:4779)
0x4877ad : jne 0x19
0x4877b3 : mov dword ptr [gOpponent_viewing_mode (DATA)], 1 	(car.c:4780)
0x4877bd : mov dword ptr [gNet_player_to_view_index (DATA)], 0xfffffffe 	(car.c:4781)
0x4877c7 : call ViewNetPlayer (FUNCTION) 	(car.c:4782)
0x4877cc : -mov eax, dword ptr [gNet_player_to_view_index (DATA)]
0x4877d1 : -cmp dword ptr [gNumber_of_net_players (DATA)], eax
0x4877d7 : -jg 0xf
         : +mov eax, dword ptr [gNumber_of_net_players (DATA)] 	(car.c:4784)
         : +cmp dword ptr [gNet_player_to_view_index (DATA)], eax
         : +jl 0xf
0x4877dd : mov dword ptr [gNet_player_to_view_index (DATA)], 0xfffffffe 	(car.c:4785)
0x4877e7 : call ViewNetPlayer (FUNCTION) 	(car.c:4786)
0x4877ec : cmp dword ptr [gNet_player_to_view_index (DATA)], 0 	(car.c:4788)
0x4877f3 : -jge 0x2c
         : +jge 0x20
0x4877f9 : call GetRaceLeader (FUNCTION)
0x4877fe : -mov dword ptr [ebp - 0x104], eax
0x487804 : -mov eax, dword ptr [ebp - 0x104]
0x48780a : -cmp dword ptr [gCar_to_view (DATA)], eax
         : +cmp eax, dword ptr [gCar_to_view (DATA)]
0x487810 : je 0xf
0x487816 : mov dword ptr [gNet_player_to_view_index (DATA)], 0xfffffffe 	(car.c:4789)
0x487820 : call ViewNetPlayer (FUNCTION) 	(car.c:4790)
0x487825 : call GetRaceTime (FUNCTION) 	(car.c:4792)
0x48782a : mov ecx, dword ptr [headup_timer (DATA)]
0x487830 : add ecx, 0x3e8
0x487836 : cmp eax, ecx
0x487838 : ja 0x11
0x48783e : call GetRaceTime (FUNCTION)
0x487843 : cmp eax, dword ptr [headup_timer (DATA)]
0x487849 : -jae 0x184
         : +jae 0x164
0x48784f : cmp dword ptr [gRace_over_reason (DATA)], -1
0x487856 : -jne 0x177
         : +jne 0x157
0x48785c : push 0xd9 	(car.c:4793)
0x487861 : call GetMiscString (FUNCTION)
0x487866 : add esp, 4
0x487869 : mov edi, eax
0x48786b : mov ecx, 0xffffffff
0x487870 : sub eax, eax
0x487872 : repne scasb al, byte ptr es:[edi]
0x487874 : not ecx
0x487876 : sub edi, ecx
0x487878 : mov eax, ecx

---
+++
@@ -0x487889,25 +0x458e3f,47 @@
0x487889 : mov ecx, eax
0x48788b : and ecx, 3
0x48788e : rep movsb byte ptr es:[edi], byte ptr [esi]
0x487890 : lea edi, [ebp - 0x100] 	(car.c:4794)
0x487896 : mov ecx, 0xffffffff
0x48789b : sub eax, eax
0x48789d : repne scasb al, byte ptr es:[edi]
0x48789f : mov ax, word ptr [" " (STRING)]
0x4878a5 : mov word ptr [edi - 1], ax
0x4878a9 : cmp dword ptr [gNet_player_to_view_index (DATA)], 0 	(car.c:4795)
0x4878b0 : -jge 0xb9
         : +jl 0x45
         : +mov eax, dword ptr [gNet_player_to_view_index (DATA)] 	(car.c:4796)
         : +shl eax, 6
         : +lea edi, [eax + eax*2 + gNet_players[0].player_name (OFFSET)]
         : +mov ecx, 0xffffffff
         : +sub eax, eax
         : +repne scasb al, byte ptr es:[edi]
         : +not ecx
         : +sub edi, ecx
         : +mov edx, edi
         : +mov ebx, ecx
         : +lea edi, [ebp - 0x100]
         : +mov ecx, 0xffffffff
         : +sub eax, eax
         : +repne scasb al, byte ptr es:[edi]
         : +dec edi
         : +mov esi, edx
         : +mov ecx, ebx
         : +shr ecx, 2
         : +rep movsd dword ptr es:[edi], dword ptr [esi]
         : +mov ecx, ebx
         : +and ecx, 3
         : +rep movsb byte ptr es:[edi], byte ptr [esi]
         : +jmp 0x94 	(car.c:4797)
0x4878b6 : mov eax, dword ptr [gCurrent_net_game (DATA)]
0x4878bb : -mov eax, dword ptr [eax + 0x74]
0x4878be : -mov dword ptr [ebp - 0x108], eax
0x4878c4 : -jmp 0x8f
         : +cmp dword ptr [eax + 0x74], 5
         : +jne 0x45
0x4878c9 : push 0xf1 	(car.c:4798)
0x4878ce : call GetMiscString (FUNCTION)
0x4878d3 : add esp, 4
0x4878d6 : mov edi, eax
0x4878d8 : mov ecx, 0xffffffff
0x4878dd : sub eax, eax
0x4878df : repne scasb al, byte ptr es:[edi]
0x4878e1 : not ecx
0x4878e3 : sub edi, ecx
0x4878e5 : mov edx, edi

---
+++
@@ -0x4878f4,21 +0x458eeb,21 @@
0x4878f4 : sub eax, eax
0x4878f6 : repne scasb al, byte ptr es:[edi]
0x4878f8 : dec edi
0x4878f9 : mov esi, edx
0x4878fb : mov ecx, ebx
0x4878fd : shr ecx, 2
0x487900 : rep movsd dword ptr es:[edi], dword ptr [esi]
0x487902 : mov ecx, ebx
0x487904 : and ecx, 3
0x487907 : rep movsb byte ptr es:[edi], byte ptr [esi]
0x487909 : -jmp 0x5c
         : +jmp 0x40 	(car.c:4799)
0x48790e : push 0xda 	(car.c:4800)
0x487913 : call GetMiscString (FUNCTION)
0x487918 : add esp, 4
0x48791b : mov edi, eax
0x48791d : mov ecx, 0xffffffff
0x487922 : sub eax, eax
0x487924 : repne scasb al, byte ptr es:[edi]
0x487926 : not ecx
0x487928 : sub edi, ecx
0x48792a : mov edx, edi

---
+++
@@ -0x487939,34 +0x458f30,25 @@
0x487939 : sub eax, eax
0x48793b : repne scasb al, byte ptr es:[edi]
0x48793d : dec edi
0x48793e : mov esi, edx
0x487940 : mov ecx, ebx
0x487942 : shr ecx, 2
0x487945 : rep movsd dword ptr es:[edi], dword ptr [esi]
0x487947 : mov ecx, ebx
0x487949 : and ecx, 3
0x48794c : rep movsb byte ptr es:[edi], byte ptr [esi]
0x48794e : -jmp 0x17
0x487953 : -jmp 0x12
0x487958 : -cmp dword ptr [ebp - 0x108], 5
0x48795f : -je -0x9c
0x487965 : -jmp -0x5c
0x48796a : -jmp 0x40
0x48796f : -mov eax, dword ptr [gNet_player_to_view_index (DATA)]
0x487974 : -shl eax, 6
0x487977 : -lea edi, [eax + eax*2 + gNet_players[0].player_name (OFFSET)]
0x48797e : -mov ecx, 0xffffffff
0x487983 : -sub eax, eax
0x487985 : -repne scasb al, byte ptr es:[edi]
0x487987 : -not ecx
0x487989 : -sub edi, ecx
0x48798b : -mov edx, edi
0x48798d : -mov ebx, ecx
0x48798f : -lea edi, [ebp - 0x100]
0x487995 : -mov ecx, 0xffffffff
0x48799a : -sub eax, eax
0x48799c : -repne scasb al, byte ptr es:[edi]
0x48799e : -dec edi
0x48799f : -mov esi, edx
0x4879a1 : -mov ecx, ebx
0x4879a3 : -shr ecx, 2
         : +call GetRaceTime (FUNCTION) 	(car.c:4802)
         : +mov dword ptr [headup_timer (DATA)], eax
         : +lea eax, [ebp - 0x100] 	(car.c:4803)
         : +push eax
         : +push -4
         : +push 0x1f4
         : +push 0
         : +push 6
         : +call NewTextHeadupSlot (FUNCTION)
         : +add esp, 0x14
         : +pop edi 	(car.c:4807)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


AmIGettingBoredWatchingCameraSpin is only 71.18% similar to the original, diff above
```

*AI generated. Time taken: 272s, tokens: 40,653*
