### PR TITLE
CrushAndDamageCar equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3524,21 +3524,26 @@ void CrushAndDamageCar(tCar_spec* c, br_vector3* pPosition, br_vector3* pForce_c
         c->who_last_hit_me = car2;
     }
 
-    if (c->driver == eDriver_non_car_unused_slot || c->driver == eDriver_non_car) {
+    if (c->driver <= eDriver_non_car) {
         return;
     }
-    fudge_multiplier = gNet_mode == eNet_mode_none || gNet_softness[gCurrent_net_game->type] == 1.0f ? 1.0f : gNet_softness[gCurrent_net_game->type];
-    BrVector3Sub(&car_to_cam, &c->pos, (br_vector3*)gCamera_to_world.m[3]);
-    ts = BrVector3LengthSquared(&car_to_cam);
-    if (c->driver == eDriver_oppo && ts > 200.0f) {
-        return;
+    if (gNet_mode != eNet_mode_none && (gNet_softness[gCurrent_net_game->type] == 1.0 ? 1 : 0)) {
+        fudge_multiplier = gNet_softness[gCurrent_net_game->type];
+    } else {
+        fudge_multiplier = 1.0f;
+    }
+    if (c->driver == eDriver_oppo) {
+        BrVector3Sub(&car_to_cam, &c->pos, (br_vector3*)gCamera_to_world.m[3]);
+        if (BrVector3LengthSquared(&car_to_cam) > 200.0f) {
+            return;
+        }
     }
     if (car2 != NULL) {
         if (car2->driver > eDriver_non_car) {
             TwoCarsHitEachOther(c, car2);
         }
         if (c->driver >= eDriver_net_human) {
-            fudge_multiplier = gDefensive_powerup_factor[c->power_up_levels[0]] * 1.2f * fudge_multiplier;
+            fudge_multiplier = (gDefensive_powerup_factor[c->power_up_levels[0]] * 1.2) * fudge_multiplier;
         }
         if (car2->driver >= eDriver_net_human) {
             if (gNet_mode != eNet_mode_none
@@ -3551,21 +3556,19 @@ void CrushAndDamageCar(tCar_spec* c, br_vector3* pPosition, br_vector3* pForce_c
         if (c->driver == eDriver_oppo && car2->driver == eDriver_oppo) {
             fudge_multiplier = fudge_multiplier * 0.2f;
         }
-        if (car2->driver <= eDriver_non_car) {
-            car2 = NULL;
+        if (car2->driver > eDriver_non_car) {
+            fudge_multiplier /= ((car2->car_model_actors[car2->principal_car_actor].crush_data.softness_factor + 0.7) / 0.7);
         } else {
-            fudge_multiplier /= ((car2->car_model_actors[car2->principal_car_actor].crush_data.softness_factor + 0.7f) / 0.7f);
+            car2 = NULL;
         }
     }
     BrVector3InvScale(&position, pPosition, WORLD_SCALE);
     BrVector3Scale(&force, pForce_car_space, fudge_multiplier * 0.03f);
-    ts = BrVector3LengthSquared(&force);
+    ts = force.v[2] * force.v[2] + force.v[0] * force.v[0] + force.v[1] * force.v[1];
     if (c->driver <= eDriver_non_car || !c->invulnerable) {
         c->damage_magnitude_accumulator += ts;
     }
-    if (c->driver < eDriver_net_human) {
-        BrVector3Scale(&force_for_bodywork, &force, 1.5f);
-    } else {
+    if (c->driver >= eDriver_net_human) {
         if (c->collision_mass_multiplier != 1.0) {
             BrVector3InvScale(&force, &force, c->collision_mass_multiplier);
         }
@@ -3573,10 +3576,12 @@ void CrushAndDamageCar(tCar_spec* c, br_vector3* pPosition, br_vector3* pForce_c
         if (c->driver == eDriver_local_human) {
             DoPratcamHit(&force);
         }
+    } else {
+        BrVector3Scale(&force_for_bodywork, &force, 1.5f);
     }
     if (gNet_mode == eNet_mode_host && (gCurrent_net_game->type == eNet_game_type_tag || gCurrent_net_game->type == eNet_game_type_foxy) && car2 != NULL
         && c->driver >= eDriver_net_human && car2->driver >= eDriver_net_human) {
-        if (gNet_players[gIt_or_fox].car == c && car2->knackered) {
+        if (gNet_players[gIt_or_fox].car == c && !car2->knackered) {
             CarInContactWithItOrFox(NetPlayerFromCar(car2));
         } else if (gNet_players[gIt_or_fox].car == car2 && !c->knackered) {
             CarInContactWithItOrFox(NetPlayerFromCar(c));
@@ -3587,26 +3592,21 @@ void CrushAndDamageCar(tCar_spec* c, br_vector3* pPosition, br_vector3* pForce_c
     }
     if (c->driver <= eDriver_non_car || !c->invulnerable) {
         for (i = 0; i < c->car_actor_count; i++) {
-            if (c->car_model_actors[i].min_distance_squared != -1.0f || (pForce_car_space->v[1] >= 0.0f && pForce_car_space->v[2] >= 0.0f)) {
-                CrushModel(c, i, c->car_model_actors[i].actor, &position, &force_for_bodywork, &c->car_model_actors[i].crush_data);
+            if (c->car_model_actors[i].min_distance_squared == -1.0f) {
+                if (pForce_car_space->v[1] < 0.0f) {
+                    continue;
+                }
+                if (pForce_car_space->v[2] < 0.0f) {
+                    continue;
+                }
             }
-        }
-        if (car2 && car2->driver == eDriver_local_human && ts > 0.003f) {
-            PipeSingleCarIncident(ts, c, &position);
-        }
-        if (!car2 && c->driver == eDriver_local_human && ts > 0.003f) {
-            BrMatrix34Copy(&m, &c->car_master_actor->t.t.mat);
-            m.m[3][0] /= WORLD_SCALE;
-            m.m[3][1] /= WORLD_SCALE;
-            m.m[3][2] /= WORLD_SCALE;
-            BrMatrix34ApplyP(&pos_w, &position, &m);
-            PipeSingleWallIncident(ts, &pos_w);
+            CrushModel(c, i, c->car_model_actors[i].actor, &position, &force_for_bodywork, &c->car_model_actors[i].crush_data);
         }
     }
-    if (car2 != NULL && car2->driver == eDriver_local_human && ts > 0.003f) {
+    if (car2 != NULL && car2->driver == eDriver_local_human && ts > 0.003) {
         PipeSingleCarIncident(ts, c, &position);
     }
-    if (car2 == NULL && c->driver == eDriver_local_human && ts > 0.003f) {
+    if (car2 == NULL && c->driver == eDriver_local_human && ts > 0.003) {
         BrMatrix34Copy(&m, &c->car_master_actor->t.t.mat);
         m.m[3][0] /= WORLD_SCALE;
         m.m[3][1] /= WORLD_SCALE;

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3527,7 +3527,7 @@ void CrushAndDamageCar(tCar_spec* c, br_vector3* pPosition, br_vector3* pForce_c
     if (c->driver <= eDriver_non_car) {
         return;
     }
-    if (gNet_mode != eNet_mode_none && (gNet_softness[gCurrent_net_game->type] == 1.0 ? 1 : 0)) {
+    if (gNet_mode != eNet_mode_none && gNet_softness[gCurrent_net_game->type] != 1.0) {
         fudge_multiplier = gNet_softness[gCurrent_net_game->type];
     } else {
         fudge_multiplier = 1.0f;
@@ -3564,7 +3564,7 @@ void CrushAndDamageCar(tCar_spec* c, br_vector3* pPosition, br_vector3* pForce_c
     }
     BrVector3InvScale(&position, pPosition, WORLD_SCALE);
     BrVector3Scale(&force, pForce_car_space, fudge_multiplier * 0.03f);
-    ts = force.v[2] * force.v[2] + force.v[0] * force.v[0] + force.v[1] * force.v[1];
+    ts = BrVector3LengthSquared(&force);
     if (c->driver <= eDriver_non_car || !c->invulnerable) {
         c->damage_magnitude_accumulator += ts;
     }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x482823,27 +0x454961,27 @@
0x482823 : fld dword ptr [ebp - 0x28]
0x482826 : fmul dword ptr [0.029999999329447746 (FLOAT)]
0x48282c : mov eax, dword ptr [ebp + 0x10]
0x48282f : fmul dword ptr [eax + 4]
0x482832 : fstp dword ptr [ebp - 0x14]
0x482835 : fld dword ptr [ebp - 0x28]
0x482838 : fmul dword ptr [0.029999999329447746 (FLOAT)]
0x48283e : mov eax, dword ptr [ebp + 0x10]
0x482841 : fmul dword ptr [eax + 8]
0x482844 : fstp dword ptr [ebp - 0x10]
0x482847 : -fld dword ptr [ebp - 0x10]
0x48284a : -fmul dword ptr [ebp - 0x10]
         : +fld dword ptr [ebp - 0x18] 	(car.c:3567)
         : +fmul dword ptr [ebp - 0x18]
0x48284d : fld dword ptr [ebp - 0x14]
0x482850 : fmul dword ptr [ebp - 0x14]
0x482853 : faddp st(1)
0x482855 : -fld dword ptr [ebp - 0x18]
0x482858 : -fmul dword ptr [ebp - 0x18]
         : +fld dword ptr [ebp - 0x10]
         : +fmul dword ptr [ebp - 0x10]
0x48285b : faddp st(1)
0x48285d : fstp dword ptr [ebp - 0x48]
0x482860 : mov eax, dword ptr [ebp + 8] 	(car.c:3568)
0x482863 : cmp dword ptr [eax + 8], 1
0x482867 : jle 0x10
0x48286d : mov eax, dword ptr [ebp + 8]
0x482870 : cmp dword ptr [eax + 0x424], 0
0x482877 : jne 0x15
0x48287d : mov eax, dword ptr [ebp + 8] 	(car.c:3569)
0x482880 : fld dword ptr [eax + 0x15c8]


CrushAndDamageCar is only 99.03% similar to the original, diff above
```

#### AI Analysis

The diff only changes the order of accumulating three squared terms: originally it computes (-0x10)^2 + (-0x14)^2 + (-0x18)^2, while the new version computes (-0x18)^2 + (-0x14)^2 + (-0x10)^2. No operands or operations are changed besides this reordering, and the final stored value is the same mathematically (ignoring floating-point rounding-order effects as requested).

#### Original match

```
---
+++
@@ -0x4825b3,85 +0x4546f1,90 @@
0x4825b3 : push edi
0x4825b4 : cmp dword ptr [ebp + 0x14], 0 	(car.c:3522)
0x4825b8 : je 0x18
0x4825be : mov eax, dword ptr [ebp + 8] 	(car.c:3523)
0x4825c1 : mov ecx, dword ptr [ebp + 0x14]
0x4825c4 : mov dword ptr [ecx + 0x338], eax
0x4825ca : mov eax, dword ptr [ebp + 0x14] 	(car.c:3524)
0x4825cd : mov ecx, dword ptr [ebp + 8]
0x4825d0 : mov dword ptr [ecx + 0x338], eax
0x4825d6 : mov eax, dword ptr [ebp + 8] 	(car.c:3527)
         : +cmp dword ptr [eax + 8], 0
         : +je 0xd
         : +mov eax, dword ptr [ebp + 8]
0x4825d9 : cmp dword ptr [eax + 8], 1
0x4825dd : -jg 0x5
0x4825e3 : -jmp 0x613
         : +jne 0x5
         : +jmp 0x6d7 	(car.c:3528)
0x4825e8 : cmp dword ptr [gNet_mode (DATA)], 0 	(car.c:3530)
0x4825ef : -je 0x37
         : +je 0x20
0x4825f5 : mov eax, dword ptr [gCurrent_net_game (DATA)]
0x4825fa : mov eax, dword ptr [eax + 0x74]
0x4825fd : fld dword ptr [eax*4 + gNet_softness[0] (DATA)]
0x482604 : -fcomp qword ptr [1.0 (FLOAT)]
         : +fcomp dword ptr [1.0 (FLOAT)]
0x48260a : fnstsw ax
0x48260c : test ah, 0x40
0x48260f : -jne 0x17
         : +je 0xc
         : +mov dword ptr [ebp - 0x28], 0x3f800000
         : +jmp 0x12
0x482615 : mov eax, dword ptr [gCurrent_net_game (DATA)]
0x48261a : mov eax, dword ptr [eax + 0x74]
0x48261d : mov eax, dword ptr [eax*4 + gNet_softness[0] (DATA)]
0x482624 : mov dword ptr [ebp - 0x28], eax
0x482627 : -jmp 0x7
0x48262c : -mov dword ptr [ebp - 0x28], 0x3f800000
0x482633 : -mov eax, dword ptr [ebp + 8]
0x482636 : -cmp dword ptr [eax + 8], 2
0x48263a : -jne 0x62
0x482640 : mov eax, dword ptr [ebp + 8] 	(car.c:3531)
0x482643 : fld dword ptr [eax + 0x9c]
0x482649 : fsub dword ptr [gCamera_to_world+36 (OFFSET)]
0x48264f : fstp dword ptr [ebp - 0x40]
0x482652 : mov eax, dword ptr [ebp + 8]
0x482655 : fld dword ptr [eax + 0xa0]
0x48265b : fsub dword ptr [gCamera_to_world+40 (OFFSET)]
0x482661 : fstp dword ptr [ebp - 0x3c]
0x482664 : mov eax, dword ptr [ebp + 8]
0x482667 : fld dword ptr [eax + 0xa4]
0x48266d : fsub dword ptr [gCamera_to_world+44 (OFFSET)]
0x482673 : fstp dword ptr [ebp - 0x38]
0x482676 : fld dword ptr [ebp - 0x3c] 	(car.c:3532)
0x482679 : fmul dword ptr [ebp - 0x3c]
0x48267c : fld dword ptr [ebp - 0x38]
0x48267f : fmul dword ptr [ebp - 0x38]
0x482682 : faddp st(1)
0x482684 : fld dword ptr [ebp - 0x40]
0x482687 : fmul dword ptr [ebp - 0x40]
0x48268a : faddp st(1)
         : +fstp dword ptr [ebp - 0x48]
         : +mov eax, dword ptr [ebp + 8] 	(car.c:3533)
         : +cmp dword ptr [eax + 8], 2
         : +jne 0x19
         : +fld dword ptr [ebp - 0x48]
0x48268c : fcomp dword ptr [200.0 (FLOAT)]
0x482692 : fnstsw ax
0x482694 : test ah, 0x41
0x482697 : jne 0x5
0x48269d : -jmp 0x559
         : +jmp 0x617 	(car.c:3534)
0x4826a2 : cmp dword ptr [ebp + 0x14], 0 	(car.c:3536)
0x4826a6 : je 0x13a
0x4826ac : mov eax, dword ptr [ebp + 0x14] 	(car.c:3537)
0x4826af : cmp dword ptr [eax + 8], 1
0x4826b3 : jle 0x10
0x4826b9 : mov eax, dword ptr [ebp + 0x14] 	(car.c:3538)
0x4826bc : push eax
0x4826bd : mov eax, dword ptr [ebp + 8]
0x4826c0 : push eax
0x4826c1 : call TwoCarsHitEachOther (FUNCTION)
0x4826c6 : add esp, 8
0x4826c9 : mov eax, dword ptr [ebp + 8] 	(car.c:3540)
0x4826cc : cmp dword ptr [eax + 8], 3
0x4826d0 : jl 0x1c
0x4826d6 : mov eax, dword ptr [ebp + 8] 	(car.c:3541)
0x4826d9 : mov eax, dword ptr [eax + 0x1a8c]
0x4826df : fld dword ptr [eax*4 + gDefensive_powerup_factor[0] (DATA)]
0x4826e6 : -fmul qword ptr [1.2 (FLOAT)]
0x4826ec : fmul dword ptr [ebp - 0x28]
         : +fmul dword ptr [1.2000000476837158 (FLOAT)]
0x4826ef : fstp dword ptr [ebp - 0x28]
0x4826f2 : mov eax, dword ptr [ebp + 0x14] 	(car.c:3543)
0x4826f5 : cmp dword ptr [eax + 8], 3
0x4826f9 : jl 0x7d
0x4826ff : cmp dword ptr [gNet_mode (DATA)], 0 	(car.c:3545)
0x482706 : je 0x51
0x48270c : mov eax, dword ptr [gCurrent_net_game (DATA)]
0x482711 : cmp dword ptr [eax + 0x74], 0
0x482715 : je 0xf
0x48271b : mov eax, dword ptr [gCurrent_net_game (DATA)]

---
+++
@@ -0x48277f,33 +0x4548d0,33 @@
0x48277f : cmp dword ptr [eax + 8], 2
0x482783 : jne 0x19
0x482789 : mov eax, dword ptr [ebp + 0x14]
0x48278c : cmp dword ptr [eax + 8], 2
0x482790 : jne 0xc
0x482796 : fld dword ptr [ebp - 0x28] 	(car.c:3552)
0x482799 : fmul dword ptr [0.20000000298023224 (FLOAT)]
0x48279f : fstp dword ptr [ebp - 0x28]
0x4827a2 : mov eax, dword ptr [ebp + 0x14] 	(car.c:3554)
0x4827a5 : cmp dword ptr [eax + 8], 1
0x4827a9 : -jle 0x30
         : +jg 0xc
         : +mov dword ptr [ebp + 0x14], 0 	(car.c:3555)
         : +jmp 0x2b 	(car.c:3556)
0x4827af : mov eax, dword ptr [ebp + 0x14] 	(car.c:3557)
0x4827b2 : mov eax, dword ptr [eax + 0x66c]
0x4827b8 : shl eax, 4
0x4827bb : lea eax, [eax + eax*2]
0x4827be : mov ecx, dword ptr [ebp + 0x14]
0x4827c1 : fld dword ptr [eax + ecx + 0x12c4]
0x4827c8 : -fadd qword ptr [0.7 (FLOAT)]
0x4827ce : -fdiv qword ptr [0.7 (FLOAT)]
         : +fadd dword ptr [0.699999988079071 (FLOAT)]
         : +fdiv dword ptr [0.699999988079071 (FLOAT)]
0x4827d4 : fdivr dword ptr [ebp - 0x28]
0x4827d7 : fstp dword ptr [ebp - 0x28]
0x4827da : -jmp 0x7
0x4827df : -mov dword ptr [ebp + 0x14], 0
0x4827e6 : mov eax, dword ptr [ebp + 0xc] 	(car.c:3560)
0x4827e9 : fld dword ptr [eax]
0x4827eb : fdiv dword ptr [6.900000095367432 (FLOAT)]
0x4827f1 : fstp dword ptr [ebp - 0x24]
0x4827f4 : mov eax, dword ptr [ebp + 0xc]
0x4827f7 : fld dword ptr [eax + 4]
0x4827fa : fdiv dword ptr [6.900000095367432 (FLOAT)]
0x482800 : fstp dword ptr [ebp - 0x20]
0x482803 : mov eax, dword ptr [ebp + 0xc]
0x482806 : fld dword ptr [eax + 8]

---
+++
@@ -0x482823,43 +0x454974,53 @@
0x482823 : fld dword ptr [ebp - 0x28]
0x482826 : fmul dword ptr [0.029999999329447746 (FLOAT)]
0x48282c : mov eax, dword ptr [ebp + 0x10]
0x48282f : fmul dword ptr [eax + 4]
0x482832 : fstp dword ptr [ebp - 0x14]
0x482835 : fld dword ptr [ebp - 0x28]
0x482838 : fmul dword ptr [0.029999999329447746 (FLOAT)]
0x48283e : mov eax, dword ptr [ebp + 0x10]
0x482841 : fmul dword ptr [eax + 8]
0x482844 : fstp dword ptr [ebp - 0x10]
0x482847 : -fld dword ptr [ebp - 0x10]
0x48284a : -fmul dword ptr [ebp - 0x10]
         : +fld dword ptr [ebp - 0x18] 	(car.c:3562)
         : +fmul dword ptr [ebp - 0x18]
0x48284d : fld dword ptr [ebp - 0x14]
0x482850 : fmul dword ptr [ebp - 0x14]
0x482853 : faddp st(1)
0x482855 : -fld dword ptr [ebp - 0x18]
0x482858 : -fmul dword ptr [ebp - 0x18]
         : +fld dword ptr [ebp - 0x10]
         : +fmul dword ptr [ebp - 0x10]
0x48285b : faddp st(1)
0x48285d : fstp dword ptr [ebp - 0x48]
0x482860 : mov eax, dword ptr [ebp + 8] 	(car.c:3563)
0x482863 : cmp dword ptr [eax + 8], 1
0x482867 : jle 0x10
0x48286d : mov eax, dword ptr [ebp + 8]
0x482870 : cmp dword ptr [eax + 0x424], 0
0x482877 : jne 0x15
0x48287d : mov eax, dword ptr [ebp + 8] 	(car.c:3564)
0x482880 : fld dword ptr [eax + 0x15c8]
0x482886 : fadd dword ptr [ebp - 0x48]
0x482889 : mov eax, dword ptr [ebp + 8]
0x48288c : fstp dword ptr [eax + 0x15c8]
0x482892 : mov eax, dword ptr [ebp + 8] 	(car.c:3566)
0x482895 : cmp dword ptr [eax + 8], 3
0x482899 : -jl 0x8c
         : +jge 0x2c
         : +fld dword ptr [ebp - 0x18] 	(car.c:3567)
         : +fmul dword ptr [1.5 (FLOAT)]
         : +fstp dword ptr [ebp - 0x84]
         : +fld dword ptr [ebp - 0x14]
         : +fmul dword ptr [1.5 (FLOAT)]
         : +fstp dword ptr [ebp - 0x80]
         : +fld dword ptr [ebp - 0x10]
         : +fmul dword ptr [1.5 (FLOAT)]
         : +fstp dword ptr [ebp - 0x7c]
         : +jmp 0x87 	(car.c:3568)
0x48289f : mov eax, dword ptr [ebp + 8] 	(car.c:3569)
0x4828a2 : fld dword ptr [eax + 0x738]
0x4828a8 : fcomp qword ptr [1.0 (FLOAT)]
0x4828ae : fnstsw ax
0x4828b0 : test ah, 0x40
0x4828b3 : jne 0x2d
0x4828b9 : fld dword ptr [ebp - 0x18] 	(car.c:3570)
0x4828bc : mov eax, dword ptr [ebp + 8]
0x4828bf : fdiv dword ptr [eax + 0x738]
0x4828c5 : fstp dword ptr [ebp - 0x18]

---
+++
@@ -0x482901,30 +0x454a7e,20 @@
0x482901 : fld dword ptr [ebp - 0x10]
0x482904 : fmul dword ptr [0.5 (FLOAT)]
0x48290a : fstp dword ptr [ebp - 0x7c]
0x48290d : mov eax, dword ptr [ebp + 8] 	(car.c:3573)
0x482910 : cmp dword ptr [eax + 8], 4
0x482914 : jne 0xc
0x48291a : lea eax, [ebp - 0x18] 	(car.c:3574)
0x48291d : push eax
0x48291e : call DoPratcamHit (FUNCTION)
0x482923 : add esp, 4
0x482926 : -jmp 0x27
0x48292b : -fld dword ptr [ebp - 0x18]
0x48292e : -fmul dword ptr [1.5 (FLOAT)]
0x482934 : -fstp dword ptr [ebp - 0x84]
0x48293a : -fld dword ptr [ebp - 0x14]
0x48293d : -fmul dword ptr [1.5 (FLOAT)]
0x482943 : -fstp dword ptr [ebp - 0x80]
0x482946 : -fld dword ptr [ebp - 0x10]
0x482949 : -fmul dword ptr [1.5 (FLOAT)]
0x48294f : -fstp dword ptr [ebp - 0x7c]
0x482952 : cmp dword ptr [gNet_mode (DATA)], 2 	(car.c:3578)
0x482959 : jne 0xc1
0x48295f : mov eax, dword ptr [gCurrent_net_game (DATA)]
0x482964 : cmp dword ptr [eax + 0x74], 5
0x482968 : je 0xf
0x48296e : mov eax, dword ptr [gCurrent_net_game (DATA)]
0x482973 : cmp dword ptr [eax + 0x74], 6
0x482977 : jne 0xa3
0x48297d : cmp dword ptr [ebp + 0x14], 0
0x482981 : je 0x99

---
+++
@@ -0x482994,21 +0x454ae5,21 @@
0x482994 : mov eax, dword ptr [ebp + 0x14]
0x482997 : cmp dword ptr [eax + 8], 3
0x48299b : jl 0x7f
0x4829a1 : mov eax, dword ptr [gIt_or_fox (DATA)] 	(car.c:3579)
0x4829a6 : shl eax, 6
0x4829a9 : mov ecx, dword ptr [ebp + 8]
0x4829ac : cmp dword ptr [eax + eax*2 + gNet_players[0].car (OFFSET)], ecx
0x4829b3 : jne 0x2a
0x4829b9 : mov eax, dword ptr [ebp + 0x14]
0x4829bc : cmp dword ptr [eax + 0x438], 0
0x4829c3 : -jne 0x1a
         : +je 0x1a
0x4829c9 : mov eax, dword ptr [ebp + 0x14] 	(car.c:3580)
0x4829cc : push eax
0x4829cd : call NetPlayerFromCar (FUNCTION)
0x4829d2 : add esp, 4
0x4829d5 : push eax
0x4829d6 : call CarInContactWithItOrFox (FUNCTION)
0x4829db : add esp, 4
0x4829de : jmp 0x3d 	(car.c:3581)
0x4829e3 : mov eax, dword ptr [gIt_or_fox (DATA)]
0x4829e8 : shl eax, 6

---
+++
@@ -0x482a46,51 +0x454b97,49 @@
0x482a46 : push eax
0x482a47 : mov eax, dword ptr [ebp + 8]
0x482a4a : push eax
0x482a4b : call DamageSystems (FUNCTION)
0x482a50 : add esp, 0x10
0x482a53 : mov eax, dword ptr [ebp + 8] 	(car.c:3588)
0x482a56 : cmp dword ptr [eax + 8], 1
0x482a5a : jle 0x10
0x482a60 : mov eax, dword ptr [ebp + 8]
0x482a63 : cmp dword ptr [eax + 0x424], 0
0x482a6a : -jne 0xc3
         : +jne 0x181
0x482a70 : mov dword ptr [ebp - 0x44], 0 	(car.c:3589)
0x482a77 : jmp 0x3
0x482a7c : inc dword ptr [ebp - 0x44]
0x482a7f : mov eax, dword ptr [ebp + 8]
0x482a82 : mov ecx, dword ptr [ebp - 0x44]
0x482a85 : cmp dword ptr [eax + 0x664], ecx
0x482a8b : -jle 0xa2
         : +jle 0x98
0x482a91 : mov eax, dword ptr [ebp - 0x44] 	(car.c:3590)
0x482a94 : shl eax, 4
0x482a97 : lea eax, [eax + eax*2]
0x482a9a : mov ecx, dword ptr [ebp + 8]
0x482a9d : fld dword ptr [eax + ecx + 0x12bc]
0x482aa4 : fcomp dword ptr [-1.0 (FLOAT)]
0x482aaa : fnstsw ax
0x482aac : test ah, 0x40
0x482aaf : -je 0x38
         : +je 0x2e
0x482ab5 : mov eax, dword ptr [ebp + 0x10]
0x482ab8 : fld dword ptr [eax + 4]
0x482abb : fcomp dword ptr [0.0 (FLOAT)]
0x482ac1 : fnstsw ax
0x482ac3 : test ah, 1
0x482ac6 : -je 0x5
0x482acc : -jmp -0x55
         : +jne 0x58
0x482ad1 : mov eax, dword ptr [ebp + 0x10]
0x482ad4 : fld dword ptr [eax + 8]
0x482ad7 : fcomp dword ptr [0.0 (FLOAT)]
0x482add : fnstsw ax
0x482adf : test ah, 1
0x482ae2 : -je 0x5
0x482ae8 : -jmp -0x71
         : +jne 0x41
0x482aed : mov eax, dword ptr [ebp - 0x44] 	(car.c:3591)
0x482af0 : shl eax, 4
0x482af3 : lea eax, [eax + eax*2]
0x482af6 : add eax, dword ptr [ebp + 8]
0x482af9 : add eax, 0x12c0
0x482afe : push eax
0x482aff : lea eax, [ebp - 0x84]
0x482b05 : push eax
0x482b06 : lea eax, [ebp - 0x24]
0x482b09 : push eax

---
+++
@@ -0x482b10,46 +0x454c57,105 @@
0x482b10 : lea eax, [eax + eax*2]
0x482b13 : mov ecx, dword ptr [ebp + 8]
0x482b16 : mov eax, dword ptr [eax + ecx + 0x12b8]
0x482b1d : push eax
0x482b1e : mov eax, dword ptr [ebp - 0x44]
0x482b21 : push eax
0x482b22 : mov eax, dword ptr [ebp + 8]
0x482b25 : push eax
0x482b26 : call CrushModel (FUNCTION)
0x482b2b : add esp, 0x18
0x482b2e : -jmp -0xb7
         : +jmp -0xad 	(car.c:3593)
0x482b33 : cmp dword ptr [ebp + 0x14], 0 	(car.c:3594)
0x482b37 : je 0x35
0x482b3d : mov eax, dword ptr [ebp + 0x14]
0x482b40 : cmp dword ptr [eax + 8], 4
0x482b44 : jne 0x28
0x482b4a : fld dword ptr [ebp - 0x48]
0x482b4d : -fcomp qword ptr [0.003 (FLOAT)]
         : +fcomp dword ptr [0.003000000026077032 (FLOAT)]
0x482b53 : fnstsw ax
0x482b55 : test ah, 0x41
0x482b58 : jne 0x14
0x482b5e : lea eax, [ebp - 0x24] 	(car.c:3595)
0x482b61 : push eax
0x482b62 : mov eax, dword ptr [ebp + 8]
0x482b65 : push eax
0x482b66 : mov eax, dword ptr [ebp - 0x48]
0x482b69 : push eax
0x482b6a : call PipeSingleCarIncident (FUNCTION)
0x482b6f : add esp, 0xc
0x482b72 : cmp dword ptr [ebp + 0x14], 0 	(car.c:3597)
0x482b76 : jne 0x7f
0x482b7c : mov eax, dword ptr [ebp + 8]
0x482b7f : cmp dword ptr [eax + 8], 4
0x482b83 : jne 0x72
0x482b89 : fld dword ptr [ebp - 0x48]
0x482b8c : -fcomp qword ptr [0.003 (FLOAT)]
         : +fcomp dword ptr [0.003000000026077032 (FLOAT)]
         : +fnstsw ax
         : +test ah, 0x41
         : +jne 0x5e
         : +mov eax, dword ptr [ebp + 8] 	(car.c:3598)
         : +mov eax, dword ptr [eax + 0xc]
         : +add eax, 0x2c
         : +push eax
         : +lea eax, [ebp - 0x78]
         : +push eax
         : +call BrMatrix34Copy (FUNCTION)
         : +add esp, 8
         : +fld dword ptr [ebp - 0x54] 	(car.c:3599)
         : +fdiv dword ptr [6.900000095367432 (FLOAT)]
         : +fstp dword ptr [ebp - 0x54]
         : +fld dword ptr [ebp - 0x50] 	(car.c:3600)
         : +fdiv dword ptr [6.900000095367432 (FLOAT)]
         : +fstp dword ptr [ebp - 0x50]
         : +fld dword ptr [ebp - 0x4c] 	(car.c:3601)
         : +fdiv dword ptr [6.900000095367432 (FLOAT)]
         : +fstp dword ptr [ebp - 0x4c]
         : +lea eax, [ebp - 0x78] 	(car.c:3602)
         : +push eax
         : +lea eax, [ebp - 0x24]
         : +push eax
         : +lea eax, [ebp - 0x34]
         : +push eax
         : +call BrMatrix34ApplyP (FUNCTION)
         : +add esp, 0xc
         : +lea eax, [ebp - 0x34] 	(car.c:3603)
         : +push eax
         : +mov eax, dword ptr [ebp - 0x48]
         : +push eax
         : +call PipeSingleWallIncident (FUNCTION)
         : +add esp, 8
         : +cmp dword ptr [ebp + 0x14], 0 	(car.c:3606)
         : +je 0x35
         : +mov eax, dword ptr [ebp + 0x14]
         : +cmp dword ptr [eax + 8], 4
         : +jne 0x28
         : +fld dword ptr [ebp - 0x48]
         : +fcomp dword ptr [0.003000000026077032 (FLOAT)]
         : +fnstsw ax
         : +test ah, 0x41
         : +jne 0x14
         : +lea eax, [ebp - 0x24] 	(car.c:3607)
         : +push eax
         : +mov eax, dword ptr [ebp + 8]
         : +push eax
         : +mov eax, dword ptr [ebp - 0x48]
         : +push eax
         : +call PipeSingleCarIncident (FUNCTION)
         : +add esp, 0xc
         : +cmp dword ptr [ebp + 0x14], 0 	(car.c:3609)
         : +jne 0x7f
         : +mov eax, dword ptr [ebp + 8]
         : +cmp dword ptr [eax + 8], 4
         : +jne 0x72
         : +fld dword ptr [ebp - 0x48]
         : +fcomp dword ptr [0.003000000026077032 (FLOAT)]
0x482b92 : fnstsw ax
0x482b94 : test ah, 0x41
0x482b97 : jne 0x5e
0x482b9d : mov eax, dword ptr [ebp + 8] 	(car.c:3610)
0x482ba0 : mov eax, dword ptr [eax + 0xc]
0x482ba3 : add eax, 0x2c
0x482ba6 : push eax
0x482ba7 : lea eax, [ebp - 0x78]
0x482baa : push eax
0x482bab : call BrMatrix34Copy (FUNCTION)


CrushAndDamageCar is only 83.37% similar to the original, diff above
```

*AI generated. Time taken: 819s, tokens: 89,333*
