### PR TITLE
SkidNoise equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3428,11 +3428,11 @@ void SkidNoise(tCar_spec* pC, int pWheel_num, br_scalar pV, int material) {
 #ifdef DETHRACE_FIX_BUGS
     if (Harness_Hook_ScaleProbabilityWithDt(0, 4, gDt)) {
 #else
-    if (IRandomBetween(0, 4) == 0) {
+    if (!IRandomBetween(0, 4)) {
 #endif
 
         last_skid_vol[i] = pV * 10.0f;
-        if ((pWheel_num & 1) != 0) {
+        if (pWheel_num & 1) {
             pos.v[0] = pC->bounds[1].max.v[0];
         } else {
             pos.v[0] = pC->bounds[1].min.v[0];
@@ -3459,7 +3459,7 @@ void SkidNoise(tCar_spec* pC, int pWheel_num, br_scalar pV, int material) {
             BrVector3Add(&wv, &wv, &pC->velocity_car_space);
             ts = -(BrVector3Dot(&wv, &pC->road_normal));
             BrVector3Scale(&wvw, &pC->road_normal, ts);
-            BrVector3Add(&wv, &wv, &wvw);
+            BrVector3Accumulate(&wv, &wvw);
             BrMatrix34ApplyV(&wvw, &wv, &pC->car_master_actor->t.t.mat);
             CreatePuffOfSmoke(&world_pos, &wvw, pV / 25.0f, 1.0, 4, pC);
         }

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3417,6 +3417,7 @@ void SkidNoise(tCar_spec* pC, int pWheel_num, br_scalar pV, int material) {
     br_vector3 wv;
     br_vector3 wvw;
     br_scalar ts;
+    // GLOBAL: CARM95 0x00514E58
     static tS3_volume last_skid_vol[2];
     int i;
 
@@ -3425,45 +3426,43 @@ void SkidNoise(tCar_spec* pC, int pWheel_num, br_scalar pV, int material) {
         return;
     }
 #ifdef DETHRACE_FIX_BUGS
-    if (!Harness_Hook_ScaleProbabilityWithDt(0, 4, gDt)) {
-        return;
-    }
+    if (Harness_Hook_ScaleProbabilityWithDt(0, 4, gDt)) {
 #else
-    if (IRandomBetween(0, 4) != 0) {
-        return;
-    }
+    if (IRandomBetween(0, 4) == 0) {
 #endif
 
-    last_skid_vol[i] = pV * 10.0f;
-    if ((pWheel_num & 1) != 0) {
-        pos.v[0] = pC->bounds[1].max.v[0];
-    } else {
-        pos.v[0] = pC->bounds[1].min.v[0];
-    }
-    pos.v[1] = pC->wpos[pWheel_num].v[1] - pC->oldd[pWheel_num];
-    pos.v[2] = pC->wpos[pWheel_num].v[2];
-    BrMatrix34ApplyP(&world_pos, &pos, &pC->car_master_actor->t.t.mat);
-    BrVector3InvScale(&world_pos, &world_pos, WORLD_SCALE);
-    if (!DRS3SoundStillPlaying(gSkid_tag[i]) || (pC->driver == eDriver_local_human && gLast_car_to_skid[i] != pC)) {
-        gSkid_tag[i] = DRS3StartSound3D(
-            gCar_outlet,
-            IRandomBetween(0, 4) + 9000,
-            &world_pos,
-            &pC->velocity_bu_per_sec,
-            1,
-            last_skid_vol[i],
-            IRandomBetween(49152, 81920),
-            0x10000);
-        gLast_car_to_skid[i] = pC;
-    }
-    if (gCurrent_race.material_modifiers[material].smoke_type == 1) {
-        BrVector3Cross(&wv, &pC->omega, &pos);
-        BrVector3Add(&wv, &wv, &pC->velocity_car_space);
-        ts = -(BrVector3Dot(&wv, &pC->road_normal));
-        BrVector3Scale(&wvw, &pC->road_normal, ts);
-        BrVector3Add(&wv, &wv, &wvw);
-        BrMatrix34ApplyV(&wvw, &wv, &pC->car_master_actor->t.t.mat);
-        CreatePuffOfSmoke(&world_pos, &wvw, pV / 25.0f, 1.0, 4, pC);
+        last_skid_vol[i] = pV * 10.0f;
+        if ((pWheel_num & 1) != 0) {
+            pos.v[0] = pC->bounds[1].max.v[0];
+        } else {
+            pos.v[0] = pC->bounds[1].min.v[0];
+        }
+        pos.v[1] = pC->wpos[pWheel_num].v[1] - pC->oldd[pWheel_num];
+        pos.v[2] = pC->wpos[pWheel_num].v[2];
+        BrMatrix34ApplyP(&world_pos, &pos, &pC->car_master_actor->t.t.mat);
+        BrVector3InvScale(&world_pos, &world_pos, WORLD_SCALE);
+        if (!DRS3SoundStillPlaying(gSkid_tag[i]) || (pC->driver == eDriver_local_human && gLast_car_to_skid[i] != pC)) {
+            gSkid_tag[i] = DRS3StartSound3D(
+                gCar_outlet,
+                IRandomBetween(0, 4) + 9000,
+                &world_pos,
+                &pC->velocity_bu_per_sec,
+                1,
+                last_skid_vol[i],
+                IRandomBetween(49152, 81920),
+                0x10000);
+            gLast_car_to_skid[i] = pC;
+        }
+        if (gCurrent_race.material_modifiers[material].smoke_type != 1) {
+        } else {
+            BrVector3Cross(&wv, &pC->omega, &pos);
+            BrVector3Add(&wv, &wv, &pC->velocity_car_space);
+            ts = -(BrVector3Dot(&wv, &pC->road_normal));
+            BrVector3Scale(&wvw, &pC->road_normal, ts);
+            BrVector3Add(&wv, &wv, &wvw);
+            BrMatrix34ApplyV(&wvw, &wv, &pC->car_master_actor->t.t.mat);
+            CreatePuffOfSmoke(&world_pos, &wvw, pV / 25.0f, 1.0, 4, pC);
+        }
     }
 }
 


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4822fc,23 +0x4544c0,23 @@
0x4822fc : mov ecx, dword ptr [ebp - 0x10]
0x4822ff : mov dword ptr [ecx*4 + gLast_car_to_skid[0] (DATA)], eax
0x482306 : mov eax, dword ptr [ebp + 0x14] 	(car.c:3455)
0x482309 : lea eax, [eax + eax*4]
0x48230c : cmp dword ptr [eax*8 + gCurrent_race+4060 (OFFSET)], 1
0x482314 : je 0x5
0x48231a : jmp 0x134 	(car.c:3456)
0x48231f : mov eax, dword ptr [ebp + 8] 	(car.c:3457)
0x482322 : fld dword ptr [eax + 0xac]
0x482328 : fmul dword ptr [ebp - 0x30]
         : +fld dword ptr [ebp - 0x34]
0x48232b : mov eax, dword ptr [ebp + 8]
0x48232e : -fld dword ptr [eax + 0xb0]
0x482334 : -fmul dword ptr [ebp - 0x34]
         : +fmul dword ptr [eax + 0xb0]
0x482337 : fsubp st(1)
0x482339 : fstp dword ptr [ebp - 0x1c]
0x48233c : mov eax, dword ptr [ebp + 8]
0x48233f : fld dword ptr [eax + 0xb0]
0x482345 : fmul dword ptr [ebp - 0x38]
0x482348 : mov eax, dword ptr [ebp + 8]
0x48234b : fld dword ptr [eax + 0xa8]
0x482351 : fmul dword ptr [ebp - 0x30]
0x482354 : fsubp st(1)
0x482356 : fstp dword ptr [ebp - 0x18]

---
+++
@@ -0x48237f,29 +0x454543,29 @@
0x48237f : fstp dword ptr [ebp - 0x1c]
0x482382 : mov eax, dword ptr [ebp + 8]
0x482385 : fld dword ptr [eax + 0x34]
0x482388 : fadd dword ptr [ebp - 0x18]
0x48238b : fstp dword ptr [ebp - 0x18]
0x48238e : mov eax, dword ptr [ebp + 8]
0x482391 : fld dword ptr [eax + 0x38]
0x482394 : fadd dword ptr [ebp - 0x14]
0x482397 : fstp dword ptr [ebp - 0x14]
0x48239a : mov eax, dword ptr [ebp + 8] 	(car.c:3459)
         : +fld dword ptr [eax + 0x15d8]
         : +fmul dword ptr [ebp - 0x18]
         : +mov eax, dword ptr [ebp + 8]
0x48239d : fld dword ptr [eax + 0x15dc]
0x4823a3 : fmul dword ptr [ebp - 0x14]
         : +faddp st(1)
0x4823a6 : mov eax, dword ptr [ebp + 8]
0x4823a9 : fld dword ptr [eax + 0x15d4]
0x4823af : fmul dword ptr [ebp - 0x1c]
0x4823b2 : -faddp st(1)
0x4823b4 : -mov eax, dword ptr [ebp + 8]
0x4823b7 : -fld dword ptr [eax + 0x15d8]
0x4823bd : -fmul dword ptr [ebp - 0x18]
0x4823c0 : faddp st(1)
0x4823c2 : fchs 
0x4823c4 : fstp dword ptr [ebp - 0x20]
0x4823c7 : mov eax, dword ptr [ebp + 8] 	(car.c:3460)
0x4823ca : fld dword ptr [eax + 0x15d4]
0x4823d0 : fmul dword ptr [ebp - 0x20]
0x4823d3 : fstp dword ptr [ebp - 0xc]
0x4823d6 : mov eax, dword ptr [ebp + 8]
0x4823d9 : fld dword ptr [eax + 0x15d8]
0x4823df : fmul dword ptr [ebp - 0x20]

---
+++
@@ -0x4823e5,22 +0x4545a9,22 @@
0x4823e5 : mov eax, dword ptr [ebp + 8]
0x4823e8 : fld dword ptr [eax + 0x15dc]
0x4823ee : fmul dword ptr [ebp - 0x20]
0x4823f1 : fstp dword ptr [ebp - 4]
0x4823f4 : fld dword ptr [ebp - 0xc] 	(car.c:3461)
0x4823f7 : fadd dword ptr [ebp - 0x1c]
0x4823fa : fstp dword ptr [ebp - 0x1c]
0x4823fd : fld dword ptr [ebp - 8]
0x482400 : fadd dword ptr [ebp - 0x18]
0x482403 : fstp dword ptr [ebp - 0x18]
0x482406 : -fld dword ptr [ebp - 4]
0x482409 : -fadd dword ptr [ebp - 0x14]
         : +fld dword ptr [ebp - 0x14]
         : +fadd dword ptr [ebp - 4]
0x48240c : fstp dword ptr [ebp - 0x14]
0x48240f : mov eax, dword ptr [ebp + 8] 	(car.c:3462)
0x482412 : mov eax, dword ptr [eax + 0xc]
0x482415 : add eax, 0x2c
0x482418 : push eax
0x482419 : lea eax, [ebp - 0x1c]
0x48241c : push eax
0x48241d : lea eax, [ebp - 0xc]
0x482420 : push eax
0x482421 : call BrMatrix34ApplyV (FUNCTION)


SkidNoise is only 96.30% similar to the original, diff above
```

#### Effective match analysis

Yes. All shown changes preserve the same algebraic computations and stores, with only operand/order reshuffling on x87 stack ops. In the first hunk, `(0xAC * -0x30) - (0xB0 * -0x34)` is computed via a different load/mul sequence but same result. In the second hunk, the three-term sum using fields `0x15d4/0x15d8/0x15dc` and locals `-0x1c/-0x18/-0x14` is reordered before `fchs`, but remains the same expression. In the third hunk, `-0x14 = -0x14 + -4` is just commuted (`a+b` vs `b+a`). With NaNs and tiny FP-order effects explicitly ignored, this diff is functionally equivalent.

#### Original match

```
---
+++
@@ -0x482185,26 +0x4542c8,27 @@
0x482185 : mov eax, dword ptr [ebp + 0x14] 	(car.c:3424)
0x482188 : lea eax, [eax + eax*4]
0x48218b : cmp dword ptr [eax*8 + gCurrent_race+4044 (OFFSET)], -1
0x482193 : jne 0x5
0x482199 : jmp 0x2b5 	(car.c:3425)
0x48219e : push 4 	(car.c:3432)
0x4821a0 : push 0
0x4821a2 : call IRandomBetween (FUNCTION)
0x4821a7 : add esp, 8
0x4821aa : test eax, eax
0x4821ac : -jne 0x2a1
         : +je 0x5
         : +jmp 0x29c 	(car.c:3433)
0x4821b2 : fld dword ptr [ebp + 0x10] 	(car.c:3437)
0x4821b5 : fmul dword ptr [10.0 (FLOAT)]
0x4821bb : call __ftol (FUNCTION)
0x4821c0 : mov ecx, dword ptr [ebp - 0x10]
0x4821c3 : -mov dword ptr [ecx*4 + <OFFSET5>], eax
         : +mov dword ptr [ecx*4 + last_skid_vol (DATA)], eax
0x4821ca : test byte ptr [ebp + 0xc], 1 	(car.c:3438)
0x4821ce : je 0x11
0x4821d4 : mov eax, dword ptr [ebp + 8] 	(car.c:3439)
0x4821d7 : mov eax, dword ptr [eax + 0x108]
0x4821dd : mov dword ptr [ebp - 0x38], eax
0x4821e0 : jmp 0xc 	(car.c:3440)
0x4821e5 : mov eax, dword ptr [ebp + 8] 	(car.c:3441)
0x4821e8 : mov eax, dword ptr [eax + 0xfc]
0x4821ee : mov dword ptr [ebp - 0x38], eax
0x4821f1 : mov eax, dword ptr [ebp + 0xc] 	(car.c:3443)

---
+++
@@ -0x48228d,21 +0x4543d5,21 @@
0x48228d : mov ecx, dword ptr [ebp + 8]
0x482290 : cmp dword ptr [eax*4 + gLast_car_to_skid[0] (DATA)], ecx
0x482297 : je 0x69
0x48229d : push 0x10000 	(car.c:3456)
0x4822a2 : push 0x14000
0x4822a7 : push 0xc000
0x4822ac : call IRandomBetween (FUNCTION)
0x4822b1 : add esp, 8
0x4822b4 : push eax
0x4822b5 : mov eax, dword ptr [ebp - 0x10]
0x4822b8 : -mov eax, dword ptr [eax*4 + <OFFSET5>]
         : +mov eax, dword ptr [eax*4 + last_skid_vol (DATA)]
0x4822bf : push eax
0x4822c0 : push 1
0x4822c2 : mov eax, dword ptr [ebp + 8]
0x4822c5 : add eax, 0x1658
0x4822ca : push eax
0x4822cb : lea eax, [ebp - 0x2c]
0x4822ce : push eax
0x4822cf : push 4
0x4822d1 : push 0
0x4822d3 : call IRandomBetween (FUNCTION)

---
+++
@@ -0x4822e7,41 +0x45442f,40 @@
0x4822e7 : call DRS3StartSound3D (FUNCTION)
0x4822ec : add esp, 0x20
0x4822ef : mov ecx, dword ptr [ebp - 0x10]
0x4822f2 : mov dword ptr [ecx*4 + gSkid_tag[0] (DATA)], eax
0x4822f9 : mov eax, dword ptr [ebp + 8] 	(car.c:3457)
0x4822fc : mov ecx, dword ptr [ebp - 0x10]
0x4822ff : mov dword ptr [ecx*4 + gLast_car_to_skid[0] (DATA)], eax
0x482306 : mov eax, dword ptr [ebp + 0x14] 	(car.c:3459)
0x482309 : lea eax, [eax + eax*4]
0x48230c : cmp dword ptr [eax*8 + gCurrent_race+4060 (OFFSET)], 1
0x482314 : -je 0x5
0x48231a : -jmp 0x134
         : +jne 0x134
0x48231f : mov eax, dword ptr [ebp + 8] 	(car.c:3460)
0x482322 : fld dword ptr [eax + 0xac]
0x482328 : fmul dword ptr [ebp - 0x30]
0x48232b : mov eax, dword ptr [ebp + 8]
0x48232e : fld dword ptr [eax + 0xb0]
0x482334 : fmul dword ptr [ebp - 0x34]
0x482337 : fsubp st(1)
0x482339 : fstp dword ptr [ebp - 0x1c]
0x48233c : mov eax, dword ptr [ebp + 8]
0x48233f : fld dword ptr [eax + 0xb0]
0x482345 : fmul dword ptr [ebp - 0x38]
0x482348 : mov eax, dword ptr [ebp + 8]
0x48234b : fld dword ptr [eax + 0xa8]
0x482351 : fmul dword ptr [ebp - 0x30]
0x482354 : fsubp st(1)
0x482356 : fstp dword ptr [ebp - 0x18]
0x482359 : -fld dword ptr [ebp - 0x34]
0x48235c : mov eax, dword ptr [ebp + 8]
0x48235f : -fmul dword ptr [eax + 0xa8]
         : +fld dword ptr [eax + 0xa8]
         : +fmul dword ptr [ebp - 0x34]
0x482365 : mov eax, dword ptr [ebp + 8]
0x482368 : fld dword ptr [eax + 0xac]
0x48236e : fmul dword ptr [ebp - 0x38]
0x482371 : fsubp st(1)
0x482373 : fstp dword ptr [ebp - 0x14]
0x482376 : mov eax, dword ptr [ebp + 8] 	(car.c:3461)
0x482379 : fld dword ptr [eax + 0x30]
0x48237c : fadd dword ptr [ebp - 0x1c]
0x48237f : fstp dword ptr [ebp - 0x1c]
0x482382 : mov eax, dword ptr [ebp + 8]

---
+++
@@ -0x482388,26 +0x4544cb,26 @@
0x482388 : fadd dword ptr [ebp - 0x18]
0x48238b : fstp dword ptr [ebp - 0x18]
0x48238e : mov eax, dword ptr [ebp + 8]
0x482391 : fld dword ptr [eax + 0x38]
0x482394 : fadd dword ptr [ebp - 0x14]
0x482397 : fstp dword ptr [ebp - 0x14]
0x48239a : mov eax, dword ptr [ebp + 8] 	(car.c:3462)
0x48239d : fld dword ptr [eax + 0x15dc]
0x4823a3 : fmul dword ptr [ebp - 0x14]
0x4823a6 : mov eax, dword ptr [ebp + 8]
         : +fld dword ptr [eax + 0x15d8]
         : +fmul dword ptr [ebp - 0x18]
         : +faddp st(1)
         : +mov eax, dword ptr [ebp + 8]
0x4823a9 : fld dword ptr [eax + 0x15d4]
0x4823af : fmul dword ptr [ebp - 0x1c]
0x4823b2 : -faddp st(1)
0x4823b4 : -mov eax, dword ptr [ebp + 8]
0x4823b7 : -fld dword ptr [eax + 0x15d8]
0x4823bd : -fmul dword ptr [ebp - 0x18]
0x4823c0 : faddp st(1)
0x4823c2 : fchs 
0x4823c4 : fstp dword ptr [ebp - 0x20]
0x4823c7 : mov eax, dword ptr [ebp + 8] 	(car.c:3463)
0x4823ca : fld dword ptr [eax + 0x15d4]
0x4823d0 : fmul dword ptr [ebp - 0x20]
0x4823d3 : fstp dword ptr [ebp - 0xc]
0x4823d6 : mov eax, dword ptr [ebp + 8]
0x4823d9 : fld dword ptr [eax + 0x15d8]
0x4823df : fmul dword ptr [ebp - 0x20]


SkidNoise is only 94.91% similar to the original, diff above
```

*AI generated. Time taken: 271s*
