### PR TITLE
GetPrecalculatedFacesUnderCar 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -7748,12 +7748,13 @@ void PipeSingleNonCar(tCollision_info* c) {
 // FUNCTION: CARM95 0x004941a2
 int GetPrecalculatedFacesUnderCar(tCar_spec* pCar, tFace_ref** pFace_refs) {
 
-    if (pCar->box_face_ref == gFace_num__car
-        || (pCar->box_face_ref == gFace_num__car - 1 && pCar->box_face_start > gFace_count)) {
-        *pFace_refs = &gFace_list__car[pCar->box_face_start];
-        return pCar->box_face_end - pCar->box_face_start;
+    if (pCar->box_face_ref != gFace_num__car) {
+        if (pCar->box_face_ref != gFace_num__car - 1 || pCar->box_face_start <= gFace_count) {
+            return 0;
+        }
     }
-    return 0;
+    *pFace_refs = &gFace_list__car[pCar->box_face_start];
+    return pCar->box_face_end - pCar->box_face_start;
 }
 
 // IDA: br_material* __cdecl SomeNearbyMaterial()


### PR DESCRIPTION
## Match result

```
0x4941a2: GetPrecalculatedFacesUnderCar 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4941a2,37 +0x465266,37 @@
0x4941a2 : push ebp 	(car.c:7749)
0x4941a3 : mov ebp, esp
0x4941a5 : push ebx
0x4941a6 : push esi
0x4941a7 : push edi
0x4941a8 : mov eax, dword ptr [ebp + 8] 	(car.c:7752)
0x4941ab : mov ecx, dword ptr [gFace_num__car (DATA)]
0x4941b1 : cmp dword ptr [eax + 0x1dc], ecx
0x4941b7 : -je 0x32
         : +je 0x2b
0x4941bd : mov eax, dword ptr [ebp + 8]
0x4941c0 : mov ecx, dword ptr [gFace_num__car (DATA)]
0x4941c6 : dec ecx
0x4941c7 : cmp dword ptr [eax + 0x1dc], ecx
0x4941cd : -jne 0x15
         : +jne 0x45
0x4941d3 : mov eax, dword ptr [ebp + 8]
0x4941d6 : mov ecx, dword ptr [gFace_count (DATA)]
0x4941dc : cmp dword ptr [eax + 0x1d4], ecx
0x4941e2 : -jg 0x7
0x4941e8 : -xor eax, eax
0x4941ea : -jmp 0x30
         : +jle 0x30
0x4941ef : mov eax, dword ptr [ebp + 8] 	(car.c:7753)
0x4941f2 : mov eax, dword ptr [eax + 0x1d4]
0x4941f8 : shl eax, 3
0x4941fb : lea eax, [eax + eax*8]
0x4941fe : add eax, gFace_list__car[0].material (DATA)
0x494203 : mov ecx, dword ptr [ebp + 0xc]
0x494206 : mov dword ptr [ecx], eax
0x494208 : mov eax, dword ptr [ebp + 8] 	(car.c:7754)
0x49420b : mov eax, dword ptr [eax + 0x1d8]
0x494211 : mov ecx, dword ptr [ebp + 8]
0x494214 : sub eax, dword ptr [ecx + 0x1d4]
         : +jmp 0x7
         : +xor eax, eax 	(car.c:7756)
0x49421a : jmp 0x0
0x49421f : pop edi 	(car.c:7757)
0x494220 : pop esi
0x494221 : pop ebx
0x494222 : leave 
0x494223 : ret 


GetPrecalculatedFacesUnderCar is only 86.49% similar to the original, diff above
```

*AI generated. Time taken: 126s, tokens: 31,061*
