### PR TITLE
DoBlack 100% effective match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1211,10 +1211,10 @@ void DoBlack(tFlic_descriptor* pFlic_info, tU32 chunk_length) {
 
     pixel_ptr = pFlic_info->first_pixel;
     the_row_bytes = pFlic_info->the_pixelmap->row_bytes;
-    the_width = pFlic_info->width;
+    the_width = (int)pFlic_info->width >> 2;
     for (i = 0; i < pFlic_info->height; i++) {
         line_pixel_ptr = (tU32*)pixel_ptr;
-        for (j = 0; j < the_width / sizeof(tU32); j++) {
+        for (j = 0; j < the_width; j++) {
             *line_pixel_ptr = 0;
             line_pixel_ptr++;
         }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x496ce7,23 +0x47bbcc,23 @@
0x496ce7 : inc dword ptr [ebp - 0x14]
0x496cea : mov eax, dword ptr [ebp + 8]
0x496ced : mov ecx, dword ptr [ebp - 0x14]
0x496cf0 : cmp dword ptr [eax + 0x48], ecx
0x496cf3 : jle 0x3e
0x496cf9 : mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1216)
0x496cfc : mov dword ptr [ebp - 4], eax
0x496cff : mov dword ptr [ebp - 0x18], 0 	(flicplay.c:1217)
0x496d06 : jmp 0x3
0x496d0b : inc dword ptr [ebp - 0x18]
0x496d0e : -mov eax, dword ptr [ebp - 0x18]
0x496d11 : -cmp dword ptr [ebp - 8], eax
0x496d14 : -jle 0x12
         : +mov eax, dword ptr [ebp - 8]
         : +cmp dword ptr [ebp - 0x18], eax
         : +jge 0x12
0x496d1a : mov eax, dword ptr [ebp - 4] 	(flicplay.c:1218)
0x496d1d : mov dword ptr [eax], 0
0x496d23 : add dword ptr [ebp - 4], 4 	(flicplay.c:1219)
0x496d27 : jmp -0x21 	(flicplay.c:1220)
0x496d2c : mov eax, dword ptr [ebp - 0xc] 	(flicplay.c:1221)
0x496d2f : add dword ptr [ebp - 0x10], eax
0x496d32 : jmp -0x50 	(flicplay.c:1222)
0x496d37 : pop edi 	(flicplay.c:1223)
0x496d38 : pop esi
0x496d39 : pop ebx


0x496cb0: DoBlack 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x496cb8,39 +0x47bb9d,39 @@
0x496cb8 : push edi
0x496cb9 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1212)
0x496cbc : mov eax, dword ptr [eax + 0x28]
0x496cbf : mov dword ptr [ebp - 0x10], eax
0x496cc2 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1213)
0x496cc5 : mov eax, dword ptr [eax + 0x38]
0x496cc8 : movsx eax, word ptr [eax + 0x28]
0x496ccc : mov dword ptr [ebp - 0xc], eax
0x496ccf : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1214)
0x496cd2 : mov eax, dword ptr [eax + 0x44]
0x496cd5 : -sar eax, 2
0x496cd8 : mov dword ptr [ebp - 8], eax
0x496cdb : mov dword ptr [ebp - 0x14], 0 	(flicplay.c:1215)
0x496ce2 : jmp 0x3
0x496ce7 : inc dword ptr [ebp - 0x14]
0x496cea : mov eax, dword ptr [ebp + 8]
0x496ced : mov ecx, dword ptr [ebp - 0x14]
0x496cf0 : cmp dword ptr [eax + 0x48], ecx
0x496cf3 : -jle 0x3e
         : +jle 0x41
0x496cf9 : mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1216)
0x496cfc : mov dword ptr [ebp - 4], eax
0x496cff : mov dword ptr [ebp - 0x18], 0 	(flicplay.c:1217)
0x496d06 : jmp 0x3
0x496d0b : inc dword ptr [ebp - 0x18]
0x496d0e : -mov eax, dword ptr [ebp - 0x18]
0x496d11 : -cmp dword ptr [ebp - 8], eax
0x496d14 : -jle 0x12
         : +mov eax, dword ptr [ebp - 8]
         : +shr eax, 2
         : +cmp eax, dword ptr [ebp - 0x18]
         : +jbe 0x12
0x496d1a : mov eax, dword ptr [ebp - 4] 	(flicplay.c:1218)
0x496d1d : mov dword ptr [eax], 0
0x496d23 : add dword ptr [ebp - 4], 4 	(flicplay.c:1219)
0x496d27 : -jmp -0x21
         : +jmp -0x24 	(flicplay.c:1220)
0x496d2c : mov eax, dword ptr [ebp - 0xc] 	(flicplay.c:1221)
0x496d2f : add dword ptr [ebp - 0x10], eax
0x496d32 : -jmp -0x50
         : +jmp -0x53 	(flicplay.c:1222)
0x496d37 : pop edi 	(flicplay.c:1223)
0x496d38 : pop esi
0x496d39 : pop ebx
0x496d3a : leave 
0x496d3b : ret 


DoBlack is only 84.09% similar to the original, diff above
```

*AI generated. Time taken: 101s, tokens: 8,855*
