### PR TITLE
CameraBugFix 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -5012,6 +5012,7 @@ void CameraBugFix(tCar_spec* c, tU32 pTime) {
     br_matrix34* m2;
     br_vector3 tv;
 
+    m2 = &gCamera->t.t.mat;
     if (gAction_replay_mode && gAction_replay_camera_mode != eAction_replay_standard && gPed_actor != NULL && !gProgram_state.cockpit_on) {
         IncidentCam(c, pTime);
     }


### PR DESCRIPTION
## Match result

```
0x487b2c: CameraBugFix 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x487b2c,21 +0x45961d,25 @@
0x487b2c : push ebp 	(car.c:5010)
0x487b2d : mov ebp, esp
0x487b2f : sub esp, 0x40
0x487b32 : push ebx
0x487b33 : push esi
0x487b34 : push edi
0x487b35 : -mov eax, dword ptr [gCamera (DATA)]
0x487b3a : -add eax, 0x2c
0x487b3d : -mov dword ptr [ebp - 0x34], eax
0x487b40 : cmp dword ptr [gAction_replay_mode (DATA)], 0 	(car.c:5015)
0x487b47 : je 0x37
0x487b4d : cmp dword ptr [gAction_replay_camera_mode (DATA)], 0
0x487b54 : je 0x2a
0x487b5a : cmp dword ptr [gPed_actor (DATA)], 0
0x487b61 : je 0x1d
0x487b67 : cmp dword ptr [gProgram_state+80 (OFFSET)], 0
0x487b6e : jne 0x10
0x487b74 : mov eax, dword ptr [ebp + 0xc] 	(car.c:5016)
0x487b77 : push eax
0x487b78 : mov eax, dword ptr [ebp + 8]
0x487b7b : push eax
         : +call IncidentCam (FUNCTION)
         : +add esp, 8
         : +pop edi 	(car.c:5018)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


CameraBugFix is only 78.26% similar to the original, diff above
```

*AI generated. Time taken: 66s, tokens: 9,935*
