### PR TITLE
ProcessFlicQueue 100% match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1797,14 +1797,14 @@ void ProcessFlicQueue(tU32 pInterval) {
     DontLetFlicFuckWithPalettes();
     TurnFlicTransparencyOn();
     the_flic = gFirst_flic;
-    last_flic = NULL;
     new_time = PDGetTotalTime();
+    last_flic = NULL;
     while (the_flic != NULL) {
-        if (new_time - the_flic->last_frame < the_flic->frame_period) {
-            finished_playing = 0;
-        } else {
+        if (new_time - the_flic->last_frame >= the_flic->frame_period) {
             the_flic->last_frame = new_time;
             finished_playing = PlayNextFlicFrame(the_flic);
+        } else {
+            finished_playing = 0;
         }
         if (finished_playing) {
             EndFlic(the_flic);


### PR DESCRIPTION
## Match result

```
0x497a71: ProcessFlicQueue 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x497a71,41 +0x47cd3f,41 @@
0x497a71 : push ebp 	(flicplay.c:1790)
0x497a72 : mov ebp, esp
0x497a74 : sub esp, 0x14
0x497a77 : push ebx
0x497a78 : push esi
0x497a79 : push edi
0x497a7a : call DontLetFlicFuckWithPalettes (FUNCTION) 	(flicplay.c:1797)
0x497a7f : call TurnFlicTransparencyOn (FUNCTION) 	(flicplay.c:1798)
0x497a84 : mov eax, dword ptr [gFirst_flic (DATA)] 	(flicplay.c:1799)
0x497a89 : mov dword ptr [ebp - 0x10], eax
         : +mov dword ptr [ebp - 8], 0 	(flicplay.c:1800)
0x497a8c : call PDGetTotalTime (FUNCTION) 	(flicplay.c:1801)
0x497a91 : mov dword ptr [ebp - 0x14], eax
0x497a94 : -mov dword ptr [ebp - 8], 0
0x497a9b : cmp dword ptr [ebp - 0x10], 0 	(flicplay.c:1802)
0x497a9f : je 0xa9
0x497aa5 : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1803)
0x497aa8 : mov ecx, dword ptr [ebp - 0x10]
0x497aab : sub eax, dword ptr [ecx + 0x34]
0x497aae : mov ecx, dword ptr [ebp - 0x10]
0x497ab1 : cmp eax, dword ptr [ecx + 0x30]
0x497ab4 : -jb 0x1d
         : +jae 0xc
         : +mov dword ptr [ebp - 4], 0 	(flicplay.c:1804)
         : +jmp 0x18 	(flicplay.c:1805)
0x497aba : mov eax, dword ptr [ebp - 0x14] 	(flicplay.c:1806)
0x497abd : mov ecx, dword ptr [ebp - 0x10]
0x497ac0 : mov dword ptr [ecx + 0x34], eax
0x497ac3 : mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1807)
0x497ac6 : push eax
0x497ac7 : call PlayNextFlicFrame (FUNCTION)
0x497acc : add esp, 4
0x497acf : mov dword ptr [ebp - 4], eax
0x497ad2 : -jmp 0x7
0x497ad7 : -mov dword ptr [ebp - 4], 0
0x497ade : cmp dword ptr [ebp - 4], 0 	(flicplay.c:1809)
0x497ae2 : je 0x52
0x497ae8 : mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1810)
0x497aeb : push eax
0x497aec : call EndFlic (FUNCTION)
0x497af1 : add esp, 4
0x497af4 : cmp dword ptr [ebp - 8], 0 	(flicplay.c:1811)
0x497af8 : je 0x11
0x497afe : mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1812)
0x497b01 : mov eax, dword ptr [eax + 0x6c]


ProcessFlicQueue is only 94.29% similar to the original, diff above
```

*AI generated. Time taken: 107s, tokens: 13,638*
