### PR TITLE
DoUncompressedTrans 100% match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1352,8 +1352,10 @@ void DoUncompressedTrans(tFlic_descriptor* pFlic_info, tU32 chunk_length) {
 #endif
             if (the_byte != '\0') {
                 *line_pixel_ptr = the_byte;
+                line_pixel_ptr++;
+            } else {
+                line_pixel_ptr++;
             }
-            line_pixel_ptr++;
         }
         pixel_ptr += the_row_bytes;
     }


### PR DESCRIPTION
## Match result

```
0x497031: DoUncompressedTrans 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x49704d,37 +0x47bf2b,41 @@
0x49704d : mov dword ptr [ebp - 0xc], eax
0x497050 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1344)
0x497053 : mov eax, dword ptr [eax + 0x44]
0x497056 : mov dword ptr [ebp - 8], eax
0x497059 : mov dword ptr [ebp - 0x18], 0 	(flicplay.c:1345)
0x497060 : jmp 0x3
0x497065 : inc dword ptr [ebp - 0x18]
0x497068 : mov eax, dword ptr [ebp + 8]
0x49706b : mov ecx, dword ptr [ebp - 0x18]
0x49706e : cmp dword ptr [eax + 0x48], ecx
0x497071 : -jle 0x60
         : +jle 0x58
0x497077 : mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1346)
0x49707a : mov dword ptr [ebp - 4], eax
0x49707d : mov dword ptr [ebp - 0x1c], 0 	(flicplay.c:1347)
0x497084 : jmp 0x3
0x497089 : inc dword ptr [ebp - 0x1c]
0x49708c : mov eax, dword ptr [ebp - 0x1c]
0x49708f : cmp dword ptr [ebp - 8], eax
0x497092 : -jle 0x34
         : +jle 0x2c
0x497098 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1351)
0x49709b : push eax
0x49709c : call MemReadU32 (FUNCTION)
0x4970a1 : add esp, 4
0x4970a4 : mov byte ptr [ebp - 0x14], al
0x4970a7 : xor eax, eax 	(flicplay.c:1353)
0x4970a9 : mov al, byte ptr [ebp - 0x14]
0x4970ac : test eax, eax
0x4970ae : -je 0x10
         : +je 0x8
0x4970b4 : mov al, byte ptr [ebp - 0x14] 	(flicplay.c:1354)
0x4970b7 : mov ecx, dword ptr [ebp - 4]
0x4970ba : mov byte ptr [ecx], al
0x4970bc : inc dword ptr [ebp - 4] 	(flicplay.c:1356)
0x4970bf : -jmp 0x3
0x4970c4 : -inc dword ptr [ebp - 4]
0x4970c7 : -jmp -0x43
         : +jmp -0x3b 	(flicplay.c:1357)
0x4970cc : mov eax, dword ptr [ebp - 0xc] 	(flicplay.c:1358)
0x4970cf : add dword ptr [ebp - 0x10], eax
         : +jmp -0x6a 	(flicplay.c:1359)
         : +pop edi 	(flicplay.c:1360)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DoUncompressedTrans is only 84.31% similar to the original, diff above
```

*AI generated. Time taken: 376s, tokens: 54,285*
