### PR TITLE
TestOldMats 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -7534,21 +7534,22 @@ int TestOldMats(tCollision_info* c1, tCollision_info* c2, int newmats) {
     }
     for (i = 0; i < 4; i++) {
         if (i == 3) {
-            BrVector3Copy(&edge, &b2->min);
+            BrVector3Copy(&p1, &b2->min);
         } else {
-            BrVector3Copy(&edge, &b2->max);
-            edge.v[i] = b2->min.v[i];
+            BrVector3Copy(&p1, &b2->max);
+            p1.v[i] = b2->min.v[i];
         }
         for (j = 0; j < 3; j++) {
-            BrVector3Copy(&tp1, &edge);
-            if (b2->max.v[j] == tp1.v[j]) {
-                tp1.v[j] = b2->min.v[j];
+            BrVector3Copy(&p2, &p1);
+            if (b2->max.v[j] == p2.v[j]) {
+                p2.v[j] = b2->min.v[j];
             } else {
-                tp1.v[j] = b2->max.v[j];
+                p2.v[j] = b2->max.v[j];
             }
-            BrMatrix34ApplyP(&p1, &edge, &mat21);
-            BrMatrix34ApplyP(&p2, &tp1, &mat21);
-            if (LineBoxColl(&p1, &p2, b1, &hp1)) {
+            BrMatrix34ApplyP(&tp1, &p1, &mat21);
+            BrMatrix34ApplyP(&tp2, &p2, &mat21);
+            plane1 = LineBoxColl(&tp1, &tp2, b1, &hp1);
+            if (plane1 != 0) {
                 n++;
             }
         }


### PR DESCRIPTION
## Match result

```
0x4936e6: TestOldMats 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x49377a,92 +0x46487d,105 @@
0x49377a : add eax, 0x3c
0x49377d : push eax
0x49377e : lea eax, [ebp - 0x78]
0x493781 : push eax
0x493782 : call BrMatrix34Mul (FUNCTION)
0x493787 : add esp, 0xc
0x49378a : mov dword ptr [ebp - 0xc8], 0 	(car.c:7535)
0x493794 : jmp 0x6
0x493799 : inc dword ptr [ebp - 0xc8]
0x49379f : cmp dword ptr [ebp - 0xc8], 4
0x4937a6 : -jge 0x17e
         : +jge 0x14f
0x4937ac : cmp dword ptr [ebp - 0xc8], 3 	(car.c:7536)
0x4937b3 : -jne 0x28
         : +jne 0x1f
0x4937b9 : mov eax, dword ptr [ebp - 4] 	(car.c:7537)
0x4937bc : mov eax, dword ptr [eax]
0x4937be : -mov dword ptr [ebp - 0xc4], eax
         : +mov dword ptr [ebp - 0x3c], eax
0x4937c4 : mov eax, dword ptr [ebp - 4]
0x4937c7 : mov eax, dword ptr [eax + 4]
0x4937ca : -mov dword ptr [ebp - 0xc0], eax
         : +mov dword ptr [ebp - 0x38], eax
0x4937d0 : mov eax, dword ptr [ebp - 4]
0x4937d3 : mov eax, dword ptr [eax + 8]
0x4937d6 : -mov dword ptr [ebp - 0xbc], eax
0x4937dc : -jmp 0x3d
         : +mov dword ptr [ebp - 0x34], eax
         : +jmp 0x31 	(car.c:7538)
0x4937e1 : mov eax, dword ptr [ebp - 4] 	(car.c:7539)
0x4937e4 : mov eax, dword ptr [eax + 0xc]
0x4937e7 : -mov dword ptr [ebp - 0xc4], eax
         : +mov dword ptr [ebp - 0x3c], eax
0x4937ed : mov eax, dword ptr [ebp - 4]
0x4937f0 : mov eax, dword ptr [eax + 0x10]
0x4937f3 : -mov dword ptr [ebp - 0xc0], eax
         : +mov dword ptr [ebp - 0x38], eax
0x4937f9 : mov eax, dword ptr [ebp - 4]
0x4937fc : mov eax, dword ptr [eax + 0x14]
0x4937ff : -mov dword ptr [ebp - 0xbc], eax
         : +mov dword ptr [ebp - 0x34], eax
0x493805 : mov eax, dword ptr [ebp - 0xc8] 	(car.c:7540)
0x49380b : mov ecx, dword ptr [ebp - 4]
0x49380e : mov edx, dword ptr [ebp - 0xc8]
0x493814 : mov eax, dword ptr [ecx + eax*4]
0x493817 : -mov dword ptr [ebp + edx*4 - 0xc4], eax
         : +mov dword ptr [ebp + edx*4 - 0x3c], eax
0x49381e : mov dword ptr [ebp - 0xd8], 0 	(car.c:7542)
0x493828 : jmp 0x6
0x49382d : inc dword ptr [ebp - 0xd8]
0x493833 : cmp dword ptr [ebp - 0xd8], 3
0x49383a : -jge 0xe5
0x493840 : -mov eax, dword ptr [ebp - 0xc4]
0x493846 : -mov dword ptr [ebp - 0xd4], eax
0x49384c : -mov eax, dword ptr [ebp - 0xc0]
0x493852 : -mov dword ptr [ebp - 0xd0], eax
0x493858 : -mov eax, dword ptr [ebp - 0xbc]
0x49385e : -mov dword ptr [ebp - 0xcc], eax
         : +jge 0xcb
         : +mov eax, dword ptr [ebp - 0x3c] 	(car.c:7543)
         : +mov dword ptr [ebp - 0x18], eax
         : +mov eax, dword ptr [ebp - 0x38]
         : +mov dword ptr [ebp - 0x14], eax
         : +mov eax, dword ptr [ebp - 0x34]
         : +mov dword ptr [ebp - 0x10], eax
0x493864 : mov eax, dword ptr [ebp - 0xd8] 	(car.c:7544)
0x49386a : mov ecx, dword ptr [ebp - 4]
0x49386d : fld dword ptr [ecx + eax*4 + 0xc]
0x493871 : mov eax, dword ptr [ebp - 0xd8]
0x493877 : -fcomp dword ptr [ebp + eax*4 - 0xd4]
         : +fcomp dword ptr [ebp + eax*4 - 0x18]
0x49387e : fnstsw ax
0x493880 : test ah, 0x40
0x493883 : -je 0x1e
         : +je 0x1b
0x493889 : mov eax, dword ptr [ebp - 0xd8] 	(car.c:7545)
0x49388f : mov ecx, dword ptr [ebp - 4]
0x493892 : mov edx, dword ptr [ebp - 0xd8]
0x493898 : mov eax, dword ptr [ecx + eax*4]
0x49389b : -mov dword ptr [ebp + edx*4 - 0xd4], eax
0x4938a2 : -jmp 0x1a
         : +mov dword ptr [ebp + edx*4 - 0x18], eax
         : +jmp 0x17 	(car.c:7546)
0x4938a7 : mov eax, dword ptr [ebp - 0xd8] 	(car.c:7547)
0x4938ad : mov ecx, dword ptr [ebp - 4]
0x4938b0 : mov edx, dword ptr [ebp - 0xd8]
0x4938b6 : mov eax, dword ptr [ecx + eax*4 + 0xc]
0x4938ba : -mov dword ptr [ebp + edx*4 - 0xd4], eax
         : +mov dword ptr [ebp + edx*4 - 0x18], eax
0x4938c1 : lea eax, [ebp - 0x78] 	(car.c:7549)
0x4938c4 : push eax
         : +lea eax, [ebp - 0x3c]
         : +push eax
0x4938c5 : lea eax, [ebp - 0xc4]
0x4938cb : -push eax
0x4938cc : -lea eax, [ebp - 0x18]
0x4938cf : push eax
0x4938d0 : call BrMatrix34ApplyP (FUNCTION)
0x4938d5 : add esp, 0xc
0x4938d8 : lea eax, [ebp - 0x78] 	(car.c:7550)
0x4938db : push eax
         : +lea eax, [ebp - 0x18]
         : +push eax
0x4938dc : lea eax, [ebp - 0xd4]
0x4938e2 : -push eax
0x4938e3 : -lea eax, [ebp - 0x24]
0x4938e6 : push eax
0x4938e7 : call BrMatrix34ApplyP (FUNCTION)
0x4938ec : add esp, 0xc
0x4938ef : lea eax, [ebp - 0xe8] 	(car.c:7551)
0x4938f5 : push eax
0x4938f6 : mov eax, dword ptr [ebp - 0x108]
0x4938fc : push eax
0x4938fd : -lea eax, [ebp - 0x24]
         : +lea eax, [ebp - 0xd4]
0x493900 : push eax
0x493901 : -lea eax, [ebp - 0x18]
         : +lea eax, [ebp - 0xc4]
0x493904 : push eax
0x493905 : call LineBoxColl (FUNCTION)
         : +add esp, 0x10
         : +test eax, eax
         : +je 0x6
         : +inc dword ptr [ebp - 0x104] 	(car.c:7552)
         : +jmp -0xde 	(car.c:7554)
         : +jmp -0x162 	(car.c:7555)
         : +mov eax, dword ptr [ebp - 0x104] 	(car.c:7556)
         : +jmp 0x0
         : +pop edi 	(car.c:7557)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


TestOldMats is only 75.79% similar to the original, diff above
```

*AI generated. Time taken: 125s, tokens: 18,715*
