### PR TITLE
DoDeltaX 100% effective match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1167,8 +1167,8 @@ void DoDeltaX(tFlic_descriptor* pFlic_info, tU32 chunk_length) {
     pixel_ptr = pFlic_info->first_pixel;
 
     for (i = 0; i < line_count;) {
-        number_of_packets = MemReadS16(&pFlic_info->data);
         line_pixel_ptr = (tU16*)pixel_ptr;
+        number_of_packets = MemReadS16(&pFlic_info->data);
 
         if (number_of_packets < 0) {
             pixel_ptr = pixel_ptr + the_row_bytes * -number_of_packets;
@@ -1177,24 +1177,23 @@ void DoDeltaX(tFlic_descriptor* pFlic_info, tU32 chunk_length) {
                 skip_count = MemReadU8(&pFlic_info->data);
                 size_count = MemReadS8(&pFlic_info->data);
                 line_pixel_ptr += skip_count / 2;
-                if (size_count < 0) {
+                if (size_count >= 0) {
+                    for (k = 0; k < size_count; k++) {
+                        *line_pixel_ptr = *(tU16*)pFlic_info->data;
+                        pFlic_info->data += 2;
+                        line_pixel_ptr++;
+                    }
+                } else {
                     the_word = *(tU16*)pFlic_info->data;
                     pFlic_info->data += 2;
                     for (k = 0; k < -size_count; k++) {
                         *line_pixel_ptr = the_word;
                         line_pixel_ptr++;
                     }
-                } else {
-                    for (k = 0; k < size_count; k++) {
-                        the_word = *(tU16*)pFlic_info->data;
-                        pFlic_info->data += 2;
-                        *line_pixel_ptr = the_word;
-                        line_pixel_ptr++;
-                    }
                 }
             }
-            pixel_ptr = pixel_ptr + the_row_bytes;
             i++;
+            pixel_ptr = pixel_ptr + the_row_bytes;
         }
     }
 }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x496b5e,44 +0x47ba3b,44 @@
0x496b5e : and eax, 0xffff
0x496b63 : mov dword ptr [ebp - 0xc], eax
0x496b66 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1166)
0x496b69 : mov eax, dword ptr [eax + 0x38]
0x496b6c : movsx eax, word ptr [eax + 0x28]
0x496b70 : mov dword ptr [ebp - 0x14], eax
0x496b73 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1167)
0x496b76 : mov eax, dword ptr [eax + 0x28]
0x496b79 : mov dword ptr [ebp - 0x18], eax
0x496b7c : mov dword ptr [ebp - 0x1c], 0 	(flicplay.c:1169)
0x496b83 : -mov eax, dword ptr [ebp - 0xc]
0x496b86 : -cmp dword ptr [ebp - 0x1c], eax
0x496b89 : -jge 0x11c
         : +mov eax, dword ptr [ebp - 0x1c]
         : +cmp dword ptr [ebp - 0xc], eax
         : +jle 0x11c
0x496b8f : mov eax, dword ptr [ebp - 0x18] 	(flicplay.c:1170)
0x496b92 : mov dword ptr [ebp - 4], eax
0x496b95 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1171)
0x496b98 : push eax
0x496b99 : call MemReadS16 (FUNCTION)
0x496b9e : add esp, 4
0x496ba1 : movsx eax, ax
0x496ba4 : mov dword ptr [ebp - 0x24], eax
0x496ba7 : cmp dword ptr [ebp - 0x24], 0 	(flicplay.c:1173)
0x496bab : jge 0x11
0x496bb1 : mov eax, dword ptr [ebp - 0x24] 	(flicplay.c:1174)
0x496bb4 : neg eax
0x496bb6 : imul eax, dword ptr [ebp - 0x14]
0x496bba : add dword ptr [ebp - 0x18], eax
0x496bbd : jmp 0xe4 	(flicplay.c:1175)
0x496bc2 : mov dword ptr [ebp - 0x20], 0 	(flicplay.c:1176)
0x496bc9 : jmp 0x3
0x496bce : inc dword ptr [ebp - 0x20]
0x496bd1 : -mov eax, dword ptr [ebp - 0x24]
0x496bd4 : -cmp dword ptr [ebp - 0x20], eax
0x496bd7 : -jge 0xc0
         : +mov eax, dword ptr [ebp - 0x20]
         : +cmp dword ptr [ebp - 0x24], eax
         : +jle 0xc0
