### PR TITLE
AddFrictionCarToCar equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3353,7 +3353,7 @@ void AddFrictionCarToCar(tCollision_info* car1, tCollision_info* car2, br_vector
         }
         BrVector3Cross(&tv, &tau1, pos1);
         BrVector3Cross(&tv2, &tau2, pos2);
-        ts = BrVector3Dot(&tv, &v_diff1) + BrVector3Dot(&tv2, &v_diff2) + 1.f / car2->M + 1.f / car1->M;
+        ts = BrVector3Dot(&tv, &v_diff1) + BrVector3Dot(&tv2, &v_diff2) + 1.0 / car2->M + 1.0 / car1->M;
         if (ts < 0.0001f) {
             BrVector3Set(max_friction, 0.f, 0.f, 0.f);
         } else {


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x49235b,40 +0x453dd1,40 @@
0x49235b : fstp dword ptr [ebp - 0x20]
0x49235e : fld dword ptr [ebp - 0xc]
0x492361 : mov eax, dword ptr [ebp + 0x10]
0x492364 : fsub dword ptr [eax + 4]
0x492367 : fstp dword ptr [ebp - 0x1c]
0x49236a : fld dword ptr [ebp - 8]
0x49236d : mov eax, dword ptr [ebp + 0x10]
0x492370 : fsub dword ptr [eax + 8]
0x492373 : fstp dword ptr [ebp - 0x18]
0x492376 : mov eax, dword ptr [ebp + 0x18] 	(car.c:3336)
         : +fld dword ptr [eax + 8]
         : +mov eax, dword ptr [ebp + 0x18]
         : +fmul dword ptr [eax + 8]
         : +mov eax, dword ptr [ebp + 0x18]
0x492379 : fld dword ptr [eax + 4]
0x49237c : mov eax, dword ptr [ebp + 0x18]
0x49237f : fmul dword ptr [eax + 4]
0x492382 : -mov eax, dword ptr [ebp + 0x18]
0x492385 : -fld dword ptr [eax + 8]
0x492388 : -mov eax, dword ptr [ebp + 0x18]
0x49238b : -fmul dword ptr [eax + 8]
0x49238e : faddp st(1)
0x492390 : mov eax, dword ptr [ebp + 0x18]
0x492393 : fld dword ptr [eax]
0x492395 : mov eax, dword ptr [ebp + 0x18]
0x492398 : fmul dword ptr [eax]
0x49239a : faddp st(1)
0x49239c : fstp dword ptr [ebp - 0x40]
0x49239f : mov eax, dword ptr [ebp + 0x18] 	(car.c:3337)
         : +fld dword ptr [eax + 8]
         : +fmul dword ptr [ebp - 0x18]
         : +mov eax, dword ptr [ebp + 0x18]
0x4923a2 : fld dword ptr [eax + 4]
0x4923a5 : fmul dword ptr [ebp - 0x1c]
0x4923a8 : -mov eax, dword ptr [ebp + 0x18]
0x4923ab : -fld dword ptr [eax + 8]
0x4923ae : -fmul dword ptr [ebp - 0x18]
0x4923b1 : faddp st(1)
0x4923b3 : mov eax, dword ptr [ebp + 0x18]
0x4923b6 : fld dword ptr [eax]
0x4923b8 : fmul dword ptr [ebp - 0x20]
0x4923bb : faddp st(1)
0x4923bd : fdiv dword ptr [ebp - 0x40]
0x4923c0 : fstp dword ptr [ebp - 0x6c]
0x4923c3 : mov eax, dword ptr [ebp + 0x18] 	(car.c:3338)
0x4923c6 : fld dword ptr [eax]
0x4923c8 : fmul dword ptr [ebp - 0x6c]

---
+++
@@ -0x4923e3,24 +0x453e59,24 @@
0x4923e3 : fstp dword ptr [ebp - 0x60]
0x4923e6 : fld dword ptr [ebp - 0x20] 	(car.c:3339)
0x4923e9 : fsub dword ptr [ebp - 0x68]
0x4923ec : fstp dword ptr [ebp - 0x20]
0x4923ef : fld dword ptr [ebp - 0x1c]
0x4923f2 : fsub dword ptr [ebp - 0x64]
0x4923f5 : fstp dword ptr [ebp - 0x1c]
0x4923f8 : fld dword ptr [ebp - 0x18]
0x4923fb : fsub dword ptr [ebp - 0x60]
0x4923fe : fstp dword ptr [ebp - 0x18]
         : +fld dword ptr [ebp - 0x18] 	(car.c:3340)
         : +fmul dword ptr [ebp - 0x18]
0x492401 : fld dword ptr [ebp - 0x1c]
0x492404 : fmul dword ptr [ebp - 0x1c]
0x492407 : -fld dword ptr [ebp - 0x18]
0x49240a : -fmul dword ptr [ebp - 0x18]
0x49240d : faddp st(1)
0x49240f : fld dword ptr [ebp - 0x20]
0x492412 : fmul dword ptr [ebp - 0x20]
0x492415 : faddp st(1)
0x492417 : call __CIsqrt (FUNCTION)
0x49241c : fcom dword ptr [0.009999999776482582 (FLOAT)] 	(car.c:3341)
0x492422 : fstp dword ptr [ebp - 0x14]
0x492425 : fnstsw ax
0x492427 : test ah, 1
0x49242a : je 0x22

---
+++
@@ -0x4925a7,23 +0x45401d,23 @@
0x4925a7 : fld dword ptr [eax]
0x4925a9 : fmul dword ptr [ebp - 0x24]
0x4925ac : mov eax, dword ptr [ebp + 0x1c]
0x4925af : fld dword ptr [eax + 8]
0x4925b2 : fmul dword ptr [ebp - 0x2c]
0x4925b5 : fsubp st(1)
0x4925b7 : fstp dword ptr [ebp - 0x64]
0x4925ba : mov eax, dword ptr [ebp + 0x1c]
0x4925bd : fld dword ptr [eax + 4]
0x4925c0 : fmul dword ptr [ebp - 0x2c]
         : +fld dword ptr [ebp - 0x28]
0x4925c3 : mov eax, dword ptr [ebp + 0x1c]
0x4925c6 : -fld dword ptr [eax]
0x4925c8 : -fmul dword ptr [ebp - 0x28]
         : +fmul dword ptr [eax]
0x4925cb : fsubp st(1)
0x4925cd : fstp dword ptr [ebp - 0x60]
0x4925d0 : mov eax, dword ptr [ebp + 0x20] 	(car.c:3355)
0x4925d3 : fld dword ptr [eax + 8]
0x4925d6 : fmul dword ptr [ebp - 0x38]
0x4925d9 : mov eax, dword ptr [ebp + 0x20]
0x4925dc : fld dword ptr [eax + 4]
0x4925df : fmul dword ptr [ebp - 0x34]
0x4925e2 : fsubp st(1)
0x4925e4 : fstp dword ptr [ebp - 0x4c]

---
+++
@@ -0x4925ea,40 +0x454060,40 @@
0x4925ea : fld dword ptr [eax]
0x4925ec : fmul dword ptr [ebp - 0x34]
0x4925ef : mov eax, dword ptr [ebp + 0x20]
0x4925f2 : fld dword ptr [eax + 8]
0x4925f5 : fmul dword ptr [ebp - 0x3c]
0x4925f8 : fsubp st(1)
0x4925fa : fstp dword ptr [ebp - 0x48]
0x4925fd : mov eax, dword ptr [ebp + 0x20]
0x492600 : fld dword ptr [eax + 4]
0x492603 : fmul dword ptr [ebp - 0x3c]
         : +fld dword ptr [ebp - 0x38]
0x492606 : mov eax, dword ptr [ebp + 0x20]
0x492609 : -fld dword ptr [eax]
0x49260b : -fmul dword ptr [ebp - 0x38]
         : +fmul dword ptr [eax]
0x49260e : fsubp st(1)
0x492610 : fstp dword ptr [ebp - 0x44]
0x492613 : -fld dword ptr [ebp - 0x48]
0x492616 : -fmul dword ptr [ebp - 0x54]
0x492619 : -fld dword ptr [ebp - 0x44]
0x49261c : -fmul dword ptr [ebp - 0x50]
         : +fld dword ptr [ebp - 0x1c] 	(car.c:3356)
         : +fmul dword ptr [ebp - 0x64]
         : +fld dword ptr [ebp - 0x18]
         : +fmul dword ptr [ebp - 0x60]
0x49261f : faddp st(1)
0x492621 : -fld dword ptr [ebp - 0x58]
0x492624 : -fmul dword ptr [ebp - 0x4c]
         : +fld dword ptr [ebp - 0x68]
         : +fmul dword ptr [ebp - 0x20]
0x492627 : faddp st(1)
0x492629 : -fld dword ptr [ebp - 0x64]
0x49262c : -fmul dword ptr [ebp - 0x1c]
0x49262f : -fld dword ptr [ebp - 0x60]
0x492632 : -fmul dword ptr [ebp - 0x18]
         : +fld dword ptr [ebp - 0x54]
         : +fmul dword ptr [ebp - 0x48]
         : +fld dword ptr [ebp - 0x50]
         : +fmul dword ptr [ebp - 0x44]
0x492635 : faddp st(1)
0x492637 : -fld dword ptr [ebp - 0x20]
0x49263a : -fmul dword ptr [ebp - 0x68]
         : +fld dword ptr [ebp - 0x4c]
         : +fmul dword ptr [ebp - 0x58]
0x49263d : faddp st(1)
0x49263f : faddp st(1)
0x492641 : fld qword ptr [1.0 (FLOAT)]
0x492647 : mov eax, dword ptr [ebp + 0xc]
0x49264a : fdiv dword ptr [eax + 0xc0]
0x492650 : faddp st(1)
0x492652 : fld qword ptr [1.0 (FLOAT)]
0x492658 : mov eax, dword ptr [ebp + 8]
0x49265b : fdiv dword ptr [eax + 0xc0]
0x492661 : faddp st(1)

---
+++
@@ -0x4926ed,23 +0x454163,23 @@
0x4926ed : mov eax, dword ptr [ebp + 8] 	(car.c:3367)
0x4926f0 : fld dword ptr [eax + 0xa8]
0x4926f6 : fadd dword ptr [ebp - 0x2c]
0x4926f9 : mov eax, dword ptr [ebp + 8]
0x4926fc : fstp dword ptr [eax + 0xa8]
0x492702 : mov eax, dword ptr [ebp + 8]
0x492705 : fld dword ptr [eax + 0xac]
0x49270b : fadd dword ptr [ebp - 0x28]
0x49270e : mov eax, dword ptr [ebp + 8]
0x492711 : fstp dword ptr [eax + 0xac]
         : +fld dword ptr [ebp - 0x24]
0x492717 : mov eax, dword ptr [ebp + 8]
0x49271a : -fld dword ptr [eax + 0xb0]
0x492720 : -fadd dword ptr [ebp - 0x24]
         : +fadd dword ptr [eax + 0xb0]
0x492723 : mov eax, dword ptr [ebp + 8]
0x492726 : fstp dword ptr [eax + 0xb0]
0x49272c : mov eax, dword ptr [ebp + 0xc] 	(car.c:3369)
0x49272f : cmp dword ptr [eax + 0xc4], 0
0x492736 : jne 0x5a
0x49273c : fld dword ptr [ebp - 0x3c] 	(car.c:3370)
0x49273f : fmul dword ptr [ebp - 4]
0x492742 : fstp dword ptr [ebp - 0x3c]
0x492745 : fld dword ptr [ebp - 0x38]
0x492748 : fmul dword ptr [ebp - 4]


AddFrictionCarToCar is only 92.86% similar to the original, diff above
```

#### Effective match analysis

All shown changes are algebraic/instruction-order rewrites within straight-line basic blocks: terms are loaded/multiplied in different order, but the same products and sums are formed and stored to the same destinations. The larger reordered block near car.c:3356 still computes the same total (just regrouped as two partial sums before final addition). No branch conditions, jump targets, or control-flow structure changed in the provided diff. Under your stated allowances (ignore register allocation, instruction scheduling, finite-precision rounding differences, and NaN behavior), this is functionally equivalent.

#### Original match

```
---
+++
@@ -0x49235b,40 +0x453dd1,40 @@
0x49235b : fstp dword ptr [ebp - 0x20]
0x49235e : fld dword ptr [ebp - 0xc]
0x492361 : mov eax, dword ptr [ebp + 0x10]
0x492364 : fsub dword ptr [eax + 4]
0x492367 : fstp dword ptr [ebp - 0x1c]
0x49236a : fld dword ptr [ebp - 8]
0x49236d : mov eax, dword ptr [ebp + 0x10]
0x492370 : fsub dword ptr [eax + 8]
0x492373 : fstp dword ptr [ebp - 0x18]
0x492376 : mov eax, dword ptr [ebp + 0x18] 	(car.c:3336)
         : +fld dword ptr [eax + 8]
         : +mov eax, dword ptr [ebp + 0x18]
         : +fmul dword ptr [eax + 8]
         : +mov eax, dword ptr [ebp + 0x18]
0x492379 : fld dword ptr [eax + 4]
0x49237c : mov eax, dword ptr [ebp + 0x18]
0x49237f : fmul dword ptr [eax + 4]
0x492382 : -mov eax, dword ptr [ebp + 0x18]
0x492385 : -fld dword ptr [eax + 8]
0x492388 : -mov eax, dword ptr [ebp + 0x18]
0x49238b : -fmul dword ptr [eax + 8]
0x49238e : faddp st(1)
0x492390 : mov eax, dword ptr [ebp + 0x18]
0x492393 : fld dword ptr [eax]
0x492395 : mov eax, dword ptr [ebp + 0x18]
0x492398 : fmul dword ptr [eax]
0x49239a : faddp st(1)
0x49239c : fstp dword ptr [ebp - 0x40]
0x49239f : mov eax, dword ptr [ebp + 0x18] 	(car.c:3337)
         : +fld dword ptr [eax + 8]
         : +fmul dword ptr [ebp - 0x18]
         : +mov eax, dword ptr [ebp + 0x18]
0x4923a2 : fld dword ptr [eax + 4]
0x4923a5 : fmul dword ptr [ebp - 0x1c]
0x4923a8 : -mov eax, dword ptr [ebp + 0x18]
0x4923ab : -fld dword ptr [eax + 8]
0x4923ae : -fmul dword ptr [ebp - 0x18]
0x4923b1 : faddp st(1)
0x4923b3 : mov eax, dword ptr [ebp + 0x18]
0x4923b6 : fld dword ptr [eax]
0x4923b8 : fmul dword ptr [ebp - 0x20]
0x4923bb : faddp st(1)
0x4923bd : fdiv dword ptr [ebp - 0x40]
0x4923c0 : fstp dword ptr [ebp - 0x6c]
0x4923c3 : mov eax, dword ptr [ebp + 0x18] 	(car.c:3338)
0x4923c6 : fld dword ptr [eax]
0x4923c8 : fmul dword ptr [ebp - 0x6c]

---
+++
@@ -0x4923e3,24 +0x453e59,24 @@
0x4923e3 : fstp dword ptr [ebp - 0x60]
0x4923e6 : fld dword ptr [ebp - 0x20] 	(car.c:3339)
0x4923e9 : fsub dword ptr [ebp - 0x68]
0x4923ec : fstp dword ptr [ebp - 0x20]
0x4923ef : fld dword ptr [ebp - 0x1c]
0x4923f2 : fsub dword ptr [ebp - 0x64]
0x4923f5 : fstp dword ptr [ebp - 0x1c]
0x4923f8 : fld dword ptr [ebp - 0x18]
0x4923fb : fsub dword ptr [ebp - 0x60]
0x4923fe : fstp dword ptr [ebp - 0x18]
         : +fld dword ptr [ebp - 0x18] 	(car.c:3340)
         : +fmul dword ptr [ebp - 0x18]
0x492401 : fld dword ptr [ebp - 0x1c]
0x492404 : fmul dword ptr [ebp - 0x1c]
0x492407 : -fld dword ptr [ebp - 0x18]
0x49240a : -fmul dword ptr [ebp - 0x18]
0x49240d : faddp st(1)
0x49240f : fld dword ptr [ebp - 0x20]
0x492412 : fmul dword ptr [ebp - 0x20]
0x492415 : faddp st(1)
0x492417 : call __CIsqrt (FUNCTION)
0x49241c : fcom dword ptr [0.009999999776482582 (FLOAT)] 	(car.c:3341)
0x492422 : fstp dword ptr [ebp - 0x14]
0x492425 : fnstsw ax
0x492427 : test ah, 1
0x49242a : je 0x22

---
+++
@@ -0x4925a7,23 +0x45401d,23 @@
0x4925a7 : fld dword ptr [eax]
0x4925a9 : fmul dword ptr [ebp - 0x24]
0x4925ac : mov eax, dword ptr [ebp + 0x1c]
0x4925af : fld dword ptr [eax + 8]
0x4925b2 : fmul dword ptr [ebp - 0x2c]
0x4925b5 : fsubp st(1)
0x4925b7 : fstp dword ptr [ebp - 0x64]
0x4925ba : mov eax, dword ptr [ebp + 0x1c]
0x4925bd : fld dword ptr [eax + 4]
0x4925c0 : fmul dword ptr [ebp - 0x2c]
         : +fld dword ptr [ebp - 0x28]
0x4925c3 : mov eax, dword ptr [ebp + 0x1c]
0x4925c6 : -fld dword ptr [eax]
0x4925c8 : -fmul dword ptr [ebp - 0x28]
         : +fmul dword ptr [eax]
0x4925cb : fsubp st(1)
0x4925cd : fstp dword ptr [ebp - 0x60]
0x4925d0 : mov eax, dword ptr [ebp + 0x20] 	(car.c:3355)
0x4925d3 : fld dword ptr [eax + 8]
0x4925d6 : fmul dword ptr [ebp - 0x38]
0x4925d9 : mov eax, dword ptr [ebp + 0x20]
0x4925dc : fld dword ptr [eax + 4]
0x4925df : fmul dword ptr [ebp - 0x34]
0x4925e2 : fsubp st(1)
0x4925e4 : fstp dword ptr [ebp - 0x4c]

---
+++
@@ -0x4925ea,47 +0x454060,47 @@
0x4925ea : fld dword ptr [eax]
0x4925ec : fmul dword ptr [ebp - 0x34]
0x4925ef : mov eax, dword ptr [ebp + 0x20]
0x4925f2 : fld dword ptr [eax + 8]
0x4925f5 : fmul dword ptr [ebp - 0x3c]
0x4925f8 : fsubp st(1)
0x4925fa : fstp dword ptr [ebp - 0x48]
0x4925fd : mov eax, dword ptr [ebp + 0x20]
0x492600 : fld dword ptr [eax + 4]
0x492603 : fmul dword ptr [ebp - 0x3c]
         : +fld dword ptr [ebp - 0x38]
0x492606 : mov eax, dword ptr [ebp + 0x20]
0x492609 : -fld dword ptr [eax]
0x49260b : -fmul dword ptr [ebp - 0x38]
         : +fmul dword ptr [eax]
0x49260e : fsubp st(1)
0x492610 : fstp dword ptr [ebp - 0x44]
0x492613 : -fld dword ptr [ebp - 0x48]
0x492616 : -fmul dword ptr [ebp - 0x54]
0x492619 : -fld dword ptr [ebp - 0x44]
0x49261c : -fmul dword ptr [ebp - 0x50]
         : +fld dword ptr [ebp - 0x1c] 	(car.c:3356)
         : +fmul dword ptr [ebp - 0x64]
         : +fld dword ptr [ebp - 0x18]
         : +fmul dword ptr [ebp - 0x60]
0x49261f : faddp st(1)
0x492621 : -fld dword ptr [ebp - 0x58]
0x492624 : -fmul dword ptr [ebp - 0x4c]
         : +fld dword ptr [ebp - 0x68]
         : +fmul dword ptr [ebp - 0x20]
0x492627 : faddp st(1)
0x492629 : -fld dword ptr [ebp - 0x64]
0x49262c : -fmul dword ptr [ebp - 0x1c]
0x49262f : -fld dword ptr [ebp - 0x60]
0x492632 : -fmul dword ptr [ebp - 0x18]
         : +fld dword ptr [ebp - 0x54]
         : +fmul dword ptr [ebp - 0x48]
         : +fld dword ptr [ebp - 0x50]
         : +fmul dword ptr [ebp - 0x44]
0x492635 : faddp st(1)
0x492637 : -fld dword ptr [ebp - 0x20]
0x49263a : -fmul dword ptr [ebp - 0x68]
         : +fld dword ptr [ebp - 0x4c]
         : +fmul dword ptr [ebp - 0x58]
0x49263d : faddp st(1)
0x49263f : faddp st(1)
0x492641 : -fld qword ptr [1.0 (FLOAT)]
         : +fld dword ptr [1.0 (FLOAT)]
0x492647 : mov eax, dword ptr [ebp + 0xc]
0x49264a : fdiv dword ptr [eax + 0xc0]
0x492650 : faddp st(1)
0x492652 : -fld qword ptr [1.0 (FLOAT)]
         : +fld dword ptr [1.0 (FLOAT)]
0x492658 : mov eax, dword ptr [ebp + 8]
0x49265b : fdiv dword ptr [eax + 0xc0]
0x492661 : faddp st(1)
0x492663 : fcom dword ptr [9.999999747378752e-05 (FLOAT)] 	(car.c:3357)
0x492669 : fstp dword ptr [ebp - 0x40]
0x49266c : fnstsw ax
0x49266e : test ah, 1
0x492671 : je 0x22
0x492677 : mov eax, dword ptr [ebp + 0x28] 	(car.c:3358)
0x49267a : mov dword ptr [eax], 0

---
+++
@@ -0x4926ed,23 +0x454163,23 @@
0x4926ed : mov eax, dword ptr [ebp + 8] 	(car.c:3367)
0x4926f0 : fld dword ptr [eax + 0xa8]
0x4926f6 : fadd dword ptr [ebp - 0x2c]
0x4926f9 : mov eax, dword ptr [ebp + 8]
0x4926fc : fstp dword ptr [eax + 0xa8]
0x492702 : mov eax, dword ptr [ebp + 8]
0x492705 : fld dword ptr [eax + 0xac]
0x49270b : fadd dword ptr [ebp - 0x28]
0x49270e : mov eax, dword ptr [ebp + 8]
0x492711 : fstp dword ptr [eax + 0xac]
         : +fld dword ptr [ebp - 0x24]
0x492717 : mov eax, dword ptr [ebp + 8]
0x49271a : -fld dword ptr [eax + 0xb0]
0x492720 : -fadd dword ptr [ebp - 0x24]
         : +fadd dword ptr [eax + 0xb0]
0x492723 : mov eax, dword ptr [ebp + 8]
0x492726 : fstp dword ptr [eax + 0xb0]
0x49272c : mov eax, dword ptr [ebp + 0xc] 	(car.c:3369)
0x49272f : cmp dword ptr [eax + 0xc4], 0
0x492736 : jne 0x5a
0x49273c : fld dword ptr [ebp - 0x3c] 	(car.c:3370)
0x49273f : fmul dword ptr [ebp - 4]
0x492742 : fstp dword ptr [ebp - 0x3c]
0x492745 : fld dword ptr [ebp - 0x38]
0x492748 : fmul dword ptr [ebp - 4]


AddFrictionCarToCar is only 92.33% similar to the original, diff above
```

*AI generated. Time taken: 387s, tokens: 106,705*
