### PR TITLE
DRScenePick2D 100% match

### DIFF
--- a/src/DETHRACE/common/raycast.c
+++ b/src/DETHRACE/common/raycast.c
@@ -273,7 +273,7 @@ int DRScenePick2D(br_actor* world, br_actor* camera, dr_pick2d_cbfn* callback, v
     camera_data = (br_camera*)camera->type_data;
     DRActorToRoot(camera, world, &camera_tfm);
     BrMatrix34Inverse(&gPick_model_to_view__raycast, &camera_tfm);
-    scale = cos(BrAngleToRadian(camera_data->field_of_view / 2)) / sin(BrAngleToRadian(camera_data->field_of_view / 2));
+    scale = cos(BrAngleToRadian((unsigned short)(camera_data->field_of_view / 2))) / sin(BrAngleToRadian((unsigned short)(camera_data->field_of_view / 2)));
 
     BrMatrix34PostScale(&gPick_model_to_view__raycast, scale / camera_data->aspect, scale, 1.0f);
     return ActorPick2D(world, model_unk1, material_unk1, callback, arg);

--- a/src/DETHRACE/common/raycast.c
+++ b/src/DETHRACE/common/raycast.c
@@ -273,7 +273,7 @@ int DRScenePick2D(br_actor* world, br_actor* camera, dr_pick2d_cbfn* callback, v
     camera_data = (br_camera*)camera->type_data;
     DRActorToRoot(camera, world, &camera_tfm);
     BrMatrix34Inverse(&gPick_model_to_view__raycast, &camera_tfm);
-    scale = cos(BrAngleToRadian((unsigned short)(camera_data->field_of_view / 2))) / sin(BrAngleToRadian((unsigned short)(camera_data->field_of_view / 2)));
+    scale = BR_COS((br_angle)(camera_data->field_of_view / 2)) / BR_SIN((br_angle)(camera_data->field_of_view / 2));
 
     BrMatrix34PostScale(&gPick_model_to_view__raycast, scale / camera_data->aspect, scale, 1.0f);
     return ActorPick2D(world, model_unk1, material_unk1, callback, arg);


### PR DESCRIPTION
## Match result

```
0x49499e: DRScenePick2D 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4949c4,33 +0x4a9555,29 @@
0x4949c4 : lea eax, [ebp - 0x38] 	(raycast.c:275)
0x4949c7 : push eax
0x4949c8 : push gPick_model_to_view__raycast (DATA)
0x4949cd : call BrMatrix34Inverse (FUNCTION)
0x4949d2 : add esp, 8
0x4949d5 : fstp st(0)
0x4949d7 : mov eax, dword ptr [ebp - 8] 	(raycast.c:276)
0x4949da : xor ecx, ecx
0x4949dc : mov cx, word ptr [eax + 6]
0x4949e0 : sar ecx, 1
0x4949e2 : -mov eax, ecx
0x4949e4 : -and eax, 0xffff
0x4949e9 : -mov dword ptr [ebp - 0x3c], eax
         : +mov dword ptr [ebp - 0x3c], ecx
0x4949ec : fild dword ptr [ebp - 0x3c]
0x4949ef : fmul qword ptr [9.587379924285257e-05 (FLOAT)]
0x4949f5 : call __CIcos (FUNCTION)
0x4949fa : mov eax, dword ptr [ebp - 8]
0x4949fd : xor ecx, ecx
0x4949ff : mov cx, word ptr [eax + 6]
0x494a03 : sar ecx, 1
0x494a05 : -mov eax, ecx
0x494a07 : -and eax, 0xffff
0x494a0c : -mov dword ptr [ebp - 0x40], eax
         : +mov dword ptr [ebp - 0x40], ecx
0x494a0f : fild dword ptr [ebp - 0x40]
0x494a12 : fmul qword ptr [9.587379924285257e-05 (FLOAT)]
0x494a18 : call __CIsin (FUNCTION)
0x494a1d : fdivp st(1)
0x494a1f : fstp dword ptr [ebp - 4]
0x494a22 : push 0x3f800000 	(raycast.c:278)
0x494a27 : mov eax, dword ptr [ebp - 4]
0x494a2a : push eax
0x494a2b : fld dword ptr [ebp - 4]
0x494a2e : mov eax, dword ptr [ebp - 8]

---
+++
@@ -0x494a47,10 +0x4a95ca,18 @@
0x494a47 : mov eax, dword ptr [ebp + 0x14] 	(raycast.c:279)
0x494a4a : push eax
0x494a4b : mov eax, dword ptr [ebp + 0x10]
0x494a4e : push eax
0x494a4f : mov eax, dword ptr [material_unk1 (DATA)]
0x494a54 : push eax
0x494a55 : mov eax, dword ptr [model_unk1 (DATA)]
0x494a5a : push eax
0x494a5b : mov eax, dword ptr [ebp + 8]
0x494a5e : push eax
         : +call ActorPick2D (FUNCTION)
         : +add esp, 0x14
         : +jmp 0x0
         : +pop edi 	(raycast.c:280)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRScenePick2D is only 88.24% similar to the original, diff above
```

*AI generated. Time taken: 70s, tokens: 14,699*
