### PR TITLE
DoRunLengthX 100% effective match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1243,15 +1243,14 @@ void DoRunLengthX(tFlic_descriptor* pFlic_info, tU32 chunk_length) {
         number_of_packets = MemReadU8(&pFlic_info->data);
         for (j = 0; j < number_of_packets; j++) {
             size_count = MemReadS8(&pFlic_info->data);
-            if (size_count >= 0) {
-                the_byte = MemReadU8(&pFlic_info->data);
-                for (k = 0; k < size_count; k++) {
-                    *line_pixel_ptr = the_byte;
+            if (size_count < 0) {
+                for (k = 0; k < -size_count; k++) {
+                    *line_pixel_ptr = MemReadU8(&pFlic_info->data);
                     line_pixel_ptr++;
                 }
             } else {
-                for (k = 0; k < -size_count; k++) {
-                    the_byte = MemReadU8(&pFlic_info->data);
+                the_byte = MemReadU8(&pFlic_info->data);
+                for (k = 0; k < size_count; k++) {
                     *line_pixel_ptr = the_byte;
                     line_pixel_ptr++;
                 }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x496dfa,23 +0x47bcdf,23 @@
0x496dfa : jmp -0x2a 	(flicplay.c:1250)
0x496dff : jmp 0x3a 	(flicplay.c:1251)
0x496e04 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1252)
0x496e07 : push eax
0x496e08 : call MemReadU8 (FUNCTION)
0x496e0d : add esp, 4
0x496e10 : mov byte ptr [ebp - 0x14], al
0x496e13 : mov dword ptr [ebp - 0x24], 0 	(flicplay.c:1253)
0x496e1a : jmp 0x3
0x496e1f : inc dword ptr [ebp - 0x24]
0x496e22 : -mov eax, dword ptr [ebp - 0x24]
0x496e25 : -cmp dword ptr [ebp - 8], eax
0x496e28 : -jle 0x10
         : +mov eax, dword ptr [ebp - 8]
         : +cmp dword ptr [ebp - 0x24], eax
         : +jge 0x10
0x496e2e : mov al, byte ptr [ebp - 0x14] 	(flicplay.c:1254)
0x496e31 : mov ecx, dword ptr [ebp - 4]
0x496e34 : mov byte ptr [ecx], al
0x496e36 : inc dword ptr [ebp - 4] 	(flicplay.c:1255)
0x496e39 : jmp -0x1f 	(flicplay.c:1256)
0x496e3e : jmp -0xa5 	(flicplay.c:1258)
0x496e43 : mov eax, dword ptr [ebp - 0xc] 	(flicplay.c:1259)
0x496e46 : add dword ptr [ebp - 0x10], eax
0x496e49 : jmp -0xe7 	(flicplay.c:1260)
0x496e4e : pop edi 	(flicplay.c:1261)


0x496d3c: DoRunLengthX 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x496d4f,75 +0x47bc34,77 @@
0x496d4f : mov dword ptr [ebp - 0xc], eax
0x496d52 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1239)
0x496d55 : mov eax, dword ptr [eax + 0x28]
0x496d58 : mov dword ptr [ebp - 0x10], eax
0x496d5b : mov dword ptr [ebp - 0x18], 0 	(flicplay.c:1241)
0x496d62 : jmp 0x3
0x496d67 : inc dword ptr [ebp - 0x18]
0x496d6a : mov eax, dword ptr [ebp + 8]
0x496d6d : mov ecx, dword ptr [ebp - 0x18]
0x496d70 : cmp dword ptr [eax + 0x48], ecx
0x496d73 : -jle 0xd5
         : +jle 0xdb
0x496d79 : mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1242)
0x496d7c : mov dword ptr [ebp - 4], eax
0x496d7f : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1243)
0x496d82 : push eax
0x496d83 : call MemReadU8 (FUNCTION)
0x496d88 : add esp, 4
0x496d8b : xor ecx, ecx
0x496d8d : mov cl, al
0x496d8f : mov dword ptr [ebp - 0x20], ecx
0x496d92 : mov dword ptr [ebp - 0x1c], 0 	(flicplay.c:1244)
0x496d99 : jmp 0x3
0x496d9e : inc dword ptr [ebp - 0x1c]
0x496da1 : mov eax, dword ptr [ebp - 0x1c]
0x496da4 : cmp dword ptr [ebp - 0x20], eax
0x496da7 : -jle 0x96
         : +jle 0x9c
0x496dad : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1245)
0x496db0 : push eax
0x496db1 : call MemReadS8 (FUNCTION)
0x496db6 : add esp, 4
0x496db9 : movsx eax, al
0x496dbc : mov dword ptr [ebp - 8], eax
0x496dbf : cmp dword ptr [ebp - 8], 0 	(flicplay.c:1246)
0x496dc3 : -jge 0x3b
0x496dc9 : -mov dword ptr [ebp - 0x24], 0
0x496dd0 : -jmp 0x3
0x496dd5 : -inc dword ptr [ebp - 0x24]
0x496dd8 : -mov eax, dword ptr [ebp - 8]
0x496ddb : -neg eax
0x496ddd : -cmp eax, dword ptr [ebp - 0x24]
0x496de0 : -jle 0x19
0x496de6 : -mov eax, dword ptr [ebp + 8]
0x496de9 : -push eax
0x496dea : -call MemReadU8 (FUNCTION)
0x496def : -add esp, 4
0x496df2 : -mov ecx, dword ptr [ebp - 4]
0x496df5 : -mov byte ptr [ecx], al
0x496df7 : -inc dword ptr [ebp - 4]
0x496dfa : -jmp -0x2a
0x496dff : -jmp 0x3a
         : +jl 0x3f
0x496e04 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1247)
0x496e07 : push eax
0x496e08 : call MemReadU8 (FUNCTION)
0x496e0d : add esp, 4
0x496e10 : mov byte ptr [ebp - 0x14], al
0x496e13 : mov dword ptr [ebp - 0x24], 0 	(flicplay.c:1248)
0x496e1a : jmp 0x3
0x496e1f : inc dword ptr [ebp - 0x24]
0x496e22 : -mov eax, dword ptr [ebp - 0x24]
0x496e25 : -cmp dword ptr [ebp - 8], eax
0x496e28 : -jle 0x10
         : +mov eax, dword ptr [ebp - 8]
         : +cmp dword ptr [ebp - 0x24], eax
         : +jge 0x10
