### PR TITLE
MaxCurvatureForCarSpeed 100% match

### DIFF
--- a/src/DETHRACE/common/oppoproc.c
+++ b/src/DETHRACE/common/oppoproc.c
@@ -72,10 +72,10 @@ br_scalar CornerFudge(tCar_spec* pCar_spec) {
 br_scalar MaxCurvatureForCarSpeed(tCar_spec* pCar, br_scalar pSpeed) {
     br_scalar curv;
 
-    if (pSpeed >= 12.5f) {
-        curv = pCar->maxcurve * 12.5f / pSpeed;
-    } else {
+    if (pSpeed < 12.5f) {
         curv = pCar->maxcurve;
+    } else {
+        curv = pCar->maxcurve * 12.5f / pSpeed;
     }
     return curv;
 }


### PR DESCRIPTION
## Match result

```
0x4a0054: MaxCurvatureForCarSpeed 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4a0054,27 +0x4913d6,27 @@
0x4a0054 : push ebp 	(oppoproc.c:72)
0x4a0055 : mov ebp, esp
0x4a0057 : sub esp, 4
0x4a005a : push ebx
0x4a005b : push esi
0x4a005c : push edi
0x4a005d : fld dword ptr [ebp + 0xc] 	(oppoproc.c:75)
0x4a0060 : fcomp dword ptr [12.5 (FLOAT)]
0x4a0066 : fnstsw ax
0x4a0068 : test ah, 1
0x4a006b : -je 0x11
0x4a0071 : -mov eax, dword ptr [ebp + 8]
0x4a0074 : -mov eax, dword ptr [eax + 0x1500]
0x4a007a : -mov dword ptr [ebp - 4], eax
0x4a007d : -jmp 0x15
         : +jne 0x1a
0x4a0082 : mov eax, dword ptr [ebp + 8] 	(oppoproc.c:76)
0x4a0085 : fld dword ptr [eax + 0x1500]
0x4a008b : fmul dword ptr [12.5 (FLOAT)]
0x4a0091 : fdiv dword ptr [ebp + 0xc]
0x4a0094 : fstp dword ptr [ebp - 4]
         : +jmp 0xc 	(oppoproc.c:77)
         : +mov eax, dword ptr [ebp + 8] 	(oppoproc.c:78)
         : +mov eax, dword ptr [eax + 0x1500]
         : +mov dword ptr [ebp - 4], eax
0x4a0097 : fld dword ptr [ebp - 4] 	(oppoproc.c:80)
0x4a009a : jmp 0x0
0x4a009f : pop edi 	(oppoproc.c:81)
0x4a00a0 : pop esi
0x4a00a1 : pop ebx
0x4a00a2 : leave 
0x4a00a3 : ret 


MaxCurvatureForCarSpeed is only 81.48% similar to the original, diff above
```

*AI generated. Time taken: 68s, tokens: 8,437*