0x496bdd : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1177)
0x496be0 : push eax
0x496be1 : call MemReadU8 (FUNCTION)
0x496be6 : add esp, 4
0x496be9 : xor ecx, ecx
0x496beb : mov cl, al
0x496bed : mov dword ptr [ebp - 0x2c], ecx
0x496bf0 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1178)
0x496bf3 : push eax
0x496bf4 : call MemReadS8 (FUNCTION)


0x496b49: DoDeltaX 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x496b5e,99 +0x47ba3b,101 @@
0x496b5e : and eax, 0xffff
0x496b63 : mov dword ptr [ebp - 0xc], eax
0x496b66 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1166)
0x496b69 : mov eax, dword ptr [eax + 0x38]
0x496b6c : movsx eax, word ptr [eax + 0x28]
0x496b70 : mov dword ptr [ebp - 0x14], eax
0x496b73 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1167)
0x496b76 : mov eax, dword ptr [eax + 0x28]
0x496b79 : mov dword ptr [ebp - 0x18], eax
0x496b7c : mov dword ptr [ebp - 0x1c], 0 	(flicplay.c:1169)
0x496b83 : -mov eax, dword ptr [ebp - 0xc]
0x496b86 : -cmp dword ptr [ebp - 0x1c], eax
0x496b89 : -jge 0x11c
0x496b8f : -mov eax, dword ptr [ebp - 0x18]
0x496b92 : -mov dword ptr [ebp - 4], eax
         : +mov eax, dword ptr [ebp - 0x1c]
         : +cmp dword ptr [ebp - 0xc], eax
         : +jle 0x124
0x496b95 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1170)
0x496b98 : push eax
0x496b99 : call MemReadS16 (FUNCTION)
0x496b9e : add esp, 4
0x496ba1 : movsx eax, ax
0x496ba4 : mov dword ptr [ebp - 0x24], eax
         : +mov eax, dword ptr [ebp - 0x18] 	(flicplay.c:1171)
         : +mov dword ptr [ebp - 4], eax
0x496ba7 : cmp dword ptr [ebp - 0x24], 0 	(flicplay.c:1173)
0x496bab : jge 0x11
0x496bb1 : mov eax, dword ptr [ebp - 0x24] 	(flicplay.c:1174)
0x496bb4 : neg eax
0x496bb6 : imul eax, dword ptr [ebp - 0x14]
0x496bba : add dword ptr [ebp - 0x18], eax
0x496bbd : -jmp 0xe4
         : +jmp 0xec 	(flicplay.c:1175)
0x496bc2 : mov dword ptr [ebp - 0x20], 0 	(flicplay.c:1176)
0x496bc9 : jmp 0x3
0x496bce : inc dword ptr [ebp - 0x20]
0x496bd1 : -mov eax, dword ptr [ebp - 0x24]
0x496bd4 : -cmp dword ptr [ebp - 0x20], eax
0x496bd7 : -jge 0xc0
         : +mov eax, dword ptr [ebp - 0x20]
         : +cmp dword ptr [ebp - 0x24], eax
         : +jle 0xc8
