### PR TITLE
LoadFlicData equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1653,28 +1653,27 @@ int LoadFlicData(char* pName, tU8** pData, tU32* pData_length) {
     FILE* f;
     tPath_name the_path;
 
-    if (*pData != NULL) {
-        MAMSLock((void**)pData);
-        return 1;
-    }
-    if (gPlay_from_disk) {
-        return 1;
-    }
-    PossibleService();
-    PathCat(the_path, gApplication_path, "ANIM");
-    PathCat(the_path, the_path, pName);
-    f = DRfopen(the_path, "rb");
-    if (f == NULL) {
-        return 0;
-    }
-    *pData_length = GetFileLength(f);
-    *pData = BrMemAllocate(*pData_length, kMem_flic_data_2);
     if (*pData == NULL) {
-        fclose(f);
-        return 0;
+        if (!gPlay_from_disk) {
+            PossibleService();
+            PathCat(the_path, gApplication_path, "ANIM");
+            PathCat(the_path, the_path, pName);
+            f = DRfopen(the_path, "rb");
+            if (f == NULL) {
+                return 0;
+            }
+            *pData_length = GetFileLength(f);
+            *pData = BrMemAllocate(*pData_length, kMem_flic_data_2);
+            if (*pData == NULL) {
+                fclose(f);
+                return 0;
+            }
+            fread(*pData, 1, *pData_length, f);
+            fclose(f);
+        }
+        return 1;
     }
-    fread(*pData, 1, *pData_length, f);
-    fclose(f);
+    MAMSLock((void**)pData);
     return 1;
 }
 


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4976cb,19 +0x47c98a,19 @@
0x4976cb : push ebp 	(flicplay.c:1652)
0x4976cc : mov ebp, esp
0x4976ce : sub esp, 0x104
0x4976d4 : push ebx
0x4976d5 : push esi
0x4976d6 : push edi
0x4976d7 : mov eax, dword ptr [ebp + 0xc] 	(flicplay.c:1656)
0x4976da : cmp dword ptr [eax], 0
0x4976dd : -jne 0xe0
         : +jne 0xe5
0x4976e3 : cmp dword ptr [gPlay_from_disk (DATA)], 0 	(flicplay.c:1657)
0x4976ea : jne 0xce
0x4976f0 : call PossibleService (FUNCTION) 	(flicplay.c:1658)
0x4976f5 : push "ANIM" (STRING) 	(flicplay.c:1659)
0x4976fa : push gApplication_path[0] (DATA)
0x4976ff : lea eax, [ebp - 0x104]
0x497705 : push eax
0x497706 : call PathCat (FUNCTION)
0x49770b : add esp, 0xc
0x49770e : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1660)

---
+++
@@ -0x497725,21 +0x47c9e4,21 @@
0x497725 : add esp, 0xc
0x497728 : push "rb" (STRING) 	(flicplay.c:1661)
0x49772d : lea eax, [ebp - 0x104]
0x497733 : push eax
0x497734 : call DRfopen (FUNCTION)
0x497739 : add esp, 8
0x49773c : mov dword ptr [ebp - 4], eax
0x49773f : cmp dword ptr [ebp - 4], 0 	(flicplay.c:1662)
0x497743 : jne 0x7
0x497749 : xor eax, eax 	(flicplay.c:1663)
0x49774b : -jmp 0x89
         : +jmp 0x8e
0x497750 : mov eax, dword ptr [ebp - 4] 	(flicplay.c:1665)
0x497753 : push eax
0x497754 : call GetFileLength (FUNCTION)
0x497759 : add esp, 4
0x49775c : mov ecx, dword ptr [ebp + 0x10]
0x49775f : mov dword ptr [ecx], eax
0x497761 : push 0x91 	(flicplay.c:1666)
0x497766 : mov eax, dword ptr [ebp + 0x10]
0x497769 : mov eax, dword ptr [eax]
0x49776b : push eax

---
+++
@@ -0x497774,37 +0x47ca33,38 @@
0x497774 : mov ecx, dword ptr [ebp + 0xc]
0x497777 : mov dword ptr [ecx], eax
0x497779 : mov eax, dword ptr [ebp + 0xc] 	(flicplay.c:1667)
0x49777c : cmp dword ptr [eax], 0
0x49777f : jne 0x13
0x497785 : mov eax, dword ptr [ebp - 4] 	(flicplay.c:1668)
0x497788 : push eax
0x497789 : call fclose (FUNCTION)
0x49778e : add esp, 4
0x497791 : xor eax, eax 	(flicplay.c:1669)
0x497793 : -jmp 0x41
         : +jmp 0x46
0x497798 : mov eax, dword ptr [ebp - 4] 	(flicplay.c:1671)
0x49779b : push eax
0x49779c : mov eax, dword ptr [ebp + 0x10]
0x49779f : mov eax, dword ptr [eax]
0x4977a1 : push eax
0x4977a2 : push 1
0x4977a4 : mov eax, dword ptr [ebp + 0xc]
0x4977a7 : mov eax, dword ptr [eax]
0x4977a9 : push eax
0x4977aa : call fread (FUNCTION)
0x4977af : add esp, 0x10
0x4977b2 : mov eax, dword ptr [ebp - 4] 	(flicplay.c:1672)
0x4977b5 : push eax
0x4977b6 : call fclose (FUNCTION)
0x4977bb : add esp, 4
0x4977be : -jmp 0xc
         : +mov eax, 1 	(flicplay.c:1674)
         : +jmp 0x16
