### PR TITLE
AddCollPoint 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3736,24 +3736,23 @@ void AddCollPoint(br_scalar dist, br_vector3* p, br_vector3* norm, br_vector3* r
     int i;
     int furthest;
 
-    if (num < 4) {
-        d[num] = dist;
-        n[num] = *norm;
-        BrVector3Sub(&r[num], p, &c->cmpos);
-        return;
-    }
-    furthest = 0;
-    for (i = 1; i < 4; i++) {
-        if (d[furthest] < d[i]) {
-            furthest = i;
+    if (num >= 4) {
+        furthest = 0;
+        for (i = 1; i < 4; i++) {
+            if (d[furthest] < d[i]) {
+                furthest = i;
+            }
         }
-    }
-    if (d[furthest] >= dist) {
+        if (d[furthest] < dist) {
+            return;
+        }
         num = furthest;
-        d[num] = dist;
-        n[num] = *norm;
-        BrVector3Sub(&r[num], p, &c->cmpos);
     }
+    d[num] = dist;
+    n[num].v[0] = norm->v[0];
+    n[num].v[1] = norm->v[1];
+    n[num].v[2] = norm->v[2];
+    BrVector3Sub(&r[num], p, &c->cmpos);
 }
 
 // IDA: br_scalar __usercall SinglePointColl@<ST0>(br_scalar *f@<EAX>, br_matrix4 *m@<EDX>, br_scalar *d@<EBX>)

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3732,6 +3732,7 @@ void CrushBoundingBox(tCar_spec* c, int crush_only) {
 // IDA: void __cdecl AddCollPoint(br_scalar dist, br_vector3 *p, br_vector3 *norm, br_vector3 *r, br_vector3 *n, br_vector3 *dir, int num, tCollision_info *c)
 // FUNCTION: CARM95 0x00483152
 void AddCollPoint(br_scalar dist, br_vector3* p, br_vector3* norm, br_vector3* r, br_vector3* n, br_vector3* dir, int num, tCollision_info* c) {
+    // GLOBAL: CARM95 0x0053A5A0
     static br_scalar d[4];
     int i;
     int furthest;

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3737,9 +3737,9 @@ void AddCollPoint(br_scalar dist, br_vector3* p, br_vector3* norm, br_vector3* r
     int i;
     int furthest;
 
-    if (num >= 4) {
+    if (num >= COUNT_OF(d)) {
         furthest = 0;
-        for (i = 1; i < 4; i++) {
+        for (i = 1; i < COUNT_OF(d); i++) {
             if (d[furthest] < d[i]) {
                 furthest = i;
             }
@@ -3750,9 +3750,7 @@ void AddCollPoint(br_scalar dist, br_vector3* p, br_vector3* norm, br_vector3* r
         num = furthest;
     }
     d[num] = dist;
-    n[num].v[0] = norm->v[0];
-    n[num].v[1] = norm->v[1];
-    n[num].v[2] = norm->v[2];
+    BrVector3Copy(&n[num], norm);
     BrVector3Sub(&r[num], p, &c->cmpos);
 }
 


### PR DESCRIPTION
## Match result

```
0x483152: AddCollPoint 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x483152,64 +0x45536c,95 @@
0x483152 : push ebp 	(car.c:3734)
0x483153 : mov ebp, esp
0x483155 : sub esp, 8
0x483158 : push ebx
0x483159 : push esi
0x48315a : push edi
0x48315b : cmp dword ptr [ebp + 0x20], 4 	(car.c:3739)
0x48315f : -jl 0x6d
         : +jge 0x83
         : +mov eax, dword ptr [ebp + 0x20] 	(car.c:3740)
         : +mov ecx, dword ptr [ebp + 8]
         : +mov dword ptr [eax*4 + d (DATA)], ecx
         : +mov eax, dword ptr [ebp + 0x10] 	(car.c:3741)
         : +mov ecx, dword ptr [ebp + 0x20]
         : +lea ecx, [ecx + ecx*2]
         : +shl ecx, 2
         : +add ecx, dword ptr [ebp + 0x18]
         : +mov edx, dword ptr [eax]
         : +mov dword ptr [ecx], edx
         : +mov edx, dword ptr [eax + 4]
         : +mov dword ptr [ecx + 4], edx
         : +mov eax, dword ptr [eax + 8]
         : +mov dword ptr [ecx + 8], eax
         : +mov eax, dword ptr [ebp + 0xc] 	(car.c:3742)
         : +fld dword ptr [eax]
         : +mov eax, dword ptr [ebp + 0x24]
         : +fsub dword ptr [eax + 0xd4]
         : +mov eax, dword ptr [ebp + 0x20]
         : +lea eax, [eax + eax*2]
         : +mov ecx, dword ptr [ebp + 0x14]
         : +fstp dword ptr [ecx + eax*4]
         : +mov eax, dword ptr [ebp + 0xc]
         : +fld dword ptr [eax + 4]
         : +mov eax, dword ptr [ebp + 0x24]
         : +fsub dword ptr [eax + 0xd8]
         : +mov eax, dword ptr [ebp + 0x20]
         : +lea eax, [eax + eax*2]
         : +mov ecx, dword ptr [ebp + 0x14]
         : +fstp dword ptr [ecx + eax*4 + 4]
         : +mov eax, dword ptr [ebp + 0xc]
         : +fld dword ptr [eax + 8]
         : +mov eax, dword ptr [ebp + 0x24]
         : +fsub dword ptr [eax + 0xdc]
         : +mov eax, dword ptr [ebp + 0x20]
         : +lea eax, [eax + eax*2]
         : +mov ecx, dword ptr [ebp + 0x14]
         : +fstp dword ptr [ecx + eax*4 + 8]
         : +jmp 0xe6 	(car.c:3743)
0x483165 : mov dword ptr [ebp - 4], 0 	(car.c:3745)
0x48316c : mov dword ptr [ebp - 8], 1 	(car.c:3746)
0x483173 : jmp 0x3
0x483178 : inc dword ptr [ebp - 8]
0x48317b : cmp dword ptr [ebp - 8], 4
0x48317f : jge 0x2a
0x483185 : mov eax, dword ptr [ebp - 4] 	(car.c:3747)
0x483188 : -fld dword ptr [eax*4 + <OFFSET1>]
         : +fld dword ptr [eax*4 + d (DATA)]
0x48318f : mov eax, dword ptr [ebp - 8]
0x483192 : -fcomp dword ptr [eax*4 + <OFFSET1>]
         : +fcomp dword ptr [eax*4 + d (DATA)]
0x483199 : fnstsw ax
0x48319b : test ah, 1
0x48319e : je 0x6
0x4831a4 : mov eax, dword ptr [ebp - 8] 	(car.c:3748)
0x4831a7 : mov dword ptr [ebp - 4], eax
0x4831aa : jmp -0x37 	(car.c:3750)
0x4831af : mov eax, dword ptr [ebp - 4] 	(car.c:3751)
0x4831b2 : -fld dword ptr [eax*4 + <OFFSET1>]
         : +fld dword ptr [eax*4 + d (DATA)]
0x4831b9 : fcomp dword ptr [ebp + 8]
0x4831bc : fnstsw ax
0x4831be : test ah, 1
0x4831c1 : -je 0x5
0x4831c7 : -jmp 0x9c
         : +jne 0x84
0x4831cc : mov eax, dword ptr [ebp - 4] 	(car.c:3752)
0x4831cf : mov dword ptr [ebp + 0x20], eax
0x4831d2 : mov eax, dword ptr [ebp + 0x20] 	(car.c:3753)
0x4831d5 : mov ecx, dword ptr [ebp + 8]
0x4831d8 : -mov dword ptr [eax*4 + <OFFSET1>], ecx
         : +mov dword ptr [eax*4 + d (DATA)], ecx
0x4831df : mov eax, dword ptr [ebp + 0x10] 	(car.c:3754)
0x4831e2 : mov ecx, dword ptr [ebp + 0x20]
0x4831e5 : lea ecx, [ecx + ecx*2]
0x4831e8 : -mov edx, dword ptr [ebp + 0x18]
0x4831eb : -mov eax, dword ptr [eax]
0x4831ed : -mov dword ptr [edx + ecx*4], eax
0x4831f0 : -mov eax, dword ptr [ebp + 0x10]
0x4831f3 : -mov ecx, dword ptr [ebp + 0x20]
0x4831f6 : -lea ecx, [ecx + ecx*2]
0x4831f9 : -mov edx, dword ptr [ebp + 0x18]
0x4831fc : -mov eax, dword ptr [eax + 4]
0x4831ff : -mov dword ptr [edx + ecx*4 + 4], eax
0x483203 : -mov eax, dword ptr [ebp + 0x10]
0x483206 : -mov ecx, dword ptr [ebp + 0x20]
0x483209 : -lea ecx, [ecx + ecx*2]
0x48320c : -mov edx, dword ptr [ebp + 0x18]
         : +shl ecx, 2
         : +add ecx, dword ptr [ebp + 0x18]
         : +mov edx, dword ptr [eax]
         : +mov dword ptr [ecx], edx
         : +mov edx, dword ptr [eax + 4]
         : +mov dword ptr [ecx + 4], edx
0x48320f : mov eax, dword ptr [eax + 8]
0x483212 : -mov dword ptr [edx + ecx*4 + 8], eax
         : +mov dword ptr [ecx + 8], eax
0x483216 : mov eax, dword ptr [ebp + 0xc] 	(car.c:3755)
0x483219 : fld dword ptr [eax]
0x48321b : mov eax, dword ptr [ebp + 0x24]
0x48321e : fsub dword ptr [eax + 0xd4]
0x483224 : mov eax, dword ptr [ebp + 0x20]
0x483227 : lea eax, [eax + eax*2]
0x48322a : mov ecx, dword ptr [ebp + 0x14]
0x48322d : fstp dword ptr [ecx + eax*4]
0x483230 : mov eax, dword ptr [ebp + 0xc]
0x483233 : fld dword ptr [eax + 4]


AddCollPoint is only 62.94% similar to the original, diff above
```

*AI generated. Time taken: 521s, tokens: 92,687*
