### PR TITLE
DrawTranslations 100% effective match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1375,33 +1375,35 @@ void DrawTranslations(tFlic_descriptor* pFlic_info, int pLast_frame) {
     int width;
     int right_edge;
 
-    for (i = 0; i < gTranslation_count; i++) {
-        trans = &gTranslations[i];
-        if (trans->flic_index == pFlic_info->the_index && (trans->every_frame || pLast_frame)) {
-            width = DRTextWidth(gTrans_fonts[trans->font_index], trans->text);
-            switch (trans->justification) {
-            case eJust_left:
-                x = trans->x;
-                right_edge = x + width;
-                break;
-            case eJust_right:
-                x = trans->x - width;
-                right_edge = x;
-                break;
-            case eJust_centre:
-                x = trans->x - width / 2;
-                right_edge = x + width / 2;
-                break;
-            default:
-                TELL_ME_IF_WE_PASS_THIS_WAY();
+    for (i = 0, trans = gTranslations; i < gTranslation_count; i++, trans++) {
+        if (trans->flic_index == pFlic_info->the_index) {
+            if (trans->every_frame || pLast_frame) {
+                width = DRTextWidth(gTrans_fonts[trans->font_index], trans->text);
+                switch (trans->justification) {
+                case eJust_left:
+                    x = trans->x;
+                    right_edge = x + width;
+                    break;
+                case eJust_right:
+                    x = trans->x - width;
+                    right_edge = x;
+                    break;
+                case eJust_centre:
+                    x = trans->x - width / 2;
+                    right_edge = x + width / 2;
+                    break;
+                }
+                if (!trans->global) {
+                    x += pFlic_info->x_offset;
+                }
+                TransDRPixelmapText(
+                    pFlic_info->the_pixelmap,
+                    x,
+                    trans->y + (trans->global ? 0 : pFlic_info->y_offset),
+                    gTrans_fonts[trans->font_index],
+                    trans->text,
+                    right_edge);
             }
-            TransDRPixelmapText(
-                pFlic_info->the_pixelmap,
-                x + (trans->global ? 0 : pFlic_info->x_offset),
-                trans->y + (trans->global ? 0 : pFlic_info->y_offset),
-                gTrans_fonts[trans->font_index],
-                trans->text,
-                right_edge);
         }
     }
 }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4970fd,23 +0x47bfd3,23 @@
0x4970fd : sub esp, 0x1c
0x497100 : push ebx
0x497101 : push esi
0x497102 : push edi
0x497103 : mov dword ptr [ebp - 0x10], 0 	(flicplay.c:1378)
0x49710a : mov eax, dword ptr [gTranslations (DATA)]
0x49710f : mov dword ptr [ebp - 0x14], eax
0x497112 : jmp 0x7
0x497117 : inc dword ptr [ebp - 0x10]
0x49711a : add dword ptr [ebp - 0x14], 0x20
0x49711e : -mov eax, dword ptr [gTranslation_count (DATA)]
0x497123 : -cmp dword ptr [ebp - 0x10], eax
0x497126 : -jge 0x147
         : +mov eax, dword ptr [ebp - 0x10]
         : +cmp dword ptr [gTranslation_count (DATA)], eax
         : +jle 0x147
0x49712c : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1379)
0x49712f : mov ecx, dword ptr [ebp + 8]
0x497132 : mov ecx, dword ptr [ecx + 0x54]
0x497135 : cmp dword ptr [eax], ecx
0x497137 : jne 0x131
0x49713d : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1380)
0x497140 : cmp dword ptr [eax + 0x14], 0
0x497144 : jne 0xa
0x49714a : cmp dword ptr [ebp + 0xc], 0
0x49714e : je 0x11a

---
+++
@@ -0x497254,16 +0x47c12b,16 @@
0x497254 : mov eax, dword ptr [eax + 8]
0x497257 : add eax, dword ptr [ebp - 0x18]
0x49725a : push eax
0x49725b : mov eax, dword ptr [ebp - 0xc]
0x49725e : push eax
0x49725f : mov eax, dword ptr [ebp + 8]
0x497262 : mov eax, dword ptr [eax + 0x38]
0x497265 : push eax
0x497266 : call TransDRPixelmapText (FUNCTION)
0x49726b : add esp, 0x18
0x49726e : -jmp -0x15c
         : +jmp -0x15d 	(flicplay.c:1408)
0x497273 : pop edi 	(flicplay.c:1409)
0x497274 : pop esi
0x497275 : pop ebx
0x497276 : leave 
0x497277 : ret 


0x4970fa: DrawTranslations 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x4970fa,117 +0x47bfd0,122 @@
0x4970fa : push ebp 	(flicplay.c:1371)
0x4970fb : mov ebp, esp
0x4970fd : -sub esp, 0x1c
         : +sub esp, 0x20
0x497100 : push ebx
0x497101 : push esi
0x497102 : push edi
0x497103 : mov dword ptr [ebp - 0x10], 0 	(flicplay.c:1378)
0x49710a : -mov eax, dword ptr [gTranslations (DATA)]
         : +jmp 0x3
         : +inc dword ptr [ebp - 0x10]
         : +mov eax, dword ptr [ebp - 0x10]
         : +cmp dword ptr [gTranslation_count (DATA)], eax
         : +jle 0x16a
         : +mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1379)
         : +shl eax, 5
         : +add eax, dword ptr [gTranslations (DATA)]
