### PR TITLE
GetKeyCoords 100% match

### DIFF
--- a/src/DETHRACE/common/options.c
+++ b/src/DETHRACE/common/options.c
@@ -935,23 +935,27 @@ void SaveOrigKeyMapping(void) {
 void GetKeyCoords(int pIndex, int* pY, int* pName_x, int* pKey_x, int* pEnd_box) {
     int col;
 
-    if (pIndex >= 0) {
-        col = gKey_count + 1;
-        *pY = (pIndex % ((gKey_count + 1) / 2)) * gCurrent_graf_data->key_assign_y_pitch + gCurrent_graf_data->key_assign_y;
-        if (pIndex < col / 2) {
-            *pName_x = gCurrent_graf_data->key_assign_col_1;
-            *pKey_x = gCurrent_graf_data->key_assign_col_1_a;
-            *pEnd_box = gCurrent_graf_data->key_assign_col_2 - 7;
-        } else {
-            *pName_x = gCurrent_graf_data->key_assign_col_2;
-            *pKey_x = gCurrent_graf_data->key_assign_col_2_a;
-            *pEnd_box = gCurrent_graf_data->key_assign_col_2 + gCurrent_graf_data->key_assign_col_2 - gCurrent_graf_data->key_assign_col_1 - 7;
-        }
-    } else {
+    if (pIndex < 0) {
         *pName_x = gCurrent_graf_data->key_assign_col_1;
         *pKey_x = 0;
         *pEnd_box = gCurrent_graf_data->key_assign_col_2 + gCurrent_graf_data->key_assign_col_2 - gCurrent_graf_data->key_assign_col_1 - 7;
         *pY = gCurrent_graf_data->key_assign_key_map_y;
+    } else {
+        if ((gKey_count + 1) / 2 <= pIndex) {
+            col = 1;
+        } else {
+            col = 0;
+        }
+        *pY = (pIndex % ((gKey_count + 1) / 2)) * gCurrent_graf_data->key_assign_y_pitch + gCurrent_graf_data->key_assign_y;
+        if (col != 0) {
+            *pName_x = gCurrent_graf_data->key_assign_col_2;
+            *pKey_x = gCurrent_graf_data->key_assign_col_2_a;
+            *pEnd_box = gCurrent_graf_data->key_assign_col_2 + gCurrent_graf_data->key_assign_col_2 - gCurrent_graf_data->key_assign_col_1 - 7;
+        } else {
+            *pName_x = gCurrent_graf_data->key_assign_col_1;
+            *pKey_x = gCurrent_graf_data->key_assign_col_1_a;
+            *pEnd_box = gCurrent_graf_data->key_assign_col_2 - 7;
+        }
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x49a8e2: GetKeyCoords 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x49a8e2,82 +0x494e1e,89 @@
0x49a8e2 : push ebp 	(options.c:935)
0x49a8e3 : mov ebp, esp
0x49a8e5 : sub esp, 4
0x49a8e8 : push ebx
0x49a8e9 : push esi
0x49a8ea : push edi
0x49a8eb : cmp dword ptr [ebp + 8], 0 	(options.c:938)
0x49a8ef : -jge 0x59
         : +jl 0xd5
         : +mov eax, dword ptr [gKey_count (DATA)] 	(options.c:939)
         : +inc eax
         : +mov dword ptr [ebp - 4], eax
         : +mov eax, dword ptr [gKey_count (DATA)] 	(options.c:940)
         : +inc eax
         : +cdq 
         : +sub eax, edx
         : +sar eax, 1
         : +mov ecx, eax
         : +mov eax, dword ptr [ebp + 8]
         : +cdq 
         : +idiv ecx
         : +mov eax, edx
         : +mov ecx, dword ptr [gCurrent_graf_data (DATA)]
         : +imul eax, dword ptr [ecx + 0x38c]
         : +mov ecx, dword ptr [gCurrent_graf_data (DATA)]
         : +add eax, dword ptr [ecx + 0x390]
         : +mov ecx, dword ptr [ebp + 0xc]
         : +mov dword ptr [ecx], eax
         : +mov eax, dword ptr [ebp - 4] 	(options.c:941)
         : +cdq 
         : +sub eax, edx
         : +sar eax, 1
         : +cmp eax, dword ptr [ebp + 8]
         : +jle 0x38
         : +mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(options.c:942)
         : +mov eax, dword ptr [eax + 0x37c]
         : +mov ecx, dword ptr [ebp + 0x10]
         : +mov dword ptr [ecx], eax
         : +mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(options.c:943)
         : +mov eax, dword ptr [eax + 0x380]
         : +mov ecx, dword ptr [ebp + 0x14]
         : +mov dword ptr [ecx], eax
         : +mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(options.c:944)
         : +mov eax, dword ptr [eax + 0x384]
         : +sub eax, 7
         : +mov ecx, dword ptr [ebp + 0x18]
         : +mov dword ptr [ecx], eax
         : +jmp 0x4b 	(options.c:945)
         : +mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(options.c:946)
         : +mov eax, dword ptr [eax + 0x384]
         : +mov ecx, dword ptr [ebp + 0x10]
         : +mov dword ptr [ecx], eax
         : +mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(options.c:947)
         : +mov eax, dword ptr [eax + 0x388]
         : +mov ecx, dword ptr [ebp + 0x14]
         : +mov dword ptr [ecx], eax
         : +mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(options.c:948)
         : +mov eax, dword ptr [eax + 0x384]
         : +mov ecx, dword ptr [gCurrent_graf_data (DATA)]
         : +add eax, dword ptr [ecx + 0x384]
         : +mov ecx, dword ptr [gCurrent_graf_data (DATA)]
         : +sub eax, dword ptr [ecx + 0x37c]
         : +sub eax, 7
         : +mov ecx, dword ptr [ebp + 0x18]
         : +mov dword ptr [ecx], eax
         : +jmp 0x54 	(options.c:950)
0x49a8f5 : mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(options.c:951)
0x49a8fa : mov eax, dword ptr [eax + 0x37c]
0x49a900 : mov ecx, dword ptr [ebp + 0x10]
0x49a903 : mov dword ptr [ecx], eax
0x49a905 : mov eax, dword ptr [ebp + 0x14] 	(options.c:952)
0x49a908 : mov dword ptr [eax], 0
0x49a90e : mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(options.c:953)
0x49a913 : mov eax, dword ptr [eax + 0x384]
0x49a919 : mov ecx, dword ptr [gCurrent_graf_data (DATA)]
0x49a91f : add eax, dword ptr [ecx + 0x384]
0x49a925 : mov ecx, dword ptr [gCurrent_graf_data (DATA)]
0x49a92b : sub eax, dword ptr [ecx + 0x37c]
0x49a931 : sub eax, 7
0x49a934 : mov ecx, dword ptr [ebp + 0x18]
0x49a937 : mov dword ptr [ecx], eax
0x49a939 : mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(options.c:954)
0x49a93e : mov eax, dword ptr [eax + 0x394]
0x49a944 : mov ecx, dword ptr [ebp + 0xc]
0x49a947 : mov dword ptr [ecx], eax
0x49a949 : -jmp 0xe7
0x49a94e : -mov eax, dword ptr [gKey_count (DATA)]
0x49a953 : -inc eax
0x49a954 : -cdq 
0x49a955 : -sub eax, edx
0x49a957 : -sar eax, 1
0x49a959 : -cmp eax, dword ptr [ebp + 8]
0x49a95c : -jg 0xc
0x49a962 : -mov dword ptr [ebp - 4], 1
0x49a969 : -jmp 0x7
0x49a96e : -mov dword ptr [ebp - 4], 0
0x49a975 : -mov eax, dword ptr [gKey_count (DATA)]
0x49a97a : -inc eax
0x49a97b : -cdq 
0x49a97c : -sub eax, edx
0x49a97e : -sar eax, 1
0x49a980 : -mov ecx, eax
0x49a982 : -mov eax, dword ptr [ebp + 8]
0x49a985 : -cdq 
0x49a986 : -idiv ecx
0x49a988 : -mov eax, edx
0x49a98a : -mov ecx, dword ptr [gCurrent_graf_data (DATA)]
0x49a990 : -imul eax, dword ptr [ecx + 0x38c]
0x49a997 : -mov ecx, dword ptr [gCurrent_graf_data (DATA)]
0x49a99d : -add eax, dword ptr [ecx + 0x390]
0x49a9a3 : -mov ecx, dword ptr [ebp + 0xc]
0x49a9a6 : -mov dword ptr [ecx], eax
0x49a9a8 : -cmp dword ptr [ebp - 4], 0
0x49a9ac : -je 0x50
0x49a9b2 : -mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x49a9b7 : -mov eax, dword ptr [eax + 0x384]
0x49a9bd : -mov ecx, dword ptr [ebp + 0x10]
0x49a9c0 : -mov dword ptr [ecx], eax
0x49a9c2 : -mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x49a9c7 : -mov eax, dword ptr [eax + 0x388]
0x49a9cd : -mov ecx, dword ptr [ebp + 0x14]
0x49a9d0 : -mov dword ptr [ecx], eax
0x49a9d2 : -mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x49a9d7 : -mov eax, dword ptr [eax + 0x384]
0x49a9dd : -mov ecx, dword ptr [gCurrent_graf_data (DATA)]
0x49a9e3 : -add eax, dword ptr [ecx + 0x384]
0x49a9e9 : -mov ecx, dword ptr [gCurrent_graf_data (DATA)]
0x49a9ef : -sub eax, dword ptr [ecx + 0x37c]
0x49a9f5 : -sub eax, 7
0x49a9f8 : -mov ecx, dword ptr [ebp + 0x18]
0x49a9fb : -mov dword ptr [ecx], eax
0x49a9fd : -jmp 0x33
0x49aa02 : -mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x49aa07 : -mov eax, dword ptr [eax + 0x37c]
0x49aa0d : -mov ecx, dword ptr [ebp + 0x10]
0x49aa10 : -mov dword ptr [ecx], eax
0x49aa12 : -mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x49aa17 : -mov eax, dword ptr [eax + 0x380]
0x49aa1d : -mov ecx, dword ptr [ebp + 0x14]
0x49aa20 : -mov dword ptr [ecx], eax
         : +pop edi 	(options.c:956)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


GetKeyCoords is only 30.41% similar to the original, diff above
```

*AI generated. Time taken: 198s, tokens: 44,798*
