### PR TITLE
KeyAssignLeft 100% match

### DIFF
--- a/src/DETHRACE/common/options.c
+++ b/src/DETHRACE/common/options.c
@@ -1104,7 +1104,9 @@ int KeyAssignLeft(int* pCurrent_choice, int* pCurrent_mode) {
         ChangeKeyMapIndex(new_index);
         RadioChanged(12, new_index);
         DRS3StartSound(gEffects_outlet, 3000);
-    } else {
+        return 1;
+    }
+    else {
         if (gCurrent_key >= (gKey_count + 1) / 2) {
             gCurrent_key -= (gKey_count + 1) / 2;
         } else {
@@ -1114,8 +1116,8 @@ int KeyAssignLeft(int* pCurrent_choice, int* pCurrent_mode) {
             }
         }
         DRS3StartSound(gEffects_outlet, 3000);
+        return 1;
     }
-    return 1;
 }
 
 // IDA: int __usercall KeyAssignRight@<EAX>(int *pCurrent_choice@<EAX>, int *pCurrent_mode@<EDX>)


### PR DESCRIPTION
## Match result

```
0x49aa3a: KeyAssignLeft 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x49aa3a,18 +0x495628,18 @@
0x49aa3a : push ebp 	(options.c:1095)
0x49aa3b : mov ebp, esp
0x49aa3d : sub esp, 4
0x49aa40 : push ebx
0x49aa41 : push esi
0x49aa42 : push edi
0x49aa43 : cmp dword ptr [gCurrent_key (DATA)], 0 	(options.c:1098)
0x49aa4a : -jge 0x5e
         : +jge 0x54
0x49aa50 : cmp dword ptr [gKey_map_index (DATA)], 0 	(options.c:1099)
0x49aa57 : jne 0xc
0x49aa5d : mov dword ptr [ebp - 4], 3 	(options.c:1100)
0x49aa64 : jmp 0x9 	(options.c:1101)
0x49aa69 : mov eax, dword ptr [gKey_map_index (DATA)] 	(options.c:1102)
0x49aa6e : dec eax
0x49aa6f : mov dword ptr [ebp - 4], eax
0x49aa72 : mov eax, dword ptr [ebp - 4] 	(options.c:1104)
0x49aa75 : push eax
0x49aa76 : call ChangeKeyMapIndex (FUNCTION)

---
+++
@@ -0x49aa7e,23 +0x49566c,21 @@
0x49aa7e : mov eax, dword ptr [ebp - 4] 	(options.c:1105)
0x49aa81 : push eax
0x49aa82 : push 0xc
0x49aa84 : call RadioChanged (FUNCTION)
0x49aa89 : add esp, 8
0x49aa8c : push 0xbb8 	(options.c:1106)
0x49aa91 : mov eax, dword ptr [gEffects_outlet (DATA)]
0x49aa96 : push eax
0x49aa97 : call DRS3StartSound (FUNCTION)
0x49aa9c : add esp, 8
0x49aa9f : -mov eax, 1
0x49aaa4 : -jmp 0x8e
0x49aaa9 : -jmp 0x89
         : +jmp 0x7f 	(options.c:1107)
0x49aaae : mov eax, dword ptr [gKey_count (DATA)] 	(options.c:1108)
0x49aab3 : inc eax
0x49aab4 : cdq 
0x49aab5 : sub eax, edx
0x49aab7 : sar eax, 1
0x49aab9 : cmp eax, dword ptr [gCurrent_key (DATA)]
0x49aabf : jg 0x1c
0x49aac5 : xor ecx, ecx 	(options.c:1109)
0x49aac7 : mov eax, dword ptr [gKey_count (DATA)]
0x49aacc : inc eax

---
+++
@@ -0x49ab0e,10 +0x4956f2,16 @@
0x49ab0e : sar eax, 1
0x49ab10 : sub ecx, eax
0x49ab12 : neg ecx
0x49ab14 : sub dword ptr [gCurrent_key (DATA)], ecx
0x49ab1a : push 0xbb8 	(options.c:1116)
0x49ab1f : mov eax, dword ptr [gEffects_outlet (DATA)]
0x49ab24 : push eax
0x49ab25 : call DRS3StartSound (FUNCTION)
0x49ab2a : add esp, 8
0x49ab2d : mov eax, 1 	(options.c:1118)
         : +jmp 0x0
         : +pop edi 	(options.c:1119)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


KeyAssignLeft is only 92.00% similar to the original, diff above
```

*AI generated. Time taken: 203s, tokens: 32,792*
