### PR TITLE
PickBoundsTestRay__raycast 100% match

### DIFF
--- a/src/DETHRACE/common/raycast.c
+++ b/src/DETHRACE/common/raycast.c
@@ -109,27 +109,29 @@ int PickBoundsTestRay__raycast(br_bounds* b, br_vector3* rp, br_vector3* rd, br_
     float t;
 
     for (i = 0; i < 3; i++) {
-        if (rd->v[i] > 0.00000023841858) {
-            s = (1.0f / rd->v[i]) * (rp->v[i] - b->max.v[i]);
-            if (s > BR_SCALAR_MAX) {
+        if (rd->v[i] > 0.00000023841858f) {
+            s = 1.0f / rd->v[i];
+            t = (rp->v[i] - b->max.v[i]) * s;
+            if (t > BR_SCALAR_MAX) {
                 t_near = BR_SCALAR_MAX;
-            } else if (s > t_near) {
-                t_near = s;
+            } else if (t > t_near) {
+                t_near = t;
             }
-            t = (1.0f / rd->v[i]) * (rp->v[i] - b->min.v[i]);
+            t = (rp->v[i] - b->min.v[i]) * s;
             if (t < BR_SCALAR_MIN) {
                 t_far = BR_SCALAR_MIN;
             } else if (t < t_far) {
                 t_far = t;
             }
-        } else if (rd->v[i] < -0.00000023841858) {
-            s = (1.0f / rd->v[i]) * (rp->v[i] - b->max.v[i]);
-            if (s < BR_SCALAR_MIN) {
+        } else if (rd->v[i] < -0.00000023841858f) {
+            s = 1.0f / rd->v[i];
+            t = (rp->v[i] - b->max.v[i]) * s;
+            if (t < BR_SCALAR_MIN) {
                 t_far = BR_SCALAR_MIN;
-            } else if (s < t_far) {
-                t_far = s;
+            } else if (t < t_far) {
+                t_far = t;
             }
-            t = (1.0f / rd->v[i]) * (rp->v[i] - b->min.v[i]);
+            t = (rp->v[i] - b->min.v[i]) * s;
             if (t > BR_SCALAR_MAX) {
                 t_near = BR_SCALAR_MAX;
             } else if (t > t_near) {
@@ -139,12 +141,13 @@ int PickBoundsTestRay__raycast(br_bounds* b, br_vector3* rp, br_vector3* rd, br_
             return 0;
         }
     }
-    if (t_far < t_near) {
+    if (t_far >= t_near) {
+        *new_t_near = t_near;
+        *new_t_far = t_far;
+        return 1;
+    } else {
         return 0;
     }
-    *new_t_near = t_near;
-    *new_t_far = t_far;
-    return 1;
 }
 
 // IDA: int __usercall ActorPick2D@<EAX>(br_actor *ap@<EAX>, br_model *model@<EDX>, br_material *material@<EBX>, dr_pick2d_cbfn *callback@<ECX>, void *arg)


### PR DESCRIPTION
## Match result

```
0x494765: PickBoundsTestRay__raycast 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x494765,116 +0x4a8ef9,122 @@
0x494765 : push ebp 	(raycast.c:106)
0x494766 : mov ebp, esp
0x494768 : sub esp, 0xc
0x49476b : push ebx
0x49476c : push esi
0x49476d : push edi
0x49476e : mov dword ptr [ebp - 0xc], 0 	(raycast.c:111)
0x494775 : jmp 0x3
0x49477a : inc dword ptr [ebp - 0xc]
0x49477d : cmp dword ptr [ebp - 0xc], 3
0x494781 : -jge 0x1db
         : +jge 0x1ef
0x494787 : mov eax, dword ptr [ebp - 0xc] 	(raycast.c:112)
0x49478a : mov ecx, dword ptr [ebp + 0x10]
0x49478d : fld dword ptr [ecx + eax*4]
0x494790 : -fcomp dword ptr [2.384185791015625e-07 (FLOAT)]
         : +fcomp qword ptr [2.3841858e-07 (FLOAT)]
0x494796 : fnstsw ax
0x494798 : test ah, 0x41
0x49479b : -jne 0xb0
0x4947a1 : -fld dword ptr [1.0 (FLOAT)]
0x4947a7 : -mov eax, dword ptr [ebp - 0xc]
0x4947aa : -mov ecx, dword ptr [ebp + 0x10]
0x4947ad : -fdiv dword ptr [ecx + eax*4]
0x4947b0 : -fstp dword ptr [ebp - 4]
         : +jne 0xba
0x4947b3 : mov eax, dword ptr [ebp - 0xc] 	(raycast.c:113)
0x4947b6 : mov ecx, dword ptr [ebp + 0xc]
0x4947b9 : fld dword ptr [ecx + eax*4]
0x4947bc : mov eax, dword ptr [ebp - 0xc]
0x4947bf : mov ecx, dword ptr [ebp + 8]
0x4947c2 : fsub dword ptr [ecx + eax*4 + 0xc]
0x4947c6 : -fmul dword ptr [ebp - 4]
         : +fld dword ptr [1.0 (FLOAT)]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 0x10]
         : +fdiv dword ptr [ecx + eax*4]
         : +fmulp st(1)
0x4947c9 : fcom dword ptr [3.4028234663852886e+38 (FLOAT)] 	(raycast.c:114)
0x4947cf : -fstp dword ptr [ebp - 8]
         : +fstp dword ptr [ebp - 4]
0x4947d2 : fnstsw ax
0x4947d4 : test ah, 0x41
0x4947d7 : jne 0xc
0x4947dd : mov dword ptr [ebp + 0x14], 0x7f7fffff 	(raycast.c:115)
0x4947e4 : jmp 0x17 	(raycast.c:116)
0x4947e9 : fld dword ptr [ebp + 0x14]
0x4947ec : -fcomp dword ptr [ebp - 8]
         : +fcomp dword ptr [ebp - 4]
0x4947ef : fnstsw ax
0x4947f1 : test ah, 1
0x4947f4 : je 0x6
0x4947fa : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp - 4] 	(raycast.c:117)
0x4947fd : mov dword ptr [ebp + 0x14], eax
0x494800 : mov eax, dword ptr [ebp - 0xc] 	(raycast.c:119)
0x494803 : mov ecx, dword ptr [ebp + 0xc]
0x494806 : fld dword ptr [ecx + eax*4]
0x494809 : mov eax, dword ptr [ebp - 0xc]
0x49480c : mov ecx, dword ptr [ebp + 8]
0x49480f : fsub dword ptr [ecx + eax*4]
0x494812 : -fmul dword ptr [ebp - 4]
         : +fld dword ptr [1.0 (FLOAT)]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 0x10]
         : +fdiv dword ptr [ecx + eax*4]
         : +fmulp st(1)
0x494815 : fcom dword ptr [-3.4028234663852886e+38 (FLOAT)] 	(raycast.c:120)
0x49481b : fstp dword ptr [ebp - 8]
0x49481e : fnstsw ax
0x494820 : test ah, 1
0x494823 : je 0xc
0x494829 : mov dword ptr [ebp + 0x18], 0xff7fffff 	(raycast.c:121)
0x494830 : jmp 0x17 	(raycast.c:122)
0x494835 : fld dword ptr [ebp + 0x18]
0x494838 : fcomp dword ptr [ebp - 8]
0x49483b : fnstsw ax
0x49483d : test ah, 0x41
0x494840 : jne 0x6
0x494846 : mov eax, dword ptr [ebp - 8] 	(raycast.c:123)
0x494849 : mov dword ptr [ebp + 0x18], eax
0x49484c : -jmp 0x10c
         : +jmp 0x116 	(raycast.c:125)
0x494851 : mov eax, dword ptr [ebp - 0xc]
0x494854 : mov ecx, dword ptr [ebp + 0x10]
0x494857 : fld dword ptr [ecx + eax*4]
0x49485a : -fcomp dword ptr [-2.384185791015625e-07 (FLOAT)]
         : +fcomp qword ptr [-2.3841858e-07 (FLOAT)]
0x494860 : fnstsw ax
0x494862 : test ah, 1
0x494865 : -je 0xb0
0x49486b : -fld dword ptr [1.0 (FLOAT)]
0x494871 : -mov eax, dword ptr [ebp - 0xc]
0x494874 : -mov ecx, dword ptr [ebp + 0x10]
0x494877 : -fdiv dword ptr [ecx + eax*4]
0x49487a : -fstp dword ptr [ebp - 4]
         : +je 0xba
0x49487d : mov eax, dword ptr [ebp - 0xc] 	(raycast.c:126)
0x494880 : mov ecx, dword ptr [ebp + 0xc]
0x494883 : fld dword ptr [ecx + eax*4]
0x494886 : mov eax, dword ptr [ebp - 0xc]
0x494889 : mov ecx, dword ptr [ebp + 8]
0x49488c : fsub dword ptr [ecx + eax*4 + 0xc]
0x494890 : -fmul dword ptr [ebp - 4]
         : +fld dword ptr [1.0 (FLOAT)]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 0x10]
         : +fdiv dword ptr [ecx + eax*4]
         : +fmulp st(1)
0x494893 : fcom dword ptr [-3.4028234663852886e+38 (FLOAT)] 	(raycast.c:127)
0x494899 : -fstp dword ptr [ebp - 8]
         : +fstp dword ptr [ebp - 4]
0x49489c : fnstsw ax
0x49489e : test ah, 1
0x4948a1 : je 0xc
0x4948a7 : mov dword ptr [ebp + 0x18], 0xff7fffff 	(raycast.c:128)
0x4948ae : jmp 0x17 	(raycast.c:129)
0x4948b3 : fld dword ptr [ebp + 0x18]
0x4948b6 : -fcomp dword ptr [ebp - 8]
         : +fcomp dword ptr [ebp - 4]
0x4948b9 : fnstsw ax
0x4948bb : test ah, 0x41
0x4948be : jne 0x6
0x4948c4 : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp - 4] 	(raycast.c:130)
0x4948c7 : mov dword ptr [ebp + 0x18], eax
0x4948ca : mov eax, dword ptr [ebp - 0xc] 	(raycast.c:132)
0x4948cd : mov ecx, dword ptr [ebp + 0xc]
0x4948d0 : fld dword ptr [ecx + eax*4]
0x4948d3 : mov eax, dword ptr [ebp - 0xc]
0x4948d6 : mov ecx, dword ptr [ebp + 8]
0x4948d9 : fsub dword ptr [ecx + eax*4]
0x4948dc : -fmul dword ptr [ebp - 4]
         : +fld dword ptr [1.0 (FLOAT)]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 0x10]
         : +fdiv dword ptr [ecx + eax*4]
         : +fmulp st(1)
0x4948df : fcom dword ptr [3.4028234663852886e+38 (FLOAT)] 	(raycast.c:133)
0x4948e5 : fstp dword ptr [ebp - 8]
0x4948e8 : fnstsw ax
0x4948ea : test ah, 0x41
0x4948ed : jne 0xc
0x4948f3 : mov dword ptr [ebp + 0x14], 0x7f7fffff 	(raycast.c:134)
0x4948fa : jmp 0x17 	(raycast.c:135)
0x4948ff : fld dword ptr [ebp + 0x14]
0x494902 : fcomp dword ptr [ebp - 8]
0x494905 : fnstsw ax

---
+++
@@ -0x494939,33 +0x4a90e1,32 @@
0x494939 : mov eax, dword ptr [ebp - 0xc]
0x49493c : mov ecx, dword ptr [ebp + 0xc]
0x49493f : fld dword ptr [ecx + eax*4]
0x494942 : mov eax, dword ptr [ebp - 0xc]
0x494945 : mov ecx, dword ptr [ebp + 8]
0x494948 : fcomp dword ptr [ecx + eax*4]
0x49494b : fnstsw ax
0x49494d : test ah, 1
0x494950 : je 0x7
0x494956 : xor eax, eax 	(raycast.c:139)
0x494958 : -jmp 0x3c
0x49495d : -jmp -0x1e8
         : +jmp 0x37
         : +jmp -0x1fc 	(raycast.c:141)
0x494962 : fld dword ptr [ebp + 0x18] 	(raycast.c:142)
0x494965 : fcomp dword ptr [ebp + 0x14]
0x494968 : fnstsw ax
0x49496a : test ah, 1
0x49496d : -jne 0x1f
         : +je 0x7
         : +xor eax, eax 	(raycast.c:143)
         : +jmp 0x1a
0x494973 : mov eax, dword ptr [ebp + 0x1c] 	(raycast.c:145)
0x494976 : mov ecx, dword ptr [ebp + 0x14]
0x494979 : mov dword ptr [eax], ecx
0x49497b : mov eax, dword ptr [ebp + 0x20] 	(raycast.c:146)
0x49497e : mov ecx, dword ptr [ebp + 0x18]
0x494981 : mov dword ptr [eax], ecx
0x494983 : mov eax, 1 	(raycast.c:147)
0x494988 : -jmp 0xc
0x49498d : -jmp 0x7
0x494992 : -xor eax, eax
0x494994 : jmp 0x0
0x494999 : pop edi 	(raycast.c:148)
0x49499a : pop esi
0x49499b : pop ebx
0x49499c : leave 
0x49499d : ret 


PickBoundsTestRay__raycast is only 79.15% similar to the original, diff above
```

*AI generated. Time taken: 188s, tokens: 21,392*
