### PR TITLE
PlayNextFlicFrame2 100% match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1494,7 +1494,11 @@ int PlayNextFlicFrame2(tFlic_descriptor* pFlic_info, int pPanel_flic) {
     }
     if (pFlic_info->f != NULL && pFlic_info->bytes_still_to_be_read) {
         data_knocked_off = pFlic_info->data - pFlic_info->data_start;
+#ifdef DETHRACE_FIX_BUGS
+        memmove(pFlic_info->data_start, pFlic_info->data, pFlic_info->bytes_in_buffer - data_knocked_off);
+#else
         memcpy(pFlic_info->data_start, pFlic_info->data, pFlic_info->bytes_in_buffer - data_knocked_off);
+#endif
         pFlic_info->data = pFlic_info->data_start;
         pFlic_info->bytes_in_buffer -= data_knocked_off;
 

--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1472,7 +1472,6 @@ int PlayNextFlicFrame2(tFlic_descriptor* pFlic_info, int pPanel_flic) {
             default:
                 LOG_WARN("unrecognized chunk type");
                 MemSkipBytes(&pFlic_info->data, chunk_length - 6);
-                break;
             }
             // Align on even byte
             pFlic_info->data = (char*)((uintptr_t)(pFlic_info->data + 1) & (~(uintptr_t)1));
@@ -1485,19 +1484,24 @@ int PlayNextFlicFrame2(tFlic_descriptor* pFlic_info, int pPanel_flic) {
     }
     pFlic_info->current_frame++;
     pFlic_info->frames_left--;
+    if (pFlic_info->frames_left == 0) {
+        last_frame = 1;
+    } else {
+        last_frame = 0;
+    }
     if (gTrans_enabled && gTranslation_count != 0 && !pPanel_flic) {
-        DrawTranslations(pFlic_info, pFlic_info->frames_left == 0);
+        DrawTranslations(pFlic_info, last_frame);
     }
     if (pFlic_info->f != NULL && pFlic_info->bytes_still_to_be_read) {
         data_knocked_off = pFlic_info->data - pFlic_info->data_start;
-        memmove(pFlic_info->data_start, pFlic_info->data, pFlic_info->bytes_in_buffer - data_knocked_off);
+        memcpy(pFlic_info->data_start, pFlic_info->data, pFlic_info->bytes_in_buffer - data_knocked_off);
         pFlic_info->data = pFlic_info->data_start;
         pFlic_info->bytes_in_buffer -= data_knocked_off;
 
-        if (pFlic_info->bytes_still_to_be_read > data_knocked_off) {
-            read_amount = data_knocked_off;
-        } else {
+        if (pFlic_info->bytes_still_to_be_read <= data_knocked_off) {
             read_amount = pFlic_info->bytes_still_to_be_read;
+        } else {
+            read_amount = data_knocked_off;
         }
         if (read_amount != 0) {
             fread(&pFlic_info->data_start[pFlic_info->bytes_in_buffer], 1, read_amount, pFlic_info->f);
@@ -1505,7 +1509,7 @@ int PlayNextFlicFrame2(tFlic_descriptor* pFlic_info, int pPanel_flic) {
         pFlic_info->bytes_in_buffer += read_amount;
         pFlic_info->bytes_still_to_be_read -= read_amount;
     }
-    return pFlic_info->frames_left == 0;
+    return last_frame;
 }
 
 // IDA: int __usercall PlayNextFlicFrame@<EAX>(tFlic_descriptor *pFlic_info@<EAX>)


### PR DESCRIPTION
## Match result

```
0x495ff5: PlayNextFlicFrame2 100% match.

OK!
```

#### Original match

```
---
+++
@@ -,144 +,145 @@
0x49602a : call MemReadU16 (FUNCTION)
0x49602f : add esp, 4
0x496032 : and eax, 0xffff
0x496037 : mov dword ptr [ebp - 0x24], eax
0x49603a : push 8 	(flicplay.c:1426)
0x49603c : mov eax, dword ptr [ebp + 8]
0x49603f : push eax
0x496040 : call MemSkipBytes (FUNCTION)
0x496045 : add esp, 8
0x496048 : cmp dword ptr [ebp - 0x10], 0xf1fa 	(flicplay.c:1427)
0x49604f : -jne 0x1fc
         : +jne 0x201
0x496055 : mov dword ptr [ebp - 8], 0 	(flicplay.c:1428)
0x49605c : jmp 0x3
0x496061 : inc dword ptr [ebp - 8]
0x496064 : mov eax, dword ptr [ebp - 0x24]
0x496067 : cmp dword ptr [ebp - 8], eax
0x49606a : -jge 0x1dc
         : +jge 0x1e1
0x496070 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1429)
0x496073 : push eax
0x496074 : call MemReadU32 (FUNCTION)
0x496079 : add esp, 4
0x49607c : mov dword ptr [ebp - 0x14], eax
0x49607f : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1430)
0x496082 : push eax
0x496083 : call MemReadU16 (FUNCTION)
0x496088 : add esp, 4
0x49608b : and eax, 0xffff
0x496090 : mov dword ptr [ebp - 0x1c], eax
0x496093 : mov eax, dword ptr [ebp - 0x1c] 	(flicplay.c:1431)
0x496096 : mov dword ptr [ebp - 0x28], eax
0x496099 : -jmp 0x148
         : +jmp 0x14d
0x49609e : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1433)
0x4960a1 : push eax
0x4960a2 : mov eax, dword ptr [ebp + 8]
0x4960a5 : push eax
0x4960a6 : call DoColour256 (FUNCTION)
0x4960ab : add esp, 8
0x4960ae : -jmp 0x186
         : +jmp 0x18b 	(flicplay.c:1434)
0x4960b3 : cmp dword ptr [gTransparency_on (DATA)], 0 	(flicplay.c:1436)
0x4960ba : je 0x15
0x4960c0 : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1437)
0x4960c3 : push eax
0x4960c4 : mov eax, dword ptr [ebp + 8]
0x4960c7 : push eax
0x4960c8 : call DoDeltaTrans (FUNCTION)
0x4960cd : add esp, 8
0x4960d0 : jmp 0x10 	(flicplay.c:1438)
0x4960d5 : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1439)
0x4960d8 : push eax
0x4960d9 : mov eax, dword ptr [ebp + 8]
0x4960dc : push eax
0x4960dd : call DoDeltaX (FUNCTION)
0x4960e2 : add esp, 8
0x4960e5 : -jmp 0x14f
         : +jmp 0x154 	(flicplay.c:1441)
0x4960ea : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1443)
0x4960ed : push eax
0x4960ee : mov eax, dword ptr [ebp + 8]
0x4960f1 : push eax
0x4960f2 : call DoColourMap (FUNCTION)
0x4960f7 : add esp, 8
0x4960fa : -jmp 0x13a
         : +jmp 0x13f 	(flicplay.c:1444)
0x4960ff : cmp dword ptr [gTransparency_on (DATA)], 0 	(flicplay.c:1446)
0x496106 : je 0x15
0x49610c : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1447)
0x49610f : push eax
0x496110 : mov eax, dword ptr [ebp + 8]
0x496113 : push eax
0x496114 : call DoDifferenceTrans (FUNCTION)
0x496119 : add esp, 8
0x49611c : jmp 0x10 	(flicplay.c:1448)
0x496121 : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1449)
0x496124 : push eax
0x496125 : mov eax, dword ptr [ebp + 8]
0x496128 : push eax
0x496129 : call DoDifferenceX (FUNCTION)
0x49612e : add esp, 8
0x496131 : -jmp 0x103
         : +jmp 0x108 	(flicplay.c:1451)
0x496136 : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1453)
0x496139 : push eax
0x49613a : mov eax, dword ptr [ebp + 8]
0x49613d : push eax
0x49613e : call DoBlack (FUNCTION)
0x496143 : add esp, 8
0x496146 : -jmp 0xee
         : +jmp 0xf3 	(flicplay.c:1454)
0x49614b : cmp dword ptr [gTransparency_on (DATA)], 0 	(flicplay.c:1456)
0x496152 : je 0x15
0x496158 : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1457)
0x49615b : push eax
0x49615c : mov eax, dword ptr [ebp + 8]
0x49615f : push eax
0x496160 : call DoRunLengthTrans (FUNCTION)
0x496165 : add esp, 8
0x496168 : jmp 0x10 	(flicplay.c:1458)
0x49616d : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1459)
0x496170 : push eax
0x496171 : mov eax, dword ptr [ebp + 8]
0x496174 : push eax
0x496175 : call DoRunLengthX (FUNCTION)
0x49617a : add esp, 8
0x49617d : -jmp 0xb7
         : +jmp 0xbc 	(flicplay.c:1461)
0x496182 : cmp dword ptr [gTransparency_on (DATA)], 0 	(flicplay.c:1463)
0x496189 : je 0x15
0x49618f : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1464)
0x496192 : push eax
0x496193 : mov eax, dword ptr [ebp + 8]
0x496196 : push eax
0x496197 : call DoUncompressedTrans (FUNCTION)
0x49619c : add esp, 8
0x49619f : jmp 0x10 	(flicplay.c:1465)
0x4961a4 : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1466)
0x4961a7 : push eax
0x4961a8 : mov eax, dword ptr [ebp + 8]
0x4961ab : push eax
0x4961ac : call DoUncompressed (FUNCTION)
0x4961b1 : add esp, 8
0x4961b4 : -jmp 0x80
         : +jmp 0x85 	(flicplay.c:1468)
0x4961b9 : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1470)
0x4961bc : push eax
0x4961bd : mov eax, dword ptr [ebp + 8]
0x4961c0 : push eax
0x4961c1 : call DoMini (FUNCTION)
0x4961c6 : add esp, 8
0x4961c9 : -jmp 0x6b
         : +jmp 0x70 	(flicplay.c:1471)
0x4961ce : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1474)
0x4961d1 : sub eax, 6
0x4961d4 : push eax
0x4961d5 : mov eax, dword ptr [ebp + 8]
0x4961d8 : push eax
0x4961d9 : call MemSkipBytes (FUNCTION)
0x4961de : add esp, 8
         : +jmp 0x58 	(flicplay.c:1475)
0x4961e1 : jmp 0x53 	(flicplay.c:1476)
0x4961e6 : sub dword ptr [ebp - 0x28], 4
0x4961ea : cmp dword ptr [ebp - 0x28], 0xe
0x4961ee : -ja -0x26
         : +ja -0x2b
0x4961f4 : mov eax, dword ptr [ebp - 0x28]
0x4961f7 : xor ecx, ecx
0x4961f9 : mov cl, byte ptr [eax + <OFFSET18>]
0x4961ff : jmp dword ptr [ecx*4 + <OFFSET19>]
 : Jump table:
0x496206 : start + 0xa9
0x49620a : start + 0xbe
0x49620e : start + 0xf5
0x496212 : start + 0x10a
0x496216 : start + 0x141

---
+++
@@ -0x496235,93 +0x47c2c3,93 @@
0x496235 : 0x5
0x496236 : 0x6
0x496237 : 0x8
0x496238 : 0x7
0x496239 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1478)
0x49623c : mov eax, dword ptr [eax]
0x49623e : inc eax
0x49623f : and eax, 0xfffffffe
0x496242 : mov ecx, dword ptr [ebp + 8]
0x496245 : mov dword ptr [ecx], eax
0x496247 : -jmp -0x1eb
         : +jmp -0x1f0 	(flicplay.c:1479)
0x49624c : jmp 0x1f 	(flicplay.c:1480)
0x496251 : mov eax, dword ptr [ebp - 0x20] 	(flicplay.c:1482)
0x496254 : sub eax, 0x10
0x496257 : push eax
0x496258 : mov eax, dword ptr [ebp + 8]
0x49625b : push eax
0x49625c : call MemSkipBytes (FUNCTION)
0x496261 : add esp, 8
0x496264 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1483)
0x496267 : inc dword ptr [eax + 0x4c]
0x49626a : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1484)
0x49626d : dec dword ptr [eax + 0x50]
0x496270 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1486)
0x496273 : inc dword ptr [eax + 0x50]
0x496276 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1487)
0x496279 : dec dword ptr [eax + 0x4c]
         : +cmp dword ptr [gTrans_enabled (DATA)], 0 	(flicplay.c:1488)
         : +je 0x2f
         : +cmp dword ptr [gTranslation_count (DATA)], 0
         : +je 0x22
         : +cmp dword ptr [ebp + 0xc], 0
         : +jne 0x18
0x49627c : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1489)
0x49627f : -cmp dword ptr [eax + 0x4c], 0
0x496283 : -jne 0xc
0x496289 : -mov dword ptr [ebp - 0xc], 1
0x496290 : -jmp 0x7
0x496295 : -mov dword ptr [ebp - 0xc], 0
0x49629c : -cmp dword ptr [gTrans_enabled (DATA)], 0
0x4962a3 : -je 0x27
0x4962a9 : -cmp dword ptr [gTranslation_count (DATA)], 0
0x4962b0 : -je 0x1a
0x4962b6 : -cmp dword ptr [ebp + 0xc], 0
0x4962ba : -jne 0x10
0x4962c0 : -mov eax, dword ptr [ebp - 0xc]
         : +cmp dword ptr [eax + 0x4c], 1
         : +sbb eax, eax
         : +neg eax
0x4962c3 : push eax
0x4962c4 : mov eax, dword ptr [ebp + 8]
0x4962c7 : push eax
0x4962c8 : call DrawTranslations (FUNCTION)
0x4962cd : add esp, 8
0x4962d0 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1491)
0x4962d3 : cmp dword ptr [eax + 0x68], 0
0x4962d7 : -je 0xb0
         : +je 0xb7
0x4962dd : mov eax, dword ptr [ebp + 8]
0x4962e0 : cmp dword ptr [eax + 0x60], 0
0x4962e4 : -je 0xa3
         : +je 0xaa
0x4962ea : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1492)
0x4962ed : mov eax, dword ptr [eax]
0x4962ef : mov ecx, dword ptr [ebp + 8]
0x4962f2 : sub eax, dword ptr [ecx + 4]
0x4962f5 : mov dword ptr [ebp - 0x18], eax
0x4962f8 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1493)
0x4962fb : mov eax, dword ptr [eax + 0x64]
0x4962fe : sub eax, dword ptr [ebp - 0x18]
0x496301 : -mov ecx, dword ptr [ebp + 8]
0x496304 : -mov edx, dword ptr [ebp + 8]
0x496307 : -mov edi, dword ptr [edx + 4]
0x49630a : -mov esi, dword ptr [ecx]
0x49630c : -mov ecx, eax
0x49630e : -rep movsb byte ptr es:[edi], byte ptr [esi]
         : +push eax
         : +mov eax, dword ptr [ebp + 8]
         : +mov eax, dword ptr [eax]
         : +push eax
         : +mov eax, dword ptr [ebp + 8]
         : +mov eax, dword ptr [eax + 4]
         : +push eax
         : +call memmove (FUNCTION)
         : +add esp, 0xc
0x496310 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1494)
0x496313 : mov eax, dword ptr [eax + 4]
0x496316 : mov ecx, dword ptr [ebp + 8]
0x496319 : mov dword ptr [ecx], eax
0x49631b : xor eax, eax 	(flicplay.c:1495)
0x49631d : sub eax, dword ptr [ebp - 0x18]
0x496320 : neg eax
0x496322 : mov ecx, dword ptr [ebp + 8]
0x496325 : sub dword ptr [ecx + 0x64], eax
0x496328 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1497)
0x49632b : mov ecx, dword ptr [ebp - 0x18]
0x49632e : cmp dword ptr [eax + 0x60], ecx
0x496331 : -jg 0xe
         : +jle 0xb
         : +mov eax, dword ptr [ebp - 0x18] 	(flicplay.c:1498)
         : +mov dword ptr [ebp - 4], eax
         : +jmp 0x9 	(flicplay.c:1499)
0x496337 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1500)
0x49633a : mov eax, dword ptr [eax + 0x60]
0x49633d : -mov dword ptr [ebp - 4], eax
0x496340 : -jmp 0x6
0x496345 : -mov eax, dword ptr [ebp - 0x18]
0x496348 : mov dword ptr [ebp - 4], eax
0x49634b : cmp dword ptr [ebp - 4], 0 	(flicplay.c:1502)
0x49634f : je 0x22
0x496355 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1503)
0x496358 : mov eax, dword ptr [eax + 0x68]
0x49635b : push eax
0x49635c : mov eax, dword ptr [ebp - 4]
0x49635f : push eax
0x496360 : push 1
0x496362 : mov eax, dword ptr [ebp + 8]

---
+++
@@ -0x49636f,17 +0x47c3ec,22 @@
0x49636f : call fread (FUNCTION)
0x496374 : add esp, 0x10
0x496377 : mov eax, dword ptr [ebp - 4] 	(flicplay.c:1505)
0x49637a : mov ecx, dword ptr [ebp + 8]
0x49637d : add dword ptr [ecx + 0x64], eax
0x496380 : xor eax, eax 	(flicplay.c:1506)
0x496382 : sub eax, dword ptr [ebp - 4]
0x496385 : neg eax
0x496387 : mov ecx, dword ptr [ebp + 8]
0x49638a : sub dword ptr [ecx + 0x60], eax
0x49638d : -mov eax, dword ptr [ebp - 0xc]
         : +mov eax, dword ptr [ebp + 8] 	(flicplay.c:1508)
         : +cmp dword ptr [eax + 0x4c], 0
         : +jne 0xa
         : +mov eax, 1
         : +jmp 0x2
         : +xor eax, eax
0x496390 : jmp 0x0
0x496395 : pop edi 	(flicplay.c:1509)
0x496396 : pop esi
0x496397 : pop ebx
0x496398 : leave 
0x496399 : ret 


PlayNextFlicFrame2 is only 86.20% similar to the original, diff above
```

*AI generated. Time taken: 379s, tokens: 47,414*
