### PR TITLE
DoRunLengthTrans 100% match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1282,22 +1282,25 @@ void DoRunLengthTrans(tFlic_descriptor* pFlic_info, tU32 chunk_length) {
         number_of_packets = MemReadU8(&pFlic_info->data);
         for (j = 0; j < number_of_packets; j++) {
             size_count = MemReadS8(&pFlic_info->data);
-            if (size_count >= 0) {
-                the_byte = MemReadU8(&pFlic_info->data);
-
-                for (k = 0; k < size_count; k++) {
-                    if (the_byte) {
-                        *line_pixel_ptr = the_byte;
-                    }
-                    line_pixel_ptr++;
-                }
-            } else {
+            if (size_count < 0) {
                 for (k = 0; k < -size_count; k++) {
                     the_byte = MemReadU8(&pFlic_info->data);
                     if (the_byte) {
                         *line_pixel_ptr = the_byte;
+                        line_pixel_ptr++;
+                    } else {
+                        line_pixel_ptr++;
                     }
-                    line_pixel_ptr++;
+                }
+            } else {
+                the_byte = MemReadU8(&pFlic_info->data);
+                if (the_byte) {
+                    for (k = 0; k < size_count; k++) {
+                        *line_pixel_ptr = the_byte;
+                        line_pixel_ptr++;
+                    }
+                } else {
+                    line_pixel_ptr += size_count;
                 }
             }
         }


### PR DESCRIPTION
## Match result

```
0x496e53: DoRunLengthTrans 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x496e66,81 +0x47bd51,85 @@
0x496e66 : mov dword ptr [ebp - 0xc], eax
0x496e69 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1278)
0x496e6c : mov eax, dword ptr [eax + 0x28]
0x496e6f : mov dword ptr [ebp - 0x10], eax
0x496e72 : mov dword ptr [ebp - 0x18], 0 	(flicplay.c:1280)
0x496e79 : jmp 0x3
0x496e7e : inc dword ptr [ebp - 0x18]
0x496e81 : mov eax, dword ptr [ebp + 8]
0x496e84 : mov ecx, dword ptr [ebp - 0x18]
0x496e87 : cmp dword ptr [eax + 0x48], ecx
0x496e8a : -jle 0x108
         : +jle 0xf5
0x496e90 : mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1281)
0x496e93 : mov dword ptr [ebp - 4], eax
0x496e96 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1282)
0x496e99 : push eax
0x496e9a : call MemReadU8 (FUNCTION)
0x496e9f : add esp, 4
0x496ea2 : xor ecx, ecx
0x496ea4 : mov cl, al
0x496ea6 : mov dword ptr [ebp - 0x20], ecx
0x496ea9 : mov dword ptr [ebp - 0x1c], 0 	(flicplay.c:1283)
0x496eb0 : jmp 0x3
0x496eb5 : inc dword ptr [ebp - 0x1c]
0x496eb8 : mov eax, dword ptr [ebp - 0x1c]
0x496ebb : cmp dword ptr [ebp - 0x20], eax
0x496ebe : -jle 0xc9
         : +jle 0xb6
0x496ec4 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1284)
0x496ec7 : push eax
0x496ec8 : call MemReadS8 (FUNCTION)
0x496ecd : add esp, 4
0x496ed0 : movsx eax, al
0x496ed3 : mov dword ptr [ebp - 8], eax
0x496ed6 : cmp dword ptr [ebp - 8], 0 	(flicplay.c:1285)
0x496eda : -jge 0x56
         : +jl 0x4c
         : +mov eax, dword ptr [ebp + 8] 	(flicplay.c:1286)
         : +push eax
         : +call MemReadU8 (FUNCTION)
         : +add esp, 4
         : +mov byte ptr [ebp - 0x14], al
         : +mov dword ptr [ebp - 0x24], 0 	(flicplay.c:1288)
         : +jmp 0x3
         : +inc dword ptr [ebp - 0x24]
         : +mov eax, dword ptr [ebp - 0x24]
         : +cmp dword ptr [ebp - 8], eax
         : +jle 0x1d
         : +xor eax, eax 	(flicplay.c:1289)
         : +mov al, byte ptr [ebp - 0x14]
         : +test eax, eax
         : +je 0x8
         : +mov al, byte ptr [ebp - 0x14] 	(flicplay.c:1290)
         : +mov ecx, dword ptr [ebp - 4]
         : +mov byte ptr [ecx], al
         : +inc dword ptr [ebp - 4] 	(flicplay.c:1292)
         : +jmp -0x2c 	(flicplay.c:1293)
         : +jmp 0x49 	(flicplay.c:1294)
0x496ee0 : mov dword ptr [ebp - 0x24], 0 	(flicplay.c:1295)
0x496ee7 : jmp 0x3
0x496eec : inc dword ptr [ebp - 0x24]
0x496eef : mov eax, dword ptr [ebp - 8]
0x496ef2 : neg eax
0x496ef4 : cmp eax, dword ptr [ebp - 0x24]
0x496ef7 : -jle 0x34
         : +jle 0x2c
0x496efd : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1296)
0x496f00 : push eax
0x496f01 : call MemReadU8 (FUNCTION)
0x496f06 : add esp, 4
0x496f09 : mov byte ptr [ebp - 0x14], al
0x496f0c : xor eax, eax 	(flicplay.c:1297)
0x496f0e : mov al, byte ptr [ebp - 0x14]
0x496f11 : test eax, eax
0x496f13 : -je 0x10
         : +je 0x8
0x496f19 : mov al, byte ptr [ebp - 0x14] 	(flicplay.c:1298)
0x496f1c : mov ecx, dword ptr [ebp - 4]
0x496f1f : mov byte ptr [ecx], al
0x496f21 : inc dword ptr [ebp - 4] 	(flicplay.c:1300)
0x496f24 : -jmp 0x3
0x496f29 : -inc dword ptr [ebp - 4]
0x496f2c : -jmp -0x45
0x496f31 : -jmp 0x52
0x496f36 : -mov eax, dword ptr [ebp + 8]
0x496f39 : -push eax
0x496f3a : -call MemReadU8 (FUNCTION)
0x496f3f : -add esp, 4
0x496f42 : -mov byte ptr [ebp - 0x14], al
0x496f45 : -xor eax, eax
0x496f47 : -mov al, byte ptr [ebp - 0x14]
0x496f4a : -test eax, eax
0x496f4c : -je 0x30
0x496f52 : -mov dword ptr [ebp - 0x24], 0
0x496f59 : -jmp 0x3
0x496f5e : -inc dword ptr [ebp - 0x24]
0x496f61 : -mov eax, dword ptr [ebp - 0x24]
0x496f64 : -cmp dword ptr [ebp - 8], eax
0x496f67 : -jle 0x10
0x496f6d : -mov al, byte ptr [ebp - 0x14]
0x496f70 : -mov ecx, dword ptr [ebp - 4]
0x496f73 : -mov byte ptr [ecx], al
0x496f75 : -inc dword ptr [ebp - 4]
0x496f78 : -jmp -0x1f
0x496f7d : -jmp 0x6
0x496f82 : -mov eax, dword ptr [ebp - 8]
0x496f85 : -add dword ptr [ebp - 4], eax
         : +jmp -0x3d 	(flicplay.c:1301)
         : +jmp -0xc5 	(flicplay.c:1303)
         : +mov eax, dword ptr [ebp - 0xc] 	(flicplay.c:1304)
         : +add dword ptr [ebp - 0x10], eax
         : +jmp -0x107 	(flicplay.c:1305)
         : +pop edi 	(flicplay.c:1306)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DoRunLengthTrans is only 63.04% similar to the original, diff above
```

*AI generated. Time taken: 226s, tokens: 53,221*
