### PR TITLE
SimpleCarCarCollisionTest equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -6398,11 +6398,14 @@ int BoundsOverlapTest_car(br_bounds* b1, br_bounds* b2) {
 // FUNCTION: CARM95 0x0048d28f
 int SimpleCarCarCollisionTest(tCollision_info* car1, tCollision_info* car2) {
 
-    if (car1->bounds_ws_type == eBounds_ws && car2->bounds_ws_type == eBounds_ws) {
-        return BoundsOverlapTest_car(&car1->bounds_world_space, &car2->bounds_world_space);
+    if (car1->bounds_ws_type == eBounds_ws) {
+        if (eBounds_ws != car2->bounds_ws_type) {
+            return 1;
+        }
     } else {
         return 1;
     }
+    return BoundsOverlapTest_car(&car1->bounds_world_space, &car2->bounds_world_space);
 }
 
 // IDA: int __usercall CollideTwoCarsWithWalls@<EAX>(tCollision_info *car1@<EAX>, tCollision_info *car2@<EDX>, br_scalar dt)

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -6397,12 +6397,7 @@ int BoundsOverlapTest_car(br_bounds* b1, br_bounds* b2) {
 // IDA: int __usercall SimpleCarCarCollisionTest@<EAX>(tCollision_info *car1@<EAX>, tCollision_info *car2@<EDX>)
 // FUNCTION: CARM95 0x0048d28f
 int SimpleCarCarCollisionTest(tCollision_info* car1, tCollision_info* car2) {
-
-    if (car1->bounds_ws_type == eBounds_ws) {
-        if (eBounds_ws != car2->bounds_ws_type) {
-            return 1;
-        }
-    } else {
+    if (car1->bounds_ws_type != eBounds_ws || car2->bounds_ws_type != eBounds_ws) {
         return 1;
     }
     return BoundsOverlapTest_car(&car1->bounds_world_space, &car2->bounds_world_space);


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x48d28f,21 +0x45ecfd,24 @@
0x48d28f : push ebp 	(car.c:6399)
0x48d290 : mov ebp, esp
0x48d292 : push ebx
0x48d293 : push esi
0x48d294 : push edi
0x48d295 : mov eax, dword ptr [ebp + 8] 	(car.c:6401)
0x48d298 : cmp dword ptr [eax + 0x278], 1
0x48d29f : -jne 0x10
         : +jne 0x1f
0x48d2a5 : mov eax, dword ptr [ebp + 0xc] 	(car.c:6402)
0x48d2a8 : cmp dword ptr [eax + 0x278], 1
0x48d2af : je 0xa
         : +mov eax, 1 	(car.c:6403)
         : +jmp 0x2e
         : +jmp 0xa 	(car.c:6405)
0x48d2b5 : mov eax, 1 	(car.c:6406)
0x48d2ba : jmp 0x1f
0x48d2bf : mov eax, dword ptr [ebp + 0xc] 	(car.c:6408)
0x48d2c2 : add eax, 0x260
0x48d2c7 : push eax
0x48d2c8 : mov eax, dword ptr [ebp + 8]
0x48d2cb : add eax, 0x260
0x48d2d0 : push eax
0x48d2d1 : call BoundsOverlapTest_car (FUNCTION)
0x48d2d6 : add esp, 8


SimpleCarCarCollisionTest is only 91.23% similar to the original, diff above
```

#### Effective match analysis

The diff shows control-flow reshuffling, not a logic change. The new code introduces extra unconditional jumps (a jump trampoline/dead block) and different branch displacements, but the observable behavior remains the same: it checks the same two `[car + 0x278]` flags, returns `1` on the same early-exit path, and otherwise calls `BoundsOverlapTest_car` with the same two `+0x260` pointers. No new memory writes or argument changes are introduced; the differences are branch layout only.

#### Original match

```
---
+++
@@ -0x48d28f,27 +0x45ecfd,28 @@
0x48d28f : push ebp 	(car.c:6399)
0x48d290 : mov ebp, esp
0x48d292 : push ebx
0x48d293 : push esi
0x48d294 : push edi
0x48d295 : mov eax, dword ptr [ebp + 8] 	(car.c:6401)
0x48d298 : cmp dword ptr [eax + 0x278], 1
0x48d29f : -jne 0x10
         : +jne 0x34
0x48d2a5 : mov eax, dword ptr [ebp + 0xc]
0x48d2a8 : cmp dword ptr [eax + 0x278], 1
0x48d2af : -je 0xa
0x48d2b5 : -mov eax, 1
0x48d2ba : -jmp 0x1f
         : +jne 0x24
0x48d2bf : mov eax, dword ptr [ebp + 0xc] 	(car.c:6402)
0x48d2c2 : add eax, 0x260
0x48d2c7 : push eax
0x48d2c8 : mov eax, dword ptr [ebp + 8]
0x48d2cb : add eax, 0x260
0x48d2d0 : push eax
0x48d2d1 : call BoundsOverlapTest_car (FUNCTION)
0x48d2d6 : add esp, 8
         : +jmp 0xf
         : +jmp 0xa 	(car.c:6403)
         : +mov eax, 1 	(car.c:6404)
0x48d2d9 : jmp 0x0
0x48d2de : pop edi 	(car.c:6406)
0x48d2df : pop esi
0x48d2e0 : pop ebx
0x48d2e1 : leave 
0x48d2e2 : ret 


SimpleCarCarCollisionTest is only 83.64% similar to the original, diff above
```

*AI generated. Time taken: 993s, tokens: 62,950*
