### PR TITLE
DoColourMap 100% effective match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -905,24 +905,16 @@ void DoColourMap(tFlic_descriptor_ptr pFlic_info, tU32 chunk_length) {
             blue = MemReadU8(&pFlic_info->data) * 4;
             // argb
 #if BR_ENDIAN_BIG
-            palette_pixels++;
-            *palette_pixels = red;
-            palette_pixels++;
-            *palette_pixels = green;
-            palette_pixels++;
-            *palette_pixels = blue;
-            palette_pixels -= 3;
-            *palette_pixels = 0;
+            *palette_pixels++ = 0;
+            *palette_pixels++ = red;
+            *palette_pixels++ = green;
+            *palette_pixels++ = blue;
 #else
-            *palette_pixels = blue;
-            palette_pixels++;
-            *palette_pixels = green;
-            palette_pixels++;
-            *palette_pixels = red;
-            palette_pixels++;
-            *palette_pixels = 0;
+            *palette_pixels++ = blue;
+            *palette_pixels++ = green;
+            *palette_pixels++ = red;
+            *palette_pixels++ = 0;
 #endif
-            palette_pixels++;
         }
         if (!gPalette_fuck_prevention) {
             DRSetPaletteEntries(gPalette, current_colour, change_count);

--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -901,22 +901,22 @@ void DoColourMap(tFlic_descriptor_ptr pFlic_info, tU32 chunk_length) {
         palette_pixels = (tU8*)gPalette_pixels + current_colour * sizeof(br_int_32);
         for (j = 0; j < change_count; j++) {
             red = MemReadU8(&pFlic_info->data) * 4;
-            blue = MemReadU8(&pFlic_info->data) * 4;
             green = MemReadU8(&pFlic_info->data) * 4;
+            blue = MemReadU8(&pFlic_info->data) * 4;
             // argb
 #if BR_ENDIAN_BIG
             palette_pixels++;
             *palette_pixels = red;
             palette_pixels++;
-            *palette_pixels = blue;
-            palette_pixels++;
             *palette_pixels = green;
+            palette_pixels++;
+            *palette_pixels = blue;
             palette_pixels -= 3;
             *palette_pixels = 0;
 #else
-            *palette_pixels = green;
-            palette_pixels++;
             *palette_pixels = blue;
+            palette_pixels++;
+            *palette_pixels = green;
             palette_pixels++;
             *palette_pixels = red;
             palette_pixels++;
@@ -2156,7 +2156,6 @@ void LoadInterfaceStrings(void) {
         fclose(f);
 #endif
     }
-
 }
 
 // IDA: void __cdecl FlushInterfaceFonts()

--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -889,34 +889,40 @@ void DoColourMap(tFlic_descriptor_ptr pFlic_info, tU32 chunk_length) {
     tU8 green;
     tU8 blue;
 
-    palette_pixels = gPalette_pixels;
-
     packet_count = MemReadU16(&pFlic_info->data);
     for (i = 0; i < packet_count; i++) {
         skip_count = MemReadU8(&pFlic_info->data);
         change_count = MemReadU8(&pFlic_info->data);
-        if (!change_count) {
+        if (change_count) {
+        } else {
             change_count = 256;
         }
-        palette_pixels += skip_count * sizeof(br_int_32);
         current_colour += skip_count;
+        palette_pixels = (tU8*)gPalette_pixels + current_colour * sizeof(br_int_32);
         for (j = 0; j < change_count; j++) {
-            red = MemReadU8(&pFlic_info->data);
-            blue = MemReadU8(&pFlic_info->data);
-            green = MemReadU8(&pFlic_info->data);
+            red = MemReadU8(&pFlic_info->data) * 4;
+            blue = MemReadU8(&pFlic_info->data) * 4;
+            green = MemReadU8(&pFlic_info->data) * 4;
             // argb
 #if BR_ENDIAN_BIG
-            palette_pixels[3] = green * 4;
-            palette_pixels[2] = blue * 4;
-            palette_pixels[1] = red * 4;
-            palette_pixels[0] = 0;
+            palette_pixels++;
+            *palette_pixels = red;
+            palette_pixels++;
+            *palette_pixels = blue;
+            palette_pixels++;
+            *palette_pixels = green;
+            palette_pixels -= 3;
+            *palette_pixels = 0;
 #else
-            palette_pixels[0] = green * 4;
-            palette_pixels[1] = blue * 4;
-            palette_pixels[2] = red * 4;
-            palette_pixels[3] = 0;
+            *palette_pixels = green;
+            palette_pixels++;
+            *palette_pixels = blue;
+            palette_pixels++;
+            *palette_pixels = red;
+            palette_pixels++;
+            *palette_pixels = 0;
 #endif
-            palette_pixels += 4;
+            palette_pixels++;
         }
         if (!gPalette_fuck_prevention) {
             DRSetPaletteEntries(gPalette, current_colour, change_count);


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x49640e,23 +0x47b256,23 @@
0x49640e : mov dword ptr [ebp - 0x28], 0x100 	(flicplay.c:898)
0x496415 : mov eax, dword ptr [ebp - 0x24] 	(flicplay.c:900)
0x496418 : add dword ptr [ebp - 0x18], eax
0x49641b : mov eax, dword ptr [ebp - 0x18] 	(flicplay.c:901)
0x49641e : shl eax, 2
0x496421 : add eax, dword ptr [gPalette_pixels (DATA)]
0x496427 : mov dword ptr [ebp - 0xc], eax
0x49642a : mov dword ptr [ebp - 0x1c], 0 	(flicplay.c:902)
0x496431 : jmp 0x3
0x496436 : inc dword ptr [ebp - 0x1c]
0x496439 : -mov eax, dword ptr [ebp - 0x1c]
0x49643c : -cmp dword ptr [ebp - 0x28], eax
0x49643f : -jle 0x71
         : +mov eax, dword ptr [ebp - 0x28]
         : +cmp dword ptr [ebp - 0x1c], eax
         : +jge 0x71
0x496445 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:903)
0x496448 : push eax
0x496449 : call MemReadU8 (FUNCTION)
0x49644e : add esp, 4
0x496451 : xor ecx, ecx
0x496453 : mov cl, al
0x496455 : shl ecx, 2
0x496458 : mov byte ptr [ebp - 8], cl
0x49645b : mov eax, dword ptr [ebp + 8] 	(flicplay.c:904)
0x49645e : push eax


0x49639a: DoColourMap 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x49639a,97 +0x47b1e2,99 @@
0x49639a : push ebp 	(flicplay.c:880)
0x49639b : mov ebp, esp
0x49639d : sub esp, 0x28
0x4963a0 : push ebx
0x4963a1 : push esi
0x4963a2 : push edi
0x4963a3 : mov dword ptr [ebp - 0x18], 0 	(flicplay.c:886)
         : +mov eax, dword ptr [gPalette_pixels (DATA)] 	(flicplay.c:892)
         : +mov dword ptr [ebp - 0xc], eax
0x4963aa : mov eax, dword ptr [ebp + 8] 	(flicplay.c:894)
0x4963ad : push eax
0x4963ae : call MemReadU16 (FUNCTION)
0x4963b3 : add esp, 4
0x4963b6 : and eax, 0xffff
0x4963bb : mov dword ptr [ebp - 4], eax
0x4963be : mov dword ptr [ebp - 0x10], 0 	(flicplay.c:895)
0x4963c5 : jmp 0x3
0x4963ca : inc dword ptr [ebp - 0x10]
0x4963cd : mov eax, dword ptr [ebp - 0x10]
0x4963d0 : cmp dword ptr [ebp - 4], eax
0x4963d3 : -jle 0x105
         : +jle 0xef
0x4963d9 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:896)
0x4963dc : push eax
0x4963dd : call MemReadU8 (FUNCTION)
0x4963e2 : add esp, 4
0x4963e5 : xor ecx, ecx
0x4963e7 : mov cl, al
0x4963e9 : mov dword ptr [ebp - 0x24], ecx
0x4963ec : mov eax, dword ptr [ebp + 8] 	(flicplay.c:897)
0x4963ef : push eax
0x4963f0 : call MemReadU8 (FUNCTION)
0x4963f5 : add esp, 4
0x4963f8 : xor ecx, ecx
0x4963fa : mov cl, al
0x4963fc : mov dword ptr [ebp - 0x28], ecx
0x4963ff : cmp dword ptr [ebp - 0x28], 0 	(flicplay.c:898)
0x496403 : -je 0x5
0x496409 : -jmp 0x7
         : +jne 0x7
0x49640e : mov dword ptr [ebp - 0x28], 0x100 	(flicplay.c:899)
0x496415 : mov eax, dword ptr [ebp - 0x24] 	(flicplay.c:901)
         : +shl eax, 2
         : +add dword ptr [ebp - 0xc], eax
         : +mov eax, dword ptr [ebp - 0x24] 	(flicplay.c:902)
0x496418 : add dword ptr [ebp - 0x18], eax
0x49641b : -mov eax, dword ptr [ebp - 0x18]
0x49641e : -shl eax, 2
0x496421 : -add eax, dword ptr [gPalette_pixels (DATA)]
0x496427 : -mov dword ptr [ebp - 0xc], eax
0x49642a : mov dword ptr [ebp - 0x1c], 0 	(flicplay.c:903)
0x496431 : jmp 0x3
0x496436 : inc dword ptr [ebp - 0x1c]
0x496439 : -mov eax, dword ptr [ebp - 0x1c]
0x49643c : -cmp dword ptr [ebp - 0x28], eax
0x49643f : -jle 0x71
         : +mov eax, dword ptr [ebp - 0x28]
         : +cmp dword ptr [ebp - 0x1c], eax
         : +jge 0x66
0x496445 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:904)
0x496448 : push eax
0x496449 : call MemReadU8 (FUNCTION)
0x49644e : add esp, 4
0x496451 : -xor ecx, ecx
0x496453 : -mov cl, al
0x496455 : -shl ecx, 2
0x496458 : -mov byte ptr [ebp - 8], cl
         : +mov byte ptr [ebp - 8], al
0x49645b : mov eax, dword ptr [ebp + 8] 	(flicplay.c:905)
0x49645e : push eax
0x49645f : call MemReadU8 (FUNCTION)
0x496464 : add esp, 4
0x496467 : -xor ecx, ecx
0x496469 : -mov cl, al
0x49646b : -shl ecx, 2
0x49646e : -mov byte ptr [ebp - 0x14], cl
         : +mov byte ptr [ebp - 0x20], al
0x496471 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:906)
0x496474 : push eax
0x496475 : call MemReadU8 (FUNCTION)
0x49647a : add esp, 4
0x49647d : -xor ecx, ecx
0x49647f : -mov cl, al
0x496481 : -shl ecx, 2
0x496484 : -mov byte ptr [ebp - 0x20], cl
0x496487 : -mov al, byte ptr [ebp - 0x20]
         : +mov byte ptr [ebp - 0x14], al
         : +xor eax, eax 	(flicplay.c:914)
         : +mov al, byte ptr [ebp - 0x14]
         : +shl eax, 2
0x49648a : mov ecx, dword ptr [ebp - 0xc]
0x49648d : mov byte ptr [ecx], al
0x49648f : -inc dword ptr [ebp - 0xc]
0x496492 : -mov al, byte ptr [ebp - 0x14]
         : +xor eax, eax 	(flicplay.c:915)
         : +mov al, byte ptr [ebp - 0x20]
         : +shl eax, 2
0x496495 : mov ecx, dword ptr [ebp - 0xc]
0x496498 : -mov byte ptr [ecx], al
0x49649a : -inc dword ptr [ebp - 0xc]
         : +mov byte ptr [ecx + 1], al
         : +xor eax, eax 	(flicplay.c:916)
0x49649d : mov al, byte ptr [ebp - 8]
         : +shl eax, 2
0x4964a0 : mov ecx, dword ptr [ebp - 0xc]
0x4964a3 : -mov byte ptr [ecx], al
0x4964a5 : -inc dword ptr [ebp - 0xc]
         : +mov byte ptr [ecx + 2], al
0x4964a8 : mov eax, dword ptr [ebp - 0xc] 	(flicplay.c:917)
0x4964ab : -mov byte ptr [eax], 0
0x4964ae : -inc dword ptr [ebp - 0xc]
0x4964b1 : -jmp -0x80
         : +mov byte ptr [eax + 3], 0
         : +add dword ptr [ebp - 0xc], 4 	(flicplay.c:919)
         : +jmp -0x75 	(flicplay.c:920)
0x4964b6 : cmp dword ptr [gPalette_fuck_prevention (DATA)], 0 	(flicplay.c:921)
0x4964bd : jne 0x16
0x4964c3 : mov eax, dword ptr [ebp - 0x28] 	(flicplay.c:922)
0x4964c6 : push eax
0x4964c7 : mov eax, dword ptr [ebp - 0x18]
0x4964ca : push eax
0x4964cb : mov eax, dword ptr [gPalette (DATA)]
0x4964d0 : push eax
         : +call DRSetPaletteEntries (FUNCTION)
         : +add esp, 0xc
         : +jmp -0xfe 	(flicplay.c:924)
         : +pop edi 	(flicplay.c:925)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DoColourMap is only 66.33% similar to the original, diff above
```

*AI generated. Time taken: 380s*
