### PR TITLE
FindHighestPolyCallBack__raycast equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/raycast.c
+++ b/src/DETHRACE/common/raycast.c
@@ -424,16 +424,17 @@ int DRModelPick2D__raycast(br_model* model, br_material* material, br_vector3* r
 int FindHighestPolyCallBack__raycast(br_model* pModel, br_material* pMaterial, br_vector3* pRay_pos, br_vector3* pRay_dir, br_scalar pT, int pF, int pE, int pV, br_vector3* pPoint, br_vector2* pMap, void* pArg) {
     br_scalar the_y;
 
-    if (pPoint->v[1] > gCurrent_y) {
-        if (gLowest_y_above > pPoint->v[1]) {
-            gLowest_y_above = pPoint->v[1];
-            gAbove_face_index = pF;
-            gAbove_model = pModel;
+    the_y = pPoint->v[1];
+    if (the_y <= gCurrent_y) {
+        if (the_y > gHighest_y_below) {
+            gHighest_y_below = the_y;
+            gBelow_face_index = pF;
+            gBelow_model = pModel;
         }
-    } else if (pPoint->v[1] > gHighest_y_below) {
-        gHighest_y_below = pPoint->v[1];
-        gBelow_face_index = pF;
-        gBelow_model = pModel;
+    } else if (gLowest_y_above > the_y) {
+        gLowest_y_above = the_y;
+        gAbove_face_index = pF;
+        gAbove_model = pModel;
     }
     return 0;
 }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x495352,25 +0x4a9c9e,25 @@
0x495352 : push esi
0x495353 : push edi
0x495354 : mov eax, dword ptr [ebp + 0x28] 	(raycast.c:427)
0x495357 : mov eax, dword ptr [eax + 4]
0x49535a : mov dword ptr [ebp - 4], eax
0x49535d : fld dword ptr [ebp - 4] 	(raycast.c:428)
0x495360 : fcomp dword ptr [gCurrent_y (DATA)]
0x495366 : fnstsw ax
0x495368 : test ah, 0x41
0x49536b : je 0x31
0x495371 : -fld dword ptr [ebp - 4]
0x495374 : -fcomp dword ptr [gHighest_y_below (DATA)]
         : +fld dword ptr [gHighest_y_below (DATA)] 	(raycast.c:429)
         : +fcomp dword ptr [ebp - 4]
0x49537a : fnstsw ax
0x49537c : -test ah, 0x41
0x49537f : -jne 0x18
         : +test ah, 1
         : +je 0x18
0x495385 : mov eax, dword ptr [ebp - 4] 	(raycast.c:430)
0x495388 : mov dword ptr [gHighest_y_below (DATA)], eax
0x49538d : mov eax, dword ptr [ebp + 0x1c] 	(raycast.c:431)
0x495390 : mov dword ptr [gBelow_face_index (DATA)], eax
0x495395 : mov eax, dword ptr [ebp + 8] 	(raycast.c:432)
0x495398 : mov dword ptr [gBelow_model (DATA)], eax
0x49539d : jmp 0x2c 	(raycast.c:434)
0x4953a2 : fld dword ptr [gLowest_y_above (DATA)]
0x4953a8 : fcomp dword ptr [ebp - 4]
0x4953ab : fnstsw ax


FindHighestPolyCallBack__raycast is only 90.91% similar to the original, diff above
```

#### Effective match analysis

Yes, for non-NaN inputs this is functionally equivalent. The changed block reverses `fcomp` operands (`value` vs `gHighest_y_below`) and correspondingly changes the flag test from `test ah, 0x41` / `jne` to `test ah, 1` / `je`. Both versions update `gHighest_y_below`, `gBelow_face_index`, and `gBelow_model` only when `value > gHighest_y_below`; they skip on `value <= gHighest_y_below`. The first compare against `gCurrent_y` is unchanged in effect, and control flow structure is not reshuffled.

#### Original match

```
---
+++
@@ -0x49534b,44 +0x4a9c97,46 @@
0x49534b : push ebp 	(raycast.c:424)
0x49534c : mov ebp, esp
0x49534e : sub esp, 4
0x495351 : push ebx
0x495352 : push esi
0x495353 : push edi
0x495354 : mov eax, dword ptr [ebp + 0x28] 	(raycast.c:427)
0x495357 : -mov eax, dword ptr [eax + 4]
0x49535a : -mov dword ptr [ebp - 4], eax
0x49535d : -fld dword ptr [ebp - 4]
         : +fld dword ptr [eax + 4]
0x495360 : fcomp dword ptr [gCurrent_y (DATA)]
0x495366 : fnstsw ax
0x495368 : test ah, 0x41
0x49536b : -je 0x31
0x495371 : -fld dword ptr [ebp - 4]
         : +jne 0x37
         : +mov eax, dword ptr [ebp + 0x28] 	(raycast.c:428)
         : +fld dword ptr [eax + 4]
         : +fcomp dword ptr [gLowest_y_above (DATA)]
         : +fnstsw ax
         : +test ah, 1
         : +je 0x1b
         : +mov eax, dword ptr [ebp + 0x28] 	(raycast.c:429)
         : +mov eax, dword ptr [eax + 4]
         : +mov dword ptr [gLowest_y_above (DATA)], eax
         : +mov eax, dword ptr [ebp + 0x1c] 	(raycast.c:430)
         : +mov dword ptr [gAbove_face_index (DATA)], eax
         : +mov eax, dword ptr [ebp + 8] 	(raycast.c:431)
         : +mov dword ptr [gAbove_model (DATA)], eax
         : +jmp 0x32 	(raycast.c:433)
         : +mov eax, dword ptr [ebp + 0x28]
         : +fld dword ptr [eax + 4]
0x495374 : fcomp dword ptr [gHighest_y_below (DATA)]
0x49537a : fnstsw ax
0x49537c : test ah, 0x41
0x49537f : -jne 0x18
0x495385 : -mov eax, dword ptr [ebp - 4]
         : +jne 0x1b
         : +mov eax, dword ptr [ebp + 0x28] 	(raycast.c:434)
         : +mov eax, dword ptr [eax + 4]
0x495388 : mov dword ptr [gHighest_y_below (DATA)], eax
0x49538d : mov eax, dword ptr [ebp + 0x1c] 	(raycast.c:435)
0x495390 : mov dword ptr [gBelow_face_index (DATA)], eax
0x495395 : mov eax, dword ptr [ebp + 8] 	(raycast.c:436)
0x495398 : mov dword ptr [gBelow_model (DATA)], eax
0x49539d : -jmp 0x2c
0x4953a2 : -fld dword ptr [gLowest_y_above (DATA)]
0x4953a8 : -fcomp dword ptr [ebp - 4]
0x4953ab : -fnstsw ax
0x4953ad : -test ah, 0x41
0x4953b0 : -jne 0x18
0x4953b6 : -mov eax, dword ptr [ebp - 4]
0x4953b9 : -mov dword ptr [gLowest_y_above (DATA)], eax
0x4953be : -mov eax, dword ptr [ebp + 0x1c]
0x4953c1 : -mov dword ptr [gAbove_face_index (DATA)], eax
0x4953c6 : -mov eax, dword ptr [ebp + 8]
0x4953c9 : -mov dword ptr [gAbove_model (DATA)], eax
0x4953ce : xor eax, eax 	(raycast.c:438)
0x4953d0 : jmp 0x0
0x4953d5 : pop edi 	(raycast.c:439)
0x4953d6 : pop esi
0x4953d7 : pop ebx
0x4953d8 : leave 
0x4953d9 : ret 


FindHighestPolyCallBack__raycast is only 55.56% similar to the original, diff above
```

*AI generated. Time taken: 616s, tokens: 81,715*
