### PR TITLE
DoDeltaTrans 100% effective match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -611,22 +611,6 @@ void* gPalette_pixels;
 // GLOBAL: CARM95 0x0053d0ac
 tFlic_descriptor* gFirst_flic;
 
-// Use this function to avoid unaligned memory access.
-// Added by DethRace
-tU16 mem_read_u16(void* memory) {
-    tU16 u16;
-
-    memcpy(&u16, memory, sizeof(tU16));
-    return u16;
-}
-
-// Use this function to avoid unaligned memory access
-// Added by DethRace
-void mem_write_u16(void* memory, tU16 u16) {
-
-    memcpy(memory, &u16, sizeof(tU16));
-}
-
 // IDA: void __cdecl EnableTranslationText()
 // FUNCTION: CARM95 0x00495990
 void EnableTranslationText(void) {
@@ -1097,19 +1081,19 @@ void DoDeltaTrans(tFlic_descriptor* pFlic_info, tU32 chunk_length) {
     the_row_bytes = pFlic_info->the_pixelmap->row_bytes;
     pixel_ptr = pFlic_info->first_pixel;
 
-    for (i = 0; !(line_count <= i);) {
+    for (i = 0; i < line_count;) {
         line_pixel_ptr = (tU16*)pixel_ptr;
         number_of_packets = MemReadS16(&pFlic_info->data);
 
         if (number_of_packets < 0) {
             pixel_ptr = pixel_ptr + the_row_bytes * -number_of_packets;
         } else {
-            for (j = 0; !(number_of_packets <= j); j++) {
+            for (j = 0; j < number_of_packets; j++) {
                 skip_count = MemReadU8(&pFlic_info->data);
                 size_count = MemReadS8(&pFlic_info->data);
                 line_pixel_ptr += skip_count / 2;
                 if (size_count >= 0) {
-                    for (k = 0; !(size_count <= k); k++) {
+                    for (k = 0; k < size_count; k++) {
                         the_byte = *pFlic_info->data++;
                         if (the_byte) {
                             *(tU8*)line_pixel_ptr = the_byte;
@@ -2169,7 +2153,6 @@ void LoadInterfaceStrings(void) {
         fclose(f);
 #endif
     }
-
 }
 
 // IDA: void __cdecl FlushInterfaceFonts()

--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1132,7 +1132,12 @@ void DoDeltaTrans(tFlic_descriptor* pFlic_info, tU32 chunk_length) {
                     if (the_byte && the_byte2) {
                         the_word = *((tU16*)pFlic_info->data - 1);
                         for (k = 0; k < -size_count; k++) {
+#ifdef DETHRACE_FIX_BUGS
+                            // Avoid unaligned memory access
+                            memcpy(line_pixel_ptr, &the_word, 2);
+#else
                             *line_pixel_ptr = the_word;
+#endif
                             line_pixel_ptr++;
                         }
                     } else {

--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1097,52 +1097,64 @@ void DoDeltaTrans(tFlic_descriptor* pFlic_info, tU32 chunk_length) {
     the_row_bytes = pFlic_info->the_pixelmap->row_bytes;
     pixel_ptr = pFlic_info->first_pixel;
 
-    for (i = 0; i < line_count;) {
-        number_of_packets = MemReadS16(&pFlic_info->data);
+    for (i = 0; !(line_count <= i);) {
         line_pixel_ptr = (tU16*)pixel_ptr;
+        number_of_packets = MemReadS16(&pFlic_info->data);
 
         if (number_of_packets < 0) {
             pixel_ptr = pixel_ptr + the_row_bytes * -number_of_packets;
         } else {
-            for (j = 0; j < number_of_packets; j++) {
+            for (j = 0; !(number_of_packets <= j); j++) {
                 skip_count = MemReadU8(&pFlic_info->data);
                 size_count = MemReadS8(&pFlic_info->data);
                 line_pixel_ptr += skip_count / 2;
-                if (size_count < 0) {
+                if (size_count >= 0) {
+                    for (k = 0; !(size_count <= k); k++) {
+                        the_byte = *pFlic_info->data++;
+                        if (the_byte) {
+                            *(tU8*)line_pixel_ptr = the_byte;
+                            line_pixel_ptr = (tU16*)((tU8*)line_pixel_ptr + 1);
+                        } else {
+                            line_pixel_ptr = (tU16*)((tU8*)line_pixel_ptr + 1);
+                        }
+                        the_byte = *pFlic_info->data++;
+                        if (the_byte) {
+                            *(tU8*)line_pixel_ptr = the_byte;
+                            line_pixel_ptr = (tU16*)((tU8*)line_pixel_ptr + 1);
+                        } else {
+                            line_pixel_ptr = (tU16*)((tU8*)line_pixel_ptr + 1);
+                        }
+                    }
+                } else {
                     the_byte = *pFlic_info->data++;
                     the_byte2 = *pFlic_info->data++;
 
                     if (the_byte && the_byte2) {
                         the_word = *((tU16*)pFlic_info->data - 1);
                         for (k = 0; k < -size_count; k++) {
-                            mem_write_u16(line_pixel_ptr, the_word);
+                            *line_pixel_ptr = the_word;
                             line_pixel_ptr++;
                         }
                     } else {
                         for (k = 0; k < -size_count; k++) {
                             if (the_byte) {
                                 *(tU8*)line_pixel_ptr = the_byte;
+                                line_pixel_ptr = (tU16*)((tU8*)line_pixel_ptr + 1);
+                            } else {
+                                line_pixel_ptr = (tU16*)((tU8*)line_pixel_ptr + 1);
                             }
-                            line_pixel_ptr = (tU16*)((tU8*)line_pixel_ptr + 1);
                             if (the_byte2) {
                                 *(tU8*)line_pixel_ptr = the_byte2;
+                                line_pixel_ptr = (tU16*)((tU8*)line_pixel_ptr + 1);
+                            } else {
+                                line_pixel_ptr = (tU16*)((tU8*)line_pixel_ptr + 1);
                             }
-                            line_pixel_ptr = (tU16*)((tU8*)line_pixel_ptr + 1);
                         }
-                    }
-                } else {
-                    for (k = 0; k < size_count; k++) {
-                        the_word = *(tU16*)pFlic_info->data;
-                        pFlic_info->data += 2;
-                        if (the_word) {
-                            mem_write_u16(line_pixel_ptr, the_word);
-                        }
-                        line_pixel_ptr++;
                     }
                 }
             }
-            pixel_ptr = pixel_ptr + the_row_bytes;
             i++;
+            pixel_ptr = pixel_ptr + the_row_bytes;
         }
     }
 }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x496917,44 +0x47b829,44 @@
0x496917 : and eax, 0xffff
0x49691c : mov dword ptr [ebp - 0xc], eax
0x49691f : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1097)
0x496922 : mov eax, dword ptr [eax + 0x38]
0x496925 : movsx eax, word ptr [eax + 0x28]
0x496929 : mov dword ptr [ebp - 0x14], eax
0x49692c : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1098)
0x49692f : mov eax, dword ptr [eax + 0x28]
0x496932 : mov dword ptr [ebp - 0x18], eax
0x496935 : mov dword ptr [ebp - 0x20], 0 	(flicplay.c:1100)
0x49693c : -mov eax, dword ptr [ebp - 0x20]
0x49693f : -cmp dword ptr [ebp - 0xc], eax
0x496942 : -jle 0x1fc
         : +mov eax, dword ptr [ebp - 0xc]
         : +cmp dword ptr [ebp - 0x20], eax
         : +jge 0x1fc
0x496948 : mov eax, dword ptr [ebp - 0x18] 	(flicplay.c:1101)
0x49694b : mov dword ptr [ebp - 4], eax
0x49694e : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1102)
0x496951 : push eax
0x496952 : call MemReadS16 (FUNCTION)
0x496957 : add esp, 4
0x49695a : movsx eax, ax
0x49695d : mov dword ptr [ebp - 0x28], eax
0x496960 : cmp dword ptr [ebp - 0x28], 0 	(flicplay.c:1104)
0x496964 : jge 0x11
0x49696a : mov eax, dword ptr [ebp - 0x28] 	(flicplay.c:1105)
0x49696d : neg eax
0x49696f : imul eax, dword ptr [ebp - 0x14]
0x496973 : add dword ptr [ebp - 0x18], eax
0x496976 : jmp 0x1c4 	(flicplay.c:1106)
0x49697b : mov dword ptr [ebp - 0x24], 0 	(flicplay.c:1107)
0x496982 : jmp 0x3
0x496987 : inc dword ptr [ebp - 0x24]
0x49698a : -mov eax, dword ptr [ebp - 0x24]
0x49698d : -cmp dword ptr [ebp - 0x28], eax
0x496990 : -jle 0x1a0
         : +mov eax, dword ptr [ebp - 0x28]
         : +cmp dword ptr [ebp - 0x24], eax
         : +jge 0x1a0
0x496996 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1108)
0x496999 : push eax
0x49699a : call MemReadU8 (FUNCTION)
0x49699f : add esp, 4
0x4969a2 : xor ecx, ecx
0x4969a4 : mov cl, al
0x4969a6 : mov dword ptr [ebp - 0x34], ecx
0x4969a9 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1109)
0x4969ac : push eax
0x4969ad : call MemReadS8 (FUNCTION)

---
+++
@@ -0x4969be,23 +0x47b8d0,23 @@
0x4969be : cdq 
0x4969bf : sub eax, edx
0x4969c1 : sar eax, 1
0x4969c3 : add eax, eax
0x4969c5 : add dword ptr [ebp - 4], eax
0x4969c8 : cmp dword ptr [ebp - 8], 0 	(flicplay.c:1111)
0x4969cc : jl 0x83
0x4969d2 : mov dword ptr [ebp - 0x2c], 0 	(flicplay.c:1112)
0x4969d9 : jmp 0x3
0x4969de : inc dword ptr [ebp - 0x2c]
0x4969e1 : -mov eax, dword ptr [ebp - 0x2c]
0x4969e4 : -cmp dword ptr [ebp - 8], eax
0x4969e7 : -jle 0x63
         : +mov eax, dword ptr [ebp - 8]
         : +cmp dword ptr [ebp - 0x2c], eax
         : +jge 0x63
0x4969ed : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1113)
0x4969f0 : mov eax, dword ptr [eax]
0x4969f2 : mov al, byte ptr [eax]
0x4969f4 : mov byte ptr [ebp - 0x1c], al
0x4969f7 : mov eax, dword ptr [ebp + 8]
0x4969fa : inc dword ptr [eax]
0x4969fc : xor eax, eax 	(flicplay.c:1114)
0x4969fe : mov al, byte ptr [ebp - 0x1c]
0x496a01 : test eax, eax
0x496a03 : je 0x10


0x496902: DoDeltaTrans 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x496917,152 +0x47b829,152 @@
0x496917 : and eax, 0xffff
0x49691c : mov dword ptr [ebp - 0xc], eax
0x49691f : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1097)
0x496922 : mov eax, dword ptr [eax + 0x38]
0x496925 : movsx eax, word ptr [eax + 0x28]
0x496929 : mov dword ptr [ebp - 0x14], eax
0x49692c : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1098)
0x49692f : mov eax, dword ptr [eax + 0x28]
0x496932 : mov dword ptr [ebp - 0x18], eax
0x496935 : mov dword ptr [ebp - 0x20], 0 	(flicplay.c:1100)
0x49693c : -mov eax, dword ptr [ebp - 0x20]
0x49693f : -cmp dword ptr [ebp - 0xc], eax
0x496942 : -jle 0x1fc
0x496948 : -mov eax, dword ptr [ebp - 0x18]
0x49694b : -mov dword ptr [ebp - 4], eax
         : +mov eax, dword ptr [ebp - 0xc]
         : +cmp dword ptr [ebp - 0x20], eax
         : +jge 0x1c7
0x49694e : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1101)
0x496951 : push eax
0x496952 : call MemReadS16 (FUNCTION)
0x496957 : add esp, 4
0x49695a : movsx eax, ax
0x49695d : mov dword ptr [ebp - 0x28], eax
         : +mov eax, dword ptr [ebp - 0x18] 	(flicplay.c:1102)
         : +mov dword ptr [ebp - 4], eax
0x496960 : cmp dword ptr [ebp - 0x28], 0 	(flicplay.c:1104)
0x496964 : jge 0x11
0x49696a : mov eax, dword ptr [ebp - 0x28] 	(flicplay.c:1105)
0x49696d : neg eax
0x49696f : imul eax, dword ptr [ebp - 0x14]
0x496973 : add dword ptr [ebp - 0x18], eax
0x496976 : -jmp 0x1c4
         : +jmp 0x18f 	(flicplay.c:1106)
0x49697b : mov dword ptr [ebp - 0x24], 0 	(flicplay.c:1107)
0x496982 : jmp 0x3
0x496987 : inc dword ptr [ebp - 0x24]
0x49698a : -mov eax, dword ptr [ebp - 0x24]
0x49698d : -cmp dword ptr [ebp - 0x28], eax
0x496990 : -jle 0x1a0
         : +mov eax, dword ptr [ebp - 0x28]
         : +cmp dword ptr [ebp - 0x24], eax
         : +jge 0x16b
0x496996 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1108)
0x496999 : push eax
0x49699a : call MemReadU8 (FUNCTION)
0x49699f : add esp, 4
0x4969a2 : xor ecx, ecx
0x4969a4 : mov cl, al
0x4969a6 : mov dword ptr [ebp - 0x34], ecx
0x4969a9 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1109)
0x4969ac : push eax
0x4969ad : call MemReadS8 (FUNCTION)
0x4969b2 : add esp, 4
0x4969b5 : movsx eax, al
0x4969b8 : mov dword ptr [ebp - 8], eax
0x4969bb : mov eax, dword ptr [ebp - 0x34] 	(flicplay.c:1110)
0x4969be : cdq 
0x4969bf : sub eax, edx
0x4969c1 : sar eax, 1
0x4969c3 : add eax, eax
0x4969c5 : add dword ptr [ebp - 4], eax
0x4969c8 : cmp dword ptr [ebp - 8], 0 	(flicplay.c:1111)
0x4969cc : -jl 0x83
0x4969d2 : -mov dword ptr [ebp - 0x2c], 0
0x4969d9 : -jmp 0x3
0x4969de : -inc dword ptr [ebp - 0x2c]
0x4969e1 : -mov eax, dword ptr [ebp - 0x2c]
0x4969e4 : -cmp dword ptr [ebp - 8], eax
0x4969e7 : -jle 0x63
0x4969ed : -mov eax, dword ptr [ebp + 8]
0x4969f0 : -mov eax, dword ptr [eax]
0x4969f2 : -mov al, byte ptr [eax]
0x4969f4 : -mov byte ptr [ebp - 0x1c], al
0x4969f7 : -mov eax, dword ptr [ebp + 8]
0x4969fa : -inc dword ptr [eax]
0x4969fc : -xor eax, eax
0x4969fe : -mov al, byte ptr [ebp - 0x1c]
0x496a01 : -test eax, eax
0x496a03 : -je 0x10
0x496a09 : -mov al, byte ptr [ebp - 0x1c]
0x496a0c : -mov ecx, dword ptr [ebp - 4]
0x496a0f : -mov byte ptr [ecx], al
0x496a11 : -inc dword ptr [ebp - 4]
0x496a14 : -jmp 0x3
0x496a19 : -inc dword ptr [ebp - 4]
0x496a1c : -mov eax, dword ptr [ebp + 8]
0x496a1f : -mov eax, dword ptr [eax]
0x496a21 : -mov al, byte ptr [eax]
0x496a23 : -mov byte ptr [ebp - 0x1c], al
0x496a26 : -mov eax, dword ptr [ebp + 8]
0x496a29 : -inc dword ptr [eax]
0x496a2b : -xor eax, eax
0x496a2d : -mov al, byte ptr [ebp - 0x1c]
0x496a30 : -test eax, eax
0x496a32 : -je 0x10
0x496a38 : -mov al, byte ptr [ebp - 0x1c]
0x496a3b : -mov ecx, dword ptr [ebp - 4]
0x496a3e : -mov byte ptr [ecx], al
0x496a40 : -inc dword ptr [ebp - 4]
0x496a43 : -jmp 0x3
0x496a48 : -inc dword ptr [ebp - 4]
0x496a4b : -jmp -0x72
0x496a50 : -jmp 0xdc
         : +jge 0xd7
0x496a55 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1112)
0x496a58 : mov eax, dword ptr [eax]
0x496a5a : mov al, byte ptr [eax]
0x496a5c : mov byte ptr [ebp - 0x1c], al
0x496a5f : mov eax, dword ptr [ebp + 8]
0x496a62 : inc dword ptr [eax]
0x496a64 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1113)
0x496a67 : mov eax, dword ptr [eax]
0x496a69 : mov al, byte ptr [eax]
0x496a6b : mov byte ptr [ebp - 0x30], al
0x496a6e : mov eax, dword ptr [ebp + 8]
0x496a71 : inc dword ptr [eax]
0x496a73 : xor eax, eax 	(flicplay.c:1115)
0x496a75 : mov al, byte ptr [ebp - 0x1c]
0x496a78 : test eax, eax
0x496a7a : -je 0x4f
         : +je 0x55
0x496a80 : xor eax, eax
0x496a82 : mov al, byte ptr [ebp - 0x30]
0x496a85 : test eax, eax
0x496a87 : -je 0x42
         : +je 0x48
0x496a8d : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1116)
0x496a90 : mov eax, dword ptr [eax]
0x496a92 : mov ax, word ptr [eax - 2]
0x496a96 : mov word ptr [ebp - 0x10], ax
0x496a9a : mov dword ptr [ebp - 0x2c], 0 	(flicplay.c:1117)
0x496aa1 : jmp 0x3
0x496aa6 : inc dword ptr [ebp - 0x2c]
0x496aa9 : mov eax, dword ptr [ebp - 8]
0x496aac : neg eax
0x496aae : cmp eax, dword ptr [ebp - 0x2c]
0x496ab1 : -jle 0x13
0x496ab7 : -mov ax, word ptr [ebp - 0x10]
0x496abb : -mov ecx, dword ptr [ebp - 4]
0x496abe : -mov word ptr [ecx], ax
         : +jle 0x19
         : +mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1118)
         : +push eax
         : +mov eax, dword ptr [ebp - 4]
         : +push eax
         : +call mem_write_u16 (FUNCTION)
         : +add esp, 8
