### PR TITLE
KeyAssignUp 100% match

### DIFF
--- a/src/DETHRACE/common/options.c
+++ b/src/DETHRACE/common/options.c
@@ -1165,11 +1165,11 @@ int KeyAssignUp(int* pCurrent_choice, int* pCurrent_mode) {
     } else if (gCurrent_key == (gKey_count + 1) / 2) {
         *pCurrent_choice = 0;
         *pCurrent_mode = 0;
-    } else if (gCurrent_key == 0) {
+    } else if (gCurrent_key != 0) {
+        gCurrent_key -= 1;
+    } else {
         *pCurrent_choice = 0;
         *pCurrent_mode = 0;
-    } else {
-        gCurrent_key -= 1;
     }
     DRS3StartSound(gEffects_outlet, 3000);
     return 1;


### PR DESCRIPTION
## Match result

```
0x49ad71: KeyAssignUp 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x49ae28,27 +0x4958cf,27 @@
0x49ae28 : sub eax, edx
0x49ae2a : sar eax, 1
0x49ae2c : cmp eax, dword ptr [gCurrent_key (DATA)]
0x49ae32 : jne 0x17
0x49ae38 : mov eax, dword ptr [ebp + 8] 	(options.c:1166)
0x49ae3b : mov dword ptr [eax], 0
0x49ae41 : mov eax, dword ptr [ebp + 0xc] 	(options.c:1167)
0x49ae44 : mov dword ptr [eax], 0
0x49ae4a : jmp 0x2a 	(options.c:1168)
0x49ae4f : cmp dword ptr [gCurrent_key (DATA)], 0
0x49ae56 : -je 0xb
0x49ae5c : -dec dword ptr [gCurrent_key (DATA)]
0x49ae62 : -jmp 0x12
         : +jne 0x17
0x49ae67 : mov eax, dword ptr [ebp + 8] 	(options.c:1169)
0x49ae6a : mov dword ptr [eax], 0
0x49ae70 : mov eax, dword ptr [ebp + 0xc] 	(options.c:1170)
0x49ae73 : mov dword ptr [eax], 0
         : +jmp 0x6 	(options.c:1171)
         : +dec dword ptr [gCurrent_key (DATA)] 	(options.c:1172)
0x49ae79 : push 0xbb8 	(options.c:1174)
0x49ae7e : mov eax, dword ptr [gEffects_outlet (DATA)]
0x49ae83 : push eax
0x49ae84 : call DRS3StartSound (FUNCTION)
0x49ae89 : add esp, 8
0x49ae8c : mov eax, 1 	(options.c:1175)
0x49ae91 : jmp 0x0
0x49ae96 : pop edi 	(options.c:1176)
0x49ae97 : pop esi
0x49ae98 : pop ebx


KeyAssignUp is only 96.20% similar to the original, diff above
```

*AI generated. Time taken: 69s, tokens: 7,889*
