### PR TITLE
DoRevs equivalent match (review carefully)

### DIFF
--- a/reccmp/get_stack_slots.py
+++ b/reccmp/get_stack_slots.py
@@ -12,7 +12,7 @@ from typing import Optional
 
 def find_function_file(function_name: str, build_dir: Path) -> Optional[Path]:
     """Find which .asm file contains the given function."""
-    search_pattern = f"_{function_name} PROC"
+    search_pattern = f"_{function_name}.*PROC"
     asm_files = glob.glob(str(build_dir / "*.asm"))
 
     if not asm_files:
@@ -36,7 +36,7 @@ def find_function_file(function_name: str, build_dir: Path) -> Optional[Path]:
 
 def extract_stack_slots(asm_file: Path, function_name: str) -> list[str]:
     """Extract stack slot definitions for the given function."""
-    proc_pattern = f"_{function_name} PROC"
+    proc_pattern = f"_{function_name}"
     slot_pattern = re.compile(r'^(_[\w$]+) = (-?\d+)$')
 
     with open(asm_file, 'r') as f:

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -2811,8 +2811,7 @@ void DoRevs(tCar_spec* c, br_scalar dt) {
             wheel_spin_force = c->force_torque_ratio * c->torque;
         } else {
             if (c->gear < 2 && (c->keys.dec || c->joystick.dec > 0) && (ts < 0.0f ? -ts : ts) < 1.0f && c->revs > 1000.0f) {
-                revs_increase = c->gear;
-                c->gear = -(revs_increase + revs_increase - revs_increase);
+                c->gear *= -1;
             }
         }
         c->revs = wheel_spin_force / c->force_torque_ratio * dt / 0.0002 + c->revs;

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -2785,27 +2785,23 @@ void DoRevs(tCar_spec* c, br_scalar dt) {
 
     ts = -BrVector3Dot((br_vector3*)c->car_master_actor->t.t.mat.m[2], &c->v);
 
-    if (c->gear) {
-        c->target_revs = ts / c->speed_revs_ratio / (double)c->gear;
+    if (!c->gear) {
+        c->target_revs = 0.0f;
     } else {
-        c->target_revs = 0.0;
+        c->target_revs = ts / c->speed_revs_ratio / (double)c->gear;
     }
-    if (c->target_revs < 0.0) {
-        c->target_revs = 0.0;
+    if (c->target_revs < 0.0f) {
+        c->target_revs = 0.0f;
         c->gear = 0;
     }
     if (!c->number_of_wheels_on_ground || ((c->wheel_slip & 2) + 1) != 0 || !c->gear) {
-        if (c->number_of_wheels_on_ground) {
-            wheel_spin_force = c->force_torque_ratio * c->torque - (double)c->gear * c->acc_force;
-        } else {
+        if (!c->number_of_wheels_on_ground) {
             wheel_spin_force = c->force_torque_ratio * c->torque;
-        }
-        if (c->gear) {
-            if (c->gear < 2 && (c->keys.dec || c->joystick.dec > 0) && fabs(ts) < 1.0 && c->revs > 1000.0) {
-                c->gear = -c->gear;
-            }
         } else {
-            if (c->revs > 1000.0 && !c->keys.brake && (c->keys.acc || c->joystick.acc > 0) && !gCountdown) {
+            wheel_spin_force = c->force_torque_ratio * c->torque - (double)c->gear * c->acc_force;
+        }
+        if (!c->gear) {
+            if (c->revs > 1000.0f && !c->keys.brake && (c->keys.acc || c->joystick.acc > 0) && !gCountdown) {
                 if (c->keys.backwards) {
                     c->gear = -1;
                 } else {
@@ -2813,29 +2809,36 @@ void DoRevs(tCar_spec* c, br_scalar dt) {
                 }
             }
             wheel_spin_force = c->force_torque_ratio * c->torque;
+        } else {
+            if (c->gear < 2 && (c->keys.dec || c->joystick.dec > 0) && (ts < 0.0f ? -ts : ts) < 1.0f && c->revs > 1000.0f) {
+                revs_increase = c->gear;
+                c->gear = -(revs_increase + revs_increase - revs_increase);
+            }
         }
         c->revs = wheel_spin_force / c->force_torque_ratio * dt / 0.0002 + c->revs;
 
-        if (c->traction_control && wheel_spin_force > 0.0 && c->revs > c->target_revs && c->gear && c->target_revs > 1000.0) {
-            c->revs = c->target_revs;
+        if (c->traction_control && wheel_spin_force > 0.0f) {
+            if (c->revs > c->target_revs && c->gear && c->target_revs > 1000.0f) {
+                c->revs = c->target_revs;
+            }
         }
-        if (c->revs <= 0.0) {
-            c->revs = 0.0;
+        if (c->revs <= 0.0f) {
+            c->revs = 0.0f;
         }
     }
-    if ((c->wheel_slip & 2) == 0 && c->target_revs > 6000.0 && c->revs > 6000.0 && c->gear < c->max_gear && c->gear > 0 && !c->just_changed_gear) {
+    if ((c->wheel_slip & 2) == 0 && c->target_revs > 6000.0f && c->revs > 6000.0f && c->gear < c->max_gear && c->gear > 0 && !c->just_changed_gear) {
         c->gear++;
     }
-    if (c->gear > 1 && c->target_revs < 3000.0 && !c->just_changed_gear) {
+    if (c->gear > 1 && c->target_revs < 3000.0f && !c->just_changed_gear) {
         c->gear--;
     }
-    if (c->revs < 200.0 && c->target_revs < 200.0 && c->gear <= 1 && !c->keys.acc && c->joystick.acc <= 0 && !c->just_changed_gear) {
+    if (c->revs < 200.0f && c->target_revs < 200.0f && c->gear <= 1 && !c->keys.acc && c->joystick.acc <= 0 && !c->just_changed_gear) {
         c->gear = 0;
     }
-    if (c->just_changed_gear && c->revs < 6000.0 && c->revs > 200.0 && (c->gear < 2 || c->revs >= 3000.0)) {
+    if (c->just_changed_gear && c->revs < 6000.0f && c->revs > 200.0f && (c->gear < 2 || c->revs >= 3000.0f)) {
         c->just_changed_gear = 0;
     }
-    if (c->revs >= 6000.0 && (c->keys.acc || c->joystick.acc > 0)) {
+    if (c->revs >= 6000.0f && (c->keys.acc || c->joystick.acc > 0)) {
         c->just_changed_gear = 0;
     }
 }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x47ef8e,26 +0x450c9c,26 @@
0x47ef8e : push ebp 	(car.c:2781)
0x47ef8f : mov ebp, esp
0x47ef91 : sub esp, 0x14
0x47ef94 : push ebx
0x47ef95 : push esi
0x47ef96 : push edi
0x47ef97 : mov eax, dword ptr [ebp + 8] 	(car.c:2786)
0x47ef9a : mov eax, dword ptr [eax + 0xc]
         : +fld dword ptr [eax + 0x48]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 0x1c]
         : +mov eax, dword ptr [ebp + 8]
         : +mov eax, dword ptr [eax + 0xc]
0x47ef9d : fld dword ptr [eax + 0x4c]
0x47efa0 : mov eax, dword ptr [ebp + 8]
0x47efa3 : fmul dword ptr [eax + 0x20]
0x47efa6 : -mov eax, dword ptr [ebp + 8]
0x47efa9 : -mov eax, dword ptr [eax + 0xc]
0x47efac : -fld dword ptr [eax + 0x48]
0x47efaf : -mov eax, dword ptr [ebp + 8]
0x47efb2 : -fmul dword ptr [eax + 0x1c]
0x47efb5 : faddp st(1)
0x47efb7 : mov eax, dword ptr [ebp + 8]
0x47efba : mov eax, dword ptr [eax + 0xc]
0x47efbd : fld dword ptr [eax + 0x44]
0x47efc0 : mov eax, dword ptr [ebp + 8]
0x47efc3 : fmul dword ptr [eax + 0x18]
0x47efc6 : faddp st(1)
0x47efc8 : fchs 
0x47efca : fstp dword ptr [ebp - 8]
0x47efcd : mov eax, dword ptr [ebp + 8] 	(car.c:2788)

---
+++
@@ -0x47f230,26 +0x450f3e,26 @@
0x47f230 : fstp dword ptr [eax + 0x15cc]
0x47f236 : mov eax, dword ptr [ebp + 8] 	(car.c:2819)
0x47f239 : cmp dword ptr [eax + 0x1568], 0
0x47f240 : je 0x6d
0x47f246 : fld dword ptr [ebp - 0xc]
0x47f249 : fcomp dword ptr [0.0 (FLOAT)]
0x47f24f : fnstsw ax
0x47f251 : test ah, 0x41
0x47f254 : jne 0x59
0x47f25a : mov eax, dword ptr [ebp + 8] 	(car.c:2820)
0x47f25d : -fld dword ptr [eax + 0x15cc]
         : +fld dword ptr [eax + 0x15d0]
0x47f263 : mov eax, dword ptr [ebp + 8]
0x47f266 : -fcomp dword ptr [eax + 0x15d0]
         : +fcomp dword ptr [eax + 0x15cc]
0x47f26c : fnstsw ax
0x47f26e : -test ah, 0x41
0x47f271 : -jne 0x3c
         : +test ah, 1
         : +je 0x3c
0x47f277 : mov eax, dword ptr [ebp + 8]
0x47f27a : cmp dword ptr [eax + 0x15e8], 0
0x47f281 : je 0x2c
0x47f287 : mov eax, dword ptr [ebp + 8]
0x47f28a : fld dword ptr [eax + 0x15d0]
0x47f290 : fcomp dword ptr [1000.0 (FLOAT)]
0x47f296 : fnstsw ax
0x47f298 : test ah, 0x41
0x47f29b : jne 0x12
0x47f2a1 : mov eax, dword ptr [ebp + 8] 	(car.c:2821)


DoRevs is only 97.15% similar to the original, diff above
```

#### Effective match analysis

Yes. In the first hunk, the two multiplicative terms are computed in opposite order before `faddp`, but the resulting expression is the same (`(x48*1c) + (x4c*20)`), with only harmless reordering. In the second hunk, the compare operands are swapped and the condition test changes from `test ah,0x41`/`jne` to `test ah,1`/`je`, but together they implement the same strict ordering check for normal numbers (`[15cc] > [15d0]`). Equality still takes the same path. The only behavioral difference is unordered/NaN handling, which you asked to ignore.

#### Original match

```
---
+++
@@ -0x47ef8e,99 +0x450c9c,128 @@
0x47ef8e : push ebp 	(car.c:2781)
0x47ef8f : mov ebp, esp
0x47ef91 : sub esp, 0x14
0x47ef94 : push ebx
0x47ef95 : push esi
0x47ef96 : push edi
0x47ef97 : mov eax, dword ptr [ebp + 8] 	(car.c:2786)
0x47ef9a : mov eax, dword ptr [eax + 0xc]
         : +fld dword ptr [eax + 0x48]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 0x1c]
         : +mov eax, dword ptr [ebp + 8]
         : +mov eax, dword ptr [eax + 0xc]
0x47ef9d : fld dword ptr [eax + 0x4c]
0x47efa0 : mov eax, dword ptr [ebp + 8]
0x47efa3 : fmul dword ptr [eax + 0x20]
0x47efa6 : -mov eax, dword ptr [ebp + 8]
0x47efa9 : -mov eax, dword ptr [eax + 0xc]
0x47efac : -fld dword ptr [eax + 0x48]
0x47efaf : -mov eax, dword ptr [ebp + 8]
0x47efb2 : -fmul dword ptr [eax + 0x1c]
0x47efb5 : faddp st(1)
0x47efb7 : mov eax, dword ptr [ebp + 8]
0x47efba : mov eax, dword ptr [eax + 0xc]
0x47efbd : fld dword ptr [eax + 0x44]
0x47efc0 : mov eax, dword ptr [ebp + 8]
0x47efc3 : fmul dword ptr [eax + 0x18]
0x47efc6 : faddp st(1)
0x47efc8 : fchs 
0x47efca : fstp dword ptr [ebp - 8]
0x47efcd : mov eax, dword ptr [ebp + 8] 	(car.c:2788)
0x47efd0 : cmp dword ptr [eax + 0x15e8], 0
0x47efd7 : -jne 0x12
0x47efdd : -mov eax, dword ptr [ebp + 8]
0x47efe0 : -mov dword ptr [eax + 0x15d0], 0
0x47efea : -jmp 0x26
         : +je 0x2b
0x47efef : fld dword ptr [ebp - 8] 	(car.c:2789)
0x47eff2 : mov eax, dword ptr [ebp + 8]
0x47eff5 : fdiv dword ptr [eax + 0x15f4]
0x47effb : mov eax, dword ptr [ebp + 8]
0x47effe : mov eax, dword ptr [eax + 0x15e8]
0x47f004 : mov dword ptr [ebp - 0x10], eax
0x47f007 : fild dword ptr [ebp - 0x10]
0x47f00a : fdivp st(1)
0x47f00c : mov eax, dword ptr [ebp + 8]
0x47f00f : fstp dword ptr [eax + 0x15d0]
         : +jmp 0xd 	(car.c:2790)
         : +mov eax, dword ptr [ebp + 8] 	(car.c:2791)
         : +mov dword ptr [eax + 0x15d0], 0
0x47f015 : mov eax, dword ptr [ebp + 8] 	(car.c:2793)
0x47f018 : fld dword ptr [eax + 0x15d0]
0x47f01e : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x47f024 : fnstsw ax
0x47f026 : test ah, 1
0x47f029 : je 0x1a
0x47f02f : mov eax, dword ptr [ebp + 8] 	(car.c:2794)
0x47f032 : mov dword ptr [eax + 0x15d0], 0
0x47f03c : mov eax, dword ptr [ebp + 8] 	(car.c:2795)
0x47f03f : mov dword ptr [eax + 0x15e8], 0
0x47f049 : mov eax, dword ptr [ebp + 8] 	(car.c:2797)
0x47f04c : cmp dword ptr [eax + 0x158c], 0
0x47f053 : je 0x23
0x47f059 : mov eax, dword ptr [ebp + 8]
0x47f05c : mov eax, dword ptr [eax + 0x14a0]
0x47f062 : and eax, 2
0x47f065 : inc eax
0x47f066 : jne 0x10
0x47f06c : mov eax, dword ptr [ebp + 8]
0x47f06f : cmp dword ptr [eax + 0x15e8], 0
0x47f076 : -jne 0x25e
         : +jne 0x258
0x47f07c : mov eax, dword ptr [ebp + 8] 	(car.c:2798)
0x47f07f : cmp dword ptr [eax + 0x158c], 0
0x47f086 : -jne 0x1a
0x47f08c : -mov eax, dword ptr [ebp + 8]
0x47f08f : -fld dword ptr [eax + 0x15f8]
0x47f095 : -mov eax, dword ptr [ebp + 8]
0x47f098 : -fmul dword ptr [eax + 0x1560]
0x47f09e : -fstp dword ptr [ebp - 0xc]
0x47f0a1 : -jmp 0x2f
         : +je 0x34
0x47f0a6 : mov eax, dword ptr [ebp + 8] 	(car.c:2799)
0x47f0a9 : fld dword ptr [eax + 0x15f8]
0x47f0af : mov eax, dword ptr [ebp + 8]
0x47f0b2 : fmul dword ptr [eax + 0x1560]
0x47f0b8 : mov eax, dword ptr [ebp + 8]
0x47f0bb : mov eax, dword ptr [eax + 0x15e8]
0x47f0c1 : mov dword ptr [ebp - 0x14], eax
0x47f0c4 : fild dword ptr [ebp - 0x14]
0x47f0c7 : mov eax, dword ptr [ebp + 8]
0x47f0ca : fmul dword ptr [eax + 0x155c]
0x47f0d0 : fsubp st(1)
0x47f0d2 : fstp dword ptr [ebp - 0xc]
         : +jmp 0x15 	(car.c:2800)
         : +mov eax, dword ptr [ebp + 8] 	(car.c:2801)
         : +fld dword ptr [eax + 0x15f8]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 0x1560]
         : +fstp dword ptr [ebp - 0xc]
0x47f0d5 : mov eax, dword ptr [ebp + 8] 	(car.c:2803)
0x47f0d8 : cmp dword ptr [eax + 0x15e8], 0
0x47f0df : -jne 0xac
         : +je 0x7d
         : +mov eax, dword ptr [ebp + 8] 	(car.c:2804)
         : +cmp dword ptr [eax + 0x15e8], 2
         : +jge 0x68
         : +mov eax, dword ptr [ebp + 8]
         : +mov eax, dword ptr [eax + 0x1574]
         : +shr eax, 0x13
         : +test al, 1
         : +jne 0x10
         : +mov eax, dword ptr [ebp + 8]
         : +cmp dword ptr [eax + 0x1584], 0
         : +jle 0x44
         : +fld dword ptr [ebp - 8]
         : +fabs 
         : +fcomp qword ptr [1.0 (FLOAT)]
         : +fnstsw ax
         : +test ah, 1
         : +je 0x2e
0x47f0e5 : mov eax, dword ptr [ebp + 8]
0x47f0e8 : fld dword ptr [eax + 0x15cc]
0x47f0ee : -fcomp dword ptr [1000.0 (FLOAT)]
         : +fcomp qword ptr [1000.0 (FLOAT)]
         : +fnstsw ax
         : +test ah, 0x41
         : +jne 0x14
         : +mov eax, dword ptr [ebp + 8] 	(car.c:2805)
         : +mov eax, dword ptr [eax + 0x15e8]
         : +neg eax
         : +mov ecx, dword ptr [ebp + 8]
         : +mov dword ptr [ecx + 0x15e8], eax
         : +jmp 0xa7 	(car.c:2807)
         : +mov eax, dword ptr [ebp + 8] 	(car.c:2808)
         : +fld dword ptr [eax + 0x15cc]
         : +fcomp qword ptr [1000.0 (FLOAT)]
0x47f0f4 : fnstsw ax
0x47f0f6 : test ah, 0x41
0x47f0f9 : jne 0x78
0x47f0ff : mov eax, dword ptr [ebp + 8]
0x47f102 : mov eax, dword ptr [eax + 0x1574]
0x47f108 : shr eax, 0x14
0x47f10b : test al, 1
0x47f10d : jne 0x64
0x47f113 : mov eax, dword ptr [ebp + 8]
0x47f116 : mov eax, dword ptr [eax + 0x1574]

---
+++
@@ -0x47f158,109 +0x450ee3,77 @@
0x47f158 : mov eax, dword ptr [ebp + 8] 	(car.c:2810)
0x47f15b : mov dword ptr [eax + 0x15e8], 0xffffffff
0x47f165 : jmp 0xd 	(car.c:2811)
0x47f16a : mov eax, dword ptr [ebp + 8] 	(car.c:2812)
0x47f16d : mov dword ptr [eax + 0x15e8], 1
0x47f177 : mov eax, dword ptr [ebp + 8] 	(car.c:2815)
0x47f17a : fld dword ptr [eax + 0x15f8]
0x47f180 : mov eax, dword ptr [ebp + 8]
0x47f183 : fmul dword ptr [eax + 0x1560]
0x47f189 : fstp dword ptr [ebp - 0xc]
0x47f18c : -jmp 0x7e
0x47f191 : -mov eax, dword ptr [ebp + 8]
0x47f194 : -cmp dword ptr [eax + 0x15e8], 2
0x47f19b : -jge 0x6e
0x47f1a1 : -mov eax, dword ptr [ebp + 8]
0x47f1a4 : -mov eax, dword ptr [eax + 0x1574]
0x47f1aa : -shr eax, 0x13
0x47f1ad : -test al, 1
0x47f1af : -jne 0x10
0x47f1b5 : -mov eax, dword ptr [ebp + 8]
0x47f1b8 : -cmp dword ptr [eax + 0x1584], 0
0x47f1bf : -jle 0x4a
0x47f1c5 : -fld dword ptr [ebp - 8]
0x47f1c8 : -fabs 
0x47f1ca : -fcomp dword ptr [1.0 (FLOAT)]
0x47f1d0 : -fnstsw ax
0x47f1d2 : -test ah, 1
0x47f1d5 : -je 0x34
0x47f1db : -mov eax, dword ptr [ebp + 8]
0x47f1de : -fld dword ptr [eax + 0x15cc]
0x47f1e4 : -fcomp dword ptr [1000.0 (FLOAT)]
0x47f1ea : -fnstsw ax
0x47f1ec : -test ah, 0x41
0x47f1ef : -jne 0x1a
0x47f1f5 : -mov eax, dword ptr [ebp + 8]
0x47f1f8 : -mov eax, dword ptr [eax + 0x15e8]
0x47f1fe : -mov ecx, eax
0x47f200 : -add eax, eax
0x47f202 : -sub eax, ecx
0x47f204 : -neg eax
0x47f206 : -mov ecx, dword ptr [ebp + 8]
0x47f209 : -mov dword ptr [ecx + 0x15e8], eax
0x47f20f : fld dword ptr [ebp - 0xc] 	(car.c:2817)
0x47f212 : mov eax, dword ptr [ebp + 8]
0x47f215 : fdiv dword ptr [eax + 0x15f8]
0x47f21b : fmul dword ptr [ebp + 0xc]
0x47f21e : fdiv qword ptr [0.0002 (FLOAT)]
0x47f224 : mov eax, dword ptr [ebp + 8]
0x47f227 : fadd dword ptr [eax + 0x15cc]
0x47f22d : mov eax, dword ptr [ebp + 8]
0x47f230 : fstp dword ptr [eax + 0x15cc]
0x47f236 : mov eax, dword ptr [ebp + 8] 	(car.c:2819)
0x47f239 : cmp dword ptr [eax + 0x1568], 0
0x47f240 : je 0x6d
0x47f246 : fld dword ptr [ebp - 0xc]
0x47f249 : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x47f24f : fnstsw ax
0x47f251 : test ah, 0x41
0x47f254 : jne 0x59
0x47f25a : mov eax, dword ptr [ebp + 8]
0x47f25d : -fld dword ptr [eax + 0x15cc]
         : +fld dword ptr [eax + 0x15d0]
0x47f263 : mov eax, dword ptr [ebp + 8]
0x47f266 : -fcomp dword ptr [eax + 0x15d0]
         : +fcomp dword ptr [eax + 0x15cc]
0x47f26c : fnstsw ax
0x47f26e : -test ah, 0x41
0x47f271 : -jne 0x3c
         : +test ah, 1
         : +je 0x3c
0x47f277 : mov eax, dword ptr [ebp + 8]
0x47f27a : cmp dword ptr [eax + 0x15e8], 0
0x47f281 : je 0x2c
0x47f287 : mov eax, dword ptr [ebp + 8]
0x47f28a : fld dword ptr [eax + 0x15d0]
0x47f290 : -fcomp dword ptr [1000.0 (FLOAT)]
         : +fcomp qword ptr [1000.0 (FLOAT)]
0x47f296 : fnstsw ax
0x47f298 : test ah, 0x41
0x47f29b : jne 0x12
0x47f2a1 : mov eax, dword ptr [ebp + 8] 	(car.c:2820)
0x47f2a4 : mov ecx, dword ptr [ebp + 8]
0x47f2a7 : mov eax, dword ptr [eax + 0x15d0]
0x47f2ad : mov dword ptr [ecx + 0x15cc], eax
0x47f2b3 : mov eax, dword ptr [ebp + 8] 	(car.c:2822)
0x47f2b6 : fld dword ptr [eax + 0x15cc]
0x47f2bc : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x47f2c2 : fnstsw ax
0x47f2c4 : test ah, 0x41
0x47f2c7 : je 0xd
0x47f2cd : mov eax, dword ptr [ebp + 8] 	(car.c:2823)
0x47f2d0 : mov dword ptr [eax + 0x15cc], 0
0x47f2da : mov eax, dword ptr [ebp + 8] 	(car.c:2826)
0x47f2dd : test byte ptr [eax + 0x14a0], 2
0x47f2e4 : jne 0x75
0x47f2ea : mov eax, dword ptr [ebp + 8]
0x47f2ed : fld dword ptr [eax + 0x15d0]
0x47f2f3 : -fcomp dword ptr [6000.0 (FLOAT)]
         : +fcomp qword ptr [6000.0 (FLOAT)]
0x47f2f9 : fnstsw ax
0x47f2fb : test ah, 0x41
0x47f2fe : jne 0x5b
0x47f304 : mov eax, dword ptr [ebp + 8]
0x47f307 : fld dword ptr [eax + 0x15cc]
0x47f30d : -fcomp dword ptr [6000.0 (FLOAT)]
         : +fcomp qword ptr [6000.0 (FLOAT)]
0x47f313 : fnstsw ax
0x47f315 : test ah, 0x41
0x47f318 : jne 0x41
0x47f31e : mov eax, dword ptr [ebp + 8]
0x47f321 : mov ecx, dword ptr [ebp + 8]
0x47f324 : mov ecx, dword ptr [ecx + 0x15f0]
0x47f32a : cmp dword ptr [eax + 0x15e8], ecx
0x47f330 : jge 0x29
0x47f336 : mov eax, dword ptr [ebp + 8]
0x47f339 : cmp dword ptr [eax + 0x15e8], 0

---
+++
@@ -0x47f346,38 +0x45104e,38 @@
0x47f346 : mov eax, dword ptr [ebp + 8]
0x47f349 : cmp dword ptr [eax + 0x15ec], 0
0x47f350 : jne 0x9
0x47f356 : mov eax, dword ptr [ebp + 8] 	(car.c:2827)
0x47f359 : inc dword ptr [eax + 0x15e8]
0x47f35f : mov eax, dword ptr [ebp + 8] 	(car.c:2829)
0x47f362 : cmp dword ptr [eax + 0x15e8], 1
0x47f369 : jle 0x33
0x47f36f : mov eax, dword ptr [ebp + 8]
0x47f372 : fld dword ptr [eax + 0x15d0]
0x47f378 : -fcomp dword ptr [3000.0 (FLOAT)]
         : +fcomp qword ptr [3000.0 (FLOAT)]
0x47f37e : fnstsw ax
0x47f380 : test ah, 1
0x47f383 : je 0x19
0x47f389 : mov eax, dword ptr [ebp + 8]
0x47f38c : cmp dword ptr [eax + 0x15ec], 0
0x47f393 : jne 0x9
0x47f399 : mov eax, dword ptr [ebp + 8] 	(car.c:2830)
0x47f39c : dec dword ptr [eax + 0x15e8]
0x47f3a2 : mov eax, dword ptr [ebp + 8] 	(car.c:2832)
0x47f3a5 : fld dword ptr [eax + 0x15cc]
0x47f3ab : -fcomp dword ptr [200.0 (FLOAT)]
         : +fcomp qword ptr [200.0 (FLOAT)]
0x47f3b1 : fnstsw ax
0x47f3b3 : test ah, 1
0x47f3b6 : je 0x6b
0x47f3bc : mov eax, dword ptr [ebp + 8]
0x47f3bf : fld dword ptr [eax + 0x15d0]
0x47f3c5 : -fcomp dword ptr [200.0 (FLOAT)]
         : +fcomp qword ptr [200.0 (FLOAT)]
0x47f3cb : fnstsw ax
0x47f3cd : test ah, 1
0x47f3d0 : je 0x51
0x47f3d6 : mov eax, dword ptr [ebp + 8]
0x47f3d9 : cmp dword ptr [eax + 0x15e8], 1
0x47f3e0 : jg 0x41
0x47f3e6 : mov eax, dword ptr [ebp + 8]
0x47f3e9 : mov eax, dword ptr [eax + 0x1574]
0x47f3ef : shr eax, 0x12
0x47f3f2 : test al, 1

---
+++
@@ -0x47f40a,46 +0x451112,52 @@
0x47f40a : mov eax, dword ptr [ebp + 8]
0x47f40d : cmp dword ptr [eax + 0x15ec], 0
0x47f414 : jne 0xd
0x47f41a : mov eax, dword ptr [ebp + 8] 	(car.c:2833)
0x47f41d : mov dword ptr [eax + 0x15e8], 0
0x47f427 : mov eax, dword ptr [ebp + 8] 	(car.c:2835)
0x47f42a : cmp dword ptr [eax + 0x15ec], 0
0x47f431 : je 0x6b
0x47f437 : mov eax, dword ptr [ebp + 8]
0x47f43a : fld dword ptr [eax + 0x15cc]
0x47f440 : -fcomp dword ptr [6000.0 (FLOAT)]
         : +fcomp qword ptr [6000.0 (FLOAT)]
0x47f446 : fnstsw ax
0x47f448 : test ah, 1
0x47f44b : je 0x51
0x47f451 : mov eax, dword ptr [ebp + 8]
0x47f454 : fld dword ptr [eax + 0x15cc]
0x47f45a : -fcomp dword ptr [200.0 (FLOAT)]
         : +fcomp qword ptr [200.0 (FLOAT)]
0x47f460 : fnstsw ax
0x47f462 : test ah, 0x41
0x47f465 : jne 0x37
0x47f46b : mov eax, dword ptr [ebp + 8]
0x47f46e : cmp dword ptr [eax + 0x15e8], 2
0x47f475 : jl 0x1a
0x47f47b : mov eax, dword ptr [ebp + 8]
0x47f47e : fld dword ptr [eax + 0x15cc]
0x47f484 : -fcomp dword ptr [3000.0 (FLOAT)]
         : +fcomp qword ptr [3000.0 (FLOAT)]
0x47f48a : fnstsw ax
0x47f48c : test ah, 1
0x47f48f : jne 0xd
0x47f495 : mov eax, dword ptr [ebp + 8] 	(car.c:2836)
0x47f498 : mov dword ptr [eax + 0x15ec], 0
0x47f4a2 : mov eax, dword ptr [ebp + 8] 	(car.c:2838)
0x47f4a5 : fld dword ptr [eax + 0x15cc]
0x47f4ab : -fcomp dword ptr [6000.0 (FLOAT)]
         : +fcomp qword ptr [6000.0 (FLOAT)]
0x47f4b1 : fnstsw ax
0x47f4b3 : test ah, 1
0x47f4b6 : jne 0x31
0x47f4bc : mov eax, dword ptr [ebp + 8]
0x47f4bf : mov eax, dword ptr [eax + 0x1574]
0x47f4c5 : shr eax, 0x12
0x47f4c8 : test al, 1
0x47f4ca : jne 0x10
0x47f4d0 : mov eax, dword ptr [ebp + 8]
0x47f4d3 : cmp dword ptr [eax + 0x1580], 0
0x47f4da : jle 0xd
0x47f4e0 : mov eax, dword ptr [ebp + 8] 	(car.c:2839)
         : +mov dword ptr [eax + 0x15ec], 0
         : +pop edi 	(car.c:2841)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DoRevs is only 77.69% similar to the original, diff above
```

*AI generated. Time taken: 1358s, tokens: 146,702*
