### PR TITLE
DoDifferenceTrans 100% effective match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -989,37 +989,39 @@ void DoDifferenceTrans(tFlic_descriptor* pFlic_info, tU32 chunk_length) {
     first_line = MemReadU16(&pFlic_info->data);
     line_count = MemReadU16(&pFlic_info->data);
     the_row_bytes = pFlic_info->the_pixelmap->row_bytes;
-    line_pixel_ptr = pFlic_info->first_pixel + first_line * the_row_bytes;
-    for (i = 0; i < line_count; i++) {
-        pixel_ptr = line_pixel_ptr;
+    pixel_ptr = pFlic_info->first_pixel + first_line * the_row_bytes;
+    for (i = 0; line_count > i; i++) {
+        line_pixel_ptr = pixel_ptr;
         number_of_packets = MemReadU8(&pFlic_info->data);
-        for (j = 0; j < number_of_packets; j++) {
+        for (j = 0; number_of_packets > j; j++) {
             skip_count = MemReadU8(&pFlic_info->data);
             size_count = MemReadS8(&pFlic_info->data);
-            pixel_ptr += skip_count;
+            line_pixel_ptr += skip_count;
             if (size_count >= 0) {
-                for (k = 0; k < size_count; k++) {
+                for (k = 0; size_count > k; k++) {
                     the_byte = *pFlic_info->data;
                     pFlic_info->data++;
                     if (the_byte != '\0') {
-                        *pixel_ptr = the_byte;
+                        *line_pixel_ptr = the_byte;
+                        line_pixel_ptr++;
+                    } else {
+                        line_pixel_ptr++;
                     }
-                    pixel_ptr++;
                 }
             } else {
                 the_byte = *pFlic_info->data;
                 pFlic_info->data++;
-                if (the_byte == '\0') {
-                    pixel_ptr += size_count;
-                } else {
+                if (the_byte != '\0') {
                     for (k = 0; k < -size_count; k++) {
-                        *pixel_ptr = the_byte;
-                        pixel_ptr++;
+                        *line_pixel_ptr = the_byte;
+                        line_pixel_ptr++;
                     }
+                } else {
+                    line_pixel_ptr += size_count;
                 }
             }
         }
-        line_pixel_ptr += the_row_bytes;
+        pixel_ptr += the_row_bytes;
     }
 }
 


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x49665c,69 +0x47b496,69 @@
0x49665c : mov eax, dword ptr [ebp + 8] 	(flicplay.c:990)
0x49665f : push eax
0x496660 : call MemReadU16 (FUNCTION)
0x496665 : add esp, 4
0x496668 : and eax, 0xffff
0x49666d : mov dword ptr [ebp - 0xc], eax
0x496670 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:991)
0x496673 : mov eax, dword ptr [eax + 0x38]
0x496676 : movsx eax, word ptr [eax + 0x28]
0x49667a : mov dword ptr [ebp - 0x10], eax
0x49667d : -mov eax, dword ptr [ebp - 0x10]
0x496680 : -imul eax, dword ptr [ebp - 0x2c]
         : +mov eax, dword ptr [ebp - 0x2c] 	(flicplay.c:992)
         : +imul eax, dword ptr [ebp - 0x10]
0x496684 : mov ecx, dword ptr [ebp + 8]
0x496687 : add eax, dword ptr [ecx + 0x28]
0x49668a : mov dword ptr [ebp - 0x14], eax
0x49668d : mov dword ptr [ebp - 0x1c], 0 	(flicplay.c:993)
0x496694 : jmp 0x3
0x496699 : inc dword ptr [ebp - 0x1c]
0x49669c : -mov eax, dword ptr [ebp - 0xc]
0x49669f : -cmp dword ptr [ebp - 0x1c], eax
0x4966a2 : -jge 0x121
         : +mov eax, dword ptr [ebp - 0x1c]
         : +cmp dword ptr [ebp - 0xc], eax
         : +jle 0x121
0x4966a8 : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:994)
0x4966ab : mov dword ptr [ebp - 4], eax
0x4966ae : mov eax, dword ptr [ebp + 8] 	(flicplay.c:995)
0x4966b1 : push eax
0x4966b2 : call MemReadU8 (FUNCTION)
0x4966b7 : add esp, 4
0x4966ba : xor ecx, ecx
0x4966bc : mov cl, al
0x4966be : mov dword ptr [ebp - 0x24], ecx
0x4966c1 : mov dword ptr [ebp - 0x20], 0 	(flicplay.c:996)
0x4966c8 : jmp 0x3
0x4966cd : inc dword ptr [ebp - 0x20]
0x4966d0 : -mov eax, dword ptr [ebp - 0x20]
0x4966d3 : -cmp dword ptr [ebp - 0x24], eax
0x4966d6 : -jle 0xe2
         : +mov eax, dword ptr [ebp - 0x24]
         : +cmp dword ptr [ebp - 0x20], eax
         : +jge 0xe2
0x4966dc : mov eax, dword ptr [ebp + 8] 	(flicplay.c:997)
0x4966df : push eax
0x4966e0 : call MemReadU8 (FUNCTION)
0x4966e5 : add esp, 4
0x4966e8 : xor ecx, ecx
0x4966ea : mov cl, al
0x4966ec : mov dword ptr [ebp - 0x30], ecx
0x4966ef : mov eax, dword ptr [ebp + 8] 	(flicplay.c:998)
0x4966f2 : push eax
0x4966f3 : call MemReadS8 (FUNCTION)
0x4966f8 : add esp, 4
0x4966fb : movsx eax, al
0x4966fe : mov dword ptr [ebp - 8], eax
0x496701 : mov eax, dword ptr [ebp - 0x30] 	(flicplay.c:999)
0x496704 : add dword ptr [ebp - 4], eax
0x496707 : cmp dword ptr [ebp - 8], 0 	(flicplay.c:1000)
0x49670b : jl 0x54
0x496711 : mov dword ptr [ebp - 0x28], 0 	(flicplay.c:1001)
0x496718 : jmp 0x3
0x49671d : inc dword ptr [ebp - 0x28]
0x496720 : -mov eax, dword ptr [ebp - 0x28]
0x496723 : -cmp dword ptr [ebp - 8], eax
0x496726 : -jle 0x34
         : +mov eax, dword ptr [ebp - 8]
         : +cmp dword ptr [ebp - 0x28], eax
         : +jge 0x34
0x49672c : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1002)
0x49672f : mov eax, dword ptr [eax]
0x496731 : mov al, byte ptr [eax]
0x496733 : mov byte ptr [ebp - 0x18], al
0x496736 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1003)
0x496739 : inc dword ptr [eax]
0x49673b : xor eax, eax 	(flicplay.c:1004)
0x49673d : mov al, byte ptr [ebp - 0x18]
0x496740 : test eax, eax
0x496742 : je 0x10