0x49710f : mov dword ptr [ebp - 0x14], eax
0x497112 : -jmp 0x7
0x497117 : -inc dword ptr [ebp - 0x10]
0x49711a : -add dword ptr [ebp - 0x14], 0x20
0x49711e : -mov eax, dword ptr [gTranslation_count (DATA)]
0x497123 : -cmp dword ptr [ebp - 0x10], eax
0x497126 : -jge 0x147
0x49712c : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1380)
0x49712f : mov ecx, dword ptr [ebp + 8]
0x497132 : mov ecx, dword ptr [ecx + 0x54]
0x497135 : cmp dword ptr [eax], ecx
0x497137 : -jne 0x131
         : +jne 0x145
0x49713d : mov eax, dword ptr [ebp - 0x14]
0x497140 : cmp dword ptr [eax + 0x14], 0
0x497144 : jne 0xa
0x49714a : cmp dword ptr [ebp + 0xc], 0
0x49714e : -je 0x11a
         : +je 0x12e
0x497154 : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1381)
0x497157 : mov eax, dword ptr [eax + 0x1c]
0x49715a : push eax
0x49715b : mov eax, dword ptr [ebp - 0x14]
0x49715e : mov eax, dword ptr [eax + 0xc]
0x497161 : mov eax, dword ptr [eax*4 + gTrans_fonts[0] (DATA)]
0x497168 : push eax
0x497169 : call DRTextWidth (FUNCTION)
0x49716e : add esp, 8
0x497171 : mov dword ptr [ebp - 4], eax
0x497174 : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1382)
0x497177 : mov eax, dword ptr [eax + 0x18]
0x49717a : -mov dword ptr [ebp - 0x1c], eax
0x49717d : -jmp 0x5b
         : +mov dword ptr [ebp - 0x20], eax
         : +jmp 0x60
0x497182 : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1384)
0x497185 : mov eax, dword ptr [eax + 4]
0x497188 : mov dword ptr [ebp - 0xc], eax
0x49718b : mov eax, dword ptr [ebp - 4] 	(flicplay.c:1385)
0x49718e : add eax, dword ptr [ebp - 0xc]
0x497191 : mov dword ptr [ebp - 8], eax
0x497194 : -jmp 0x67
         : +jmp 0x6c 	(flicplay.c:1386)
0x497199 : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1388)
0x49719c : mov eax, dword ptr [eax + 4]
0x49719f : sub eax, dword ptr [ebp - 4]
0x4971a2 : mov dword ptr [ebp - 0xc], eax
0x4971a5 : mov eax, dword ptr [ebp - 0xc] 	(flicplay.c:1389)
0x4971a8 : mov dword ptr [ebp - 8], eax
0x4971ab : -jmp 0x50
         : +jmp 0x55 	(flicplay.c:1390)
