### PR TITLE
ShowFlic 100% match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1578,7 +1578,7 @@ void ShowFlic(int pIndex) {
             gMain_flic_list[pIndex].interruptable,
             gMain_flic_list[pIndex].frame_rate);
     } while (gMain_flic_list[pIndex].repeat && !AnyKeyDown());
-    gLast_flic_name[0] = *""; // byte_10344C;
+    strcpy(gLast_flic_name, "");
 }
 
 // IDA: void __cdecl InitFlics()
@@ -2152,7 +2152,6 @@ void LoadInterfaceStrings(void) {
         fclose(f);
 #endif
     }
-
 }
 
 // IDA: void __cdecl FlushInterfaceFonts()

--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1578,7 +1578,7 @@ void ShowFlic(int pIndex) {
             gMain_flic_list[pIndex].interruptable,
             gMain_flic_list[pIndex].frame_rate);
     } while (gMain_flic_list[pIndex].repeat && !AnyKeyDown());
-    gLast_flic_name[0] = '\0'; // byte_10344C;
+    gLast_flic_name[0] = *""; // byte_10344C;
 }
 
 // IDA: void __cdecl InitFlics()


### PR DESCRIPTION
## Match result

```
0x4973a3: ShowFlic 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x49740b,14 +0x47c6e2,16 @@
0x49740b : push eax
0x49740c : call PlayFlic (FUNCTION)
0x497411 : add esp, 0x24
0x497414 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1580)
0x497417 : shl eax, 2
0x49741a : cmp dword ptr [eax + eax*8 + gMain_flic_list[0].repeat (OFFSET)], 0
0x497422 : je 0xd
0x497428 : call AnyKeyDown (FUNCTION)
0x49742d : test eax, eax
0x49742f : je -0x8c
0x497435 : -mov al, byte ptr [<OFFSET12>]
0x49743a : -mov byte ptr [gLast_flic_name[0] (DATA)], al
         : +mov byte ptr [gLast_flic_name[0] (DATA)], 0 	(flicplay.c:1581)
0x49743f : pop edi 	(flicplay.c:1582)
0x497440 : pop esi
         : +pop ebx
         : +leave 
         : +ret 


ShowFlic is only 93.75% similar to the original, diff above
```

*AI generated. Time taken: 117s, tokens: 21,527*