0x4977c3 : mov eax, dword ptr [ebp + 0xc] 	(flicplay.c:1676)
0x4977c6 : push eax
0x4977c7 : call MAMSLock (FUNCTION)
0x4977cc : add esp, 4
0x4977cf : mov eax, 1 	(flicplay.c:1677)
0x4977d4 : jmp 0x0
0x4977d9 : pop edi 	(flicplay.c:1678)
0x4977da : pop esi
0x4977db : pop ebx
0x4977dc : leave 


LoadFlicData is only 94.80% similar to the original, diff above
```

#### Effective match analysis

The diffs are consistent with address/offset drift and one small block split, not a behavioral change. All changed conditional/unconditional jump immediates (`jne`/`jmp`) still serve the same branch purposes after layout changes. The only substantive-looking edit (`jmp 0xc` replaced by `mov eax, 1; jmp ...`) preserves the same outcome on that path: return value is set to 1 and `MAMSLock` is still only executed in its original separate path. No data-flow or side-effect differences are evident from the shown instructions.

#### Original match

```
---
+++
@@ -0x4976cb,21 +0x47c98a,29 @@
0x4976cb : push ebp 	(flicplay.c:1652)
0x4976cc : mov ebp, esp
0x4976ce : sub esp, 0x104
0x4976d4 : push ebx
0x4976d5 : push esi
0x4976d6 : push edi
0x4976d7 : mov eax, dword ptr [ebp + 0xc] 	(flicplay.c:1656)
0x4976da : cmp dword ptr [eax], 0
0x4976dd : -jne 0xe0
         : +je 0x16
         : +mov eax, dword ptr [ebp + 0xc] 	(flicplay.c:1657)
         : +push eax
         : +call MAMSLock (FUNCTION)
         : +add esp, 4
         : +mov eax, 1 	(flicplay.c:1658)
         : +jmp 0xef
0x4976e3 : cmp dword ptr [gPlay_from_disk (DATA)], 0 	(flicplay.c:1660)
0x4976ea : -jne 0xce
         : +je 0xa
         : +mov eax, 1 	(flicplay.c:1661)
         : +jmp 0xd8
0x4976f0 : call PossibleService (FUNCTION) 	(flicplay.c:1663)
0x4976f5 : push "ANIM" (STRING) 	(flicplay.c:1664)
0x4976fa : push gApplication_path[0] (DATA)
0x4976ff : lea eax, [ebp - 0x104]
0x497705 : push eax
0x497706 : call PathCat (FUNCTION)
0x49770b : add esp, 0xc
0x49770e : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1665)
0x497711 : push eax
0x497712 : lea eax, [ebp - 0x104]

---
+++
@@ -0x497725,21 +0x47ca04,21 @@
0x497725 : add esp, 0xc
0x497728 : push "rb" (STRING) 	(flicplay.c:1666)
0x49772d : lea eax, [ebp - 0x104]
0x497733 : push eax
0x497734 : call DRfopen (FUNCTION)
0x497739 : add esp, 8
0x49773c : mov dword ptr [ebp - 4], eax
0x49773f : cmp dword ptr [ebp - 4], 0 	(flicplay.c:1667)
0x497743 : jne 0x7
0x497749 : xor eax, eax 	(flicplay.c:1668)
0x49774b : -jmp 0x89
         : +jmp 0x78
0x497750 : mov eax, dword ptr [ebp - 4] 	(flicplay.c:1670)
0x497753 : push eax
0x497754 : call GetFileLength (FUNCTION)
0x497759 : add esp, 4
0x49775c : mov ecx, dword ptr [ebp + 0x10]
0x49775f : mov dword ptr [ecx], eax
0x497761 : push 0x91 	(flicplay.c:1671)
0x497766 : mov eax, dword ptr [ebp + 0x10]
0x497769 : mov eax, dword ptr [eax]
0x49776b : push eax

---
+++
@@ -0x497774,38 +0x47ca53,33 @@
0x497774 : mov ecx, dword ptr [ebp + 0xc]
0x497777 : mov dword ptr [ecx], eax
0x497779 : mov eax, dword ptr [ebp + 0xc] 	(flicplay.c:1672)
0x49777c : cmp dword ptr [eax], 0
0x49777f : jne 0x13
0x497785 : mov eax, dword ptr [ebp - 4] 	(flicplay.c:1673)
0x497788 : push eax
0x497789 : call fclose (FUNCTION)
0x49778e : add esp, 4
0x497791 : xor eax, eax 	(flicplay.c:1674)
0x497793 : -jmp 0x41
         : +jmp 0x30
0x497798 : mov eax, dword ptr [ebp - 4] 	(flicplay.c:1676)
0x49779b : push eax
0x49779c : mov eax, dword ptr [ebp + 0x10]
0x49779f : mov eax, dword ptr [eax]
0x4977a1 : push eax
0x4977a2 : push 1
0x4977a4 : mov eax, dword ptr [ebp + 0xc]
0x4977a7 : mov eax, dword ptr [eax]
0x4977a9 : push eax
0x4977aa : call fread (FUNCTION)
0x4977af : add esp, 0x10
0x4977b2 : mov eax, dword ptr [ebp - 4] 	(flicplay.c:1677)
0x4977b5 : push eax
0x4977b6 : call fclose (FUNCTION)
0x4977bb : add esp, 4
0x4977be : -jmp 0xc
0x4977c3 : -mov eax, dword ptr [ebp + 0xc]
0x4977c6 : -push eax
0x4977c7 : -call MAMSLock (FUNCTION)
0x4977cc : -add esp, 4
0x4977cf : mov eax, 1 	(flicplay.c:1678)
0x4977d4 : jmp 0x0
0x4977d9 : pop edi 	(flicplay.c:1679)
0x4977da : pop esi
0x4977db : pop ebx
0x4977dc : leave 
0x4977dd : ret 


LoadFlicData is only 88.00% similar to the original, diff above
```

*AI generated. Time taken: 311s*
