### PR TITLE
PlayFlic 100% effective match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1536,13 +1536,11 @@ int PlayFlic(int pIndex, tU32 pSize, tS8* pData_ptr, br_pixelmap* pDest_pixelmap
     last_frame = 0;
     while ((!pInterruptable || !AnyKeyDown()) && !finished_playing) {
         new_time = PDGetTotalTime();
-        frame_period = new_time - last_frame;
-
         if (gSound_time != 0 && new_time >= gSound_time) {
             DRS3StartSound(gEffects_outlet, gSound_ID);
             gSound_time = 0;
         }
-        if (frame_period >= the_flic.frame_period) {
+        if (new_time - last_frame >= the_flic.frame_period) {
             last_frame = new_time;
             finished_playing = PlayNextFlicFrame(&the_flic);
             DoPerFrame();


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4972b1,36 +0x47c56c,36 @@
0x4972b1 : push eax
0x4972b2 : mov eax, dword ptr [ebp + 8]
0x4972b5 : shl eax, 2
0x4972b8 : mov eax, dword ptr [eax + eax*8 + gMain_flic_list[0].file_name (DATA)]
0x4972bf : push eax
0x4972c0 : call StartFlic (FUNCTION)
0x4972c5 : add esp, 0x24
0x4972c8 : test eax, eax
0x4972ca : je 0xa
0x4972d0 : mov eax, 0xffffffff 	(flicplay.c:1533)
0x4972d5 : -jmp 0xc4
         : +jmp 0xc5
0x4972da : mov dword ptr [ebp - 4], 0 	(flicplay.c:1536)
0x4972e1 : cmp dword ptr [ebp + 0x24], 0 	(flicplay.c:1537)
0x4972e5 : je 0xd
0x4972eb : call AnyKeyDown (FUNCTION)
0x4972f0 : test eax, eax
0x4972f2 : -jne 0x8e
         : +jne 0x8f
0x4972f8 : cmp dword ptr [ebp - 0xc], 0
0x4972fc : -jne 0x84
         : +jne 0x85
0x497302 : call PDGetTotalTime (FUNCTION) 	(flicplay.c:1538)
0x497307 : mov dword ptr [ebp - 0x80], eax
0x49730a : cmp dword ptr [gSound_time (DATA)], 0 	(flicplay.c:1539)
0x497311 : -je 0x2c
0x497317 : -mov eax, dword ptr [gSound_time (DATA)]
0x49731c : -cmp dword ptr [ebp - 0x80], eax
0x49731f : -jb 0x1e
         : +je 0x2d
         : +mov eax, dword ptr [ebp - 0x80]
         : +cmp dword ptr [gSound_time (DATA)], eax
         : +ja 0x1e
0x497325 : mov eax, dword ptr [gSound_ID (DATA)] 	(flicplay.c:1540)
0x49732a : push eax
0x49732b : mov eax, dword ptr [gEffects_outlet (DATA)]
0x497330 : push eax
0x497331 : call DRS3StartSound (FUNCTION)
0x497336 : add esp, 8
0x497339 : mov dword ptr [gSound_time (DATA)], 0 	(flicplay.c:1541)
0x497343 : mov eax, dword ptr [ebp - 0x80] 	(flicplay.c:1543)
0x497346 : sub eax, dword ptr [ebp - 4]
0x497349 : cmp eax, dword ptr [ebp - 0x4c]

---
+++
@@ -0x497358,21 +0x47c614,21 @@
0x497358 : lea eax, [ebp - 0x7c] 	(flicplay.c:1545)
0x49735b : push eax
0x49735c : call PlayNextFlicFrame (FUNCTION)
0x497361 : add esp, 4
0x497364 : mov dword ptr [ebp - 0xc], eax
0x497367 : call dword ptr [ebp + 0x20] 	(flicplay.c:1546)
0x49736a : cmp dword ptr [gDark_mode (DATA)], 0 	(flicplay.c:1547)
0x497371 : jne 0x5
0x497377 : call EnsurePaletteUp (FUNCTION) 	(flicplay.c:1548)
0x49737c : call ServiceGame (FUNCTION) 	(flicplay.c:1550)
0x497381 : -jmp -0xa5
         : +jmp -0xa6 	(flicplay.c:1552)
0x497386 : call ServiceGame (FUNCTION) 	(flicplay.c:1553)
0x49738b : lea eax, [ebp - 0x7c] 	(flicplay.c:1554)
0x49738e : push eax
0x49738f : call EndFlic (FUNCTION)
0x497394 : add esp, 4
0x497397 : xor eax, eax 	(flicplay.c:1555)
0x497399 : jmp 0x0
0x49739e : pop edi 	(flicplay.c:1556)
0x49739f : pop esi
0x4973a0 : pop ebx


0x497278: PlayFlic 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x4972b1,60 +0x47c56c,62 @@
0x4972b1 : push eax
0x4972b2 : mov eax, dword ptr [ebp + 8]
0x4972b5 : shl eax, 2
0x4972b8 : mov eax, dword ptr [eax + eax*8 + gMain_flic_list[0].file_name (DATA)]
0x4972bf : push eax
0x4972c0 : call StartFlic (FUNCTION)
0x4972c5 : add esp, 0x24
0x4972c8 : test eax, eax
0x4972ca : je 0xa
0x4972d0 : mov eax, 0xffffffff 	(flicplay.c:1533)
0x4972d5 : -jmp 0xc4
         : +jmp 0xcb
0x4972da : mov dword ptr [ebp - 4], 0 	(flicplay.c:1536)
0x4972e1 : cmp dword ptr [ebp + 0x24], 0 	(flicplay.c:1537)
0x4972e5 : je 0xd
0x4972eb : call AnyKeyDown (FUNCTION)
0x4972f0 : test eax, eax
0x4972f2 : -jne 0x8e
         : +jne 0x95
0x4972f8 : cmp dword ptr [ebp - 0xc], 0
0x4972fc : -jne 0x84
         : +jne 0x8b
0x497302 : call PDGetTotalTime (FUNCTION) 	(flicplay.c:1538)
0x497307 : mov dword ptr [ebp - 0x80], eax
         : +mov eax, dword ptr [ebp - 0x80] 	(flicplay.c:1539)
         : +sub eax, dword ptr [ebp - 4]
         : +mov dword ptr [ebp - 8], eax
0x49730a : cmp dword ptr [gSound_time (DATA)], 0 	(flicplay.c:1541)
0x497311 : -je 0x2c
0x497317 : -mov eax, dword ptr [gSound_time (DATA)]
0x49731c : -cmp dword ptr [ebp - 0x80], eax
0x49731f : -jb 0x1e
         : +je 0x2d
         : +mov eax, dword ptr [ebp - 0x80]
         : +cmp dword ptr [gSound_time (DATA)], eax
         : +ja 0x1e
0x497325 : mov eax, dword ptr [gSound_ID (DATA)] 	(flicplay.c:1542)
0x49732a : push eax
0x49732b : mov eax, dword ptr [gEffects_outlet (DATA)]
0x497330 : push eax
0x497331 : call DRS3StartSound (FUNCTION)
0x497336 : add esp, 8
0x497339 : mov dword ptr [gSound_time (DATA)], 0 	(flicplay.c:1543)
0x497343 : -mov eax, dword ptr [ebp - 0x80]
0x497346 : -sub eax, dword ptr [ebp - 4]
0x497349 : -cmp eax, dword ptr [ebp - 0x4c]
0x49734c : -jb 0x2f
         : +mov eax, dword ptr [ebp - 8] 	(flicplay.c:1545)
         : +cmp dword ptr [ebp - 0x4c], eax
         : +ja 0x2f
0x497352 : mov eax, dword ptr [ebp - 0x80] 	(flicplay.c:1546)
0x497355 : mov dword ptr [ebp - 4], eax
0x497358 : lea eax, [ebp - 0x7c] 	(flicplay.c:1547)
0x49735b : push eax
0x49735c : call PlayNextFlicFrame (FUNCTION)
0x497361 : add esp, 4
0x497364 : mov dword ptr [ebp - 0xc], eax
0x497367 : call dword ptr [ebp + 0x20] 	(flicplay.c:1548)
0x49736a : cmp dword ptr [gDark_mode (DATA)], 0 	(flicplay.c:1549)
0x497371 : jne 0x5
0x497377 : call EnsurePaletteUp (FUNCTION) 	(flicplay.c:1550)
0x49737c : call ServiceGame (FUNCTION) 	(flicplay.c:1552)
0x497381 : -jmp -0xa5
         : +jmp -0xac 	(flicplay.c:1554)
0x497386 : call ServiceGame (FUNCTION) 	(flicplay.c:1555)
0x49738b : lea eax, [ebp - 0x7c] 	(flicplay.c:1556)
0x49738e : push eax
0x49738f : call EndFlic (FUNCTION)
0x497394 : add esp, 4
0x497397 : xor eax, eax 	(flicplay.c:1557)
0x497399 : jmp 0x0
0x49739e : pop edi 	(flicplay.c:1558)
0x49739f : pop esi
0x4973a0 : pop ebx


PlayFlic is only 84.88% similar to the original, diff above
```

*AI generated. Time taken: 110s, tokens: 22,583*
