### PR TITLE
ExpandBoundingBox 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3630,10 +3630,10 @@ int ExpandBoundingBox(tCar_spec* c) {
     l = 0;
     min_z = c->bounds[1].min.v[2];
     max_z = c->bounds[1].max.v[2];
-    memcpy(&old_pos, c->oldmat.m + 3, sizeof(old_pos));
+    BrVector3Copy(&old_pos, (br_vector3*)&c->oldmat.m[3][0]);
     CrushBoundingBox(c, 0);
-    l = 0;
-    while (l < 5 && !TestForCarInSensiblePlace(c)) {
+
+    while (!TestForCarInSensiblePlace(c) && l < 5) {
         if (c->old_point.v[2] > 0.0f) {
             dist = c->bounds[1].max.v[2] - max_z;
         } else {
@@ -3641,27 +3641,27 @@ int ExpandBoundingBox(tCar_spec* c) {
         }
         if (dist < 0.0f) {
             l = 5;
-        } else {
-            dist += BR_SCALAR(0.005);
-            BrVector3Scale(&c->old_norm, &c->old_norm, dist);
-            BrMatrix34ApplyV(&tv, &c->old_norm, &c->car_master_actor->t.t.mat);
-            c->oldmat.m[3][0] += tv.v[0];
-            c->oldmat.m[3][1] += tv.v[1];
-            c->oldmat.m[3][2] += tv.v[2];
-            l++;
+            continue;
         }
+        dist += 0.005;
+        BrVector3Scale(&c->old_norm, &c->old_norm, dist);
+        BrMatrix34ApplyV(&tv, &c->old_norm, &c->car_master_actor->t.t.mat);
+        c->oldmat.m[3][0] += tv.v[0];
+        c->oldmat.m[3][1] += tv.v[1];
+        c->oldmat.m[3][2] += tv.v[2];
         l++;
     }
     if (l < 5) {
         return 1;
+    } else {
+        BrVector3Copy((br_vector3*)&c->oldmat.m[3][0], &old_pos);
+        c->bounds[1].min.v[2] = min_z;
+        c->bounds[1].max.v[2] = max_z;
+        if (c->driver == eDriver_local_human) {
+            NewTextHeadupSlot(eHeadupSlot_misc, 0, 1000, -kFont_MEDIUMHD, GetMiscString(kMiscString_RepairObstructed));
+        }
+        return 0;
     }
-    memcpy(c->oldmat.m + 3, &old_pos, sizeof(old_pos));
-    c->bounds[1].min.v[2] = min_z;
-    c->bounds[1].max.v[2] = max_z;
-    if (c->driver == eDriver_local_human) {
-        NewTextHeadupSlot(eHeadupSlot_misc, 0, 1000, -kFont_MEDIUMHD, GetMiscString(kMiscString_RepairObstructed));
-    }
-    return 0;
 }
 
 // IDA: void __usercall CrushBoundingBox(tCar_spec *c@<EAX>, int crush_only@<EDX>)

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3630,7 +3630,7 @@ int ExpandBoundingBox(tCar_spec* c) {
     l = 0;
     min_z = c->bounds[1].min.v[2];
     max_z = c->bounds[1].max.v[2];
-    BrVector3Copy(&old_pos, (br_vector3*)&c->oldmat.m[3][0]);
+    BrVector3Copy(&old_pos, (br_vector3*)c->oldmat.m[3]);
     CrushBoundingBox(c, 0);
 
     while (!TestForCarInSensiblePlace(c) && l < 5) {

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3654,7 +3654,7 @@ int ExpandBoundingBox(tCar_spec* c) {
     if (l < 5) {
         return 1;
     } else {
-        BrVector3Copy((br_vector3*)&c->oldmat.m[3][0], &old_pos);
+        BrVector3Copy((br_vector3*)c->oldmat.m[3], &old_pos);
         c->bounds[1].min.v[2] = min_z;
         c->bounds[1].max.v[2] = max_z;
         if (c->driver == eDriver_local_human) {

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3630,33 +3630,32 @@ int ExpandBoundingBox(tCar_spec* c) {
     l = 0;
     min_z = c->bounds[1].min.v[2];
     max_z = c->bounds[1].max.v[2];
-    old_pos = *(br_vector3*)&c->oldmat.m[3][0];
+    memcpy(&old_pos, c->oldmat.m + 3, sizeof(old_pos));
     CrushBoundingBox(c, 0);
-    for (l = 0; l < 5; l++) {
-        if (TestForCarInSensiblePlace(c)) {
-            break;
-        }
-        if (c->old_point.v[2] <= 0.0f) {
-            dist = min_z - c->bounds[1].min.v[2];
-        } else {
+    l = 0;
+    while (l < 5 && !TestForCarInSensiblePlace(c)) {
+        if (c->old_point.v[2] > 0.0f) {
             dist = c->bounds[1].max.v[2] - max_z;
+        } else {
+            dist = min_z - c->bounds[1].min.v[2];
         }
-        if (dist >= 0.0f) {
-            dist += 0.005f;
+        if (dist < 0.0f) {
+            l = 5;
+        } else {
+            dist += BR_SCALAR(0.005);
             BrVector3Scale(&c->old_norm, &c->old_norm, dist);
             BrMatrix34ApplyV(&tv, &c->old_norm, &c->car_master_actor->t.t.mat);
             c->oldmat.m[3][0] += tv.v[0];
             c->oldmat.m[3][1] += tv.v[1];
             c->oldmat.m[3][2] += tv.v[2];
             l++;
-        } else {
-            l = 5;
         }
+        l++;
     }
     if (l < 5) {
         return 1;
     }
-    *(br_vector3*)&c->oldmat.m[3][0] = old_pos;
+    memcpy(c->oldmat.m + 3, &old_pos, sizeof(old_pos));
     c->bounds[1].min.v[2] = min_z;
     c->bounds[1].max.v[2] = max_z;
     if (c->driver == eDriver_local_human) {


### PR DESCRIPTION
## Match result

```
0x482c00: ExpandBoundingBox 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x482c07,65 +0x454e16,67 @@
0x482c07 : push esi
0x482c08 : push edi
0x482c09 : mov dword ptr [ebp - 0x4c], 0 	(car.c:3630)
0x482c10 : mov eax, dword ptr [ebp + 8] 	(car.c:3631)
0x482c13 : mov eax, dword ptr [eax + 0x104]
0x482c19 : mov dword ptr [ebp - 0x10], eax
0x482c1c : mov eax, dword ptr [ebp + 8] 	(car.c:3632)
0x482c1f : mov eax, dword ptr [eax + 0x110]
0x482c25 : mov dword ptr [ebp - 0x48], eax
0x482c28 : mov eax, dword ptr [ebp + 8] 	(car.c:3633)
0x482c2b : -mov eax, dword ptr [eax + 0x60]
0x482c2e : -mov dword ptr [ebp - 0xc], eax
0x482c31 : -mov eax, dword ptr [ebp + 8]
0x482c34 : -mov eax, dword ptr [eax + 0x64]
0x482c37 : -mov dword ptr [ebp - 8], eax
0x482c3a : -mov eax, dword ptr [ebp + 8]
0x482c3d : -mov eax, dword ptr [eax + 0x68]
0x482c40 : -mov dword ptr [ebp - 4], eax
         : +add eax, 0x60
         : +lea ecx, [ebp - 0xc]
         : +mov edx, dword ptr [eax]
         : +mov dword ptr [ecx], edx
         : +mov edx, dword ptr [eax + 4]
         : +mov dword ptr [ecx + 4], edx
         : +mov eax, dword ptr [eax + 8]
         : +mov dword ptr [ecx + 8], eax
0x482c43 : push 0 	(car.c:3634)
0x482c45 : mov eax, dword ptr [ebp + 8]
0x482c48 : push eax
0x482c49 : call CrushBoundingBox (FUNCTION)
0x482c4e : add esp, 8
         : +mov dword ptr [ebp - 0x4c], 0 	(car.c:3635)
         : +jmp 0x3
         : +inc dword ptr [ebp - 0x4c]
         : +cmp dword ptr [ebp - 0x4c], 5
         : +jge 0x115
0x482c51 : mov eax, dword ptr [ebp + 8] 	(car.c:3636)
0x482c54 : push eax
0x482c55 : call TestForCarInSensiblePlace (FUNCTION)
0x482c5a : add esp, 4
0x482c5d : test eax, eax
0x482c5f : -jne 0x106
0x482c65 : -cmp dword ptr [ebp - 0x4c], 5
0x482c69 : -jge 0xfc
         : +je 0x5
         : +jmp 0xfc 	(car.c:3637)
0x482c6f : mov eax, dword ptr [ebp + 8] 	(car.c:3639)
0x482c72 : fld dword ptr [eax + 0x1c4]
0x482c78 : fcomp dword ptr [0.0 (FLOAT)]
0x482c7e : fnstsw ax
0x482c80 : test ah, 0x41
0x482c83 : -jne 0x14
         : +je 0x14
         : +fld dword ptr [ebp - 0x10] 	(car.c:3640)
         : +mov eax, dword ptr [ebp + 8]
         : +fsub dword ptr [eax + 0x104]
         : +fstp dword ptr [ebp - 0x44]
         : +jmp 0xf 	(car.c:3641)
0x482c89 : mov eax, dword ptr [ebp + 8] 	(car.c:3642)
0x482c8c : fld dword ptr [eax + 0x110]
0x482c92 : fsub dword ptr [ebp - 0x48]
0x482c95 : -fstp dword ptr [ebp - 0x44]
0x482c98 : -jmp 0xf
0x482c9d : -fld dword ptr [ebp - 0x10]
0x482ca0 : -mov eax, dword ptr [ebp + 8]
0x482ca3 : -fsub dword ptr [eax + 0x104]
0x482ca9 : fstp dword ptr [ebp - 0x44]
0x482cac : fld dword ptr [ebp - 0x44] 	(car.c:3644)
0x482caf : fcomp dword ptr [0.0 (FLOAT)]
0x482cb5 : fnstsw ax
0x482cb7 : test ah, 1
0x482cba : -je 0xc
0x482cc0 : -mov dword ptr [ebp - 0x4c], 5
0x482cc7 : -jmp -0x7b
         : +jne 0x9f
0x482ccc : fld dword ptr [ebp - 0x44] 	(car.c:3645)
0x482ccf : -fadd qword ptr [0.005 (FLOAT)]
         : +fadd dword ptr [0.004999999888241291 (FLOAT)]
0x482cd5 : fstp dword ptr [ebp - 0x44]
0x482cd8 : mov eax, dword ptr [ebp + 8] 	(car.c:3646)
0x482cdb : fld dword ptr [eax + 0x1c8]
0x482ce1 : fmul dword ptr [ebp - 0x44]
0x482ce4 : mov eax, dword ptr [ebp + 8]
0x482ce7 : fstp dword ptr [eax + 0x1c8]
0x482ced : mov eax, dword ptr [ebp + 8]
0x482cf0 : fld dword ptr [eax + 0x1cc]
0x482cf6 : fmul dword ptr [ebp - 0x44]
0x482cf9 : mov eax, dword ptr [ebp + 8]

---
+++
@@ -0x482d48,35 +0x454f5d,36 @@
0x482d48 : fld dword ptr [eax + 0x64]
0x482d4b : fadd dword ptr [ebp - 0x54]
0x482d4e : mov eax, dword ptr [ebp + 8]
0x482d51 : fstp dword ptr [eax + 0x64]
0x482d54 : mov eax, dword ptr [ebp + 8] 	(car.c:3650)
0x482d57 : fld dword ptr [eax + 0x68]
0x482d5a : fadd dword ptr [ebp - 0x50]
0x482d5d : mov eax, dword ptr [ebp + 8]
0x482d60 : fstp dword ptr [eax + 0x68]
0x482d63 : inc dword ptr [ebp - 0x4c] 	(car.c:3651)
0x482d66 : -jmp -0x11a
         : +jmp 0x7 	(car.c:3652)
         : +mov dword ptr [ebp - 0x4c], 5 	(car.c:3653)
         : +jmp -0x122 	(car.c:3655)
0x482d6b : cmp dword ptr [ebp - 0x4c], 5 	(car.c:3656)
0x482d6f : -jge 0xf
         : +jge 0xa
0x482d75 : mov eax, 1 	(car.c:3657)
0x482d7a : -jmp 0x6a
0x482d7f : -jmp 0x65
0x482d84 : -mov eax, dword ptr [ebp + 8]
0x482d87 : -mov ecx, dword ptr [ebp - 0xc]
0x482d8a : -mov dword ptr [eax + 0x60], ecx
0x482d8d : -mov eax, dword ptr [ebp + 8]
0x482d90 : -mov ecx, dword ptr [ebp - 8]
0x482d93 : -mov dword ptr [eax + 0x64], ecx
0x482d96 : -mov eax, dword ptr [ebp + 8]
0x482d99 : -mov ecx, dword ptr [ebp - 4]
0x482d9c : -mov dword ptr [eax + 0x68], ecx
         : +jmp 0x63
         : +lea eax, [ebp - 0xc] 	(car.c:3659)
         : +mov ecx, dword ptr [ebp + 8]
         : +add ecx, 0x60
         : +mov edx, dword ptr [eax]
         : +mov dword ptr [ecx], edx
         : +mov edx, dword ptr [eax + 4]
         : +mov dword ptr [ecx + 4], edx
         : +mov eax, dword ptr [eax + 8]
         : +mov dword ptr [ecx + 8], eax
0x482d9f : mov eax, dword ptr [ebp + 8] 	(car.c:3660)
0x482da2 : mov ecx, dword ptr [ebp - 0x10]
0x482da5 : mov dword ptr [eax + 0x104], ecx
0x482dab : mov eax, dword ptr [ebp + 8] 	(car.c:3661)
0x482dae : mov ecx, dword ptr [ebp - 0x48]
0x482db1 : mov dword ptr [eax + 0x110], ecx
0x482db7 : mov eax, dword ptr [ebp + 8] 	(car.c:3662)
0x482dba : cmp dword ptr [eax + 8], 4
0x482dbe : jne 0x1e
0x482dc4 : push 6 	(car.c:3663)


ExpandBoundingBox is only 75.43% similar to the original, diff above
```

*AI generated. Time taken: 880s, tokens: 201,506*
