### PR TITLE
SoundOptionsRight 100% match

### DIFF
--- a/src/DETHRACE/common/options.c
+++ b/src/DETHRACE/common/options.c
@@ -174,18 +174,17 @@ int SoundOptionsRight(int* pCurrent_choice, int* pCurrent_mode) {
     int old_value;
     int* the_value;
 
-    if (*pCurrent_choice == 2) {
-        return 0;
+    if (*pCurrent_choice != 2) {
+        the_value = (*pCurrent_choice == 0) ? &gProgram_state.music_volume : &gProgram_state.effects_volume;
+        old_value = *the_value;
+        *the_value += 1;
+        if (*the_value > 6) {
+            *the_value = 6;
+        }
+        SetSoundVolumes();
+        DRS3StartSound(gEffects_outlet, 3000);
+        MoveDialFromTo(*pCurrent_choice, 4 * old_value, 4 * *the_value);
     }
-    the_value = (*pCurrent_choice == 0) ? &gProgram_state.music_volume : &gProgram_state.effects_volume;
-    old_value = *the_value;
-    *the_value += 1;
-    if (*the_value >= 6) {
-        *the_value = 6;
-    }
-    SetSoundVolumes();
-    DRS3StartSound(gEffects_outlet, 3000);
-    MoveDialFromTo(*pCurrent_choice, 4 * old_value, 4 * *the_value);
     return 0;
 }
 


### PR DESCRIPTION
## Match result

```
0x499c49: SoundOptionsRight 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x499c49,37 +0x493dd9,39 @@
0x499c49 : push ebp 	(options.c:173)
0x499c4a : mov ebp, esp
0x499c4c : sub esp, 8
0x499c4f : push ebx
0x499c50 : push esi
0x499c51 : push edi
0x499c52 : mov eax, dword ptr [ebp + 8] 	(options.c:177)
0x499c55 : cmp dword ptr [eax], 2
0x499c58 : -je 0x7f
         : +jne 0x7
         : +xor eax, eax 	(options.c:178)
         : +jmp 0x86
0x499c5e : mov eax, dword ptr [ebp + 8] 	(options.c:180)
0x499c61 : cmp dword ptr [eax], 0
0x499c64 : jne 0x10
0x499c6a : mov eax, gProgram_state (DATA)
0x499c6f : add eax, 0x70
0x499c72 : mov dword ptr [ebp - 4], eax
0x499c75 : jmp 0xb
0x499c7a : mov eax, gProgram_state (DATA)
0x499c7f : add eax, 0x74
0x499c82 : mov dword ptr [ebp - 4], eax
0x499c85 : mov eax, dword ptr [ebp - 4] 	(options.c:181)
0x499c88 : mov eax, dword ptr [eax]
0x499c8a : mov dword ptr [ebp - 8], eax
0x499c8d : mov eax, dword ptr [ebp - 4] 	(options.c:182)
0x499c90 : inc dword ptr [eax]
0x499c92 : mov eax, dword ptr [ebp - 4] 	(options.c:183)
0x499c95 : cmp dword ptr [eax], 6
0x499c98 : -jle 0x9
         : +jl 0x9
0x499c9e : mov eax, dword ptr [ebp - 4] 	(options.c:184)
0x499ca1 : mov dword ptr [eax], 6
0x499ca7 : call SetSoundVolumes (FUNCTION) 	(options.c:186)
0x499cac : push 0xbb8 	(options.c:187)
0x499cb1 : mov eax, dword ptr [gEffects_outlet (DATA)]
0x499cb6 : push eax
0x499cb7 : call DRS3StartSound (FUNCTION)
0x499cbc : add esp, 8
0x499cbf : mov eax, dword ptr [ebp - 4] 	(options.c:188)
0x499cc2 : mov eax, dword ptr [eax]


SoundOptionsRight is only 94.55% similar to the original, diff above
```

*AI generated. Time taken: 78s, tokens: 18,212*
