### PR TITLE
SetFlipUpCar 100% match

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -1770,13 +1770,13 @@ void SortOutRecover(tCar_spec* pCar) {
 // FUNCTION: CARM95 0x004a22f4
 void SetFlipUpCar(tCar_spec* pCar) {
 
-    if (gNet_mode != eNet_mode_none && pCar->driver == eDriver_local_human) {
-        DisableCar(pCar);
-        gPalette_fade_time = GetRaceTime();
-        NetPlayerStatusChanged(ePlayer_status_recovering);
-    } else {
+    if (gNet_mode == eNet_mode_none || pCar->driver != eDriver_local_human) {
         FlipUpCar(pCar);
+        return;
     }
+    DisableCar(pCar);
+    gPalette_fade_time = GetRaceTime();
+    NetPlayerStatusChanged(ePlayer_status_recovering);
 }
 
 // IDA: void __usercall FlipUpCar(tCar_spec *car@<EAX>)


### PR DESCRIPTION
## Match result

```
0x4a22f4: SetFlipUpCar 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4a22f4,29 +0x467b9c,29 @@
0x4a22f4 : push ebp 	(controls.c:1771)
0x4a22f5 : mov ebp, esp
0x4a22f7 : push ebx
0x4a22f8 : push esi
0x4a22f9 : push edi
0x4a22fa : cmp dword ptr [gNet_mode (DATA)], 0 	(controls.c:1773)
0x4a2301 : -je 0xd
         : +je 0x32
0x4a2307 : mov eax, dword ptr [ebp + 8]
0x4a230a : cmp dword ptr [eax + 8], 4
0x4a230e : -je 0x11
0x4a2314 : -mov eax, dword ptr [ebp + 8]
0x4a2317 : -push eax
0x4a2318 : -call FlipUpCar (FUNCTION)
0x4a231d : -add esp, 4
0x4a2320 : -jmp 0x20
         : +jne 0x25
0x4a2325 : mov eax, dword ptr [ebp + 8] 	(controls.c:1774)
0x4a2328 : push eax
0x4a2329 : call DisableCar (FUNCTION)
0x4a232e : add esp, 4
0x4a2331 : call GetRaceTime (FUNCTION) 	(controls.c:1775)
0x4a2336 : mov dword ptr [gPalette_fade_time (DATA)], eax
0x4a233b : push 8 	(controls.c:1776)
0x4a233d : call NetPlayerStatusChanged (FUNCTION)
0x4a2342 : add esp, 4
         : +jmp 0xc 	(controls.c:1777)
         : +mov eax, dword ptr [ebp + 8] 	(controls.c:1778)
         : +push eax
         : +call FlipUpCar (FUNCTION)
         : +add esp, 4
0x4a2345 : pop edi 	(controls.c:1780)
0x4a2346 : pop esi
0x4a2347 : pop ebx
0x4a2348 : leave 
0x4a2349 : ret 


SetFlipUpCar is only 75.86% similar to the original, diff above
```

*AI generated. Time taken: 107s, tokens: 16,765*
