### PR TITLE
BoundsOverlapTest_car 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -6386,12 +6386,16 @@ void BringCarToAGrindingHalt(tCollision_info* car) {
 // FUNCTION: CARM95 0x0048d2e3
 int BoundsOverlapTest_car(br_bounds* b1, br_bounds* b2) {
 
-    return b2->max.v[0] >= b1->min.v[0]
-        && b1->max.v[0] >= b2->min.v[0]
-        && b2->max.v[1] >= b1->min.v[1]
-        && b1->max.v[1] >= b2->min.v[1]
-        && b2->max.v[2] >= b1->min.v[2]
-        && b1->max.v[2] >= b2->min.v[2];
+    if (b2->max.v[0] < b1->min.v[0]
+        || b1->max.v[0] < b2->min.v[0]
+        || b2->max.v[1] < b1->min.v[1]
+        || b1->max.v[1] < b2->min.v[1]
+        || b2->max.v[2] < b1->min.v[2]
+        || b1->max.v[2] < b2->min.v[2]) {
+        return 0;
+    } else {
+        return 1;
+    }
 }
 
 // IDA: int __usercall SimpleCarCarCollisionTest@<EAX>(tCollision_info *car1@<EAX>, tCollision_info *car2@<EDX>)


### PR DESCRIPTION
## Match result

```
0x48d2e3: BoundsOverlapTest_car 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x48d2e4,51 +0x45ec5a,55 @@
0x48d2e4 : mov ebp, esp
0x48d2e6 : push ebx
0x48d2e7 : push esi
0x48d2e8 : push edi
0x48d2e9 : mov eax, dword ptr [ebp + 0xc] 	(car.c:6394)
0x48d2ec : fld dword ptr [eax + 0xc]
0x48d2ef : mov eax, dword ptr [ebp + 8]
0x48d2f2 : fcomp dword ptr [eax]
0x48d2f4 : fnstsw ax
0x48d2f6 : test ah, 1
0x48d2f9 : -jne 0x72
         : +jne 0x7c
0x48d2ff : mov eax, dword ptr [ebp + 8]
0x48d302 : fld dword ptr [eax + 0xc]
0x48d305 : mov eax, dword ptr [ebp + 0xc]
0x48d308 : fcomp dword ptr [eax]
0x48d30a : fnstsw ax
0x48d30c : test ah, 1
0x48d30f : -jne 0x5c
         : +jne 0x66
0x48d315 : mov eax, dword ptr [ebp + 0xc]
0x48d318 : fld dword ptr [eax + 0x10]
0x48d31b : mov eax, dword ptr [ebp + 8]
0x48d31e : fcomp dword ptr [eax + 4]
0x48d321 : fnstsw ax
0x48d323 : test ah, 1
0x48d326 : -jne 0x45
         : +jne 0x4f
0x48d32c : mov eax, dword ptr [ebp + 8]
0x48d32f : fld dword ptr [eax + 0x10]
0x48d332 : mov eax, dword ptr [ebp + 0xc]
0x48d335 : fcomp dword ptr [eax + 4]
0x48d338 : fnstsw ax
0x48d33a : test ah, 1
0x48d33d : -jne 0x2e
         : +jne 0x38
0x48d343 : mov eax, dword ptr [ebp + 0xc]
0x48d346 : fld dword ptr [eax + 0x14]
0x48d349 : mov eax, dword ptr [ebp + 8]
0x48d34c : fcomp dword ptr [eax + 8]
0x48d34f : fnstsw ax
0x48d351 : test ah, 1
0x48d354 : -jne 0x17
         : +jne 0x21
0x48d35a : mov eax, dword ptr [ebp + 8]
0x48d35d : fld dword ptr [eax + 0x14]
0x48d360 : mov eax, dword ptr [ebp + 0xc]
0x48d363 : fcomp dword ptr [eax + 8]
0x48d366 : fnstsw ax
0x48d368 : test ah, 1
0x48d36b : -je 0xc
         : +jne 0xa
         : +mov eax, 1
         : +jmp 0x2
0x48d371 : xor eax, eax
0x48d373 : -jmp 0xf
0x48d378 : -jmp 0xa
0x48d37d : -mov eax, 1
0x48d382 : jmp 0x0
         : +pop edi 	(car.c:6395)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


BoundsOverlapTest_car is only 79.63% similar to the original, diff above
```

*AI generated. Time taken: 546s, tokens: 55,259*
