### PR TITLE
StripControls 100% match

### DIFF
--- a/src/DETHRACE/common/options.c
+++ b/src/DETHRACE/common/options.c
@@ -881,7 +881,7 @@ void StripControls(unsigned char* pStr) {
     len = strlen((char*)pStr);
     for (i = 0; i < len; i++) {
         if (pStr[i] < ' ') {
-            memmove(&pStr[i], &pStr[i + 1], (len - i) * sizeof(char));
+            memcpy(&pStr[i], &pStr[i] + 1, (len - i) * sizeof(char));
             len--;
 #ifdef DETHRACE_FIX_BUGS
             // correctly handle stripping multiple control characters

--- a/src/DETHRACE/common/options.c
+++ b/src/DETHRACE/common/options.c
@@ -881,7 +881,11 @@ void StripControls(unsigned char* pStr) {
     len = strlen((char*)pStr);
     for (i = 0; i < len; i++) {
         if (pStr[i] < ' ') {
+#ifdef DETHRACE_FIX_BUGS
+            memmove(&pStr[i], &pStr[i] + 1, (len - i) * sizeof(char));
+#else
             memcpy(&pStr[i], &pStr[i] + 1, (len - i) * sizeof(char));
+#endif
             len--;
 #ifdef DETHRACE_FIX_BUGS
             // correctly handle stripping multiple control characters


### PR DESCRIPTION
## Match result

```
0x49c0b4: StripControls 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x49c0c5,32 +0x494c44,36 @@
0x49c0c5 : sub eax, eax
0x49c0c7 : repne scasb al, byte ptr es:[edi]
0x49c0c9 : not ecx
0x49c0cb : lea eax, [ecx - 1]
0x49c0ce : mov dword ptr [ebp - 8], eax
0x49c0d1 : mov dword ptr [ebp - 4], 0 	(options.c:882)
0x49c0d8 : jmp 0x3
0x49c0dd : inc dword ptr [ebp - 4]
0x49c0e0 : mov eax, dword ptr [ebp - 4]
0x49c0e3 : cmp dword ptr [ebp - 8], eax
0x49c0e6 : -jle 0x42
         : +jle 0x3a
0x49c0ec : mov eax, dword ptr [ebp - 4] 	(options.c:883)
0x49c0ef : mov ecx, dword ptr [ebp + 8]
0x49c0f2 : xor edx, edx
0x49c0f4 : mov dl, byte ptr [eax + ecx]
0x49c0f7 : cmp edx, 0x20
0x49c0fa : -jge 0x29
         : +jge 0x21
0x49c100 : mov eax, dword ptr [ebp - 8] 	(options.c:884)
0x49c103 : sub eax, dword ptr [ebp - 4]
0x49c106 : -mov ecx, dword ptr [ebp - 4]
0x49c109 : -mov edx, dword ptr [ebp + 8]
0x49c10c : -mov ebx, dword ptr [ebp - 4]
0x49c10f : -add ebx, dword ptr [ebp + 8]
0x49c112 : -mov edi, ebx
0x49c114 : -lea esi, [ecx + edx + 1]
0x49c118 : -mov ecx, eax
0x49c11a : -shr ecx, 2
0x49c11d : -rep movsd dword ptr es:[edi], dword ptr [esi]
0x49c11f : -mov ecx, eax
0x49c121 : -and ecx, 3
0x49c124 : -rep movsb byte ptr es:[edi], byte ptr [esi]
         : +push eax
         : +mov eax, dword ptr [ebp - 4]
         : +inc eax
         : +add eax, dword ptr [ebp + 8]
         : +push eax
         : +mov eax, dword ptr [ebp - 4]
         : +add eax, dword ptr [ebp + 8]
         : +push eax
         : +call memmove (FUNCTION)
         : +add esp, 0xc
0x49c126 : dec dword ptr [ebp - 8] 	(options.c:885)
         : +jmp -0x49 	(options.c:891)
         : +pop edi 	(options.c:892)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


StripControls is only 61.90% similar to the original, diff above
```

*AI generated. Time taken: 99s, tokens: 9,310*
