### PR TITLE
PanningExternalCamera equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -5271,19 +5271,19 @@ void PanningExternalCamera(tCar_spec* c, tU32 pTime) {
     // GLOBAL: CARM95 0x514e80
     static int inside_camera_zone = 1;
 
-    BrVector3Sub(&tv, &gCamera->t.t.translate.t, &c->pos);
+    m2 = &gCamera->t.t.mat;
+    m1 = &c->car_master_actor->t.t.mat;
+    BrVector3Sub(&tv, (br_vector3*)m2->m[3], &c->pos);
     ts = BrVector3LengthSquared(&tv);
-    if (ts > 102.91955471539592f || (gSwitch_time != 0 && (PipeSearchForwards() ? (gSwitch_time <= GetTotalTime()) : (gSwitch_time >= GetTotalTime())))) {
-        if ((inside_camera_zone || ts > 205.83910943079184f) && (ts > 25.f || CheckForWall(&c->pos, &gCamera->t.t.translate.t))) {
+    if (ts > 102.91955471539592 || (gSwitch_time != 0 && (PipeSearchForwards() ? (gSwitch_time <= GetTotalTime()) : (gSwitch_time >= GetTotalTime())))) {
+        if ((inside_camera_zone || ts > 205.83910943079184) && (ts > 25.f || CheckForWall(&c->pos, &gCamera->t.t.translate.t))) {
             SetUpPanningCamera(c);
             inside_camera_zone = 0;
         }
     } else {
         inside_camera_zone = 1;
     }
-    m1 = &c->car_master_actor->t.t.mat;
-    m2 = &gCamera->t.t.mat;
-    PointCameraAtCar(c, m1, m2);
+    PointCameraAtCar(c, &c->car_master_actor->t.t.mat, &gCamera->t.t.mat);
 }
 
 // IDA: int __usercall CheckForWall@<EAX>(br_vector3 *start@<EAX>, br_vector3 *end@<EDX>)


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x488d77,24 +0x45a7e8,24 @@
0x488d77 : mov eax, dword ptr [ebp - 0xc]
0x488d7a : fld dword ptr [eax + 0x28]
0x488d7d : mov eax, dword ptr [ebp + 8]
0x488d80 : fsub dword ptr [eax + 0xa0]
0x488d86 : fstp dword ptr [ebp - 0x14]
0x488d89 : mov eax, dword ptr [ebp - 0xc]
0x488d8c : fld dword ptr [eax + 0x2c]
0x488d8f : mov eax, dword ptr [ebp + 8]
0x488d92 : fsub dword ptr [eax + 0xa4]
0x488d98 : fstp dword ptr [ebp - 0x10]
         : +fld dword ptr [ebp - 0x14] 	(car.c:5277)
         : +fmul dword ptr [ebp - 0x14]
0x488d9b : fld dword ptr [ebp - 0x10]
0x488d9e : fmul dword ptr [ebp - 0x10]
0x488da1 : -fld dword ptr [ebp - 0x14]
0x488da4 : -fmul dword ptr [ebp - 0x14]
0x488da7 : faddp st(1)
0x488da9 : fld dword ptr [ebp - 0x18]
0x488dac : fmul dword ptr [ebp - 0x18]
0x488daf : faddp st(1)
0x488db1 : fcom qword ptr [102.91955471539592 (FLOAT)] 	(car.c:5278)
0x488db7 : fstp dword ptr [ebp - 4]
0x488dba : fnstsw ax
0x488dbc : test ah, 0x41
0x488dbf : je 0x71
0x488dc5 : cmp dword ptr [gSwitch_time (DATA)], 0


PanningExternalCamera is only 98.11% similar to the original, diff above
```

#### AI Analysis

Yes for normal execution: the diff only reorders the two independent square computations (`[ebp-0x14]^2` and `[ebp-0x10]^2`) before the same `faddp st(1)`, so the computed sum and subsequent control flow are unchanged. The x87 stack state at the `faddp` is still two squared terms, just swapped, and addition is commutative. Only edge-case FP metadata behavior (e.g., NaN payload selection/exception nuances) could differ, not the intended numeric logic.

#### Original match

```
---
+++
@@ -0x488d45,47 +0x45a7b6,40 @@
0x488d45 : push ebp 	(car.c:5266)
0x488d46 : mov ebp, esp
0x488d48 : sub esp, 0x1c
0x488d4b : push ebx
0x488d4c : push esi
0x488d4d : push edi
0x488d4e : mov eax, dword ptr [gCamera (DATA)] 	(car.c:5274)
0x488d53 : -add eax, 0x2c
0x488d56 : -mov dword ptr [ebp - 0xc], eax
0x488d59 : -mov eax, dword ptr [ebp + 8]
0x488d5c : -mov eax, dword ptr [eax + 0xc]
0x488d5f : -add eax, 0x2c
0x488d62 : -mov dword ptr [ebp - 8], eax
0x488d65 : -mov eax, dword ptr [ebp - 0xc]
0x488d68 : -fld dword ptr [eax + 0x24]
         : +fld dword ptr [eax + 0x50]
0x488d6b : mov eax, dword ptr [ebp + 8]
0x488d6e : fsub dword ptr [eax + 0x9c]
0x488d74 : fstp dword ptr [ebp - 0x18]
0x488d77 : -mov eax, dword ptr [ebp - 0xc]
0x488d7a : -fld dword ptr [eax + 0x28]
         : +mov eax, dword ptr [gCamera (DATA)]
         : +fld dword ptr [eax + 0x54]
0x488d7d : mov eax, dword ptr [ebp + 8]
0x488d80 : fsub dword ptr [eax + 0xa0]
0x488d86 : fstp dword ptr [ebp - 0x14]
0x488d89 : -mov eax, dword ptr [ebp - 0xc]
0x488d8c : -fld dword ptr [eax + 0x2c]
         : +mov eax, dword ptr [gCamera (DATA)]
         : +fld dword ptr [eax + 0x58]
0x488d8f : mov eax, dword ptr [ebp + 8]
0x488d92 : fsub dword ptr [eax + 0xa4]
0x488d98 : fstp dword ptr [ebp - 0x10]
         : +fld dword ptr [ebp - 0x14] 	(car.c:5275)
         : +fmul dword ptr [ebp - 0x14]
0x488d9b : fld dword ptr [ebp - 0x10]
0x488d9e : fmul dword ptr [ebp - 0x10]
0x488da1 : -fld dword ptr [ebp - 0x14]
0x488da4 : -fmul dword ptr [ebp - 0x14]
0x488da7 : faddp st(1)
0x488da9 : fld dword ptr [ebp - 0x18]
0x488dac : fmul dword ptr [ebp - 0x18]
0x488daf : faddp st(1)
0x488db1 : -fcom qword ptr [102.91955471539592 (FLOAT)]
         : +fcom dword ptr [102.9195556640625 (FLOAT)] 	(car.c:5276)
0x488db7 : fstp dword ptr [ebp - 4]
0x488dba : fnstsw ax
0x488dbc : test ah, 0x41
0x488dbf : je 0x71
0x488dc5 : cmp dword ptr [gSwitch_time (DATA)], 0
0x488dcc : je 0xd6
0x488dd2 : call PipeSearchForwards (FUNCTION)
0x488dd7 : test eax, eax
0x488dd9 : je 0x29
0x488ddf : call GetTotalTime (FUNCTION)

---
+++
@@ -0x488e0d,21 +0x45a86d,21 @@
0x488e0d : cmp eax, dword ptr [gSwitch_time (DATA)]
0x488e13 : ja 0xc
0x488e19 : mov dword ptr [ebp - 0x1c], 1
0x488e20 : jmp 0x7
0x488e25 : mov dword ptr [ebp - 0x1c], 0
0x488e2c : cmp dword ptr [ebp - 0x1c], 0
0x488e30 : je 0x72
0x488e36 : cmp dword ptr [inside_camera_zone (DATA)], 0 	(car.c:5277)
0x488e3d : jne 0x14
0x488e43 : fld dword ptr [ebp - 4]
0x488e46 : -fcomp qword ptr [205.83910943079184 (FLOAT)]
         : +fcomp dword ptr [205.839111328125 (FLOAT)]
0x488e4c : fnstsw ax
0x488e4e : test ah, 0x41
0x488e51 : jne 0x4c
0x488e57 : fld dword ptr [ebp - 4]
0x488e5a : fcomp dword ptr [25.0 (FLOAT)]
0x488e60 : fnstsw ax
0x488e62 : test ah, 0x41
0x488e65 : je 0x22
0x488e6b : mov eax, dword ptr [gCamera (DATA)]
0x488e70 : add eax, 0x50

---
+++
@@ -0x488e82,21 +0x45a8e2,30 @@
0x488e82 : add esp, 8
0x488e85 : test eax, eax
0x488e87 : je 0x16
0x488e8d : mov eax, dword ptr [ebp + 8] 	(car.c:5278)
0x488e90 : push eax
0x488e91 : call SetUpPanningCamera (FUNCTION)
0x488e96 : add esp, 4
0x488e99 : mov dword ptr [inside_camera_zone (DATA)], 0 	(car.c:5279)
0x488ea3 : jmp 0xa 	(car.c:5281)
0x488ea8 : mov dword ptr [inside_camera_zone (DATA)], 1 	(car.c:5282)
0x488eb2 : -mov eax, dword ptr [gCamera (DATA)]
0x488eb7 : -add eax, 0x2c
0x488eba : -push eax
0x488ebb : mov eax, dword ptr [ebp + 8] 	(car.c:5284)
0x488ebe : mov eax, dword ptr [eax + 0xc]
0x488ec1 : add eax, 0x2c
         : +mov dword ptr [ebp - 8], eax
         : +mov eax, dword ptr [gCamera (DATA)] 	(car.c:5285)
         : +add eax, 0x2c
         : +mov dword ptr [ebp - 0xc], eax
         : +mov eax, dword ptr [ebp - 0xc] 	(car.c:5286)
         : +push eax
         : +mov eax, dword ptr [ebp - 8]
0x488ec4 : push eax
0x488ec5 : mov eax, dword ptr [ebp + 8]
0x488ec8 : push eax
0x488ec9 : call PointCameraAtCar (FUNCTION)
0x488ece : add esp, 0xc
         : +pop edi 	(car.c:5287)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


PanningExternalCamera is only 80.39% similar to the original, diff above
```

*AI generated. Time taken: 0s*
