### PR TITLE
AddToFlicQueue 100% match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1854,47 +1854,48 @@ void FlushFlicQueue(void) {
 // IDA: void __usercall AddToFlicQueue(int pIndex@<EAX>, int pX@<EDX>, int pY@<EBX>, int pMust_finish@<ECX>)
 // FUNCTION: CARM95 0x00497bec
 void AddToFlicQueue(int pIndex, int pX, int pY, int pMust_finish) {
-    tFlic_descriptor* the_flic = NULL;
+    tFlic_descriptor* the_flic;
     tFlic_descriptor* new_flic = NULL;
-    tFlic_descriptor* last_flic = NULL;
-    tFlic_descriptor* doomed_flic = NULL;
+    tFlic_descriptor* last_flic;
+    tFlic_descriptor* doomed_flic;
 
     the_flic = gFirst_flic;
+    last_flic = NULL;
     while (the_flic != NULL) {
         if (pX == the_flic->x_offset && pY == the_flic->y_offset) {
+            EndFlic(the_flic);
+            if (last_flic != NULL) {
+                last_flic->next = the_flic->next;
+            } else {
+                gFirst_flic = the_flic->next;
+            }
             doomed_flic = the_flic;
+            the_flic = the_flic->next;
+            BrMemFree(doomed_flic);
             break;
         }
         last_flic = the_flic;
         the_flic = the_flic->next;
     }
 
-    if (doomed_flic != NULL) {
-        EndFlic(doomed_flic);
-        if (last_flic != NULL) {
-            last_flic->next = doomed_flic->next;
-        } else {
-            gFirst_flic = doomed_flic->next;
-        }
-        BrMemFree(doomed_flic);
-    }
-
     LoadFlic(pIndex);
-    new_flic = BrMemAllocate(sizeof(tFlic_descriptor), kMem_queued_flic);
-    new_flic->next = NULL;
+    if (new_flic == NULL) {
+        new_flic = BrMemAllocate(sizeof(tFlic_descriptor), kMem_queued_flic);
+        new_flic->next = NULL;
+    }
     the_flic = gFirst_flic;
-    if (gFirst_flic != NULL) {
+    if (the_flic == NULL) {
+        gFirst_flic = new_flic;
+    } else {
         while (the_flic->next != NULL) {
             the_flic = the_flic->next;
         }
         the_flic->next = new_flic;
-    } else {
-        gFirst_flic = new_flic;
     }
     new_flic->last_frame = 0;
-    new_flic->data_start = NULL;
     new_flic->the_index = pIndex;
     new_flic->must_finish = pMust_finish;
+    new_flic->data_start = NULL;
 
     StartFlic(
         gMain_flic_list[pIndex].file_name,


### PR DESCRIPTION
## Match result

```
0x497bec: AddToFlicQueue 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x497bec,100 +0x47ceba,99 @@
0x497bec : push ebp 	(flicplay.c:1856)
0x497bed : mov ebp, esp
0x497bef : sub esp, 0x18
0x497bf2 : push ebx
0x497bf3 : push esi
0x497bf4 : push edi
         : +mov dword ptr [ebp - 0x10], 0 	(flicplay.c:1857)
0x497bf5 : mov dword ptr [ebp - 4], 0 	(flicplay.c:1858)
         : +mov dword ptr [ebp - 8], 0 	(flicplay.c:1859)
         : +mov dword ptr [ebp - 0xc], 0 	(flicplay.c:1860)
0x497bfc : mov eax, dword ptr [gFirst_flic (DATA)] 	(flicplay.c:1862)
0x497c01 : mov dword ptr [ebp - 0x10], eax
0x497c04 : -mov dword ptr [ebp - 8], 0
0x497c0b : cmp dword ptr [ebp - 0x10], 0 	(flicplay.c:1863)
0x497c0f : -je 0x84
         : +je 0x3d
0x497c15 : mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1864)
0x497c18 : mov ecx, dword ptr [ebp + 0xc]
0x497c1b : cmp dword ptr [eax + 0x3c], ecx
0x497c1e : -jne 0x61
         : +jne 0x1a
0x497c24 : mov eax, dword ptr [ebp - 0x10]
0x497c27 : mov ecx, dword ptr [ebp + 0x10]
0x497c2a : cmp dword ptr [eax + 0x40], ecx
0x497c2d : -jne 0x52
0x497c33 : -mov eax, dword ptr [ebp - 0x10]
0x497c36 : -push eax
0x497c37 : -call EndFlic (FUNCTION)
0x497c3c : -add esp, 4
0x497c3f : -cmp dword ptr [ebp - 8], 0
0x497c43 : -je 0x11
0x497c49 : -mov eax, dword ptr [ebp - 0x10]
0x497c4c : -mov eax, dword ptr [eax + 0x6c]
0x497c4f : -mov ecx, dword ptr [ebp - 8]
0x497c52 : -mov dword ptr [ecx + 0x6c], eax
0x497c55 : -jmp 0xb
0x497c5a : -mov eax, dword ptr [ebp - 0x10]
0x497c5d : -mov eax, dword ptr [eax + 0x6c]
0x497c60 : -mov dword ptr [gFirst_flic (DATA)], eax
         : +jne 0xb
0x497c65 : mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1865)
0x497c68 : mov dword ptr [ebp - 0xc], eax
0x497c6b : -mov eax, dword ptr [ebp - 0x10]
0x497c6e : -mov eax, dword ptr [eax + 0x6c]
0x497c71 : -mov dword ptr [ebp - 0x10], eax
0x497c74 : -mov eax, dword ptr [ebp - 0xc]
0x497c77 : -push eax
0x497c78 : -call BrMemFree (FUNCTION)
0x497c7d : -add esp, 4
0x497c80 : jmp 0x14 	(flicplay.c:1866)
0x497c85 : mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1868)
0x497c88 : mov dword ptr [ebp - 8], eax
0x497c8b : mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1869)
0x497c8e : mov eax, dword ptr [eax + 0x6c]
0x497c91 : mov dword ptr [ebp - 0x10], eax
0x497c94 : -jmp -0x8e
         : +jmp -0x47 	(flicplay.c:1870)
         : +cmp dword ptr [ebp - 0xc], 0 	(flicplay.c:1872)
         : +je 0x3e
         : +mov eax, dword ptr [ebp - 0xc] 	(flicplay.c:1873)
         : +push eax
         : +call EndFlic (FUNCTION)
         : +add esp, 4
         : +cmp dword ptr [ebp - 8], 0 	(flicplay.c:1874)
         : +je 0x11
         : +mov eax, dword ptr [ebp - 0xc] 	(flicplay.c:1875)
         : +mov eax, dword ptr [eax + 0x6c]
         : +mov ecx, dword ptr [ebp - 8]
         : +mov dword ptr [ecx + 0x6c], eax
         : +jmp 0xb 	(flicplay.c:1876)
         : +mov eax, dword ptr [ebp - 0xc] 	(flicplay.c:1877)
         : +mov eax, dword ptr [eax + 0x6c]
         : +mov dword ptr [gFirst_flic (DATA)], eax
         : +mov eax, dword ptr [ebp - 0xc] 	(flicplay.c:1879)
         : +push eax
         : +call BrMemFree (FUNCTION)
         : +add esp, 4
0x497c99 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1882)
0x497c9c : push eax
0x497c9d : call LoadFlic (FUNCTION)
0x497ca2 : add esp, 4
0x497ca5 : -cmp dword ptr [ebp - 4], 0
0x497ca9 : -jne 0x1c
0x497caf : push 0x92 	(flicplay.c:1883)
0x497cb4 : push 0x70
0x497cb6 : call BrMemAllocate (FUNCTION)
0x497cbb : add esp, 8
0x497cbe : mov dword ptr [ebp - 4], eax
0x497cc1 : mov eax, dword ptr [ebp - 4] 	(flicplay.c:1884)
0x497cc4 : mov dword ptr [eax + 0x6c], 0
0x497ccb : mov eax, dword ptr [gFirst_flic (DATA)] 	(flicplay.c:1885)
0x497cd0 : mov dword ptr [ebp - 0x10], eax
0x497cd3 : -cmp dword ptr [ebp - 0x10], 0
0x497cd7 : -jne 0xd
0x497cdd : -mov eax, dword ptr [ebp - 4]
0x497ce0 : -mov dword ptr [gFirst_flic (DATA)], eax
0x497ce5 : -jmp 0x24
         : +cmp dword ptr [gFirst_flic (DATA)], 0 	(flicplay.c:1886)
         : +je 0x29
0x497cea : mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1887)
0x497ced : cmp dword ptr [eax + 0x6c], 0
0x497cf1 : je 0xe
0x497cf7 : mov eax, dword ptr [ebp - 0x10] 	(flicplay.c:1888)
0x497cfa : mov eax, dword ptr [eax + 0x6c]
0x497cfd : mov dword ptr [ebp - 0x10], eax
0x497d00 : jmp -0x1b 	(flicplay.c:1889)
0x497d05 : mov eax, dword ptr [ebp - 4] 	(flicplay.c:1890)
0x497d08 : mov ecx, dword ptr [ebp - 0x10]
0x497d0b : mov dword ptr [ecx + 0x6c], eax
         : +jmp 0x8 	(flicplay.c:1891)
         : +mov eax, dword ptr [ebp - 4] 	(flicplay.c:1892)
         : +mov dword ptr [gFirst_flic (DATA)], eax
0x497d0e : mov eax, dword ptr [ebp - 4] 	(flicplay.c:1894)
0x497d11 : mov dword ptr [eax + 0x34], 0
         : +mov eax, dword ptr [ebp - 4] 	(flicplay.c:1895)
         : +mov dword ptr [eax + 4], 0
0x497d18 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:1896)
0x497d1b : mov ecx, dword ptr [ebp - 4]
0x497d1e : mov dword ptr [ecx + 0x54], eax
0x497d21 : mov eax, dword ptr [ebp + 0x14] 	(flicplay.c:1897)
0x497d24 : mov ecx, dword ptr [ebp - 4]
0x497d27 : mov dword ptr [ecx + 0x5c], eax
0x497d2a : -mov eax, dword ptr [ebp - 4]
0x497d2d : -mov dword ptr [eax + 4], 0
0x497d34 : cmp dword ptr [ebp + 0x10], 0 	(flicplay.c:1908)
0x497d38 : jl 0xb
0x497d3e : mov eax, dword ptr [ebp + 0x10]
0x497d41 : mov dword ptr [ebp - 0x14], eax
0x497d44 : jmp 0x10
0x497d49 : mov eax, dword ptr [ebp + 8]
0x497d4c : shl eax, 2
0x497d4f : mov eax, dword ptr [eax + eax*8 + gMain_flic_list[0].y_offset (OFFSET)]
0x497d56 : mov dword ptr [ebp - 0x14], eax
0x497d59 : cmp dword ptr [ebp + 0xc], 0


AddToFlicQueue is only 74.91% similar to the original, diff above
```

*AI generated. Time taken: 572s, tokens: 86,191*
