### PR TITLE
InitialiseFlicPanel 100% match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -1919,10 +1919,10 @@ void InitialiseFlicPanel(int pIndex, int pLeft, int pTop, int pWidth, int pHeigh
     the_pixels = BrMemAllocate(pHeight * ((pWidth + 3) & ~3), kFlic_panel_pixels);
     if (gScreen->row_bytes < 0) {
         BrFatal(
-            "..\\..\\source\\common\\flicplay.c",
+            "C:\\Msdev\\Projects\\DethRace\\Flicplay.c",
             2116,
-            "Bruce bug at line %d, file ..\\..\\source\\common\\flicplay.c",
-            68);
+            "Bruce bug at line %d, file C:\\Msdev\\Projects\\DethRace\\Flicplay.c",
+            2116);
     }
     gPanel_buffer[pIndex] = DRPixelmapAllocate(
 #ifdef DETHRACE_3DFX_PATCH


### PR DESCRIPTION
## Match result

```
0x497dcd: InitialiseFlicPanel 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x497e0f,33 +0x47d0e5,36 @@
0x497e0f : add eax, 3
0x497e12 : and eax, 0xfffffffc
0x497e15 : imul eax, dword ptr [ebp + 0x18]
0x497e19 : push eax
0x497e1a : call BrMemAllocate (FUNCTION)
0x497e1f : add esp, 8
0x497e22 : mov dword ptr [ebp - 4], eax
0x497e25 : mov eax, dword ptr [gScreen (DATA)] 	(flicplay.c:1920)
0x497e2a : movsx eax, word ptr [eax + 0x28]
0x497e2e : test eax, eax
0x497e30 : -jge 0x1c
         : +jge 0x19
         : +push 0x44 	(flicplay.c:1925)
         : +push "Bruce bug at line %d, file ..\\..\\source\\common\\flicplay.c" (STRING)
0x497e36 : push 0x844
0x497e3b : -push "Bruce bug at line %d, file C:\\Msdev\\Projects\\DethRace\\Flicplay.c" (STRING)
0x497e40 : -push 0x844
0x497e45 : -push "C:\\Msdev\\Projects\\DethRace\\Flicplay.c" (STRING)
         : +push "..\\..\\source\\common\\flicplay.c" (STRING)
0x497e4a : call BrFatal (FUNCTION)
0x497e4f : add esp, 0x10
0x497e52 : push 0 	(flicplay.c:1936)
0x497e54 : mov eax, dword ptr [ebp - 4]
0x497e57 : push eax
0x497e58 : mov eax, dword ptr [ebp + 0x18]
0x497e5b : push eax
0x497e5c : mov eax, dword ptr [ebp + 0x14]
0x497e5f : push eax
0x497e60 : mov eax, dword ptr [gScreen (DATA)]
0x497e65 : mov al, byte ptr [eax + 0x2c]
0x497e68 : push eax
0x497e69 : call DRPixelmapAllocate (FUNCTION)
0x497e6e : add esp, 0x14
0x497e71 : mov ecx, dword ptr [ebp + 8]
0x497e74 : mov dword ptr [ecx*4 + gPanel_buffer[0] (DATA)], eax
0x497e7b : pop edi 	(flicplay.c:1937)
0x497e7c : pop esi
         : +pop ebx
         : +leave 
         : +ret 


InitialiseFlicPanel is only 89.91% similar to the original, diff above
```

*AI generated. Time taken: 67s, tokens: 13,168*
