### PR TITLE
CheckDisablePlingMaterials 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -4942,9 +4942,7 @@ void CheckDisablePlingMaterials(tCar_spec* pCar) {
     int i;
 
     height = 0.f;
-    if (pCar->water_d == 10000.f) {
-        DisablePlingMaterials();
-    } else {
+    if (pCar->water_d != 10000.f) {
         mat = &pCar->car_master_actor->t.t.mat;
         for (i = 0; i < 3; i++) {
             if (mat->m[i][1] > 0.f) {
@@ -4953,9 +4951,12 @@ void CheckDisablePlingMaterials(tCar_spec* pCar) {
                 height += pCar->bounds[0].min.v[i] * mat->m[i][1];
             }
         }
-        if (mat->m[3][1] / WORLD_SCALE + height < pCar->water_d) {
+        height += mat->m[3][1] / WORLD_SCALE;
+        if (height < pCar->water_d) {
             DisablePlingMaterials();
         }
+    } else {
+        DisablePlingMaterials();
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x487a3b: CheckDisablePlingMaterials 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x487a3e,21 +0x4593a5,23 @@
0x487a3e : sub esp, 0xc
0x487a41 : push ebx
0x487a42 : push esi
0x487a43 : push edi
0x487a44 : mov dword ptr [ebp - 0xc], 0 	(car.c:4944)
0x487a4b : mov eax, dword ptr [ebp + 8] 	(car.c:4945)
0x487a4e : fld dword ptr [eax + 0x2a4]
0x487a54 : fcomp dword ptr [10000.0 (FLOAT)]
0x487a5a : fnstsw ax
0x487a5c : test ah, 0x40
0x487a5f : -jne 0xbd
         : +je 0xa
         : +call DisablePlingMaterials (FUNCTION) 	(car.c:4946)
         : +jmp 0xb5 	(car.c:4947)
0x487a65 : mov eax, dword ptr [ebp + 8] 	(car.c:4948)
0x487a68 : mov eax, dword ptr [eax + 0xc]
0x487a6b : add eax, 0x2c
0x487a6e : mov dword ptr [ebp - 4], eax
0x487a71 : mov dword ptr [ebp - 8], 0 	(car.c:4949)
0x487a78 : jmp 0x3
0x487a7d : inc dword ptr [ebp - 8]
0x487a80 : cmp dword ptr [ebp - 8], 3
0x487a84 : jge 0x68
0x487a8a : mov eax, dword ptr [ebp - 8] 	(car.c:4950)

---
+++
@@ -0x487add,21 +0x45944e,21 @@
0x487add : lea eax, [eax + eax*2]
0x487ae0 : mov ecx, dword ptr [ebp - 4]
0x487ae3 : fmul dword ptr [ecx + eax*4 + 4]
0x487ae7 : fadd dword ptr [ebp - 0xc]
0x487aea : fstp dword ptr [ebp - 0xc]
0x487aed : jmp -0x75 	(car.c:4955)
0x487af2 : mov eax, dword ptr [ebp - 4] 	(car.c:4956)
0x487af5 : fld dword ptr [eax + 0x28]
0x487af8 : fdiv dword ptr [6.900000095367432 (FLOAT)]
0x487afe : fadd dword ptr [ebp - 0xc]
0x487b01 : -fst dword ptr [ebp - 0xc]
0x487b04 : mov eax, dword ptr [ebp + 8]
0x487b07 : fcomp dword ptr [eax + 0x2a4]
0x487b0d : fnstsw ax
0x487b0f : test ah, 1
0x487b12 : je 0x5
0x487b18 : call DisablePlingMaterials (FUNCTION) 	(car.c:4957)
0x487b1d : -jmp 0x5
0x487b22 : -call DisablePlingMaterials (FUNCTION)
0x487b27 : pop edi 	(car.c:4960)
0x487b28 : pop esi
         : +pop ebx
         : +leave 
         : +ret 


CheckDisablePlingMaterials is only 92.42% similar to the original, diff above
```

*AI generated. Time taken: 0s*
