### PR TITLE
ExplodeCar 100% match

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -1489,15 +1489,16 @@ void ExplodeCar(tCar_spec* pCar) {
     br_vector3 pos;
 
     pCar->last_car_car_collision = 0;
-    pos.v[0] = .1449275f * pCar->cmpos.v[0];
-    pos.v[1] = .1449275f * pCar->cmpos.v[1];
-    pos.v[2] = pCar->bounds[0].min.v[2] + .3f * (pCar->bounds[0].max.v[2] - pCar->bounds[0].min.v[2]);
-    BrMatrix34ApplyP(&tv, &pos, &pCar->car_master_actor->t.t.mat);
-    CreatePuffOfSmoke(&tv, &pCar->v, 1.f, 1.f, 7, pCar);
+    tv.v[0] = .14492753f * pCar->cmpos.v[0];
+    tv.v[1] = .14492753f * pCar->cmpos.v[1];
+    tv.v[2] = .14492753f * pCar->cmpos.v[2];
+    tv.v[2] = pCar->bounds[0].min.v[2] + .3 * (pCar->bounds[0].max.v[2] - pCar->bounds[0].min.v[2]);
+    BrMatrix34ApplyP(&pos, &tv, &pCar->car_master_actor->t.t.mat);
+    CreatePuffOfSmoke(&pos, &pCar->v, 1.f, 1.f, 7, pCar);
 
-    pos.v[2] = pCar->bounds[0].min.v[2] + .7f * (pCar->bounds[0].max.v[2] - pCar->bounds[0].min.v[2]);
-    BrMatrix34ApplyP(&tv, &pos, &pCar->car_master_actor->t.t.mat);
-    CreatePuffOfSmoke(&tv, &pCar->v, 1.f, 1.f, 7, pCar);
+    tv.v[2] = pCar->bounds[0].min.v[2] + .7 * (pCar->bounds[0].max.v[2] - pCar->bounds[0].min.v[2]);
+    BrMatrix34ApplyP(&pos, &tv, &pCar->car_master_actor->t.t.mat);
+    CreatePuffOfSmoke(&pos, &pCar->v, 1.f, 1.f, 7, pCar);
 
     DisableCar(pCar);
 }

