### PR TITLE
CheckHornLocal 100% match

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -1308,7 +1308,7 @@ void CheckHornLocal(tCar_spec* pCar) {
     if (pCar->keys.horn == 1 && pCar->horn_sound_tag == 0) {
         pCar->horn_sound_tag = DRS3StartSound(gEffects_outlet, 5209);
     } else if (pCar->keys.horn == 0 && pCar->horn_sound_tag != 0) {
-        if (S3SoundStillPlaying(pCar->horn_sound_tag) != 0) {
+        while (S3SoundStillPlaying(pCar->horn_sound_tag) != 0) {
             DRS3StopSound(pCar->horn_sound_tag);
             DRS3StopOutletSound(gEffects_outlet);
         }


### PR DESCRIPTION
## Match result

```
0x4a34a8: CheckHornLocal 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4a34c2,45 +0x4666b9,49 @@
0x4a34c2 : mov eax, dword ptr [ebp + 8]
0x4a34c5 : cmp dword ptr [eax + 0x1a98], 0
0x4a34cc : jne 0x21
0x4a34d2 : push 0x1459 	(controls.c:1309)
0x4a34d7 : mov eax, dword ptr [gEffects_outlet (DATA)]
0x4a34dc : push eax
0x4a34dd : call DRS3StartSound (FUNCTION)
0x4a34e2 : add esp, 8
0x4a34e5 : mov ecx, dword ptr [ebp + 8]
0x4a34e8 : mov dword ptr [ecx + 0x1a98], eax
0x4a34ee : -jmp 0x8a
         : +jmp 0x85 	(controls.c:1310)
0x4a34f3 : mov eax, dword ptr [ebp + 8]
0x4a34f6 : mov eax, dword ptr [eax + 0x1574]
0x4a34fc : shr eax, 0x1b
0x4a34ff : test al, 1
0x4a3501 : -jne 0x76
         : +jne 0x71
0x4a3507 : mov eax, dword ptr [ebp + 8]
0x4a350a : cmp dword ptr [eax + 0x1a98], 0
0x4a3511 : -je 0x66
         : +je 0x61
0x4a3517 : mov eax, dword ptr [ebp + 8] 	(controls.c:1311)
0x4a351a : mov eax, dword ptr [eax + 0x1a98]
0x4a3520 : push eax
0x4a3521 : call S3SoundStillPlaying (FUNCTION)
0x4a3526 : add esp, 4
0x4a3529 : test eax, eax
0x4a352b : -je 0x25
         : +je 0x20
0x4a3531 : mov eax, dword ptr [ebp + 8] 	(controls.c:1312)
0x4a3534 : mov eax, dword ptr [eax + 0x1a98]
0x4a353a : push eax
0x4a353b : call DRS3StopSound (FUNCTION)
0x4a3540 : add esp, 4
0x4a3543 : mov eax, dword ptr [gEffects_outlet (DATA)] 	(controls.c:1313)
0x4a3548 : push eax
0x4a3549 : call DRS3StopOutletSound (FUNCTION)
0x4a354e : add esp, 4
0x4a3551 : -jmp -0x3f
0x4a3556 : mov eax, dword ptr [ebp + 8] 	(controls.c:1315)
0x4a3559 : mov eax, dword ptr [eax + 0x1a98]
0x4a355f : push eax
0x4a3560 : call S3SoundStillPlaying (FUNCTION)
0x4a3565 : add esp, 4
0x4a3568 : test eax, eax
0x4a356a : jne 0xd
0x4a3570 : mov eax, dword ptr [ebp + 8] 	(controls.c:1316)
0x4a3573 : mov dword ptr [eax + 0x1a98], 0
         : +pop edi 	(controls.c:1319)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


CheckHornLocal is only 87.72% similar to the original, diff above
```

*AI generated. Time taken: 66s, tokens: 9,508*
