### PR TITLE
KeyAssignRight equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/options.c
+++ b/src/DETHRACE/common/options.c
@@ -1124,25 +1124,25 @@ int KeyAssignRight(int* pCurrent_choice, int* pCurrent_mode) {
     int new_index;
 
     if (gCurrent_key < 0) {
-        if (gKey_map_index < 3) {
-            new_index = gKey_map_index + 1;
-        } else {
+        if (gKey_map_index >= 3) {
             new_index = 0;
+        } else {
+            new_index = gKey_map_index + 1;
         }
         ChangeKeyMapIndex(new_index);
         RadioChanged(12, new_index);
         DRS3StartSound(gEffects_outlet, 3000);
-    } else {
-        if (gCurrent_key >= (gKey_count + 1) / 2) {
-            gCurrent_key -= (gKey_count + 1) / 2;
-        } else {
-            gCurrent_key += (gKey_count + 1) / 2;
-            if (gCurrent_key >= gKey_count) {
-                gCurrent_key -= (gKey_count + 1) / 2;
-            }
-        }
-        DRS3StartSound(gEffects_outlet, 3000);
+        return 1;
     }
+    if (gCurrent_key >= (gKey_count + 1) / 2) {
+        gCurrent_key -= (gKey_count + 1) / 2;
+    } else {
+        gCurrent_key += (gKey_count + 1) / 2;
+        if (gCurrent_key >= gKey_count) {
+            gCurrent_key -= (gKey_count + 1) / 2;
+        }
+    }
+    DRS3StartSound(gEffects_outlet, 3000);
     return 1;
 }
 


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x49ac6f,18 +0x495720,18 @@
0x49ac6f : push ebp 	(options.c:1123)
0x49ac70 : mov ebp, esp
0x49ac72 : sub esp, 4
0x49ac75 : push ebx
0x49ac76 : push esi
0x49ac77 : push edi
0x49ac78 : cmp dword ptr [gCurrent_key (DATA)], 0 	(options.c:1126)
0x49ac7f : -jge 0x5e
         : +jge 0x59
0x49ac85 : cmp dword ptr [gKey_map_index (DATA)], 3 	(options.c:1127)
0x49ac8c : jl 0xc
0x49ac92 : mov dword ptr [ebp - 4], 0 	(options.c:1128)
0x49ac99 : jmp 0x9 	(options.c:1129)
0x49ac9e : mov eax, dword ptr [gKey_map_index (DATA)] 	(options.c:1130)
0x49aca3 : inc eax
0x49aca4 : mov dword ptr [ebp - 4], eax
0x49aca7 : mov eax, dword ptr [ebp - 4] 	(options.c:1132)
0x49acaa : push eax
0x49acab : call ChangeKeyMapIndex (FUNCTION)

---
+++
@@ -0x49acb6,21 +0x495767,20 @@
0x49acb6 : push eax
0x49acb7 : push 0xc
0x49acb9 : call RadioChanged (FUNCTION)
0x49acbe : add esp, 8
0x49acc1 : push 0xbb8 	(options.c:1134)
0x49acc6 : mov eax, dword ptr [gEffects_outlet (DATA)]
0x49accb : push eax
0x49accc : call DRS3StartSound (FUNCTION)
0x49acd1 : add esp, 8
0x49acd4 : mov eax, 1 	(options.c:1135)
0x49acd9 : -jmp 0x8e
0x49acde : jmp 0x89
0x49ace3 : mov eax, dword ptr [gKey_count (DATA)] 	(options.c:1137)
0x49ace8 : inc eax
0x49ace9 : cdq 
0x49acea : sub eax, edx
0x49acec : sar eax, 1
0x49acee : cmp eax, dword ptr [gCurrent_key (DATA)]
0x49acf4 : jg 0x1c
0x49acfa : xor ecx, ecx 	(options.c:1138)
0x49acfc : mov eax, dword ptr [gKey_count (DATA)]

---
+++
@@ -0x49ad45,10 +0x4957f1,15 @@
0x49ad45 : sub ecx, eax
0x49ad47 : neg ecx
0x49ad49 : sub dword ptr [gCurrent_key (DATA)], ecx
0x49ad4f : push 0xbb8 	(options.c:1145)
0x49ad54 : mov eax, dword ptr [gEffects_outlet (DATA)]
0x49ad59 : push eax
0x49ad5a : call DRS3StartSound (FUNCTION)
0x49ad5f : add esp, 8
0x49ad62 : mov eax, 1 	(options.c:1146)
0x49ad67 : jmp 0x0
         : +pop edi 	(options.c:1147)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


KeyAssignRight is only 94.74% similar to the original, diff above
```

#### Effective match analysis

All shown differences are control-transfer layout changes, not state/logic changes: branch displacements were adjusted to new code positions, and one `jmp` to a shared exit was replaced with an inlined epilogue (`pop`/`leave`/`ret`). The observable updates (key index/current key handling, sound call, and return value `eax=1`) are unchanged in the diffed regions.

#### Original match

```
---
+++
@@ -0x49ac6f,42 +0x495720,40 @@
0x49ac6f : push ebp 	(options.c:1123)
0x49ac70 : mov ebp, esp
0x49ac72 : sub esp, 4
0x49ac75 : push ebx
0x49ac76 : push esi
0x49ac77 : push edi
0x49ac78 : cmp dword ptr [gCurrent_key (DATA)], 0 	(options.c:1126)
0x49ac7f : -jge 0x5e
         : +jge 0x54
0x49ac85 : cmp dword ptr [gKey_map_index (DATA)], 3 	(options.c:1127)
0x49ac8c : -jl 0xc
0x49ac92 : -mov dword ptr [ebp - 4], 0
0x49ac99 : -jmp 0x9
         : +jge 0xe
0x49ac9e : mov eax, dword ptr [gKey_map_index (DATA)] 	(options.c:1128)
0x49aca3 : inc eax
0x49aca4 : mov dword ptr [ebp - 4], eax
         : +jmp 0x7 	(options.c:1129)
         : +mov dword ptr [ebp - 4], 0 	(options.c:1130)
0x49aca7 : mov eax, dword ptr [ebp - 4] 	(options.c:1132)
0x49acaa : push eax
0x49acab : call ChangeKeyMapIndex (FUNCTION)
0x49acb0 : add esp, 4
0x49acb3 : mov eax, dword ptr [ebp - 4] 	(options.c:1133)
0x49acb6 : push eax
0x49acb7 : push 0xc
0x49acb9 : call RadioChanged (FUNCTION)
0x49acbe : add esp, 8
0x49acc1 : push 0xbb8 	(options.c:1134)
0x49acc6 : mov eax, dword ptr [gEffects_outlet (DATA)]
0x49accb : push eax
0x49accc : call DRS3StartSound (FUNCTION)
0x49acd1 : add esp, 8
0x49acd4 : -mov eax, 1
0x49acd9 : -jmp 0x8e
0x49acde : -jmp 0x89
         : +jmp 0x7f 	(options.c:1135)
0x49ace3 : mov eax, dword ptr [gKey_count (DATA)] 	(options.c:1136)
0x49ace8 : inc eax
0x49ace9 : cdq 
0x49acea : sub eax, edx
0x49acec : sar eax, 1
0x49acee : cmp eax, dword ptr [gCurrent_key (DATA)]
0x49acf4 : jg 0x1c
0x49acfa : xor ecx, ecx 	(options.c:1137)
0x49acfc : mov eax, dword ptr [gKey_count (DATA)]
0x49ad01 : inc eax

---
+++
@@ -0x49ad43,10 +0x4957ea,16 @@
0x49ad43 : sar eax, 1
0x49ad45 : sub ecx, eax
0x49ad47 : neg ecx
0x49ad49 : sub dword ptr [gCurrent_key (DATA)], ecx
0x49ad4f : push 0xbb8 	(options.c:1144)
0x49ad54 : mov eax, dword ptr [gEffects_outlet (DATA)]
0x49ad59 : push eax
0x49ad5a : call DRS3StartSound (FUNCTION)
0x49ad5f : add esp, 8
0x49ad62 : mov eax, 1 	(options.c:1146)
         : +jmp 0x0
         : +pop edi 	(options.c:1147)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


KeyAssignRight is only 88.00% similar to the original, diff above
```

*AI generated. Time taken: 821s*