--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -1489,9 +1489,7 @@ void ExplodeCar(tCar_spec* pCar) {
     br_vector3 pos;
 
     pCar->last_car_car_collision = 0;
-    tv.v[0] = .14492753f * pCar->cmpos.v[0];
-    tv.v[1] = .14492753f * pCar->cmpos.v[1];
-    tv.v[2] = .14492753f * pCar->cmpos.v[2];
+    BrVector3Scale(&tv, &pCar->cmpos, .14492753f);
     tv.v[2] = pCar->bounds[0].min.v[2] + .3 * (pCar->bounds[0].max.v[2] - pCar->bounds[0].min.v[2]);
     BrMatrix34ApplyP(&pos, &tv, &pCar->car_master_actor->t.t.mat);
     CreatePuffOfSmoke(&pos, &pCar->v, 1.f, 1.f, 7, pCar);


### PR DESCRIPTION
## Match result

```
0x4a20e9: ExplodeCar 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4a20e9,79 +0x466e3d,85 @@
0x4a20e9 : push ebp 	(controls.c:1487)
0x4a20ea : mov ebp, esp
0x4a20ec : sub esp, 0x18
0x4a20ef : push ebx
0x4a20f0 : push esi
0x4a20f1 : push edi
0x4a20f2 : mov eax, dword ptr [ebp + 8] 	(controls.c:1491)
0x4a20f5 : mov dword ptr [eax + 0x330], 0
0x4a20ff : mov eax, dword ptr [ebp + 8] 	(controls.c:1492)
0x4a2102 : fld dword ptr [eax + 0xd4]
0x4a2108 : -fmul dword ptr [0.14492753148078918 (FLOAT)]
0x4a210e : -fstp dword ptr [ebp - 0xc]
         : +fmul dword ptr [0.1449275016784668 (FLOAT)]
         : +fstp dword ptr [ebp - 0x18]
0x4a2111 : mov eax, dword ptr [ebp + 8] 	(controls.c:1493)
0x4a2114 : fld dword ptr [eax + 0xd8]
0x4a211a : -fmul dword ptr [0.14492753148078918 (FLOAT)]
0x4a2120 : -fstp dword ptr [ebp - 8]
0x4a2123 : -mov eax, dword ptr [ebp + 8]
0x4a2126 : -fld dword ptr [eax + 0xdc]
0x4a212c : -fmul dword ptr [0.14492753148078918 (FLOAT)]
0x4a2132 : -fstp dword ptr [ebp - 4]
         : +fmul dword ptr [0.1449275016784668 (FLOAT)]
         : +fstp dword ptr [ebp - 0x14]
0x4a2135 : mov eax, dword ptr [ebp + 8] 	(controls.c:1494)
0x4a2138 : fld dword ptr [eax + 0xf8]
0x4a213e : mov eax, dword ptr [ebp + 8]
0x4a2141 : fsub dword ptr [eax + 0xec]
0x4a2147 : -fmul qword ptr [0.3 (FLOAT)]
         : +fmul dword ptr [0.30000001192092896 (FLOAT)]
0x4a214d : mov eax, dword ptr [ebp + 8]
0x4a2150 : fadd dword ptr [eax + 0xec]
0x4a2156 : -fstp dword ptr [ebp - 4]
         : +fstp dword ptr [ebp - 0x10]
0x4a2159 : mov eax, dword ptr [ebp + 8] 	(controls.c:1495)
0x4a215c : mov eax, dword ptr [eax + 0xc]
0x4a215f : add eax, 0x2c
0x4a2162 : push eax
         : +lea eax, [ebp - 0x18]
         : +push eax
0x4a2163 : lea eax, [ebp - 0xc]
0x4a2166 : -push eax
0x4a2167 : -lea eax, [ebp - 0x18]
0x4a216a : push eax
0x4a216b : call BrMatrix34ApplyP (FUNCTION)
0x4a2170 : add esp, 0xc
0x4a2173 : mov eax, dword ptr [ebp + 8] 	(controls.c:1496)
0x4a2176 : push eax
0x4a2177 : push 7
0x4a2179 : push 0x3f800000
0x4a217e : push 0x3f800000
0x4a2183 : mov eax, dword ptr [ebp + 8]
0x4a2186 : add eax, 0x18
0x4a2189 : push eax
0x4a218a : -lea eax, [ebp - 0x18]
         : +lea eax, [ebp - 0xc]
0x4a218d : push eax
0x4a218e : call CreatePuffOfSmoke (FUNCTION)
0x4a2193 : add esp, 0x18
0x4a2196 : mov eax, dword ptr [ebp + 8] 	(controls.c:1498)
0x4a2199 : fld dword ptr [eax + 0xf8]
0x4a219f : mov eax, dword ptr [ebp + 8]
0x4a21a2 : fsub dword ptr [eax + 0xec]
0x4a21a8 : -fmul qword ptr [0.7 (FLOAT)]
         : +fmul dword ptr [0.699999988079071 (FLOAT)]
0x4a21ae : mov eax, dword ptr [ebp + 8]
0x4a21b1 : fadd dword ptr [eax + 0xec]
0x4a21b7 : -fstp dword ptr [ebp - 4]
         : +fstp dword ptr [ebp - 0x10]
0x4a21ba : mov eax, dword ptr [ebp + 8] 	(controls.c:1499)
0x4a21bd : mov eax, dword ptr [eax + 0xc]
0x4a21c0 : add eax, 0x2c
0x4a21c3 : push eax
         : +lea eax, [ebp - 0x18]
         : +push eax
0x4a21c4 : lea eax, [ebp - 0xc]
0x4a21c7 : -push eax
0x4a21c8 : -lea eax, [ebp - 0x18]
0x4a21cb : push eax
0x4a21cc : call BrMatrix34ApplyP (FUNCTION)
0x4a21d1 : add esp, 0xc
0x4a21d4 : mov eax, dword ptr [ebp + 8] 	(controls.c:1500)
0x4a21d7 : push eax
0x4a21d8 : push 7
0x4a21da : push 0x3f800000
0x4a21df : push 0x3f800000
0x4a21e4 : mov eax, dword ptr [ebp + 8]
0x4a21e7 : add eax, 0x18
0x4a21ea : push eax
0x4a21eb : -lea eax, [ebp - 0x18]
         : +lea eax, [ebp - 0xc]
0x4a21ee : push eax
0x4a21ef : call CreatePuffOfSmoke (FUNCTION)
         : +add esp, 0x18
         : +mov eax, dword ptr [ebp + 8] 	(controls.c:1502)
         : +push eax
         : +call DisableCar (FUNCTION)
         : +add esp, 4
         : +pop edi 	(controls.c:1503)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


ExplodeCar is only 74.39% similar to the original, diff above
```

*AI generated. Time taken: 111s, tokens: 21,753*
