### PR TITLE
FlushFlicQueue 100% match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1844,8 +1844,7 @@ void FlushFlicQueue(void) {
     the_flic = gFirst_flic;
     while (the_flic != NULL) {
         EndFlic(the_flic);
-        old_flic = the_flic;
-        the_flic = the_flic->next;
+        the_flic = (old_flic = the_flic, old_flic->next);
         BrMemFree(old_flic);
     }
     gFirst_flic = NULL;

--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1843,8 +1843,9 @@ void FlushFlicQueue(void) {
     }
     the_flic = gFirst_flic;
     while (the_flic != NULL) {
+        old_flic = the_flic;
         EndFlic(the_flic);
-        the_flic = (old_flic = the_flic, old_flic->next);
+        the_flic = old_flic->next;
         BrMemFree(old_flic);
     }
     gFirst_flic = NULL;
@@ -2151,7 +2152,6 @@ void LoadInterfaceStrings(void) {
         fclose(f);
 #endif
     }
-
 }
 
 // IDA: void __cdecl FlushInterfaceFonts()


### PR DESCRIPTION
## Match result

```
0x497b5d: FlushFlicQueue 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x497b8b,26 +0x47ce59,26 @@
0x497b8b : call DoMouseCursor (FUNCTION) 	(flicplay.c:1841)
0x497b90 : push 0 	(flicplay.c:1842)
0x497b92 : call PDScreenBufferSwap (FUNCTION)
0x497b97 : add esp, 4
0x497b9a : jmp -0x39 	(flicplay.c:1843)
0x497b9f : mov eax, dword ptr [gFirst_flic (DATA)] 	(flicplay.c:1844)
0x497ba4 : mov dword ptr [ebp - 8], eax
0x497ba7 : cmp dword ptr [ebp - 8], 0 	(flicplay.c:1845)
0x497bab : je 0x2c
0x497bb1 : mov eax, dword ptr [ebp - 8] 	(flicplay.c:1846)
0x497bb4 : -mov dword ptr [ebp - 4], eax
0x497bb7 : -mov eax, dword ptr [ebp - 8]
0x497bba : push eax
0x497bbb : call EndFlic (FUNCTION)
0x497bc0 : add esp, 4
0x497bc3 : -mov eax, dword ptr [ebp - 4]
         : +mov eax, dword ptr [ebp - 8] 	(flicplay.c:1847)
         : +mov dword ptr [ebp - 4], eax
         : +mov eax, dword ptr [ebp - 8] 	(flicplay.c:1848)
0x497bc6 : mov eax, dword ptr [eax + 0x6c]
0x497bc9 : mov dword ptr [ebp - 8], eax
0x497bcc : mov eax, dword ptr [ebp - 4] 	(flicplay.c:1849)
0x497bcf : push eax
0x497bd0 : call BrMemFree (FUNCTION)
0x497bd5 : add esp, 4
0x497bd8 : jmp -0x36 	(flicplay.c:1850)
0x497bdd : mov dword ptr [gFirst_flic (DATA)], 0 	(flicplay.c:1851)
0x497be7 : pop edi 	(flicplay.c:1852)
0x497be8 : pop esi


FlushFlicQueue is only 93.33% similar to the original, diff above
```

*AI generated. Time taken: 886s, tokens: 63,940*
