### PR TITLE
DoDifferenceX 100% match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -943,30 +943,30 @@ void DoDifferenceX(tFlic_descriptor* pFlic_info, tU32 chunk_length) {
     first_line = MemReadU16(&pFlic_info->data);
     line_count = MemReadU16(&pFlic_info->data);
     the_row_bytes = pFlic_info->the_pixelmap->row_bytes;
-    line_pixel_ptr = pFlic_info->first_pixel + first_line * the_row_bytes;
+    pixel_ptr = pFlic_info->first_pixel + first_line * the_row_bytes;
     for (i = 0; i < line_count; i++) {
-        pixel_ptr = line_pixel_ptr;
+        line_pixel_ptr = pixel_ptr;
         number_of_packets = MemReadU8(&pFlic_info->data);
         for (j = 0; j < number_of_packets; j++) {
             skip_count = MemReadU8(&pFlic_info->data);
             size_count = MemReadS8(&pFlic_info->data);
-            pixel_ptr += skip_count;
+            line_pixel_ptr += skip_count;
             if (size_count >= 0) {
                 for (k = 0; k < size_count; k++) {
-                    *pixel_ptr = *pFlic_info->data;
+                    *line_pixel_ptr = *pFlic_info->data;
                     pFlic_info->data++;
-                    pixel_ptr++;
+                    line_pixel_ptr++;
                 }
             } else {
                 the_byte = *pFlic_info->data;
                 pFlic_info->data++;
                 for (k = 0; k < -size_count; k++) {
-                    *pixel_ptr = the_byte;
-                    pixel_ptr++;
+                    *line_pixel_ptr = the_byte;
+                    line_pixel_ptr++;
                 }
             }
         }
-        line_pixel_ptr += the_row_bytes;
+        pixel_ptr += the_row_bytes;
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4964e3: DoDifferenceX 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x49650c,29 +0x47b346,29 @@
0x49650c : and eax, 0xffff
0x496511 : mov dword ptr [ebp - 0xc], eax
0x496514 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:945)
0x496517 : mov eax, dword ptr [eax + 0x38]
0x49651a : movsx eax, word ptr [eax + 0x28]
0x49651e : mov dword ptr [ebp - 0x10], eax
0x496521 : mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:946)
0x496524 : imul eax, dword ptr [ebp - 0x2c]
0x496528 : mov ecx, dword ptr [ebp + 8]
0x49652b : add eax, dword ptr [ecx + 0x28]
0x49652e : -mov dword ptr [ebp - 0x14], eax
         : +mov dword ptr [ebp - 4], eax
0x496531 : mov dword ptr [ebp - 0x1c], 0 	(flicplay.c:947)
0x496538 : jmp 0x3
0x49653d : inc dword ptr [ebp - 0x1c]
0x496540 : mov eax, dword ptr [ebp - 0x1c]
0x496543 : cmp dword ptr [ebp - 0xc], eax
0x496546 : jle 0xee
0x49654c : -mov eax, dword ptr [ebp - 0x14]
0x49654f : -mov dword ptr [ebp - 4], eax
         : +mov eax, dword ptr [ebp - 4] 	(flicplay.c:948)
         : +mov dword ptr [ebp - 0x14], eax
0x496552 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:949)
0x496555 : push eax
0x496556 : call MemReadU8 (FUNCTION)
0x49655b : add esp, 4
0x49655e : xor ecx, ecx
0x496560 : mov cl, al
0x496562 : mov dword ptr [ebp - 0x24], ecx
0x496565 : mov dword ptr [ebp - 0x20], 0 	(flicplay.c:950)
0x49656c : jmp 0x3
0x496571 : inc dword ptr [ebp - 0x20]

---
+++
@@ -0x49658c,56 +0x47b3c6,56 @@
0x49658c : xor ecx, ecx
0x49658e : mov cl, al
0x496590 : mov dword ptr [ebp - 0x30], ecx
0x496593 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:952)
0x496596 : push eax
0x496597 : call MemReadS8 (FUNCTION)
0x49659c : add esp, 4
0x49659f : movsx eax, al
0x4965a2 : mov dword ptr [ebp - 8], eax
0x4965a5 : mov eax, dword ptr [ebp - 0x30] 	(flicplay.c:953)
0x4965a8 : -add dword ptr [ebp - 4], eax
         : +add dword ptr [ebp - 0x14], eax
0x4965ab : cmp dword ptr [ebp - 8], 0 	(flicplay.c:954)
0x4965af : jl 0x39
0x4965b5 : mov dword ptr [ebp - 0x28], 0 	(flicplay.c:955)
0x4965bc : jmp 0x3
0x4965c1 : inc dword ptr [ebp - 0x28]
0x4965c4 : mov eax, dword ptr [ebp - 0x28]
0x4965c7 : cmp dword ptr [ebp - 8], eax
0x4965ca : jle 0x19
0x4965d0 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:956)
0x4965d3 : mov eax, dword ptr [eax]
0x4965d5 : mov al, byte ptr [eax]
0x4965d7 : -mov ecx, dword ptr [ebp - 4]
         : +mov ecx, dword ptr [ebp - 0x14]
0x4965da : mov byte ptr [ecx], al
0x4965dc : mov eax, dword ptr [ebp + 8] 	(flicplay.c:957)
0x4965df : inc dword ptr [eax]
0x4965e1 : -inc dword ptr [ebp - 4]
         : +inc dword ptr [ebp - 0x14] 	(flicplay.c:958)
0x4965e4 : jmp -0x28 	(flicplay.c:959)
0x4965e9 : jmp 0x3c 	(flicplay.c:960)
0x4965ee : mov eax, dword ptr [ebp + 8] 	(flicplay.c:961)
0x4965f1 : mov eax, dword ptr [eax]
0x4965f3 : mov al, byte ptr [eax]
0x4965f5 : mov byte ptr [ebp - 0x18], al
0x4965f8 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:962)
0x4965fb : inc dword ptr [eax]
0x4965fd : mov dword ptr [ebp - 0x28], 0 	(flicplay.c:963)
0x496604 : jmp 0x3
0x496609 : inc dword ptr [ebp - 0x28]
0x49660c : mov eax, dword ptr [ebp - 8]
0x49660f : neg eax
0x496611 : cmp eax, dword ptr [ebp - 0x28]
0x496614 : jle 0x10
0x49661a : mov al, byte ptr [ebp - 0x18] 	(flicplay.c:964)
0x49661d : -mov ecx, dword ptr [ebp - 4]
         : +mov ecx, dword ptr [ebp - 0x14]
0x496620 : mov byte ptr [ecx], al
0x496622 : -inc dword ptr [ebp - 4]
         : +inc dword ptr [ebp - 0x14] 	(flicplay.c:965)
0x496625 : jmp -0x21 	(flicplay.c:966)
0x49662a : jmp -0xbe 	(flicplay.c:968)
0x49662f : mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:969)
0x496632 : -add dword ptr [ebp - 0x14], eax
         : +add dword ptr [ebp - 4], eax
0x496635 : jmp -0xfd 	(flicplay.c:970)
0x49663a : pop edi 	(flicplay.c:971)
0x49663b : pop esi
0x49663c : pop ebx
0x49663d : leave 
0x49663e : ret 


DoDifferenceX is only 91.67% similar to the original, diff above
```

*AI generated. Time taken: 76s, tokens: 27,374*
