### PR TITLE
CrashCarsTogether 100% effective match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -6127,20 +6127,20 @@ void CrashCarsTogether(br_scalar dt) {
     int i;
     tCollison_data collide_list[32];
 
-    for (i = 0; i < gNum_cars_and_non_cars; i++) {
+    pass = 0;
+    k = 0;
+    for (i = 0; !(i >= gNum_cars_and_non_cars); i++) {
         collide_list[i].car = NULL;
         collide_list[i].ref = gNum_cars_and_non_cars - 1;
         gActive_car_list[i]->infinite_mass = 0;
     }
-    for (pass = 0; pass < 5; pass++) {
+    do {
         k = CrashCarsTogetherSinglePass(dt, pass, collide_list);
-        if (k <= 0) {
-            break;
-        }
-    }
+        pass++;
+    } while (pass < 5 && k > 0);
     if (k > 0) {
-        for (i = 0; i < gNum_cars_and_non_cars; i++) {
-            BringCarToAGrindingHalt((tCollision_info*)gActive_car_list[i]);
+        for (pass = 0; pass < gNum_cars_and_non_cars; pass++) {
+            BringCarToAGrindingHalt((tCollision_info*)gActive_car_list[pass]);
         }
     }
 }

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -6129,7 +6129,7 @@ void CrashCarsTogether(br_scalar dt) {
 
     pass = 0;
     k = 0;
-    for (i = 0; !(i >= gNum_cars_and_non_cars); i++) {
+    for (i = 0; i < gNum_cars_and_non_cars; i++) {
         collide_list[i].car = NULL;
         collide_list[i].ref = gNum_cars_and_non_cars - 1;
         gActive_car_list[i]->infinite_mass = 0;


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x48c796,33 +0x45e1a5,33 @@
0x48c796 : mov ebp, esp
0x48c798 : sub esp, 0x10c
0x48c79e : push ebx
0x48c79f : push esi
0x48c7a0 : push edi
0x48c7a1 : mov dword ptr [ebp - 0x108], 0 	(car.c:6130)
0x48c7ab : mov dword ptr [ebp - 0x10c], 0 	(car.c:6131)
0x48c7b5 : mov dword ptr [ebp - 0x104], 0 	(car.c:6132)
0x48c7bf : jmp 0x6
0x48c7c4 : inc dword ptr [ebp - 0x104]
0x48c7ca : -mov eax, dword ptr [gNum_cars_and_non_cars (DATA)]
0x48c7cf : -cmp dword ptr [ebp - 0x104], eax
0x48c7d5 : -jge 0x40
         : +mov eax, dword ptr [ebp - 0x104]
         : +cmp dword ptr [gNum_cars_and_non_cars (DATA)], eax
         : +jle 0x40
0x48c7db : mov eax, dword ptr [ebp - 0x104] 	(car.c:6133)
0x48c7e1 : mov dword ptr [ebp + eax*8 - 0xfc], 0
0x48c7ec : mov eax, dword ptr [gNum_cars_and_non_cars (DATA)] 	(car.c:6134)
0x48c7f1 : dec eax
0x48c7f2 : mov ecx, dword ptr [ebp - 0x104]
0x48c7f8 : mov dword ptr [ebp + ecx*8 - 0x100], eax
0x48c7ff : mov eax, dword ptr [ebp - 0x104] 	(car.c:6135)
0x48c805 : mov eax, dword ptr [eax*4 + gActive_car_list[0] (DATA)]
0x48c80c : mov dword ptr [eax + 0xc4], 0
0x48c816 : -jmp -0x57
         : +jmp -0x58 	(car.c:6136)
0x48c81b : lea eax, [ebp - 0x100] 	(car.c:6138)
0x48c821 : push eax
0x48c822 : mov eax, dword ptr [ebp - 0x108]
0x48c828 : push eax
0x48c829 : mov eax, dword ptr [ebp + 8]
0x48c82c : push eax
0x48c82d : call CrashCarsTogetherSinglePass (FUNCTION)
0x48c832 : add esp, 0xc
0x48c835 : mov dword ptr [ebp - 0x10c], eax
0x48c83b : inc dword ptr [ebp - 0x108] 	(car.c:6139)


0x48c795: CrashCarsTogether 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x48c795,57 +0x45e1a4,59 @@
0x48c795 : push ebp 	(car.c:6124)
0x48c796 : mov ebp, esp
0x48c798 : sub esp, 0x10c
0x48c79e : push ebx
0x48c79f : push esi
0x48c7a0 : push edi
0x48c7a1 : -mov dword ptr [ebp - 0x108], 0
0x48c7ab : -mov dword ptr [ebp - 0x10c], 0
0x48c7b5 : mov dword ptr [ebp - 0x104], 0 	(car.c:6130)
0x48c7bf : jmp 0x6
0x48c7c4 : inc dword ptr [ebp - 0x104]
0x48c7ca : -mov eax, dword ptr [gNum_cars_and_non_cars (DATA)]
0x48c7cf : -cmp dword ptr [ebp - 0x104], eax
0x48c7d5 : -jge 0x40
         : +mov eax, dword ptr [ebp - 0x104]
         : +cmp dword ptr [gNum_cars_and_non_cars (DATA)], eax
         : +jle 0x40
0x48c7db : mov eax, dword ptr [ebp - 0x104] 	(car.c:6131)
0x48c7e1 : mov dword ptr [ebp + eax*8 - 0xfc], 0
0x48c7ec : mov eax, dword ptr [gNum_cars_and_non_cars (DATA)] 	(car.c:6132)
0x48c7f1 : dec eax
0x48c7f2 : mov ecx, dword ptr [ebp - 0x104]
0x48c7f8 : mov dword ptr [ebp + ecx*8 - 0x100], eax
0x48c7ff : mov eax, dword ptr [ebp - 0x104] 	(car.c:6133)
0x48c805 : mov eax, dword ptr [eax*4 + gActive_car_list[0] (DATA)]
0x48c80c : mov dword ptr [eax + 0xc4], 0
0x48c816 : -jmp -0x57
         : +jmp -0x58 	(car.c:6134)
         : +mov dword ptr [ebp - 0x108], 0 	(car.c:6135)
         : +jmp 0x6
         : +inc dword ptr [ebp - 0x108]
         : +cmp dword ptr [ebp - 0x108], 5
         : +jge 0x37
0x48c81b : lea eax, [ebp - 0x100] 	(car.c:6136)
0x48c821 : push eax
0x48c822 : mov eax, dword ptr [ebp - 0x108]
0x48c828 : push eax
0x48c829 : mov eax, dword ptr [ebp + 8]
0x48c82c : push eax
0x48c82d : call CrashCarsTogetherSinglePass (FUNCTION)
0x48c832 : add esp, 0xc
0x48c835 : mov dword ptr [ebp - 0x10c], eax
0x48c83b : -inc dword ptr [ebp - 0x108]
0x48c841 : -cmp dword ptr [ebp - 0x108], 5
0x48c848 : -jge 0xd
0x48c84e : cmp dword ptr [ebp - 0x10c], 0 	(car.c:6137)
0x48c855 : -jg -0x40
         : +jg 0x5
         : +jmp 0x5 	(car.c:6138)
         : +jmp -0x4a 	(car.c:6140)
0x48c85b : cmp dword ptr [ebp - 0x10c], 0 	(car.c:6141)
0x48c862 : jle 0x42
0x48c868 : -mov dword ptr [ebp - 0x108], 0
         : +mov dword ptr [ebp - 0x104], 0 	(car.c:6142)
0x48c872 : jmp 0x6
0x48c877 : -inc dword ptr [ebp - 0x108]
0x48c87d : -mov eax, dword ptr [ebp - 0x108]
         : +inc dword ptr [ebp - 0x104]
         : +mov eax, dword ptr [ebp - 0x104]
0x48c883 : cmp dword ptr [gNum_cars_and_non_cars (DATA)], eax
0x48c889 : jle 0x1b
0x48c88f : -mov eax, dword ptr [ebp - 0x108]
         : +mov eax, dword ptr [ebp - 0x104] 	(car.c:6143)
0x48c895 : mov eax, dword ptr [eax*4 + gActive_car_list[0] (DATA)]
0x48c89c : push eax
0x48c89d : call BringCarToAGrindingHalt (FUNCTION)
0x48c8a2 : add esp, 4
0x48c8a5 : jmp -0x33 	(car.c:6144)
0x48c8aa : pop edi 	(car.c:6146)
0x48c8ab : pop esi
0x48c8ac : pop ebx
0x48c8ad : leave 
0x48c8ae : ret 


CrashCarsTogether is only 74.14% similar to the original, diff above
```

*AI generated. Time taken: 387s, tokens: 35,062*
