### PR TITLE
CrashNoise equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3495,12 +3495,14 @@ void CrashNoise(br_vector3* pForce, br_vector3* position, int material) {
         if (vol > 255) {
             vol = 255;
         }
-        if (crunch_tag == 0 || (!DRS3SoundStillPlaying(crunch_tag) && vol > 30)) {
-            last_crunch_vol = vol;
-            BrVector3Set(&velocity, 0.f, 0.f, 0.f);
-            crunch_tag = DRS3StartSound3D(gCar_outlet,
-                gMetal_crunch_sound_id__car[IRandomBetween(0, COUNT_OF(gMetal_crunch_sound_id__car) - 1)],
-                position, &velocity, 1, vol, IRandomBetween(49152, 81920), 0x10000);
+        if (crunch_tag == 0 || !DRS3SoundStillPlaying(crunch_tag)) {
+            if (vol > 30) {
+                last_crunch_vol = vol;
+                BrVector3Set(&velocity, 0.f, 0.f, 0.f);
+                crunch_tag = DRS3StartSound3D(gCar_outlet,
+                    gMetal_crunch_sound_id__car[IRandomBetween(0, COUNT_OF(gMetal_crunch_sound_id__car) - 1)],
+                    position, &velocity, 1, vol, IRandomBetween(49152, 81920), 0x10000);
+            }
         }
     }
 }

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3489,14 +3489,14 @@ void CrashNoise(br_vector3* pForce, br_vector3* position, int material) {
     tS3_volume vol;
     br_vector3 velocity;
 
-    vol = 60.f * BrVector3Length(pForce);
-    if (gCurrent_race.material_modifiers[material].crash_noise_index != -1) {
-        if (vol >= 256) {
+    vol = 60.0 * BrVector3Length(pForce);
+    if (gCurrent_race.material_modifiers[material].crash_noise_index == -1) {
+    } else {
+        if (vol > 255) {
             vol = 255;
         }
         if (crunch_tag == 0 || (!DRS3SoundStillPlaying(crunch_tag) && vol > 30)) {
             last_crunch_vol = vol;
-            (void)last_crunch_vol;
             BrVector3Set(&velocity, 0.f, 0.f, 0.f);
             crunch_tag = DRS3StartSound3D(gCar_outlet,
                 gMetal_crunch_sound_id__car[IRandomBetween(0, COUNT_OF(gMetal_crunch_sound_id__car) - 1)],


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x48249d,24 +0x4545e0,24 @@
0x48249d : push ebp 	(car.c:3484)
0x48249e : mov ebp, esp
0x4824a0 : sub esp, 0x10
0x4824a3 : push ebx
0x4824a4 : push esi
0x4824a5 : push edi
0x4824a6 : mov eax, dword ptr [ebp + 8] 	(car.c:3492)
         : +fld dword ptr [eax + 4]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 4]
         : +mov eax, dword ptr [ebp + 8]
0x4824a9 : fld dword ptr [eax + 8]
0x4824ac : mov eax, dword ptr [ebp + 8]
0x4824af : fmul dword ptr [eax + 8]
0x4824b2 : -mov eax, dword ptr [ebp + 8]
0x4824b5 : -fld dword ptr [eax + 4]
0x4824b8 : -mov eax, dword ptr [ebp + 8]
0x4824bb : -fmul dword ptr [eax + 4]
0x4824be : faddp st(1)
0x4824c0 : mov eax, dword ptr [ebp + 8]
0x4824c3 : fld dword ptr [eax]
0x4824c5 : mov eax, dword ptr [ebp + 8]
0x4824c8 : fmul dword ptr [eax]
0x4824ca : faddp st(1)
0x4824cc : call __CIsqrt (FUNCTION)
0x4824d1 : fmul qword ptr [60.0 (FLOAT)]
0x4824d7 : call __ftol (FUNCTION)
0x4824dc : mov dword ptr [ebp - 4], eax


CrashNoise is only 94.74% similar to the original, diff above
```

#### AI Analysis

Both versions compute the same expression: sqrt(x*x + y*y + z*z) * 60, then convert to integer via __ftol. The diff only changes the order of computing y^2 and z^2 before the first faddp; since both terms are squared then added, this is functionally the same aside from negligible FP edge behavior (e.g., NaN payload/sign-of-zero details), which you asked to ignore.

#### Original match

```
---
+++
@@ -0x48249d,44 +0x4545e0,43 @@
0x48249d : push ebp 	(car.c:3484)
0x48249e : mov ebp, esp
0x4824a0 : sub esp, 0x10
0x4824a3 : push ebx
0x4824a4 : push esi
0x4824a5 : push edi
0x4824a6 : mov eax, dword ptr [ebp + 8] 	(car.c:3492)
         : +fld dword ptr [eax + 4]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 4]
         : +mov eax, dword ptr [ebp + 8]
0x4824a9 : fld dword ptr [eax + 8]
0x4824ac : mov eax, dword ptr [ebp + 8]
0x4824af : fmul dword ptr [eax + 8]
0x4824b2 : -mov eax, dword ptr [ebp + 8]
0x4824b5 : -fld dword ptr [eax + 4]
0x4824b8 : -mov eax, dword ptr [ebp + 8]
0x4824bb : -fmul dword ptr [eax + 4]
0x4824be : faddp st(1)
0x4824c0 : mov eax, dword ptr [ebp + 8]
0x4824c3 : fld dword ptr [eax]
0x4824c5 : mov eax, dword ptr [ebp + 8]
0x4824c8 : fmul dword ptr [eax]
0x4824ca : faddp st(1)
0x4824cc : call __CIsqrt (FUNCTION)
0x4824d1 : -fmul qword ptr [60.0 (FLOAT)]
         : +fmul dword ptr [60.0 (FLOAT)]
0x4824d7 : call __ftol (FUNCTION)
0x4824dc : mov dword ptr [ebp - 4], eax
0x4824df : mov eax, dword ptr [ebp + 0x10] 	(car.c:3493)
0x4824e2 : lea eax, [eax + eax*4]
0x4824e5 : cmp dword ptr [eax*8 + gCurrent_race+4048 (OFFSET)], -1
0x4824ed : -jne 0x5
0x4824f3 : -jmp 0xab
0x4824f8 : -cmp dword ptr [ebp - 4], 0xff
0x4824ff : -jle 0x7
         : +je 0xab
         : +cmp dword ptr [ebp - 4], 0x100 	(car.c:3494)
         : +jl 0x7
0x482505 : mov dword ptr [ebp - 4], 0xff 	(car.c:3495)
0x48250c : cmp dword ptr [crunch_tag (DATA)], 0 	(car.c:3497)
0x482513 : -je 0x16
         : +je 0x20
0x482519 : mov eax, dword ptr [crunch_tag (DATA)]
0x48251e : push eax
0x48251f : call DRS3SoundStillPlaying (FUNCTION)
0x482524 : add esp, 4
0x482527 : test eax, eax
0x482529 : jne 0x74
0x48252f : cmp dword ptr [ebp - 4], 0x1e
0x482533 : jle 0x6a
0x482539 : mov eax, dword ptr [ebp - 4] 	(car.c:3498)
0x48253c : mov dword ptr [last_crunch_vol (DATA)], eax

---
+++
@@ -0x48257e,10 +0x4546bc,15 @@
0x48257e : push 0
0x482580 : call IRandomBetween (FUNCTION)
0x482585 : add esp, 8
0x482588 : mov eax, dword ptr [eax*4 + gMetal_crunch_sound_id__car[0] (DATA)]
0x48258f : push eax
0x482590 : mov eax, dword ptr [gCar_outlet (DATA)]
0x482595 : push eax
0x482596 : call DRS3StartSound3D (FUNCTION)
0x48259b : add esp, 0x20
0x48259e : mov dword ptr [crunch_tag (DATA)], eax
         : +pop edi 	(car.c:3506)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


CrashNoise is only 83.56% similar to the original, diff above
```

*AI generated. Time taken: 582s, tokens: 120,864*
