### PR TITLE
RestoreCameraPosition 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -5395,11 +5395,12 @@ void SaveCameraPosition(int i) {
 // FUNCTION: CARM95 0x004894f8
 void RestoreCameraPosition(int i) {
 
-    if (gSave_camera[i].saved != 0) {
-        gCamera_zoom = gSave_camera[i].zoom;
-        gCamera_yaw = gSave_camera[i].yaw;
-        gSave_camera[i].saved = 0;
+    if (gSave_camera[i].saved == 0) {
+        return;
     }
+    gCamera_zoom = gSave_camera[i].zoom;
+    gCamera_yaw = gSave_camera[i].yaw;
+    gSave_camera[i].saved = 0;
 }
 
 // IDA: void __usercall NormalPositionExternalCamera(tCar_spec *c@<EAX>, tU32 pTime@<EDX>)


### PR DESCRIPTION
## Match result

```
0x4894f8: RestoreCameraPosition 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4894f8,21 +0x45af8e,25 @@
0x4894f8 : push ebp 	(car.c:5396)
0x4894f9 : mov ebp, esp
0x4894fb : push ebx
0x4894fc : push esi
0x4894fd : push edi
0x4894fe : mov eax, dword ptr [ebp + 8] 	(car.c:5398)
0x489501 : lea eax, [eax + eax*2]
0x489504 : cmp dword ptr [eax*4 + gSave_camera[0].saved (DATA)], 0
0x48950c : -jne 0x5
0x489512 : -jmp 0x37
         : +je 0x37
0x489517 : mov eax, dword ptr [ebp + 8] 	(car.c:5399)
0x48951a : lea eax, [eax + eax*2]
0x48951d : mov eax, dword ptr [eax*4 + gSave_camera[0].zoom (OFFSET)]
0x489524 : mov dword ptr [gCamera_zoom (DATA)], eax
0x489529 : mov eax, dword ptr [ebp + 8] 	(car.c:5400)
0x48952c : lea eax, [eax + eax*2]
0x48952f : mov ax, word ptr [eax*4 + gSave_camera[0].yaw (OFFSET)]
0x489537 : mov word ptr [gCamera_yaw (DATA)], ax
0x48953d : mov eax, dword ptr [ebp + 8] 	(car.c:5401)
0x489540 : lea eax, [eax + eax*2]
0x489543 : mov dword ptr [eax*4 + gSave_camera[0].saved (DATA)], 0
         : +pop edi 	(car.c:5403)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


RestoreCameraPosition is only 82.61% similar to the original, diff above
```

*AI generated. Time taken: 71s, tokens: 21,777*
