### PR TITLE
DoEditModeKey equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -656,22 +656,22 @@ void ShowSpecialVolumesIfRequ(void) {
 void DoEditModeKey(int pIndex) {
     int modifiers;
 
-    if (gI_am_cheating == 0xa11ee75d || (gI_am_cheating == 0x564e78b9 && gNet_mode == eNet_mode_none)) {
-        modifiers = 0;
-        if (PDKeyDown(KEY_SHIFT_ANY)) {
-            modifiers |= 4;
+    if (gI_am_cheating != 0xa11ee75d) {
+        if (gI_am_cheating != 0x564e78b9 || gNet_mode != eNet_mode_none) {
+            gWhich_edit_mode = eEdit_mode_options;
+            return;
         }
-        if (PDKeyDown(KEY_ALT_ANY)) {
-            modifiers |= 2;
-        }
-        if (PDKeyDown(KEY_CTRL_ANY)) {
-            modifiers |= 1;
-        }
-        if (gEdit_funcs[gWhich_edit_mode][pIndex][modifiers] != NULL) {
-            gEdit_funcs[gWhich_edit_mode][pIndex][modifiers]();
-        }
+    }
+
+    if (PDKeyDown(KEY_SHIFT_ANY)) {
+        modifiers = 4;
     } else {
-        gWhich_edit_mode = eEdit_mode_options;
+        modifiers = 0;
+    }
+    modifiers = PDKeyDown(KEY_ALT_ANY) ? modifiers | 2 : modifiers;
+    modifiers = PDKeyDown(KEY_CTRL_ANY) ? modifiers | 1 : modifiers;
+    if (gEdit_funcs[gWhich_edit_mode][pIndex][modifiers] != NULL) {
+        (*gEdit_funcs[gWhich_edit_mode][pIndex][modifiers])();
     }
 }
 


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4a0f08,16 +0x465667,16 @@
0x4a0f08 : shl ecx, 5
0x4a0f0b : cmp dword ptr [eax + ecx + gEdit_funcs[0].[0] (DATA)], 0
0x4a0f13 : je 0x1f
0x4a0f19 : mov eax, dword ptr [ebp - 4] 	(controls.c:674)
0x4a0f1c : mov ecx, dword ptr [gWhich_edit_mode (DATA)]
0x4a0f22 : lea ecx, [ecx + ecx*8]
0x4a0f25 : shl ecx, 6
0x4a0f28 : lea eax, [ecx + eax*4]
0x4a0f2b : mov ecx, dword ptr [ebp + 8]
0x4a0f2e : shl ecx, 5
0x4a0f31 : -call dword ptr [eax + ecx + 0x51b600]
         : +call dword ptr [eax + ecx + 0x526e30]
0x4a0f38 : pop edi 	(controls.c:676)
0x4a0f39 : pop esi
0x4a0f3a : pop ebx
0x4a0f3b : leave 
0x4a0f3c : ret 


DoEditModeKey is only 98.28% similar to the original, diff above
```

#### Effective match analysis

The shown instruction sequence and control flow are identical except for the absolute displacement used in the indirect call (`[eax + ecx + 0x51b600]` vs `[eax + ecx + 0x526e30]`). Given this is a data-address change (likely the relocated base of the same function-pointer table, consistent with the earlier `gEdit_funcs` access), the computation and branch structure are unchanged, so the functional behavior is equivalent.

#### Original match

```
---
+++
@@ -0x4a0e53,50 +0x4655b2,55 @@
0x4a0e53 : push ebp 	(controls.c:656)
0x4a0e54 : mov ebp, esp
0x4a0e56 : sub esp, 4
0x4a0e59 : push ebx
0x4a0e5a : push esi
0x4a0e5b : push edi
0x4a0e5c : cmp dword ptr [gI_am_cheating (DATA)], 0xa11ee75d 	(controls.c:659)
0x4a0e66 : -je 0x2c
         : +je 0x1d
0x4a0e6c : cmp dword ptr [gI_am_cheating (DATA)], 0x564e78b9
0x4a0e76 : -jne 0xd
         : +jne 0xa0
0x4a0e7c : cmp dword ptr [gNet_mode (DATA)], 0
0x4a0e83 : -je 0xf
0x4a0e89 : -mov dword ptr [gWhich_edit_mode (DATA)], 9
0x4a0e93 : -jmp 0xa0
         : +jne 0x93
         : +mov dword ptr [ebp - 4], 0 	(controls.c:660)
0x4a0e98 : push 0 	(controls.c:661)
0x4a0e9a : call PDKeyDown (FUNCTION)
0x4a0e9f : add esp, 4
0x4a0ea2 : test eax, eax
0x4a0ea4 : -je 0xc
0x4a0eaa : -mov dword ptr [ebp - 4], 4
0x4a0eb1 : -jmp 0x7
0x4a0eb6 : -mov dword ptr [ebp - 4], 0
         : +je 0x4
         : +or dword ptr [ebp - 4], 4 	(controls.c:662)
0x4a0ebd : push 1 	(controls.c:664)
0x4a0ebf : call PDKeyDown (FUNCTION)
0x4a0ec4 : add esp, 4
0x4a0ec7 : test eax, eax
0x4a0ec9 : -je 0x9
         : +je 0x4
0x4a0ecf : or dword ptr [ebp - 4], 2 	(controls.c:665)
0x4a0ed3 : -jmp 0x0
0x4a0ed8 : push 2 	(controls.c:667)
0x4a0eda : call PDKeyDown (FUNCTION)
0x4a0edf : add esp, 4
0x4a0ee2 : test eax, eax
0x4a0ee4 : -je 0x9
         : +je 0x4
0x4a0eea : or dword ptr [ebp - 4], 1 	(controls.c:668)
0x4a0eee : -jmp 0x0
0x4a0ef3 : mov eax, dword ptr [ebp - 4] 	(controls.c:670)
0x4a0ef6 : mov ecx, dword ptr [gWhich_edit_mode (DATA)]
0x4a0efc : lea ecx, [ecx + ecx*8]
0x4a0eff : shl ecx, 6
0x4a0f02 : lea eax, [ecx + eax*4]
0x4a0f05 : mov ecx, dword ptr [ebp + 8]
0x4a0f08 : shl ecx, 5
0x4a0f0b : cmp dword ptr [eax + ecx + gEdit_funcs[0].[0] (DATA)], 0
0x4a0f13 : je 0x1f
0x4a0f19 : mov eax, dword ptr [ebp - 4] 	(controls.c:671)
0x4a0f1c : mov ecx, dword ptr [gWhich_edit_mode (DATA)]
0x4a0f22 : lea ecx, [ecx + ecx*8]
0x4a0f25 : shl ecx, 6
0x4a0f28 : lea eax, [ecx + eax*4]
         : +mov ecx, dword ptr [ebp + 8]
         : +shl ecx, 5
         : +call dword ptr [eax + ecx + 0x526e30]
         : +jmp 0xa 	(controls.c:673)
         : +mov dword ptr [gWhich_edit_mode (DATA)], 9 	(controls.c:674)
         : +pop edi 	(controls.c:676)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DoEditModeKey is only 70.48% similar to the original, diff above
```

*AI generated. Time taken: 261s, tokens: 24,296*
