### PR TITLE
FindYVerticallyBelow2 100% match

### DIFF
--- a/src/DETHRACE/common/raycast.c
+++ b/src/DETHRACE/common/raycast.c
@@ -529,13 +529,14 @@ br_scalar FindYVerticallyBelow2(br_vector3* pCast_point) {
     int number_of_attempts;
     br_vector3 cast_point;
 
+    number_of_attempts = 0;
+#if 0
     BrVector3Copy(&cast_point, pCast_point);
-    for (number_of_attempts = 0; number_of_attempts <= 10; number_of_attempts++) {
+#endif
+    cast_point = *pCast_point;
+    do {
         result = FindYVerticallyBelow(&cast_point);
         cast_point.v[Y] += .2f;
-        if (result >= -100.f) {
-            return result;
-        }
-    }
+    } while (result < -100.f && number_of_attempts++ < 10);
     return result;
 }

--- a/src/DETHRACE/common/raycast.c
+++ b/src/DETHRACE/common/raycast.c
@@ -530,9 +530,6 @@ br_scalar FindYVerticallyBelow2(br_vector3* pCast_point) {
     br_vector3 cast_point;
 
     number_of_attempts = 0;
-#if 0
-    BrVector3Copy(&cast_point, pCast_point);
-#endif
     cast_point = *pCast_point;
     do {
         result = FindYVerticallyBelow(&cast_point);


### PR DESCRIPTION
## Match result

```
0x49564b: FindYVerticallyBelow2 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x49564b,40 +0x4aa0bd,43 @@
0x49564b : push ebp 	(raycast.c:527)
0x49564c : mov ebp, esp
0x49564e : -sub esp, 0x18
         : +sub esp, 0x14
0x495651 : push ebx
0x495652 : push esi
0x495653 : push edi
         : +mov eax, dword ptr [ebp + 8] 	(raycast.c:532)
         : +mov eax, dword ptr [eax]
         : +mov dword ptr [ebp - 0x14], eax
         : +mov eax, dword ptr [ebp + 8]
         : +mov eax, dword ptr [eax + 4]
         : +mov dword ptr [ebp - 0x10], eax
         : +mov eax, dword ptr [ebp + 8]
         : +mov eax, dword ptr [eax + 8]
         : +mov dword ptr [ebp - 0xc], eax
0x495654 : mov dword ptr [ebp - 8], 0 	(raycast.c:533)
0x49565b : -mov eax, dword ptr [ebp + 8]
0x49565e : -lea ecx, [ebp - 0x14]
0x495661 : -mov edx, dword ptr [eax]
0x495663 : -mov dword ptr [ecx], edx
0x495665 : -mov edx, dword ptr [eax + 4]
0x495668 : -mov dword ptr [ecx + 4], edx
0x49566b : -mov eax, dword ptr [eax + 8]
0x49566e : -mov dword ptr [ecx + 8], eax
         : +jmp 0x3
         : +inc dword ptr [ebp - 8]
         : +cmp dword ptr [ebp - 8], 0xa
         : +jg 0x3c
0x495671 : lea eax, [ebp - 0x14] 	(raycast.c:534)
0x495674 : push eax
0x495675 : call FindYVerticallyBelow (FUNCTION)
0x49567a : add esp, 4
0x49567d : fstp dword ptr [ebp - 4]
0x495680 : fld dword ptr [ebp - 0x10] 	(raycast.c:535)
0x495683 : fadd dword ptr [0.20000000298023224 (FLOAT)]
0x495689 : fstp dword ptr [ebp - 0x10]
0x49568c : fld dword ptr [ebp - 4] 	(raycast.c:536)
0x49568f : fcomp dword ptr [-100.0 (FLOAT)]
0x495695 : fnstsw ax
0x495697 : test ah, 1
0x49569a : -je 0x13
0x4956a0 : -mov eax, dword ptr [ebp - 8]
0x4956a3 : -mov dword ptr [ebp - 0x18], eax
0x4956a6 : -inc dword ptr [ebp - 8]
0x4956a9 : -cmp dword ptr [ebp - 0x18], 0xa
0x4956ad : -jl -0x42
         : +jne 0x8
         : +fld dword ptr [ebp - 4] 	(raycast.c:537)
         : +jmp 0xd
         : +jmp -0x49 	(raycast.c:539)
0x4956b3 : fld dword ptr [ebp - 4] 	(raycast.c:540)
0x4956b6 : jmp 0x0
0x4956bb : pop edi 	(raycast.c:541)
0x4956bc : pop esi
0x4956bd : pop ebx
0x4956be : leave 
0x4956bf : ret 


FindYVerticallyBelow2 is only 60.24% similar to the original, diff above
```

*AI generated. Time taken: 572s, tokens: 48,324*