0x496bdd : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1177)
0x496be0 : push eax
0x496be1 : call MemReadU8 (FUNCTION)
0x496be6 : add esp, 4
0x496be9 : xor ecx, ecx
0x496beb : mov cl, al
0x496bed : mov dword ptr [ebp - 0x2c], ecx
0x496bf0 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1178)
0x496bf3 : push eax
0x496bf4 : call MemReadS8 (FUNCTION)
0x496bf9 : add esp, 4
0x496bfc : movsx eax, al
0x496bff : mov dword ptr [ebp - 8], eax
0x496c02 : mov eax, dword ptr [ebp - 0x2c] 	(flicplay.c:1179)
0x496c05 : cdq 
0x496c06 : sub eax, edx
0x496c08 : sar eax, 1
0x496c0a : add eax, eax
0x496c0c : add dword ptr [ebp - 4], eax
0x496c0f : cmp dword ptr [ebp - 8], 0 	(flicplay.c:1180)
0x496c13 : -jl 0x3d
0x496c19 : -mov dword ptr [ebp - 0x28], 0
0x496c20 : -jmp 0x3
0x496c25 : -inc dword ptr [ebp - 0x28]
0x496c28 : -mov eax, dword ptr [ebp - 0x28]
0x496c2b : -cmp dword ptr [ebp - 8], eax
0x496c2e : -jle 0x1d
0x496c34 : -mov eax, dword ptr [ebp + 8]
0x496c37 : -mov eax, dword ptr [eax]
0x496c39 : -mov ax, word ptr [eax]
0x496c3c : -mov ecx, dword ptr [ebp - 4]
0x496c3f : -mov word ptr [ecx], ax
0x496c42 : -mov eax, dword ptr [ebp + 8]
0x496c45 : -add dword ptr [eax], 2
0x496c48 : -add dword ptr [ebp - 4], 2
0x496c4c : -jmp -0x2c
0x496c51 : -jmp 0x42
         : +jge 0x47
0x496c56 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1181)
0x496c59 : mov eax, dword ptr [eax]
0x496c5b : mov ax, word ptr [eax]
0x496c5e : mov word ptr [ebp - 0x10], ax
0x496c62 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1182)
0x496c65 : add dword ptr [eax], 2
0x496c68 : mov dword ptr [ebp - 0x28], 0 	(flicplay.c:1183)
0x496c6f : jmp 0x3
0x496c74 : inc dword ptr [ebp - 0x28]
0x496c77 : mov eax, dword ptr [ebp - 8]
0x496c7a : neg eax
0x496c7c : cmp eax, dword ptr [ebp - 0x28]
0x496c7f : jle 0x13
0x496c85 : mov ax, word ptr [ebp - 0x10] 	(flicplay.c:1184)
0x496c89 : mov ecx, dword ptr [ebp - 4]
0x496c8c : mov word ptr [ecx], ax
0x496c8f : add dword ptr [ebp - 4], 2 	(flicplay.c:1185)
0x496c93 : jmp -0x24 	(flicplay.c:1186)
0x496c98 : -jmp -0xcf
0x496c9d : -inc dword ptr [ebp - 0x1c]
         : +jmp 0x40 	(flicplay.c:1187)
         : +mov dword ptr [ebp - 0x28], 0 	(flicplay.c:1188)
         : +jmp 0x3
         : +inc dword ptr [ebp - 0x28]
         : +mov eax, dword ptr [ebp - 0x28]
         : +cmp dword ptr [ebp - 8], eax
         : +jle 0x25
         : +mov eax, dword ptr [ebp + 8] 	(flicplay.c:1189)
         : +mov eax, dword ptr [eax]
         : +mov ax, word ptr [eax]
         : +mov word ptr [ebp - 0x10], ax
         : +mov eax, dword ptr [ebp + 8] 	(flicplay.c:1190)
         : +add dword ptr [eax], 2
         : +mov ax, word ptr [ebp - 0x10] 	(flicplay.c:1191)
         : +mov ecx, dword ptr [ebp - 4]
         : +mov word ptr [ecx], ax
         : +add dword ptr [ebp - 4], 2 	(flicplay.c:1192)
         : +jmp -0x34 	(flicplay.c:1193)
         : +jmp -0xd7 	(flicplay.c:1195)
0x496ca0 : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1196)
0x496ca3 : add dword ptr [ebp - 0x18], eax
0x496ca6 : -jmp -0x128
         : +inc dword ptr [ebp - 0x1c] 	(flicplay.c:1197)
         : +jmp -0x130 	(flicplay.c:1199)
0x496cab : pop edi 	(flicplay.c:1200)
0x496cac : pop esi
0x496cad : pop ebx
0x496cae : leave 
0x496caf : ret 


DoDeltaX is only 72.73% similar to the original, diff above
```

*AI generated. Time taken: 120s, tokens: 23,412*
