### PR TITLE
UnlockFlic 100% match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1640,10 +1640,11 @@ int LoadFlic(int pIndex) {
 // IDA: void __usercall UnlockFlic(int pIndex@<EAX>)
 // FUNCTION: CARM95 0x00497683
 void UnlockFlic(int pIndex) {
-    if (pIndex >= 0) {
-        if (gMain_flic_list[pIndex].data_ptr != NULL) {
-            MAMSUnlock((void**)&gMain_flic_list[pIndex].data_ptr);
-        }
+    if (pIndex < 0) {
+        return;
+    }
+    if (gMain_flic_list[pIndex].data_ptr != NULL) {
+        MAMSUnlock((void**)&gMain_flic_list[pIndex].data_ptr);
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x497683: UnlockFlic 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x497683,20 +0x47c947,24 @@
0x497683 : push ebp 	(flicplay.c:1642)
0x497684 : mov ebp, esp
0x497686 : push ebx
0x497687 : push esi
0x497688 : push edi
0x497689 : cmp dword ptr [ebp + 8], 0 	(flicplay.c:1643)
0x49768d : -jge 0x5
0x497693 : -jmp 0x2e
         : +jl 0x2e
0x497698 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1644)
0x49769b : shl eax, 2
0x49769e : cmp dword ptr [eax + eax*8 + gMain_flic_list[0].data_ptr (OFFSET)], 0
0x4976a6 : je 0x1a
0x4976ac : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1645)
0x4976af : shl eax, 2
0x4976b2 : lea eax, [eax + eax*8]
0x4976b5 : add eax, gMain_flic_list[0].file_name (DATA)
0x4976ba : add eax, 0x1c
0x4976bd : push eax
0x4976be : call MAMSUnlock (FUNCTION)
0x4976c3 : add esp, 4
         : +pop edi 	(flicplay.c:1648)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


UnlockFlic is only 81.82% similar to the original, diff above
```

*AI generated. Time taken: 117s, tokens: 9,945*
