### PR TITLE
SetCarSuspGiveAndHeight 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -7406,17 +7406,19 @@ void SetCarSuspGiveAndHeight(tCar_spec* pCar, br_scalar pFront_give_factor, br_s
     br_scalar ratio;
     int i;
 
+#define UNK_SUSPENION_FACTOR 5.0f
+
     front_give = pCar->susp_give[1] * pFront_give_factor;
     front_give *= WORLD_SCALE;
     rear_give = pCar->susp_give[0] * pRear_give_factor;
     rear_give *= WORLD_SCALE;
     damping = pCar->damping * pDamping_factor;
     ratio = fabs((pCar->wpos[0].v[2] - pCar->cmpos.v[2]) / (pCar->wpos[2].v[2] - pCar->cmpos.v[2]));
-    pCar->sk[0] = pCar->M / (ratio + 1.0f) * 5.0f / rear_give;
-    pCar->sb[0] = pCar->M / (ratio + 1.0f) * sqrt(5.0f) / sqrt(rear_give);
+    pCar->sk[0] = pCar->M / (ratio + 1.0f) * UNK_SUSPENION_FACTOR / rear_give;
+    pCar->sb[0] = pCar->M / (ratio + 1.0f) * sqrt(UNK_SUSPENION_FACTOR) / sqrt(rear_give);
     ratio = 1.0 / ratio;
-    pCar->sk[1] = pCar->M / (ratio + 1.0f) * 5.0f / front_give;
-    pCar->sb[1] = pCar->M / (ratio + 1.0f) * sqrt(5.0f) / sqrt(front_give);
+    pCar->sk[1] = pCar->M / (ratio + 1.0f) * UNK_SUSPENION_FACTOR / front_give;
+    pCar->sb[1] = pCar->M / (ratio + 1.0f) * sqrt(UNK_SUSPENION_FACTOR) / sqrt(front_give);
 
     pCar->sb[0] *= damping;
     pCar->sb[1] *= damping;
@@ -7425,6 +7427,8 @@ void SetCarSuspGiveAndHeight(tCar_spec* pCar, br_scalar pFront_give_factor, br_s
 
     pCar->bounds[0].min.v[1] = (front_give <= rear_give ? -rear_give : -front_give) + (pExtra_front_height <= pExtra_rear_height ? -pExtra_rear_height : -pExtra_front_height);
     pCar->bounds[0].min.v[1] /= WORLD_SCALE;
+
+#undef UNK_SUSPENION_FACTOR
 }
 
 // IDA: int __usercall TestForCarInSensiblePlace@<EAX>(tCar_spec *car@<EAX>)

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -7406,27 +7406,25 @@ void SetCarSuspGiveAndHeight(tCar_spec* pCar, br_scalar pFront_give_factor, br_s
     br_scalar ratio;
     int i;
 
-#define UNK_SUSPENION_FACTOR 5.0f
-
-    front_give = pCar->susp_give[1] * pFront_give_factor * WORLD_SCALE;
-    rear_give = pCar->susp_give[0] * pRear_give_factor * WORLD_SCALE;
+    front_give = pCar->susp_give[1] * pFront_give_factor;
+    front_give *= WORLD_SCALE;
+    rear_give = pCar->susp_give[0] * pRear_give_factor;
+    rear_give *= WORLD_SCALE;
     damping = pCar->damping * pDamping_factor;
     ratio = fabs((pCar->wpos[0].v[2] - pCar->cmpos.v[2]) / (pCar->wpos[2].v[2] - pCar->cmpos.v[2]));
-    pCar->sk[0] = pCar->M / (ratio + 1.0f) * UNK_SUSPENION_FACTOR / rear_give;
-    pCar->sb[0] = pCar->M / (ratio + 1.0f) * sqrt(UNK_SUSPENION_FACTOR) / sqrt(rear_give);
-    ratio = 1.0f / ratio;
-    pCar->sk[1] = pCar->M / (ratio + 1.0f) * UNK_SUSPENION_FACTOR / front_give;
-    pCar->sb[1] = pCar->M / (ratio + 1.0f) * sqrt(UNK_SUSPENION_FACTOR) / sqrt(front_give);
+    pCar->sk[0] = pCar->M / (ratio + 1.0f) * 5.0f / rear_give;
+    pCar->sb[0] = pCar->M / (ratio + 1.0f) * sqrt(5.0f) / sqrt(rear_give);
+    ratio = 1.0 / ratio;
+    pCar->sk[1] = pCar->M / (ratio + 1.0f) * 5.0f / front_give;
+    pCar->sb[1] = pCar->M / (ratio + 1.0f) * sqrt(5.0f) / sqrt(front_give);
 
     pCar->sb[0] *= damping;
     pCar->sb[1] *= damping;
     pCar->susp_height[0] = pCar->ride_height + rear_give + pExtra_rear_height;
     pCar->susp_height[1] = pCar->ride_height + front_give + pExtra_front_height;
 
-    pCar->bounds[0].min.v[1] = -MAX(rear_give, front_give) + -MAX(pExtra_rear_height, pExtra_front_height);
+    pCar->bounds[0].min.v[1] = (front_give <= rear_give ? -rear_give : -front_give) + (pExtra_front_height <= pExtra_rear_height ? -pExtra_rear_height : -pExtra_front_height);
     pCar->bounds[0].min.v[1] /= WORLD_SCALE;
-
-#undef UNK_SUSPENION_FACTOR
 }
 
 // IDA: int __usercall TestForCarInSensiblePlace@<EAX>(tCar_spec *car@<EAX>)


### PR DESCRIPTION
## Match result

```
0x493087: SetCarSuspGiveAndHeight 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x493087,26 +0x4641b5,24 @@
0x493087 : push ebp 	(car.c:7402)
0x493088 : mov ebp, esp
0x49308a : -sub esp, 0x1c
         : +sub esp, 0x14
0x49308d : push ebx
0x49308e : push esi
0x49308f : push edi
0x493090 : mov eax, dword ptr [ebp + 8] 	(car.c:7411)
0x493093 : fld dword ptr [eax + 0x14bc]
0x493099 : fmul dword ptr [ebp + 0xc]
0x49309c : -fst dword ptr [ebp - 8]
0x49309f : fmul dword ptr [6.900000095367432 (FLOAT)]
0x4930a5 : fstp dword ptr [ebp - 8]
0x4930a8 : mov eax, dword ptr [ebp + 8] 	(car.c:7412)
0x4930ab : fld dword ptr [eax + 0x14b8]
0x4930b1 : fmul dword ptr [ebp + 0x10]
0x4930b4 : -fst dword ptr [ebp - 4]
0x4930b7 : fmul dword ptr [6.900000095367432 (FLOAT)]
0x4930bd : fstp dword ptr [ebp - 4]
0x4930c0 : mov eax, dword ptr [ebp + 8] 	(car.c:7413)
0x4930c3 : fld dword ptr [eax + 0x14a4]
0x4930c9 : fmul dword ptr [ebp + 0x14]
0x4930cc : fstp dword ptr [ebp - 0x14]
0x4930cf : mov eax, dword ptr [ebp + 8] 	(car.c:7414)
0x4930d2 : fld dword ptr [eax + 0x14d4]
0x4930d8 : mov eax, dword ptr [ebp + 8]
0x4930db : fsub dword ptr [eax + 0xdc]

---
+++
@@ -0x493124,21 +0x46424c,21 @@
0x493124 : mov eax, dword ptr [ebp + 8]
0x493127 : fdivr dword ptr [eax + 0xc0]
0x49312d : fld qword ptr [5.0 (FLOAT)]
0x493133 : call __CIsqrt (FUNCTION)
0x493138 : fmulp st(1)
0x49313a : fld dword ptr [ebp - 4]
0x49313d : call __CIsqrt (FUNCTION)
0x493142 : fdivp st(1)
0x493144 : mov eax, dword ptr [ebp + 8]
0x493147 : fstp dword ptr [eax + 0x14b0]
0x49314d : -fld qword ptr [1.0 (FLOAT)]
         : +fld dword ptr [1.0 (FLOAT)] 	(car.c:7417)
0x493153 : fdiv dword ptr [ebp - 0x10]
0x493156 : fst dword ptr [ebp - 0x10]
0x493159 : fadd dword ptr [1.0 (FLOAT)] 	(car.c:7418)
0x49315f : mov eax, dword ptr [ebp + 8]
0x493162 : fdivr dword ptr [eax + 0xc0]
0x493168 : fmul dword ptr [5.0 (FLOAT)]
0x49316e : fdiv dword ptr [ebp - 8]
0x493171 : mov eax, dword ptr [ebp + 8]
0x493174 : fstp dword ptr [eax + 0x14ac]
0x49317a : fld dword ptr [ebp - 0x10] 	(car.c:7419)

---
+++
@@ -0x4931e2,35 +0x46430a,40 @@
0x4931e2 : fadd dword ptr [ebp + 0x1c]
0x4931e5 : mov eax, dword ptr [ebp + 8]
0x4931e8 : fstp dword ptr [eax + 0x14c0]
0x4931ee : mov eax, dword ptr [ebp + 8] 	(car.c:7424)
0x4931f1 : fld dword ptr [eax + 0x14c8]
0x4931f7 : fadd dword ptr [ebp - 8]
0x4931fa : fadd dword ptr [ebp + 0x18]
0x4931fd : mov eax, dword ptr [ebp + 8]
0x493200 : fstp dword ptr [eax + 0x14c4]
0x493206 : fld dword ptr [ebp - 4] 	(car.c:7426)
0x493209 : -fcomp dword ptr [ebp - 8]
         : +fld dword ptr [ebp - 8]
         : +fcom st(1)
0x49320c : fnstsw ax
0x49320e : test ah, 1
0x493211 : -je 0xd
0x493217 : -fld dword ptr [ebp - 8]
         : +jne 0x2
         : +fxch st(1)
         : +fstp st(0)
0x49321a : fchs 
0x49321c : -fstp dword ptr [ebp - 0x18]
0x49321f : -jmp 0x8
0x493224 : -fld dword ptr [ebp - 4]
0x493227 : -fchs 
0x493229 : -fstp dword ptr [ebp - 0x18]
0x49322c : fld dword ptr [ebp + 0x1c]
0x49322f : -fcomp dword ptr [ebp + 0x18]
         : +fld dword ptr [ebp + 0x18]
         : +fcom st(1)
0x493232 : fnstsw ax
0x493234 : test ah, 1
0x493237 : -je 0xd
0x49323d : -fld dword ptr [ebp + 0x18]
         : +jne 0x2
         : +fxch st(1)
         : +fstp st(0)
0x493240 : fchs 
0x493242 : -fstp dword ptr [ebp - 0x1c]
0x493245 : -jmp 0x8
0x49324a : -fld dword ptr [ebp + 0x1c]
0x49324d : -fchs 
0x49324f : -fstp dword ptr [ebp - 0x1c]
0x493252 : -fld dword ptr [ebp - 0x18]
0x493255 : -fadd dword ptr [ebp - 0x1c]
         : +faddp st(1)
         : +mov eax, dword ptr [ebp + 8]
         : +fstp dword ptr [eax + 0xe8]
         : +mov eax, dword ptr [ebp + 8] 	(car.c:7427)
         : +fld dword ptr [eax + 0xe8]
         : +fdiv dword ptr [6.900000095367432 (FLOAT)]
         : +mov eax, dword ptr [ebp + 8]
         : +fstp dword ptr [eax + 0xe8]
         : +pop edi 	(car.c:7430)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


SetCarSuspGiveAndHeight is only 80.97% similar to the original, diff above
```

*AI generated. Time taken: 574s, tokens: 57,098*