0x496e2e : mov al, byte ptr [ebp - 0x14] 	(flicplay.c:1249)
0x496e31 : mov ecx, dword ptr [ebp - 4]
0x496e34 : mov byte ptr [ecx], al
0x496e36 : inc dword ptr [ebp - 4] 	(flicplay.c:1250)
0x496e39 : jmp -0x1f 	(flicplay.c:1251)
0x496e3e : -jmp -0xa5
         : +jmp 0x3c 	(flicplay.c:1252)
         : +mov dword ptr [ebp - 0x24], 0 	(flicplay.c:1253)
         : +jmp 0x3
         : +inc dword ptr [ebp - 0x24]
         : +mov eax, dword ptr [ebp - 8]
         : +neg eax
         : +cmp eax, dword ptr [ebp - 0x24]
         : +jle 0x1f
         : +mov eax, dword ptr [ebp + 8] 	(flicplay.c:1254)
         : +push eax
         : +call MemReadU8 (FUNCTION)
         : +add esp, 4
         : +mov byte ptr [ebp - 0x14], al
         : +mov al, byte ptr [ebp - 0x14] 	(flicplay.c:1255)
         : +mov ecx, dword ptr [ebp - 4]
         : +mov byte ptr [ecx], al
         : +inc dword ptr [ebp - 4] 	(flicplay.c:1256)
         : +jmp -0x30 	(flicplay.c:1257)
         : +jmp -0xab 	(flicplay.c:1259)
0x496e43 : mov eax, dword ptr [ebp - 0xc] 	(flicplay.c:1260)
0x496e46 : add dword ptr [ebp - 0x10], eax
0x496e49 : -jmp -0xe7
         : +jmp -0xed 	(flicplay.c:1261)
0x496e4e : pop edi 	(flicplay.c:1262)
0x496e4f : pop esi
0x496e50 : pop ebx
0x496e51 : leave 
0x496e52 : ret 


DoRunLengthX is only 70.59% similar to the original, diff above
```

*AI generated. Time taken: 78s, tokens: 10,666*