0x49663f: DoDifferenceTrans 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x49665c,105 +0x47b496,109 @@
0x49665c : mov eax, dword ptr [ebp + 8] 	(flicplay.c:990)
0x49665f : push eax
0x496660 : call MemReadU16 (FUNCTION)
0x496665 : add esp, 4
0x496668 : and eax, 0xffff
0x49666d : mov dword ptr [ebp - 0xc], eax
0x496670 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:991)
0x496673 : mov eax, dword ptr [eax + 0x38]
0x496676 : movsx eax, word ptr [eax + 0x28]
0x49667a : mov dword ptr [ebp - 0x10], eax
0x49667d : -mov eax, dword ptr [ebp - 0x10]
0x496680 : -imul eax, dword ptr [ebp - 0x2c]
         : +mov eax, dword ptr [ebp - 0x2c] 	(flicplay.c:992)
         : +imul eax, dword ptr [ebp - 0x10]
0x496684 : mov ecx, dword ptr [ebp + 8]
0x496687 : add eax, dword ptr [ecx + 0x28]
0x49668a : -mov dword ptr [ebp - 0x14], eax
         : +mov dword ptr [ebp - 4], eax
0x49668d : mov dword ptr [ebp - 0x1c], 0 	(flicplay.c:993)
0x496694 : jmp 0x3
0x496699 : inc dword ptr [ebp - 0x1c]
0x49669c : -mov eax, dword ptr [ebp - 0xc]
0x49669f : -cmp dword ptr [ebp - 0x1c], eax
0x4966a2 : -jge 0x121
0x4966a8 : -mov eax, dword ptr [ebp - 0x14]
0x4966ab : -mov dword ptr [ebp - 4], eax
         : +mov eax, dword ptr [ebp - 0x1c]
         : +cmp dword ptr [ebp - 0xc], eax
         : +jle 0x119
         : +mov eax, dword ptr [ebp - 4] 	(flicplay.c:994)
         : +mov dword ptr [ebp - 0x14], eax
0x4966ae : mov eax, dword ptr [ebp + 8] 	(flicplay.c:995)
0x4966b1 : push eax
0x4966b2 : call MemReadU8 (FUNCTION)
0x4966b7 : add esp, 4
0x4966ba : xor ecx, ecx
0x4966bc : mov cl, al
0x4966be : mov dword ptr [ebp - 0x24], ecx
0x4966c1 : mov dword ptr [ebp - 0x20], 0 	(flicplay.c:996)
0x4966c8 : jmp 0x3
0x4966cd : inc dword ptr [ebp - 0x20]
0x4966d0 : -mov eax, dword ptr [ebp - 0x20]
0x4966d3 : -cmp dword ptr [ebp - 0x24], eax
0x4966d6 : -jle 0xe2
         : +mov eax, dword ptr [ebp - 0x24]
         : +cmp dword ptr [ebp - 0x20], eax
         : +jge 0xda
