### PR TITLE
SaveCameraPosition 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -5384,11 +5384,12 @@ void SetUpPanningCamera(tCar_spec* c) {
 // FUNCTION: CARM95 0x0048949c
 void SaveCameraPosition(int i) {
 
-    if (gSave_camera[i].saved != 1) {
-        gSave_camera[i].zoom = gCamera_zoom;
-        gSave_camera[i].yaw = gCamera_yaw;
-        gSave_camera[i].saved = 1;
+    if (gSave_camera[i].saved == 1) {
+        return;
     }
+    gSave_camera[i].zoom = gCamera_zoom;
+    gSave_camera[i].yaw = gCamera_yaw;
+    gSave_camera[i].saved = 1;
 }
 
 // IDA: void __usercall RestoreCameraPosition(int i@<EAX>)


### PR DESCRIPTION
## Match result

```
0x48949c: SaveCameraPosition 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x48949c,21 +0x45af37,25 @@
0x48949c : push ebp 	(car.c:5385)
0x48949d : mov ebp, esp
0x48949f : push ebx
0x4894a0 : push esi
0x4894a1 : push edi
0x4894a2 : mov eax, dword ptr [ebp + 8] 	(car.c:5387)
0x4894a5 : lea eax, [eax + eax*2]
0x4894a8 : cmp dword ptr [eax*4 + gSave_camera[0].saved (DATA)], 1
0x4894b0 : -jne 0x5
0x4894b6 : -jmp 0x38
         : +je 0x38
0x4894bb : mov eax, dword ptr [ebp + 8] 	(car.c:5388)
0x4894be : lea eax, [eax + eax*2]
0x4894c1 : mov ecx, dword ptr [gCamera_zoom (DATA)]
0x4894c7 : mov dword ptr [eax*4 + gSave_camera[0].zoom (OFFSET)], ecx
0x4894ce : mov ax, word ptr [gCamera_yaw (DATA)] 	(car.c:5389)
0x4894d4 : mov ecx, dword ptr [ebp + 8]
0x4894d7 : lea ecx, [ecx + ecx*2]
0x4894da : mov word ptr [ecx*4 + gSave_camera[0].yaw (OFFSET)], ax
0x4894e2 : mov eax, dword ptr [ebp + 8] 	(car.c:5390)
0x4894e5 : lea eax, [eax + eax*2]
0x4894e8 : mov dword ptr [eax*4 + gSave_camera[0].saved (DATA)], 1
         : +pop edi 	(car.c:5392)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


SaveCameraPosition is only 82.61% similar to the original, diff above
```

*AI generated. Time taken: 59s, tokens: 6,658*
