### PR TITLE
FindFloorInBoxBU2 100% effective match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -4023,36 +4023,33 @@ int FindFloorInBoxBU2(br_vector3* a, br_vector3* b, br_vector3* nor, br_scalar* 
     j = 0; // added to keep compiler happy
 #endif
     *d = 2.f;
-    for (i = c->box_face_start; i < c->box_face_end; i++) {
-        face_ref = &gFace_list__car[i];
-        if (!gEliminate_faces || SLOBYTE(face_ref->flags) >= 0) {
-            CheckSingleFace(face_ref, a, b, &nor2, &dist);
-            if (*d > dist) {
-                if (face_ref->material->user == DOUBLESIDED_USER_FLAG || (face_ref->material->flags & (BR_MATF_ALWAYS_VISIBLE | BR_MATF_TWO_SIDED)) != 0) {
-                    BrVector3Sub(&tv, &c->pos, a);
-                    if (BrVector3Dot(&tv, &nor2) >= 0.f) {
-                        *d = dist;
-                        j = i;
-                        BrVector3Copy(nor, &nor2);
-                    }
-                } else {
+    for (i = c->box_face_start, face_ref = &gFace_list__car[i]; i < c->box_face_end; i++, face_ref++) {
+        if (gEliminate_faces) {
+            if ((face_ref->flags & 0x80) != 0) {
+                continue;
+            }
+        }
+        CheckSingleFace(face_ref, a, b, &nor2, &dist);
+        if (*d > dist) {
+            if (*(br_int_32*)&face_ref->material->depth_bias == (br_int_32)DOUBLESIDED_USER_FLAG || (face_ref->material->flags & (BR_MATF_ALWAYS_VISIBLE | BR_MATF_TWO_SIDED)) != 0) {
+                BrVector3Sub(&tv, &c->pos, a);
+                if (BrVector3Dot(&tv, &nor2) >= 0.f) {
                     *d = dist;
                     j = i;
                     BrVector3Copy(nor, &nor2);
                 }
+            } else {
+                *d = dist;
+                j = i;
+                BrVector3Copy(nor, &nor2);
             }
         }
-        face_ref++;
     }
     if (*d >= 2.f) {
         return 0;
     }
     i = gFace_list__car[j].material->identifier[0] - ('0' - 1);
-    if (i < 0 || i >= 11) {
-        return 0;
-    } else {
-        return i;
-    }
+    return (i < 0 || i >= 11) ? 0 : i;
 }
 
 // IDA: int __usercall FindFloorInBoxM2@<EAX>(br_vector3 *a@<EAX>, br_vector3 *b@<EDX>, br_vector3 *nor@<EBX>, br_scalar *d@<ECX>, tCollision_info *c)

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -4032,7 +4032,7 @@ int FindFloorInBoxBU2(br_vector3* a, br_vector3* b, br_vector3* nor, br_scalar* 
         }
         CheckSingleFace(face_ref, a, b, &nor2, &dist);
         if (*d > dist) {
-            if (*(br_int_32*)&face_ref->material->depth_bias == (br_int_32)DOUBLESIDED_USER_FLAG || (face_ref->material->flags & (BR_MATF_ALWAYS_VISIBLE | BR_MATF_TWO_SIDED)) != 0) {
+            if (face_ref->material->colour_map_1 == DOUBLESIDED_USER_FLAG || (face_ref->material->flags & (BR_MATF_ALWAYS_VISIBLE | BR_MATF_TWO_SIDED)) != 0) {
                 BrVector3Sub(&tv, &c->pos, a);
                 if (BrVector3Dot(&tv, &nor2) >= 0.f) {
                     *d = dist;

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -4045,11 +4045,13 @@ int FindFloorInBoxBU2(br_vector3* a, br_vector3* b, br_vector3* nor, br_scalar* 
             }
         }
     }
-    if (*d >= 2.f) {
-        return 0;
+    if (*d < 2.f) {
+        i = gFace_list__car[j].material->identifier[0] - ('0' - 1);
+        if (i >= 0 && i < 11) {
+            return i;
+        }
     }
-    i = gFace_list__car[j].material->identifier[0] - ('0' - 1);
-    return (i < 0 || i >= 11) ? 0 : i;
+    return 0;
 }
 
 // IDA: int __usercall FindFloorInBoxM2@<EAX>(br_vector3 *a@<EAX>, br_vector3 *b@<EDX>, br_vector3 *nor@<EBX>, br_scalar *d@<ECX>, tCollision_info *c)

--- a/src/DETHRACE/common/loading.c
+++ b/src/DETHRACE/common/loading.c
@@ -1793,7 +1793,7 @@ int RemoveDoubleSided(br_model* pModel) {
 
         for (i = 0, face = pModel->faces; i < pModel->nfaces; i++, face++) {
             if (face->material) {
-                if (face->material->user == DOUBLESIDED_USER_FLAG) {
+                if (face->material->colour_map_1 == DOUBLESIDED_USER_FLAG) {
                     num_double_sided_faces++;
                 }
             }
@@ -1804,7 +1804,7 @@ int RemoveDoubleSided(br_model* pModel) {
             orig_nfaces = pModel->nfaces;
 
             for (i = 0, face = pModel->faces; i < orig_nfaces; i++, face++) {
-                if (face->material && face->material->user == DOUBLESIDED_USER_FLAG) {
+                if (face->material && face->material->colour_map_1 == DOUBLESIDED_USER_FLAG) {
                     faces[pModel->nfaces].vertices[0] = face->vertices[1];
                     faces[pModel->nfaces].vertices[1] = face->vertices[0];
                     faces[pModel->nfaces].vertices[2] = face->vertices[2];
@@ -2269,7 +2269,7 @@ void LoadCar(char* pCar_name, tDriver pDriver, tCar_spec* pCar_spec, int pOwner,
                 if (its_a_floorpan) {
                     pStorage_space->materials[i]->flags &= ~BR_MATF_TWO_SIDED;
                 } else {
-                    pStorage_space->materials[i]->user = DOUBLESIDED_USER_FLAG;
+                    pStorage_space->materials[i]->colour_map_1 = DOUBLESIDED_USER_FLAG;
                     pStorage_space->materials[i]->flags &= ~BR_MATF_TWO_SIDED;
                 }
             }

--- a/src/DETHRACE/common/world.c
+++ b/src/DETHRACE/common/world.c
@@ -2725,7 +2725,7 @@ void LoadTrack(char* pFile_name, tTrack_spec* pTrack_spec, tRace_info* pRace_inf
             if (gTrack_storage_space.materials[i]->flags & (BR_MATF_LIGHT | BR_MATF_PRELIT | BR_MATF_SMOOTH)) {
                 gTrack_storage_space.materials[i]->flags &= ~(BR_MATF_LIGHT | BR_MATF_PRELIT | BR_MATF_SMOOTH);
                 if (gTrack_storage_space.materials[i]->flags & BR_MATF_TWO_SIDED) {
-                    gTrack_storage_space.materials[i]->user = DOUBLESIDED_USER_FLAG;
+                    gTrack_storage_space.materials[i]->colour_map_1 = DOUBLESIDED_USER_FLAG;
                     gTrack_storage_space.materials[i]->flags &= ~BR_MATF_TWO_SIDED;
                 }
                 BrMaterialUpdate(gTrack_storage_space.materials[i], BR_MATU_RENDERING);


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x483f5f,22 +0x455ff9,22 @@
0x483f5f : mov eax, dword ptr [ebp + 0x18]
0x483f62 : fld dword ptr [eax + 0xa0]
0x483f68 : mov eax, dword ptr [ebp + 8]
0x483f6b : fsub dword ptr [eax + 4]
0x483f6e : fstp dword ptr [ebp - 0x24]
0x483f71 : mov eax, dword ptr [ebp + 0x18]
0x483f74 : fld dword ptr [eax + 0xa4]
0x483f7a : mov eax, dword ptr [ebp + 8]
0x483f7d : fsub dword ptr [eax + 8]
0x483f80 : fstp dword ptr [ebp - 0x20]
0x483f83 : -fld dword ptr [ebp - 0x20]
0x483f86 : -fmul dword ptr [ebp - 0xc]
         : +fld dword ptr [ebp - 0xc] 	(car.c:4037)
         : +fmul dword ptr [ebp - 0x20]
0x483f89 : fld dword ptr [ebp - 0x24]
0x483f8c : fmul dword ptr [ebp - 0x10]
0x483f8f : faddp st(1)
0x483f91 : fld dword ptr [ebp - 0x28]
0x483f94 : fmul dword ptr [ebp - 0x14]
0x483f97 : faddp st(1)
0x483f99 : fcomp dword ptr [0.0 (FLOAT)]
0x483f9f : fnstsw ax
0x483fa1 : test ah, 1
0x483fa4 : jne 0x28


0x483e92: FindFloorInBoxBU2 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x483e93,59 +0x45603d,58 @@
0x483e93 : mov ebp, esp
0x483e95 : sub esp, 0x28
0x483e98 : push ebx
0x483e99 : push esi
0x483e9a : push edi
0x483e9b : mov eax, dword ptr [ebp + 0x14] 	(car.c:4025)
0x483e9e : mov dword ptr [eax], 0x40000000
0x483ea4 : mov eax, dword ptr [ebp + 0x18] 	(car.c:4026)
0x483ea7 : mov eax, dword ptr [eax + 0x1d4]
0x483ead : mov dword ptr [ebp - 0x18], eax
         : +jmp 0x3
         : +inc dword ptr [ebp - 0x18]
         : +mov eax, dword ptr [ebp + 0x18]
         : +mov ecx, dword ptr [ebp - 0x18]
         : +cmp dword ptr [eax + 0x1d8], ecx
         : +jle 0x137
0x483eb0 : mov eax, dword ptr [ebp - 0x18] 	(car.c:4027)
0x483eb3 : shl eax, 3
0x483eb6 : lea eax, [eax + eax*8]
0x483eb9 : add eax, gFace_list__car[0].material (DATA)
0x483ebe : mov dword ptr [ebp - 8], eax
0x483ec1 : -jmp 0x7
0x483ec6 : -inc dword ptr [ebp - 0x18]
0x483ec9 : -add dword ptr [ebp - 8], 0x48
0x483ecd : -mov eax, dword ptr [ebp + 0x18]
0x483ed0 : -mov ecx, dword ptr [ebp - 0x18]
0x483ed3 : -cmp dword ptr [eax + 0x1d8], ecx
0x483ed9 : -jle 0x125
0x483edf : cmp dword ptr [gEliminate_faces (DATA)], 0 	(car.c:4028)
0x483ee6 : -je 0x12
         : +je 0xf
0x483eec : mov eax, dword ptr [ebp - 8]
0x483eef : -test byte ptr [eax + 0x40], 0x80
0x483ef3 : -je 0x5
0x483ef9 : -jmp -0x38
         : +movsx eax, byte ptr [eax + 0x40]
         : +test eax, eax
         : +jl 0x101
0x483efe : lea eax, [ebp - 4] 	(car.c:4029)
0x483f01 : push eax
0x483f02 : lea eax, [ebp - 0x14]
0x483f05 : push eax
0x483f06 : mov eax, dword ptr [ebp + 0xc]
0x483f09 : push eax
0x483f0a : mov eax, dword ptr [ebp + 8]
0x483f0d : push eax
0x483f0e : mov eax, dword ptr [ebp - 8]
0x483f11 : push eax
0x483f12 : call CheckSingleFace (FUNCTION)
0x483f17 : add esp, 0x14
0x483f1a : mov eax, dword ptr [ebp + 0x14] 	(car.c:4030)
0x483f1d : fld dword ptr [eax]
0x483f1f : fcomp dword ptr [ebp - 4]
0x483f22 : fnstsw ax
0x483f24 : test ah, 0x41
0x483f27 : jne 0xd2
0x483f2d : mov eax, dword ptr [ebp - 8] 	(car.c:4031)
0x483f30 : mov eax, dword ptr [eax]
0x483f32 : -cmp dword ptr [eax + 0x6c], 0x3039
         : +cmp dword ptr [eax + 0x70], 0x3039
0x483f39 : je 0xf
0x483f3f : mov eax, dword ptr [ebp - 8]
0x483f42 : mov eax, dword ptr [eax]
0x483f44 : test byte ptr [eax + 0x21], 0x18
0x483f48 : je 0x89
0x483f4e : mov eax, dword ptr [ebp + 0x18] 	(car.c:4032)
0x483f51 : fld dword ptr [eax + 0x9c]
0x483f57 : mov eax, dword ptr [ebp + 8]
0x483f5a : fsub dword ptr [eax]
0x483f5c : fstp dword ptr [ebp - 0x28]

---
+++
@@ -0x483f68,25 +0x45610b,25 @@
0x483f68 : mov eax, dword ptr [ebp + 8]
0x483f6b : fsub dword ptr [eax + 4]
0x483f6e : fstp dword ptr [ebp - 0x24]
0x483f71 : mov eax, dword ptr [ebp + 0x18]
0x483f74 : fld dword ptr [eax + 0xa4]
0x483f7a : mov eax, dword ptr [ebp + 8]
0x483f7d : fsub dword ptr [eax + 8]
0x483f80 : fstp dword ptr [ebp - 0x20]
0x483f83 : fld dword ptr [ebp - 0x20] 	(car.c:4033)
0x483f86 : fmul dword ptr [ebp - 0xc]
         : +fld dword ptr [ebp - 0x28]
         : +fmul dword ptr [ebp - 0x14]
         : +faddp st(1)
0x483f89 : fld dword ptr [ebp - 0x24]
0x483f8c : fmul dword ptr [ebp - 0x10]
0x483f8f : -faddp st(1)
0x483f91 : -fld dword ptr [ebp - 0x28]
0x483f94 : -fmul dword ptr [ebp - 0x14]
0x483f97 : faddp st(1)
0x483f99 : fcomp dword ptr [0.0 (FLOAT)]
0x483f9f : fnstsw ax
0x483fa1 : test ah, 1
0x483fa4 : jne 0x28
0x483faa : mov eax, dword ptr [ebp + 0x14] 	(car.c:4034)
0x483fad : mov ecx, dword ptr [ebp - 4]
0x483fb0 : mov dword ptr [eax], ecx
0x483fb2 : mov eax, dword ptr [ebp - 0x18] 	(car.c:4035)
0x483fb5 : mov dword ptr [ebp - 0x1c], eax

---
+++
@@ -0x483fe2,37 +0x456185,41 @@
0x483fe2 : mov dword ptr [ebp - 0x1c], eax
0x483fe5 : mov eax, dword ptr [ebp + 0x10] 	(car.c:4041)
0x483fe8 : mov ecx, dword ptr [ebp - 0x14]
0x483feb : mov dword ptr [eax], ecx
0x483fed : mov eax, dword ptr [ebp + 0x10]
0x483ff0 : mov ecx, dword ptr [ebp - 0x10]
0x483ff3 : mov dword ptr [eax + 4], ecx
0x483ff6 : mov eax, dword ptr [ebp + 0x10]
0x483ff9 : mov ecx, dword ptr [ebp - 0xc]
0x483ffc : mov dword ptr [eax + 8], ecx
0x483fff : -jmp -0x13e
         : +add dword ptr [ebp - 8], 0x48 	(car.c:4045)
         : +jmp -0x14c 	(car.c:4046)
0x484004 : mov eax, dword ptr [ebp + 0x14] 	(car.c:4047)
0x484007 : fld dword ptr [eax]
0x484009 : fcomp dword ptr [2.0 (FLOAT)]
0x48400f : fnstsw ax
0x484011 : test ah, 1
0x484014 : -je 0x35
         : +jne 0x7
         : +xor eax, eax 	(car.c:4048)
         : +jmp 0x41
0x48401a : mov eax, dword ptr [ebp - 0x1c] 	(car.c:4050)
0x48401d : shl eax, 3
0x484020 : mov eax, dword ptr [eax + eax*8 + gFace_list__car[0].material (DATA)]
0x484027 : mov eax, dword ptr [eax + 4]
0x48402a : movsx eax, byte ptr [eax]
0x48402d : sub eax, 0x2f
0x484030 : mov dword ptr [ebp - 0x18], eax
0x484033 : cmp dword ptr [ebp - 0x18], 0 	(car.c:4051)
0x484037 : -jl 0x12
         : +jl 0xa
0x48403d : cmp dword ptr [ebp - 0x18], 0xb
0x484041 : -jge 0x8
         : +jl 0xc
         : +xor eax, eax 	(car.c:4052)
         : +jmp 0xd
         : +jmp 0x8 	(car.c:4053)
0x484047 : mov eax, dword ptr [ebp - 0x18] 	(car.c:4054)
0x48404a : -jmp 0x7
0x48404f : -xor eax, eax
0x484051 : jmp 0x0
0x484056 : pop edi 	(car.c:4056)
0x484057 : pop esi
0x484058 : pop ebx
0x484059 : leave 
0x48405a : ret 


FindFloorInBoxBU2 is only 83.87% similar to the original, diff above
```

*AI generated. Time taken: 1178s, tokens: 253,301*