0x4966dc : mov eax, dword ptr [ebp + 8] 	(flicplay.c:997)
0x4966df : push eax
0x4966e0 : call MemReadU8 (FUNCTION)
0x4966e5 : add esp, 4
0x4966e8 : xor ecx, ecx
0x4966ea : mov cl, al
0x4966ec : mov dword ptr [ebp - 0x30], ecx
0x4966ef : mov eax, dword ptr [ebp + 8] 	(flicplay.c:998)
0x4966f2 : push eax
0x4966f3 : call MemReadS8 (FUNCTION)
0x4966f8 : add esp, 4
0x4966fb : movsx eax, al
0x4966fe : mov dword ptr [ebp - 8], eax
0x496701 : mov eax, dword ptr [ebp - 0x30] 	(flicplay.c:999)
0x496704 : -add dword ptr [ebp - 4], eax
         : +add dword ptr [ebp - 0x14], eax
0x496707 : cmp dword ptr [ebp - 8], 0 	(flicplay.c:1000)
0x49670b : -jl 0x54
         : +jl 0x4c
0x496711 : mov dword ptr [ebp - 0x28], 0 	(flicplay.c:1001)
0x496718 : jmp 0x3
0x49671d : inc dword ptr [ebp - 0x28]
0x496720 : -mov eax, dword ptr [ebp - 0x28]
0x496723 : -cmp dword ptr [ebp - 8], eax
0x496726 : -jle 0x34
         : +mov eax, dword ptr [ebp - 8]
         : +cmp dword ptr [ebp - 0x28], eax
         : +jge 0x2c
0x49672c : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1002)
0x49672f : mov eax, dword ptr [eax]
0x496731 : mov al, byte ptr [eax]
0x496733 : mov byte ptr [ebp - 0x18], al
0x496736 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1003)
0x496739 : inc dword ptr [eax]
0x49673b : xor eax, eax 	(flicplay.c:1004)
0x49673d : mov al, byte ptr [ebp - 0x18]
0x496740 : test eax, eax
0x496742 : -je 0x10
         : +je 0x8
0x496748 : mov al, byte ptr [ebp - 0x18] 	(flicplay.c:1005)
0x49674b : -mov ecx, dword ptr [ebp - 4]
         : +mov ecx, dword ptr [ebp - 0x14]
0x49674e : mov byte ptr [ecx], al
0x496750 : -inc dword ptr [ebp - 4]
0x496753 : -jmp 0x3
0x496758 : -inc dword ptr [ebp - 4]
0x49675b : -jmp -0x43
         : +inc dword ptr [ebp - 0x14] 	(flicplay.c:1007)
         : +jmp -0x3b 	(flicplay.c:1008)
0x496760 : jmp 0x54 	(flicplay.c:1009)
0x496765 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1010)
0x496768 : mov eax, dword ptr [eax]
0x49676a : mov al, byte ptr [eax]
0x49676c : mov byte ptr [ebp - 0x18], al
0x49676f : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1011)
0x496772 : inc dword ptr [eax]
0x496774 : xor eax, eax 	(flicplay.c:1012)
0x496776 : mov al, byte ptr [ebp - 0x18]
0x496779 : test eax, eax
0x49677b : -je 0x32
         : +jne 0xb
         : +mov eax, dword ptr [ebp - 8] 	(flicplay.c:1013)
         : +add dword ptr [ebp - 0x14], eax
         : +jmp 0x2d 	(flicplay.c:1014)
0x496781 : mov dword ptr [ebp - 0x28], 0 	(flicplay.c:1015)
0x496788 : jmp 0x3
0x49678d : inc dword ptr [ebp - 0x28]
0x496790 : mov eax, dword ptr [ebp - 8]
0x496793 : neg eax
0x496795 : cmp eax, dword ptr [ebp - 0x28]
0x496798 : jle 0x10
0x49679e : mov al, byte ptr [ebp - 0x18] 	(flicplay.c:1016)
0x4967a1 : -mov ecx, dword ptr [ebp - 4]
         : +mov ecx, dword ptr [ebp - 0x14]
0x4967a4 : mov byte ptr [ecx], al
0x4967a6 : -inc dword ptr [ebp - 4]
         : +inc dword ptr [ebp - 0x14] 	(flicplay.c:1017)
0x4967a9 : jmp -0x21 	(flicplay.c:1018)
0x4967ae : -jmp 0x6
0x4967b3 : -mov eax, dword ptr [ebp - 8]
         : +jmp -0xe9 	(flicplay.c:1021)
         : +mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1022)
0x4967b6 : add dword ptr [ebp - 4], eax
0x4967b9 : -jmp -0xf1
0x4967be : -mov eax, dword ptr [ebp - 0x10]
0x4967c1 : -add dword ptr [ebp - 0x14], eax
         : +jmp -0x128 	(flicplay.c:1023)
         : +pop edi 	(flicplay.c:1024)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DoDifferenceTrans is only 73.11% similar to the original, diff above
```

*AI generated. Time taken: 95s, tokens: 16,278*