0x496ac1 : add dword ptr [ebp - 4], 2 	(flicplay.c:1119)
0x496ac5 : -jmp -0x24
0x496aca : -jmp 0x62
         : +jmp -0x2a 	(flicplay.c:1120)
         : +jmp 0x52 	(flicplay.c:1121)
0x496acf : mov dword ptr [ebp - 0x2c], 0 	(flicplay.c:1122)
0x496ad6 : jmp 0x3
0x496adb : inc dword ptr [ebp - 0x2c]
0x496ade : mov eax, dword ptr [ebp - 8]
0x496ae1 : neg eax
0x496ae3 : cmp eax, dword ptr [ebp - 0x2c]
0x496ae6 : -jle 0x45
         : +jle 0x35
0x496aec : xor eax, eax 	(flicplay.c:1123)
0x496aee : mov al, byte ptr [ebp - 0x1c]
0x496af1 : test eax, eax
0x496af3 : -je 0x10
         : +je 0x8
0x496af9 : mov al, byte ptr [ebp - 0x1c] 	(flicplay.c:1124)
0x496afc : mov ecx, dword ptr [ebp - 4]
0x496aff : mov byte ptr [ecx], al
0x496b01 : inc dword ptr [ebp - 4] 	(flicplay.c:1126)
0x496b04 : -jmp 0x3
0x496b09 : -inc dword ptr [ebp - 4]
0x496b0c : xor eax, eax 	(flicplay.c:1127)
0x496b0e : mov al, byte ptr [ebp - 0x30]
0x496b11 : test eax, eax
         : +je 0x8
         : +mov al, byte ptr [ebp - 0x30] 	(flicplay.c:1128)
         : +mov ecx, dword ptr [ebp - 4]
         : +mov byte ptr [ecx], al
         : +inc dword ptr [ebp - 4] 	(flicplay.c:1130)
         : +jmp -0x46 	(flicplay.c:1131)
         : +jmp 0x53 	(flicplay.c:1133)
         : +mov dword ptr [ebp - 0x2c], 0 	(flicplay.c:1134)
         : +jmp 0x3
         : +inc dword ptr [ebp - 0x2c]
         : +mov eax, dword ptr [ebp - 8]
         : +cmp dword ptr [ebp - 0x2c], eax
         : +jge 0x38
         : +mov eax, dword ptr [ebp + 8] 	(flicplay.c:1135)
         : +mov eax, dword ptr [eax]
         : +mov ax, word ptr [eax]
         : +mov word ptr [ebp - 0x10], ax
         : +mov eax, dword ptr [ebp + 8] 	(flicplay.c:1136)
         : +add dword ptr [eax], 2
         : +test dword ptr [ebp - 0x10], 0xffff 	(flicplay.c:1137)
         : +je 0x10
         : +mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1138)
         : +push eax
         : +mov eax, dword ptr [ebp - 4]
         : +push eax
         : +call mem_write_u16 (FUNCTION)
         : +add esp, 8
         : +add dword ptr [ebp - 4], 2 	(flicplay.c:1140)
         : +jmp -0x47 	(flicplay.c:1141)
         : +jmp -0x17a 	(flicplay.c:1143)
         : +mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1144)
         : +add dword ptr [ebp - 0x18], eax
         : +inc dword ptr [ebp - 0x20] 	(flicplay.c:1145)
         : +jmp -0x1d3 	(flicplay.c:1147)
         : +pop edi 	(flicplay.c:1148)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DoDeltaTrans is only 61.73% similar to the original, diff above
```

*AI generated. Time taken: 321s, tokens: 75,660*
