### PR TITLE
BadDiv__raycast 100% match

### DIFF
--- a/src/DETHRACE/common/raycast.c
+++ b/src/DETHRACE/common/raycast.c
@@ -324,8 +324,8 @@ int DRModelPick2D__raycast(br_model* model, br_material* material, br_vector3* r
         grp_ptr = &V11MODEL(model)->groups[group];
         for (f = 0; f < V11MODEL(model)->groups[group].nfaces; f++) {
             eqn = &V11MODEL(model)->groups[group].eqn[f];
-            if (V11MODEL(model)->groups[group].face_colours != NULL) {
-                this_material = (br_material*)(uintptr_t)V11MODEL(model)->groups[group].face_colours[0];
+            if (V11MODEL(model)->groups[group].user != NULL) {
+                this_material = V11MODEL(model)->groups[group].user;
             } else {
                 this_material = material;
             }
@@ -342,19 +342,15 @@ int DRModelPick2D__raycast(br_model* model, br_material* material, br_vector3* r
                         if (fabs(eqn->v[2]) > fabs(eqn->v[axis_m])) {
                             axis_m = 2;
                         }
-                        switch (axis_m) {
-                        case 0:
+                        if (axis_m == 0) {
                             axis_0 = 1;
                             axis_1 = 2;
-                            break;
-                        case 1:
+                        } else if (axis_m == 1) {
                             axis_0 = 0;
                             axis_1 = 2;
-                            break;
-                        case 2:
+                        } else if (axis_m == 2) {
                             axis_0 = 0;
                             axis_1 = 1;
-                            break;
                         }
 
                         v0 = grp_ptr->position[grp_ptr->vertex_numbers[f].v[0]].v[axis_0];

--- a/src/DETHRACE/common/raycast.c
+++ b/src/DETHRACE/common/raycast.c
@@ -88,7 +88,7 @@ void InitRayCasting(void) {
 // FUNCTION: CARM95 0x004952ca
 int BadDiv__raycast(br_scalar a, br_scalar b) {
     //
-    return fabs(b) < 1.0 && fabs(a) > fabs(b) * BR_SCALAR_MAX;
+    return (float)fabs(b) < 1.0f && (float)fabs(a) > (float)fabs(b) * BR_SCALAR_MAX;
 }
 
 // IDA: void __usercall DRVector2AccumulateScale(br_vector2 *a@<EAX>, br_vector2 *b@<EDX>, br_scalar s)
@@ -324,8 +324,8 @@ int DRModelPick2D__raycast(br_model* model, br_material* material, br_vector3* r
         grp_ptr = &V11MODEL(model)->groups[group];
         for (f = 0; f < V11MODEL(model)->groups[group].nfaces; f++) {
             eqn = &V11MODEL(model)->groups[group].eqn[f];
-            if (V11MODEL(model)->groups[group].user != NULL) {
-                this_material = V11MODEL(model)->groups[group].user;
+            if (V11MODEL(model)->groups[group].face_colours != NULL) {
+                this_material = (br_material*)(uintptr_t)V11MODEL(model)->groups[group].face_colours[0];
             } else {
                 this_material = material;
             }
@@ -342,15 +342,19 @@ int DRModelPick2D__raycast(br_model* model, br_material* material, br_vector3* r
                         if (fabs(eqn->v[2]) > fabs(eqn->v[axis_m])) {
                             axis_m = 2;
                         }
-                        if (axis_m == 0) {
+                        switch (axis_m) {
+                        case 0:
                             axis_0 = 1;
                             axis_1 = 2;
-                        } else if (axis_m == 1) {
+                            break;
+                        case 1:
                             axis_0 = 0;
                             axis_1 = 2;
-                        } else if (axis_m == 2) {
+                            break;
+                        case 2:
                             axis_0 = 0;
                             axis_1 = 1;
+                            break;
                         }
 
                         v0 = grp_ptr->position[grp_ptr->vertex_numbers[f].v[0]].v[axis_0];


### PR DESCRIPTION
## Match result

```
0x4952ca: BadDiv__raycast 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4952ca,24 +0x4a8e78,24 @@
0x4952ca : push ebp 	(raycast.c:89)
0x4952cb : mov ebp, esp
0x4952cd : push ebx
0x4952ce : push esi
0x4952cf : push edi
0x4952d0 : fld dword ptr [ebp + 0xc] 	(raycast.c:91)
0x4952d3 : fabs 
0x4952d5 : -fcomp dword ptr [1.0 (FLOAT)]
         : +fcomp qword ptr [1.0 (FLOAT)]
0x4952db : fnstsw ax
0x4952dd : test ah, 1
0x4952e0 : je 0x27
0x4952e6 : fld dword ptr [ebp + 0xc]
0x4952e9 : fabs 
0x4952eb : -fmul dword ptr [3.4028234663852886e+38 (FLOAT)]
         : +fmul qword ptr [3.4028234663852886e+38 (FLOAT)]
0x4952f1 : fld dword ptr [ebp + 8]
0x4952f4 : fabs 
0x4952f6 : fcompp 
0x4952f8 : fnstsw ax
0x4952fa : test ah, 0x41
0x4952fd : jne 0xa
0x495303 : mov eax, 1
0x495308 : jmp 0x2
0x49530d : xor eax, eax
0x49530f : jmp 0x0


BadDiv__raycast is only 93.10% similar to the original, diff above
```

*AI generated. Time taken: 114s, tokens: 21,258*
