### PR TITLE
CheckForDeAttachmentOfNonCars equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -7643,12 +7643,11 @@ void CheckForDeAttachmentOfNonCars(tU32 pTime) {
     tTrack_spec* track_spec;
     br_matrix34 mat;
 
+    last_free_slot = 0;
+    track_spec = &gProgram_state.track_spec;
     if (gNum_active_non_cars == 0) {
         return;
     }
-
-    last_free_slot = 0;
-    track_spec = &gProgram_state.track_spec;
 
     StartPipingSession(ePipe_chunk_non_car);
     for (i = 0; i < gNum_active_non_cars; i++) {
@@ -7663,7 +7662,7 @@ void CheckForDeAttachmentOfNonCars(tU32 pTime) {
         return;
     }
     total_time = 0;
-    for (i = 0; i < gNum_active_non_cars; i++) {
+    for (i = 0; i < gNum_active_non_cars; i++, last_free_slot++) {
         c = &gActive_non_car_list[i]->collision_info;
         if (c->car_master_actor->t.t.translate.t.v[1] < gMin_world_y) {
             c->doing_nothing_flag = 1;
@@ -7676,37 +7675,43 @@ void CheckForDeAttachmentOfNonCars(tU32 pTime) {
         }
         actor = c->car_master_actor;
         gActive_non_car_list[last_free_slot] = gActive_non_car_list[i];
-        if (c->doing_nothing_flag) {
-            drop = 1;
-            for (j = 0; j < gNum_cars_and_non_cars; j++) {
-                c2 = (tCollision_info*)gActive_car_list[j];
-                if (c2 != c && !c2->doing_nothing_flag) {
-                    BrMatrix34Mul(&mat, &actor->t.t.mat, &c2->last_box_inv_mat);
-                    GetNewBoundingBox(&bnds, &actor->model->bounds, &mat);
-                    if (c2->last_box.max.v[0] >= bnds.min.v[0]
-                        && c2->last_box.max.v[1] >= bnds.min.v[1]
-                        && c2->last_box.max.v[2] >= bnds.min.v[2]
-                        && c2->last_box.min.v[0] <= bnds.max.v[0]
-                        && c2->last_box.min.v[1] <= bnds.max.v[1]
-                        && c2->last_box.min.v[2] <= bnds.max.v[2]) {
+        if (!c->doing_nothing_flag) {
+            continue;
+        }
+        drop = 1;
+        for (j = 0; j < gNum_cars_and_non_cars; j++) {
+            c2 = (tCollision_info*)gActive_car_list[j];
+            if (c2 == c) {
+                continue;
+            }
+            if (c2->doing_nothing_flag) {
+                continue;
+            }
+            BrMatrix34Mul(&mat, &actor->t.t.mat, &c2->last_box_inv_mat);
+            GetNewBoundingBox(&bnds, &actor->model->bounds, &mat);
+            if (c2->last_box.max.v[0] >= bnds.min.v[0]
+                && c2->last_box.max.v[1] >= bnds.min.v[1]
+                && c2->last_box.max.v[2] >= bnds.min.v[2]
+                && c2->last_box.min.v[0] <= bnds.max.v[0]) {
+                if (c2->last_box.min.v[1] <= bnds.max.v[1]) {
+                    if (c2->last_box.min.v[2] <= bnds.max.v[2]) {
                         drop = 0;
                         break;
                     }
                 }
             }
-            if (drop) {
-                BrActorRemove(actor);
-                c->driver = eDriver_non_car_unused_slot;
-                last_free_slot--;
-                XZToColumnXZ(&cx, &cz, actor->t.t.mat.m[3][0], actor->t.t.mat.m[3][2], track_spec);
-                if (track_spec->columns[cz][cx] != NULL) {
-                    BrActorAdd(track_spec->columns[cz][cx], actor);
-                } else {
-                    BrActorAdd(gTrack_actor, actor);
-                }
+        }
+        if (drop) {
+            BrActorRemove(actor);
+            c->driver = eDriver_non_car_unused_slot;
+            last_free_slot--;
+            XZToColumnXZ(&cx, &cz, actor->t.t.mat.m[3][0], actor->t.t.mat.m[3][2], track_spec);
+            if (track_spec->columns[cz][cx] != NULL) {
+                BrActorAdd(track_spec->columns[cz][cx], actor);
+            } else {
+                BrActorAdd(gTrack_actor, actor);
             }
         }
-        last_free_slot++;
     }
     gNum_active_non_cars = last_free_slot;
 }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x493ee0,26 +0x464fb3,26 @@
0x493ee0 : fcomp dword ptr [ebp - 0x50]
0x493ee3 : fnstsw ax
0x493ee5 : test ah, 1
0x493ee8 : jne 0x51
0x493eee : mov eax, dword ptr [ebp - 0x3c]
0x493ef1 : fld dword ptr [eax + 0x210]
0x493ef7 : fcomp dword ptr [ebp - 0x4c]
0x493efa : fnstsw ax
0x493efc : test ah, 0x41
0x493eff : je 0x3a
         : +fld dword ptr [ebp - 0x48] 	(car.c:7696)
0x493f05 : mov eax, dword ptr [ebp - 0x3c]
0x493f08 : -fld dword ptr [eax + 0x214]
0x493f0e : -fcomp dword ptr [ebp - 0x48]
         : +fcomp dword ptr [eax + 0x214]
0x493f11 : fnstsw ax
0x493f13 : -test ah, 0x41
0x493f16 : -je 0x23
         : +test ah, 1
         : +jne 0x23
0x493f1c : mov eax, dword ptr [ebp - 0x3c] 	(car.c:7697)
0x493f1f : fld dword ptr [eax + 0x218]
0x493f25 : fcomp dword ptr [ebp - 0x44]
0x493f28 : fnstsw ax
0x493f2a : test ah, 0x41
0x493f2d : je 0xc
0x493f33 : mov dword ptr [ebp - 0x40], 0 	(car.c:7698)
0x493f3a : jmp 0x5 	(car.c:7699)
0x493f3f : jmp -0x115 	(car.c:7703)
0x493f44 : cmp dword ptr [ebp - 0x40], 0 	(car.c:7704)


CheckForDeAttachmentOfNonCars is only 98.35% similar to the original, diff above
```

#### Effective match analysis

The only substantive change is the compare around `[eax+0x214]` vs `[ebp-0x48]`: original does `fld [eax+0x214]; fcomp [ebp-0x48]; test ah,0x41; je ...` (branch when `[eax+0x214] > [ebp-0x48]`), while new does `fld [ebp-0x48]; fcomp [eax+0x214]; test ah,1; jne ...` (branch when `[ebp-0x48] < [eax+0x214]`). These are the same ordered condition, so functional behavior matches under your stated tolerances. The NaN/unordered case differs, but you explicitly said to ignore NaN behavior.

#### Original match

```
---
+++
@@ -0x493c46,23 +0x464d19,23 @@
0x493c46 : push ebp 	(car.c:7630)
0x493c47 : mov ebp, esp
0x493c49 : sub esp, 0x70
0x493c4c : push ebx
0x493c4d : push esi
0x493c4e : push edi
         : +cmp dword ptr [gNum_active_non_cars (DATA)], 0 	(car.c:7646)
         : +jne 0x5
         : +jmp 0x37d 	(car.c:7647)
0x493c4f : mov dword ptr [ebp - 0x5c], 0 	(car.c:7650)
0x493c56 : mov eax, gProgram_state (DATA) 	(car.c:7651)
0x493c5b : add eax, 0x1c84
0x493c60 : mov dword ptr [ebp - 0x38], eax
0x493c63 : -cmp dword ptr [gNum_active_non_cars (DATA)], 0
0x493c6a : -jne 0x5
0x493c70 : -jmp 0x378
0x493c75 : push 0x17 	(car.c:7653)
0x493c77 : call StartPipingSession (FUNCTION)
0x493c7c : add esp, 4
0x493c7f : mov dword ptr [ebp - 0x60], 0 	(car.c:7654)
0x493c86 : jmp 0x3
0x493c8b : inc dword ptr [ebp - 0x60]
0x493c8e : mov eax, dword ptr [gNum_active_non_cars (DATA)]
0x493c93 : cmp dword ptr [ebp - 0x60], eax
0x493c96 : jge 0x46
0x493c9c : mov eax, dword ptr [ebp - 0x60] 	(car.c:7655)

---
+++
@@ -0x493ccd,29 +0x464da0,28 @@
0x493ccd : mov cx, word ptr [eax + 0x250]
0x493cd4 : push ecx
0x493cd5 : call AddNonCarToPipingSession (FUNCTION)
0x493cda : add esp, 8
0x493cdd : jmp -0x57 	(car.c:7658)
0x493ce2 : call EndPipingSession (FUNCTION) 	(car.c:7659)
0x493ce7 : mov eax, dword ptr [ebp + 8] 	(car.c:7661)
0x493cea : add dword ptr [total_time (DATA)], eax
0x493cf0 : cmp dword ptr [total_time (DATA)], 0x3e8 	(car.c:7662)
0x493cfa : jae 0x5
0x493d00 : -jmp 0x2e8
         : +jmp 0x2d9 	(car.c:7663)
0x493d05 : mov dword ptr [total_time (DATA)], 0 	(car.c:7665)
0x493d0f : mov dword ptr [ebp - 0x60], 0 	(car.c:7666)
0x493d16 : -jmp 0x6
         : +jmp 0x3
0x493d1b : inc dword ptr [ebp - 0x60]
0x493d1e : -inc dword ptr [ebp - 0x5c]
0x493d21 : mov eax, dword ptr [gNum_active_non_cars (DATA)]
0x493d26 : cmp dword ptr [ebp - 0x60], eax
0x493d29 : -jge 0x2b6
         : +jge 0x2aa
0x493d2f : mov eax, dword ptr [ebp - 0x60] 	(car.c:7667)
0x493d32 : mov eax, dword ptr [eax*4 + gActive_non_car_list[0] (DATA)]
0x493d39 : mov dword ptr [ebp - 0x34], eax
0x493d3c : mov eax, dword ptr [ebp - 0x34] 	(car.c:7668)
0x493d3f : mov eax, dword ptr [eax + 0xc]
0x493d42 : fld dword ptr [eax + 0x54]
0x493d45 : fcomp dword ptr [gMin_world_y (DATA)]
0x493d4b : fnstsw ax
0x493d4d : test ah, 1
0x493d50 : je 0xd

---
+++
@@ -0x493de0,40 +0x464eb0,37 @@
0x493de0 : mov dword ptr [eax + 0x228], 1
0x493dea : mov eax, dword ptr [ebp - 0x34] 	(car.c:7677)
0x493ded : mov eax, dword ptr [eax + 0xc]
0x493df0 : mov dword ptr [ebp - 0x70], eax
0x493df3 : mov eax, dword ptr [ebp - 0x60] 	(car.c:7678)
0x493df6 : mov eax, dword ptr [eax*4 + gActive_non_car_list[0] (DATA)]
0x493dfd : mov ecx, dword ptr [ebp - 0x5c]
0x493e00 : mov dword ptr [ecx*4 + gActive_non_car_list[0] (DATA)], eax
0x493e07 : mov eax, dword ptr [ebp - 0x34] 	(car.c:7679)
0x493e0a : cmp dword ptr [eax + 0x228], 0
0x493e11 : -jne 0x5
0x493e17 : -jmp -0x101
         : +je 0x1ba
0x493e1c : mov dword ptr [ebp - 0x40], 1 	(car.c:7680)
0x493e23 : mov dword ptr [ebp - 0x68], 0 	(car.c:7681)
0x493e2a : jmp 0x3
0x493e2f : inc dword ptr [ebp - 0x68]
0x493e32 : mov eax, dword ptr [gNum_cars_and_non_cars (DATA)]
0x493e37 : cmp dword ptr [ebp - 0x68], eax
0x493e3a : -jge 0x104
         : +jge 0xfa
0x493e40 : mov eax, dword ptr [ebp - 0x68] 	(car.c:7682)
0x493e43 : mov eax, dword ptr [eax*4 + gActive_car_list[0] (DATA)]
0x493e4a : mov dword ptr [ebp - 0x3c], eax
0x493e4d : mov eax, dword ptr [ebp - 0x34] 	(car.c:7683)
0x493e50 : cmp dword ptr [ebp - 0x3c], eax
0x493e53 : -jne 0x5
0x493e59 : -jmp -0x2f
         : +je 0xdc
0x493e5e : mov eax, dword ptr [ebp - 0x3c]
0x493e61 : cmp dword ptr [eax + 0x228], 0
0x493e68 : -je 0x5
0x493e6e : -jmp -0x44
         : +jne 0xcc
0x493e73 : mov eax, dword ptr [ebp - 0x3c] 	(car.c:7684)
0x493e76 : add eax, 0x1e0
0x493e7b : push eax
0x493e7c : mov eax, dword ptr [ebp - 0x70]
0x493e7f : add eax, 0x2c
0x493e82 : push eax
0x493e83 : lea eax, [ebp - 0x30]
0x493e86 : push eax
0x493e87 : call BrMatrix34Mul (FUNCTION)
0x493e8c : add esp, 0xc

---
+++
@@ -0x493ee0,35 +0x464fa1,35 @@
0x493ee0 : fcomp dword ptr [ebp - 0x50]
0x493ee3 : fnstsw ax
0x493ee5 : test ah, 1
0x493ee8 : jne 0x51
0x493eee : mov eax, dword ptr [ebp - 0x3c]
0x493ef1 : fld dword ptr [eax + 0x210]
0x493ef7 : fcomp dword ptr [ebp - 0x4c]
0x493efa : fnstsw ax
0x493efc : test ah, 0x41
0x493eff : je 0x3a
         : +fld dword ptr [ebp - 0x48]
0x493f05 : mov eax, dword ptr [ebp - 0x3c]
0x493f08 : -fld dword ptr [eax + 0x214]
0x493f0e : -fcomp dword ptr [ebp - 0x48]
         : +fcomp dword ptr [eax + 0x214]
0x493f11 : fnstsw ax
0x493f13 : -test ah, 0x41
0x493f16 : -je 0x23
         : +test ah, 1
         : +jne 0x23
0x493f1c : mov eax, dword ptr [ebp - 0x3c]
0x493f1f : fld dword ptr [eax + 0x218]
0x493f25 : fcomp dword ptr [ebp - 0x44]
0x493f28 : fnstsw ax
0x493f2a : test ah, 0x41
0x493f2d : je 0xc
0x493f33 : mov dword ptr [ebp - 0x40], 0 	(car.c:7692)
0x493f3a : jmp 0x5 	(car.c:7693)
0x493f3f : -jmp -0x115
         : +jmp -0x10b 	(car.c:7696)
0x493f44 : cmp dword ptr [ebp - 0x40], 0 	(car.c:7697)
0x493f48 : je 0x92
0x493f4e : mov eax, dword ptr [ebp - 0x70] 	(car.c:7698)
0x493f51 : push eax
0x493f52 : call BrActorRemove (FUNCTION)
0x493f57 : add esp, 4
0x493f5a : mov eax, dword ptr [ebp - 0x34] 	(car.c:7699)
0x493f5d : mov dword ptr [eax + 8], 0
0x493f64 : dec dword ptr [ebp - 0x5c] 	(car.c:7700)
0x493f67 : mov eax, dword ptr [ebp - 0x38] 	(car.c:7701)

---
+++
@@ -0x493fc0,10 +0x465081,19 @@
0x493fc0 : push eax
0x493fc1 : call BrActorAdd (FUNCTION)
0x493fc6 : add esp, 8
0x493fc9 : jmp 0x12 	(car.c:7704)
0x493fce : mov eax, dword ptr [ebp - 0x70] 	(car.c:7705)
0x493fd1 : push eax
0x493fd2 : mov eax, dword ptr [gTrack_actor (DATA)]
0x493fd7 : push eax
0x493fd8 : call BrActorAdd (FUNCTION)
0x493fdd : add esp, 8
         : +inc dword ptr [ebp - 0x5c] 	(car.c:7709)
         : +jmp -0x2bb 	(car.c:7710)
         : +mov eax, dword ptr [ebp - 0x5c] 	(car.c:7711)
         : +mov dword ptr [gNum_active_non_cars (DATA)], eax
         : +pop edi 	(car.c:7712)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


CheckForDeAttachmentOfNonCars is only 90.95% similar to the original, diff above
```

*AI generated. Time taken: 692s, tokens: 66,602*
