### PR TITLE
DoUncompressed 100% match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1211,7 +1211,7 @@ void DoBlack(tFlic_descriptor* pFlic_info, tU32 chunk_length) {
 
     pixel_ptr = pFlic_info->first_pixel;
     the_row_bytes = pFlic_info->the_pixelmap->row_bytes;
-    the_width = pFlic_info->width;
+    the_width = pFlic_info->width >> 2;
     for (i = 0; i < pFlic_info->height; i++) {
         line_pixel_ptr = (tU32*)pixel_ptr;
         for (j = 0; j < the_width / sizeof(tU32); j++) {
@@ -1317,10 +1317,10 @@ void DoUncompressed(tFlic_descriptor* pFlic_info, tU32 chunk_length) {
 
     pixel_ptr = pFlic_info->first_pixel;
     the_row_bytes = pFlic_info->the_pixelmap->row_bytes;
-    the_width = pFlic_info->width;
+    the_width = pFlic_info->width >> 2;
     for (i = 0; i < pFlic_info->height; i++) {
         line_pixel_ptr = (tU32*)pixel_ptr;
-        for (j = 0; j < the_width / 4; j++) {
+        for (j = 0; j < the_width; j++) {
             *line_pixel_ptr = MemReadU32(&pFlic_info->data);
             line_pixel_ptr++;
         }

--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1211,7 +1211,7 @@ void DoBlack(tFlic_descriptor* pFlic_info, tU32 chunk_length) {
 
     pixel_ptr = pFlic_info->first_pixel;
     the_row_bytes = pFlic_info->the_pixelmap->row_bytes;
-    the_width = pFlic_info->width >> 2;
+    the_width = pFlic_info->width;
     for (i = 0; i < pFlic_info->height; i++) {
         line_pixel_ptr = (tU32*)pixel_ptr;
         for (j = 0; j < the_width / sizeof(tU32); j++) {
@@ -1317,7 +1317,7 @@ void DoUncompressed(tFlic_descriptor* pFlic_info, tU32 chunk_length) {
 
     pixel_ptr = pFlic_info->first_pixel;
     the_row_bytes = pFlic_info->the_pixelmap->row_bytes;
-    the_width = pFlic_info->width >> 2;
+    the_width = pFlic_info->width / 4;
     for (i = 0; i < pFlic_info->height; i++) {
         line_pixel_ptr = (tU32*)pixel_ptr;
         for (j = 0; j < the_width; j++) {
@@ -2152,7 +2152,6 @@ void LoadInterfaceStrings(void) {
         fclose(f);
 #endif
     }
-
 }
 
 // IDA: void __cdecl FlushInterfaceFonts()


### PR DESCRIPTION
## Match result

```
0x496f9d: DoUncompressed 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x496fa5,43 +0x47be7d,46 @@
0x496fa5 : push edi
0x496fa6 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1318)
0x496fa9 : mov eax, dword ptr [eax + 0x28]
0x496fac : mov dword ptr [ebp - 0x10], eax
0x496faf : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1319)
0x496fb2 : mov eax, dword ptr [eax + 0x38]
0x496fb5 : movsx eax, word ptr [eax + 0x28]
0x496fb9 : mov dword ptr [ebp - 0xc], eax
0x496fbc : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1320)
0x496fbf : mov eax, dword ptr [eax + 0x44]
0x496fc2 : -sar eax, 2
0x496fc5 : mov dword ptr [ebp - 8], eax
0x496fc8 : mov dword ptr [ebp - 0x14], 0 	(flicplay.c:1321)
0x496fcf : jmp 0x3
0x496fd4 : inc dword ptr [ebp - 0x14]
0x496fd7 : mov eax, dword ptr [ebp + 8]
0x496fda : mov ecx, dword ptr [ebp - 0x14]
0x496fdd : cmp dword ptr [eax + 0x48], ecx
0x496fe0 : -jle 0x46
         : +jle 0x4f
0x496fe6 : mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1322)
0x496fe9 : mov dword ptr [ebp - 4], eax
0x496fec : mov dword ptr [ebp - 0x18], 0 	(flicplay.c:1323)
0x496ff3 : jmp 0x3
0x496ff8 : inc dword ptr [ebp - 0x18]
0x496ffb : -mov eax, dword ptr [ebp - 0x18]
0x496ffe : -cmp dword ptr [ebp - 8], eax
         : +mov eax, dword ptr [ebp - 8]
         : +cdq 
         : +and edx, 3
         : +add eax, edx
         : +sar eax, 2
         : +cmp eax, dword ptr [ebp - 0x18]
0x497001 : jle 0x1a
0x497007 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1324)
0x49700a : push eax
0x49700b : call MemReadU32 (FUNCTION)
0x497010 : add esp, 4
0x497013 : mov ecx, dword ptr [ebp - 4]
0x497016 : mov dword ptr [ecx], eax
0x497018 : add dword ptr [ebp - 4], 4 	(flicplay.c:1325)
0x49701c : -jmp -0x29
         : +jmp -0x32 	(flicplay.c:1326)
0x497021 : mov eax, dword ptr [ebp - 0xc] 	(flicplay.c:1327)
0x497024 : add dword ptr [ebp - 0x10], eax
0x497027 : -jmp -0x58
         : +jmp -0x61 	(flicplay.c:1328)
0x49702c : pop edi 	(flicplay.c:1329)
0x49702d : pop esi
0x49702e : pop ebx
0x49702f : leave 
0x497030 : ret 


DoUncompressed is only 84.85% similar to the original, diff above
```

*AI generated. Time taken: 229s, tokens: 48,412*
