### PR TITLE
CarWorldOffFallenCheckThingy 100% match

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -1231,9 +1231,10 @@ int CarWorldOffFallenCheckThingy(tCar_spec* pCar, int pCheck_around) {
                 if (FindYVerticallyBelow2(&car_pos) < -100.f) {
                     BrVector3Set(&offset_c, 0.f, 1.f, 0.f);
                     BrMatrix34ApplyV(&offset_w, &offset_c, &pCar->car_master_actor->t.t.mat);
-                    car_pos.v[0] = pCar->car_master_actor->t.t.translate.t.v[0] + offset_w.v[0];
-                    car_pos.v[1] = pCar->car_master_actor->t.t.translate.t.v[1] + offset_w.v[1];
-                    car_pos.v[2] = pCar->car_master_actor->t.t.translate.t.v[2] + offset_w.v[2];
+                    BrVector3Copy(&car_pos, &pCar->car_master_actor->t.t.translate.t);
+                    car_pos.v[0] += offset_w.v[0];
+                    car_pos.v[1] += offset_w.v[1];
+                    car_pos.v[2] += offset_w.v[2];
                     if (FindYVerticallyBelow2(&car_pos) < -100.f) {
                         if (pCheck_around) {
                             pCar->car_master_actor->t.t.translate.t.v[0] += 0.05f;

--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -1231,10 +1231,7 @@ int CarWorldOffFallenCheckThingy(tCar_spec* pCar, int pCheck_around) {
                 if (FindYVerticallyBelow2(&car_pos) < -100.f) {
                     BrVector3Set(&offset_c, 0.f, 1.f, 0.f);
                     BrMatrix34ApplyV(&offset_w, &offset_c, &pCar->car_master_actor->t.t.mat);
-                    BrVector3Copy(&car_pos, &pCar->car_master_actor->t.t.translate.t);
-                    car_pos.v[0] += offset_w.v[0];
-                    car_pos.v[1] += offset_w.v[1];
-                    car_pos.v[2] += offset_w.v[2];
+                    BrVector3Add(&car_pos, &pCar->car_master_actor->t.t.translate.t, &offset_w);
                     if (FindYVerticallyBelow2(&car_pos) < -100.f) {
                         if (pCheck_around) {
                             pCar->car_master_actor->t.t.translate.t.v[0] += 0.05f;

--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -1223,41 +1223,38 @@ int CarWorldOffFallenCheckThingy(tCar_spec* pCar, int pCheck_around) {
     br_vector3 offset_w;
     int result;
 
-    if (pCar->number_of_wheels_on_ground != 0) {
-        return 0;
+    if (pCar->number_of_wheels_on_ground == 0) {
+        if (!gCar_flying || pCar->driver != eDriver_local_human) {
+            if (!gAction_replay_mode) {
+                BrVector3Copy(&car_pos, &pCar->car_master_actor->t.t.translate.t);
+                car_pos.v[1] += 0.5f;
+                if (FindYVerticallyBelow2(&car_pos) < -100.f) {
+                    BrVector3Set(&offset_c, 0.f, 1.f, 0.f);
+                    BrMatrix34ApplyV(&offset_w, &offset_c, &pCar->car_master_actor->t.t.mat);
+                    car_pos.v[0] = pCar->car_master_actor->t.t.translate.t.v[0] + offset_w.v[0];
+                    car_pos.v[1] = pCar->car_master_actor->t.t.translate.t.v[1] + offset_w.v[1];
+                    car_pos.v[2] = pCar->car_master_actor->t.t.translate.t.v[2] + offset_w.v[2];
+                    if (FindYVerticallyBelow2(&car_pos) < -100.f) {
+                        if (pCheck_around) {
+                            pCar->car_master_actor->t.t.translate.t.v[0] += 0.05f;
+                            result = CarWorldOffFallenCheckThingy(pCar, 0);
+                            pCar->car_master_actor->t.t.translate.t.v[0] -= 0.05f;
+                            if (!result) {
+                                return 0;
+                            }
+                            pCar->car_master_actor->t.t.translate.t.v[2] += 0.05f;
+                            result = CarWorldOffFallenCheckThingy(pCar, 0);
+                            pCar->car_master_actor->t.t.translate.t.v[2] -= 0.05f;
+                            return result;
+                        } else {
+                            return 1;
+                        }
+                    }
+                }
+            }
+        }
     }
-    if (pCar->driver == eDriver_local_human && gCar_flying) {
-        return 0;
-    }
-    if (gAction_replay_mode) {
-        return 0;
-    }
-    BrVector3Copy(&car_pos, &pCar->car_master_actor->t.t.translate.t);
-    if (FindYVerticallyBelow2(&car_pos) >= -100.f) {
-        return 0;
-    }
-    BrVector3Set(&offset_c, 0.f, 1.f, 0.f);
-    BrMatrix34ApplyV(&offset_w, &offset_c, &pCar->car_master_actor->t.t.mat);
-    if (FindYVerticallyBelow2(&car_pos) >= -100.f) {
-        // FIXME: testing twice using `FindYVerticallyBelow2' is meaningless
-        return 0;
-    }
-    if (!pCheck_around) {
-        return 1;
-    }
-    pCar->car_master_actor->t.t.translate.t.v[0] += 0.05f;
-    result = CarWorldOffFallenCheckThingy(pCar, 0);
-    pCar->car_master_actor->t.t.translate.t.v[0] -= 0.05f;
-    if (!result) {
-        return 0;
-    }
-    pCar->car_master_actor->t.t.translate.t.v[2] += 0.05f;
-    result = CarWorldOffFallenCheckThingy(pCar, 0);
-    pCar->car_master_actor->t.t.translate.t.v[2] -= 0.05f;
-    if (!result) {
-        return 0;
-    }
-    return 1;
+    return 0;
 }
 
 // IDA: int __usercall HasCarFallenOffWorld@<EAX>(tCar_spec *pCar@<EAX>)


### PR DESCRIPTION
## Match result

```
0x4a1b4d: CarWorldOffFallenCheckThingy 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4a1b4d,87 +0x4663c7,81 @@
0x4a1b4d : push ebp 	(controls.c:1220)
0x4a1b4e : mov ebp, esp
0x4a1b50 : sub esp, 0x28
0x4a1b53 : push ebx
0x4a1b54 : push esi
0x4a1b55 : push edi
0x4a1b56 : mov eax, dword ptr [ebp + 8] 	(controls.c:1226)
0x4a1b59 : cmp dword ptr [eax + 0x158c], 0
0x4a1b60 : -jne 0x1a1
0x4a1b66 : -cmp dword ptr [gCar_flying (DATA)], 0
0x4a1b6d : -je 0xd
         : +je 0x7
         : +xor eax, eax 	(controls.c:1227)
         : +jmp 0x192
0x4a1b73 : mov eax, dword ptr [ebp + 8] 	(controls.c:1229)
0x4a1b76 : cmp dword ptr [eax + 8], 4
0x4a1b7a : -je 0x187
         : +jne 0x14
         : +cmp dword ptr [gCar_flying (DATA)], 0
         : +je 0x7
         : +xor eax, eax 	(controls.c:1230)
         : +jmp 0x171
0x4a1b80 : cmp dword ptr [gAction_replay_mode (DATA)], 0 	(controls.c:1232)
0x4a1b87 : -jne 0x17a
         : +je 0x7
         : +xor eax, eax 	(controls.c:1233)
         : +jmp 0x15d
0x4a1b8d : mov eax, dword ptr [ebp + 8] 	(controls.c:1235)
0x4a1b90 : mov eax, dword ptr [eax + 0xc]
0x4a1b93 : mov eax, dword ptr [eax + 0x50]
0x4a1b96 : mov dword ptr [ebp - 0x10], eax
0x4a1b99 : mov eax, dword ptr [ebp + 8]
0x4a1b9c : mov eax, dword ptr [eax + 0xc]
0x4a1b9f : mov eax, dword ptr [eax + 0x54]
0x4a1ba2 : mov dword ptr [ebp - 0xc], eax
0x4a1ba5 : mov eax, dword ptr [ebp + 8]
0x4a1ba8 : mov eax, dword ptr [eax + 0xc]
0x4a1bab : mov eax, dword ptr [eax + 0x58]
0x4a1bae : mov dword ptr [ebp - 8], eax
0x4a1bb1 : -fld dword ptr [ebp - 0xc]
0x4a1bb4 : -fadd dword ptr [0.5 (FLOAT)]
0x4a1bba : -fstp dword ptr [ebp - 0xc]
0x4a1bbd : lea eax, [ebp - 0x10] 	(controls.c:1236)
0x4a1bc0 : push eax
0x4a1bc1 : call FindYVerticallyBelow2 (FUNCTION)
0x4a1bc6 : add esp, 4
0x4a1bc9 : fcomp dword ptr [-100.0 (FLOAT)]
0x4a1bcf : fnstsw ax
0x4a1bd1 : test ah, 1
0x4a1bd4 : -je 0x12d
         : +jne 0x7
         : +xor eax, eax 	(controls.c:1237)
         : +jmp 0x115
0x4a1bda : mov dword ptr [ebp - 0x1c], 0 	(controls.c:1239)
0x4a1be1 : mov dword ptr [ebp - 0x18], 0x3f800000
0x4a1be8 : mov dword ptr [ebp - 0x14], 0
0x4a1bef : mov eax, dword ptr [ebp + 8] 	(controls.c:1240)
0x4a1bf2 : mov eax, dword ptr [eax + 0xc]
0x4a1bf5 : add eax, 0x2c
0x4a1bf8 : push eax
0x4a1bf9 : lea eax, [ebp - 0x1c]
0x4a1bfc : push eax
0x4a1bfd : lea eax, [ebp - 0x28]
0x4a1c00 : push eax
0x4a1c01 : call BrMatrix34ApplyV (FUNCTION)
0x4a1c06 : add esp, 0xc
0x4a1c09 : -mov eax, dword ptr [ebp + 8]
0x4a1c0c : -mov eax, dword ptr [eax + 0xc]
0x4a1c0f : -fld dword ptr [eax + 0x50]
0x4a1c12 : -fadd dword ptr [ebp - 0x28]
0x4a1c15 : -fstp dword ptr [ebp - 0x10]
0x4a1c18 : -mov eax, dword ptr [ebp + 8]
0x4a1c1b : -mov eax, dword ptr [eax + 0xc]
0x4a1c1e : -fld dword ptr [eax + 0x54]
0x4a1c21 : -fadd dword ptr [ebp - 0x24]
0x4a1c24 : -fstp dword ptr [ebp - 0xc]
0x4a1c27 : -mov eax, dword ptr [ebp + 8]
0x4a1c2a : -mov eax, dword ptr [eax + 0xc]
0x4a1c2d : -fld dword ptr [eax + 0x58]
0x4a1c30 : -fadd dword ptr [ebp - 0x20]
0x4a1c33 : -fstp dword ptr [ebp - 8]
0x4a1c36 : lea eax, [ebp - 0x10] 	(controls.c:1241)
0x4a1c39 : push eax
0x4a1c3a : call FindYVerticallyBelow2 (FUNCTION)
0x4a1c3f : add esp, 4
0x4a1c42 : fcomp dword ptr [-100.0 (FLOAT)]
0x4a1c48 : fnstsw ax
0x4a1c4a : test ah, 1
0x4a1c4d : -je 0xb4
         : +jne 0x7
         : +xor eax, eax 	(controls.c:1243)
         : +jmp 0xc2
0x4a1c53 : cmp dword ptr [ebp + 0xc], 0 	(controls.c:1245)
0x4a1c57 : -je 0xa0
         : +jne 0xa
         : +mov eax, 1 	(controls.c:1246)
         : +jmp 0xae
0x4a1c5d : mov eax, dword ptr [ebp + 8] 	(controls.c:1248)
0x4a1c60 : mov eax, dword ptr [eax + 0xc]
0x4a1c63 : fld dword ptr [eax + 0x50]
0x4a1c66 : fadd dword ptr [0.05000000074505806 (FLOAT)]
0x4a1c6c : mov eax, dword ptr [ebp + 8]
0x4a1c6f : mov eax, dword ptr [eax + 0xc]
0x4a1c72 : fstp dword ptr [eax + 0x50]
0x4a1c75 : push 0 	(controls.c:1249)
0x4a1c77 : mov eax, dword ptr [ebp + 8]
0x4a1c7a : push eax

---
+++
@@ -0x4a1c86,35 +0x4664f4,42 @@
0x4a1c86 : mov eax, dword ptr [ebp + 8] 	(controls.c:1250)
0x4a1c89 : mov eax, dword ptr [eax + 0xc]
0x4a1c8c : fld dword ptr [eax + 0x50]
0x4a1c8f : fsub dword ptr [0.05000000074505806 (FLOAT)]
0x4a1c95 : mov eax, dword ptr [ebp + 8]
0x4a1c98 : mov eax, dword ptr [eax + 0xc]
0x4a1c9b : fstp dword ptr [eax + 0x50]
0x4a1c9e : cmp dword ptr [ebp - 4], 0 	(controls.c:1251)
0x4a1ca2 : jne 0x7
0x4a1ca8 : xor eax, eax 	(controls.c:1252)
0x4a1caa : -jmp 0x5f
         : +jmp 0x5c
0x4a1caf : mov eax, dword ptr [ebp + 8] 	(controls.c:1254)
0x4a1cb2 : mov eax, dword ptr [eax + 0xc]
0x4a1cb5 : fld dword ptr [eax + 0x58]
0x4a1cb8 : fadd dword ptr [0.05000000074505806 (FLOAT)]
0x4a1cbe : mov eax, dword ptr [ebp + 8]
0x4a1cc1 : mov eax, dword ptr [eax + 0xc]
0x4a1cc4 : fstp dword ptr [eax + 0x58]
0x4a1cc7 : push 0 	(controls.c:1255)
0x4a1cc9 : mov eax, dword ptr [ebp + 8]
0x4a1ccc : push eax
0x4a1ccd : call CarWorldOffFallenCheckThingy (FUNCTION)
0x4a1cd2 : add esp, 8
0x4a1cd5 : mov dword ptr [ebp - 4], eax
0x4a1cd8 : mov eax, dword ptr [ebp + 8] 	(controls.c:1256)
0x4a1cdb : mov eax, dword ptr [eax + 0xc]
0x4a1cde : fld dword ptr [eax + 0x58]
0x4a1ce1 : fsub dword ptr [0.05000000074505806 (FLOAT)]
0x4a1ce7 : mov eax, dword ptr [ebp + 8]
0x4a1cea : mov eax, dword ptr [eax + 0xc]
0x4a1ced : fstp dword ptr [eax + 0x58]
0x4a1cf0 : -mov eax, dword ptr [ebp - 4]
0x4a1cf3 : -jmp 0x16
         : +cmp dword ptr [ebp - 4], 0 	(controls.c:1257)
         : +jne 0x7
         : +xor eax, eax 	(controls.c:1258)
0x4a1cf8 : jmp 0xa
0x4a1cfd : mov eax, 1 	(controls.c:1260)
         : +jmp 0x0
         : +pop edi 	(controls.c:1261)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


CarWorldOffFallenCheckThingy is only 76.49% similar to the original, diff above
```

*AI generated. Time taken: 325s, tokens: 126,913*
