### PR TITLE
SetFlicSound 100% match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -645,8 +645,8 @@ void DisableTranslationText(void) {
 // FUNCTION: CARM95 0x004959ba
 void SetFlicSound(int pSound_ID, tU32 pSound_time) {
 
-    gSound_time = pSound_time;
     gSound_ID = pSound_ID;
+    gSound_time = pSound_time;
 }
 
 // IDA: int __cdecl TranslationMode()


### PR DESCRIPTION
## Match result

```
0x4959ba: SetFlicSound 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4959ba,14 +0x47abc0,14 @@
0x4959ba : push ebp 	(flicplay.c:646)
0x4959bb : mov ebp, esp
0x4959bd : push ebx
0x4959be : push esi
0x4959bf : push edi
         : +mov eax, dword ptr [ebp + 0xc] 	(flicplay.c:648)
         : +mov dword ptr [gSound_time (DATA)], eax
0x4959c0 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:649)
0x4959c3 : mov dword ptr [gSound_ID (DATA)], eax
0x4959c8 : -mov eax, dword ptr [ebp + 0xc]
0x4959cb : -mov dword ptr [gSound_time (DATA)], eax
0x4959d0 : pop edi 	(flicplay.c:650)
0x4959d1 : pop esi
0x4959d2 : pop ebx
0x4959d3 : leave 
0x4959d4 : ret 


SetFlicSound is only 85.71% similar to the original, diff above
```

*AI generated. Time taken: 91s, tokens: 11,547*
