### PR TITLE
FindYVerticallyBelowPolyCallBack 100% match

### DIFF
--- a/src/DETHRACE/common/raycast.c
+++ b/src/DETHRACE/common/raycast.c
@@ -473,11 +473,12 @@ void FindBestY(br_vector3* pPosition, br_actor* gWorld, br_scalar pStarting_heig
 int FindYVerticallyBelowPolyCallBack(br_model* pModel, br_material* pMaterial, br_vector3* pRay_pos, br_vector3* pRay_dir, br_scalar pT, int pF, int pE, int pV, br_vector3* pPoint, br_vector2* pMap, void* pArg) {
     br_scalar the_y;
 
-    if (pMaterial->identifier == NULL || pMaterial->identifier[0] != '!') {
-        the_y = pPoint->v[Y];
-        if (the_y > gHighest_y_below) {
-            gHighest_y_below = the_y;
-        }
+    if (pMaterial->identifier != NULL && pMaterial->identifier[0] == '!') {
+        return 0;
+    }
+    the_y = pPoint->v[Y];
+    if (the_y > gHighest_y_below) {
+        gHighest_y_below = the_y;
     }
     return 0;
 }


### PR DESCRIPTION
## Match result

```
0x4955eb: FindYVerticallyBelowPolyCallBack 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4955eb,27 +0x4a9e43,31 @@
0x4955eb : push ebp 	(raycast.c:473)
0x4955ec : mov ebp, esp
0x4955ee : sub esp, 4
0x4955f1 : push ebx
0x4955f2 : push esi
0x4955f3 : push edi
0x4955f4 : mov eax, dword ptr [ebp + 0xc] 	(raycast.c:476)
0x4955f7 : cmp dword ptr [eax + 4], 0
0x4955fb : -je 0x19
         : +je 0x12
0x495601 : mov eax, dword ptr [ebp + 0xc]
0x495604 : mov eax, dword ptr [eax + 4]
0x495607 : movsx eax, byte ptr [eax]
0x49560a : cmp eax, 0x21
0x49560d : -jne 0x7
0x495613 : -xor eax, eax
0x495615 : -jmp 0x2c
         : +je 0x25
0x49561a : mov eax, dword ptr [ebp + 0x28] 	(raycast.c:477)
0x49561d : mov eax, dword ptr [eax + 4]
0x495620 : mov dword ptr [ebp - 4], eax
0x495623 : fld dword ptr [ebp - 4] 	(raycast.c:478)
0x495626 : fcomp dword ptr [gHighest_y_below (DATA)]
0x49562c : fnstsw ax
0x49562e : test ah, 0x41
0x495631 : jne 0x8
0x495637 : mov eax, dword ptr [ebp - 4] 	(raycast.c:479)
0x49563a : mov dword ptr [gHighest_y_below (DATA)], eax
0x49563f : xor eax, eax 	(raycast.c:482)
         : +jmp 0x0
         : +pop edi 	(raycast.c:483)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


FindYVerticallyBelowPolyCallBack is only 79.31% similar to the original, diff above
```

*AI generated. Time taken: 74s, tokens: 21,023*
