### PR TITLE
ChangePanelFlic 100% match

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -569,13 +569,13 @@ tFlic_bunch gFlic_bunch[9] = {
 // GLOBAL: CARM95 0x00518758
 char gLast_flic_name[14];
 
-// GLOBAL: CARM95 0x0053d060
+// GLOBAL: CARM95 0x0053d0b8
 tU32 gPanel_flic_data_length[2];
 
 // GLOBAL: CARM95 0x0053d1b8
 tU32 gLast_panel_frame_time[2];
 
-// GLOBAL: CARM95 0x0053d0b8
+// GLOBAL: CARM95 0x0053d060
 tU8* gPanel_flic_data[2];
 
 // GLOBAL: CARM95 0x0053d0c0
@@ -2012,15 +2012,15 @@ void ServicePanelFlics(int pCopy_to_buffer) {
 void ChangePanelFlic(int pIndex, tU8* pData, tU32 pData_length) {
 
     EndFlic(&gPanel_flic[pIndex]);
-    gPanel_flic_data[pIndex] = (tU8*)pData_length;
-    gPanel_flic_data_length[pIndex] = (tU32)pData;
+    gPanel_flic_data_length[pIndex] = pData_length;
+    gPanel_flic_data[pIndex] = pData;
     BrPixelmapFill(gPanel_buffer[pIndex], 0);
     StartFlic(
         gPanel_flic[pIndex].file_name,
         pIndex,
         &gPanel_flic[pIndex],
-        (tU32)gPanel_flic_data[pIndex],
-        (tS8*)gPanel_flic_data_length[pIndex],
+        gPanel_flic_data_length[pIndex],
+        (tS8*)gPanel_flic_data[pIndex],
         gPanel_buffer[pIndex],
         0,
         0,
@@ -2152,7 +2152,6 @@ void LoadInterfaceStrings(void) {
         fclose(f);
 #endif
     }
-
 }
 
 // IDA: void __cdecl FlushInterfaceFonts()

--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -2012,15 +2012,15 @@ void ServicePanelFlics(int pCopy_to_buffer) {
 void ChangePanelFlic(int pIndex, tU8* pData, tU32 pData_length) {
 
     EndFlic(&gPanel_flic[pIndex]);
-    gPanel_flic_data[pIndex] = pData;
-    gPanel_flic_data_length[pIndex] = pData_length;
+    gPanel_flic_data[pIndex] = (tU8*)pData_length;
+    gPanel_flic_data_length[pIndex] = (tU32)pData;
     BrPixelmapFill(gPanel_buffer[pIndex], 0);
     StartFlic(
         gPanel_flic[pIndex].file_name,
         pIndex,
         &gPanel_flic[pIndex],
-        gPanel_flic_data_length[pIndex],
-        (tS8*)gPanel_flic_data[pIndex],
+        (tU32)gPanel_flic_data[pIndex],
+        (tS8*)gPanel_flic_data_length[pIndex],
         gPanel_buffer[pIndex],
         0,
         0,


### PR DESCRIPTION
## Match result

```
0x4980ec: ChangePanelFlic 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4980f1,43 +0x47d3ca,43 @@
0x4980f1 : push edi
0x4980f2 : mov eax, dword ptr [ebp + 8] 	(flicplay.c:2014)
0x4980f5 : mov ecx, eax
0x4980f7 : shl eax, 3
0x4980fa : sub eax, ecx
0x4980fc : shl eax, 4
0x4980ff : add eax, gPanel_flic[0].data (DATA)
0x498104 : push eax
0x498105 : call EndFlic (FUNCTION)
0x49810a : add esp, 4
0x49810d : -mov eax, dword ptr [ebp + 0x10]
         : +mov eax, dword ptr [ebp + 0xc] 	(flicplay.c:2015)
0x498110 : mov ecx, dword ptr [ebp + 8]
0x498113 : mov dword ptr [ecx*4 + gPanel_flic_data[0] (DATA)], eax
0x49811a : -mov eax, dword ptr [ebp + 0xc]
         : +mov eax, dword ptr [ebp + 0x10] 	(flicplay.c:2016)
0x49811d : mov ecx, dword ptr [ebp + 8]
0x498120 : mov dword ptr [ecx*4 + gPanel_flic_data_length[0] (DATA)], eax
0x498127 : push 0 	(flicplay.c:2017)
0x498129 : mov eax, dword ptr [ebp + 8]
0x49812c : mov eax, dword ptr [eax*4 + gPanel_buffer[0] (DATA)]
0x498133 : push eax
0x498134 : call BrPixelmapFill (FUNCTION)
0x498139 : add esp, 8
0x49813c : push 0 	(flicplay.c:2027)
0x49813e : push 0
0x498140 : push 0
0x498142 : mov eax, dword ptr [ebp + 8]
0x498145 : mov eax, dword ptr [eax*4 + gPanel_buffer[0] (DATA)]
0x49814c : push eax
0x49814d : mov eax, dword ptr [ebp + 8]
0x498150 : -mov eax, dword ptr [eax*4 + gPanel_flic_data_length[0] (DATA)]
         : +mov eax, dword ptr [eax*4 + gPanel_flic_data[0] (DATA)]
0x498157 : push eax
0x498158 : mov eax, dword ptr [ebp + 8]
0x49815b : -mov eax, dword ptr [eax*4 + gPanel_flic_data[0] (DATA)]
         : +mov eax, dword ptr [eax*4 + gPanel_flic_data_length[0] (DATA)]
0x498162 : push eax
0x498163 : mov eax, dword ptr [ebp + 8]
0x498166 : mov ecx, eax
0x498168 : shl eax, 3
0x49816b : sub eax, ecx
0x49816d : shl eax, 4
0x498170 : add eax, gPanel_flic[0].data (DATA)
0x498175 : push eax
0x498176 : mov eax, dword ptr [ebp + 8]
0x498179 : push eax


ChangePanelFlic is only 94.03% similar to the original, diff above
```

*AI generated. Time taken: 78s, tokens: 18,136*