0x4971b0 : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1392)
0x4971b3 : mov ecx, dword ptr [eax + 4]
0x4971b6 : mov eax, dword ptr [ebp - 4]
0x4971b9 : cdq 
0x4971ba : sub eax, edx
0x4971bc : sar eax, 1
0x4971be : sub ecx, eax
0x4971c0 : mov dword ptr [ebp - 0xc], ecx
0x4971c3 : mov eax, dword ptr [ebp - 4] 	(flicplay.c:1393)
0x4971c6 : cdq 
0x4971c7 : sub eax, edx
0x4971c9 : sar eax, 1
0x4971cb : mov ecx, dword ptr [ebp - 0xc]
0x4971ce : add ecx, eax
0x4971d0 : mov dword ptr [ebp - 8], ecx
0x4971d3 : -jmp 0x28
         : +jmp 0x2d 	(flicplay.c:1394)
         : +call abort (FUNCTION) 	(flicplay.c:1396)
0x4971d8 : jmp 0x23 	(flicplay.c:1397)
0x4971dd : -cmp dword ptr [ebp - 0x1c], 0
0x4971e1 : -je -0x65
0x4971e7 : -cmp dword ptr [ebp - 0x1c], 1
0x4971eb : -je -0x58
0x4971f1 : -cmp dword ptr [ebp - 0x1c], 2
0x4971f5 : -je -0x4b
0x4971fb : -jmp 0x0
0x497200 : -mov eax, dword ptr [ebp - 0x14]
0x497203 : -cmp dword ptr [eax + 0x10], 0
0x497207 : -jne 0x9
0x49720d : -mov eax, dword ptr [ebp + 8]
0x497210 : -mov eax, dword ptr [eax + 0x3c]
0x497213 : -add dword ptr [ebp - 0xc], eax
         : +cmp dword ptr [ebp - 0x20], 0
         : +je -0x6a
         : +cmp dword ptr [ebp - 0x20], 1
         : +je -0x5d
         : +cmp dword ptr [ebp - 0x20], 2
         : +je -0x50
         : +jmp -0x2d
0x497216 : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1404)
0x497219 : cmp dword ptr [eax + 0x10], 0
0x49721d : je 0xc
0x497223 : mov dword ptr [ebp - 0x18], 0
0x49722a : jmp 0x9
0x49722f : mov eax, dword ptr [ebp + 8]
0x497232 : mov eax, dword ptr [eax + 0x40]
0x497235 : mov dword ptr [ebp - 0x18], eax
         : +mov eax, dword ptr [ebp - 0x14]
         : +cmp dword ptr [eax + 0x10], 0
         : +je 0xc
         : +mov dword ptr [ebp - 0x1c], 0
         : +jmp 0x9
         : +mov eax, dword ptr [ebp + 8]
         : +mov eax, dword ptr [eax + 0x3c]
         : +mov dword ptr [ebp - 0x1c], eax
0x497238 : mov eax, dword ptr [ebp - 8]
0x49723b : push eax
0x49723c : mov eax, dword ptr [ebp - 0x14]
0x49723f : mov eax, dword ptr [eax + 0x1c]
0x497242 : push eax
0x497243 : mov eax, dword ptr [ebp - 0x14]
0x497246 : mov eax, dword ptr [eax + 0xc]
0x497249 : mov eax, dword ptr [eax*4 + gTrans_fonts[0] (DATA)]
0x497250 : push eax
0x497251 : mov eax, dword ptr [ebp - 0x14]
0x497254 : mov eax, dword ptr [eax + 8]
0x497257 : add eax, dword ptr [ebp - 0x18]
0x49725a : push eax
0x49725b : -mov eax, dword ptr [ebp - 0xc]
         : +mov eax, dword ptr [ebp - 0x1c]
         : +add eax, dword ptr [ebp - 0xc]
0x49725e : push eax
0x49725f : mov eax, dword ptr [ebp + 8]
0x497262 : mov eax, dword ptr [eax + 0x38]
0x497265 : push eax
0x497266 : call TransDRPixelmapText (FUNCTION)
0x49726b : add esp, 0x18
0x49726e : -jmp -0x15c
         : +jmp -0x17c 	(flicplay.c:1406)
0x497273 : pop edi 	(flicplay.c:1407)
0x497274 : pop esi
0x497275 : pop ebx
0x497276 : leave 
0x497277 : ret 


DrawTranslations is only 72.80% similar to the original, diff above
```

*AI generated. Time taken: 307s, tokens: 55,114*
