### PR TITLE
CheckMapRenderMove equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -1432,10 +1432,11 @@ void CheckMapRenderMove(void) {
     float old_x;
     float old_y;
 
-    old_y = gMap_render_y;
     old_x = gMap_render_x;
+    old_y = gMap_render_y;
     if (gMap_mode) {
-        amount = gFrame_period * .1f;
+        amount = gFrame_period * .1;
+        shift_down = KeyIsDown(KEYMAP_SHIFT_ANY);
         if (KeyIsDown(KEYMAP_MOVE_UP)) {
             gMap_render_y -= amount;
         } else if (KeyIsDown(KEYMAP_MOVE_DOWN)) {
@@ -1446,39 +1447,40 @@ void CheckMapRenderMove(void) {
         } else if (KeyIsDown(KEYMAP_MOVE_RIGHT)) {
             gMap_render_x += amount;
         }
-        if (gMap_render_x != old_x || gMap_render_y != old_y) {
-            SetIntegerMapRenders();
-            if (gMap_render_x_i < gCurrent_graf_data->map_render_x_marg) {
-                if (gReal_graf_data_index == 0) {
-                    gMap_render_x = (gCurrent_graf_data->map_render_x_marg + 3) & ~3;
-                } else {
-                    gMap_render_x = ((gCurrent_graf_data->map_render_x_marg + 3) & ~3) / 2;
-                }
-            }
-            if (gMap_render_y_i < gCurrent_graf_data->map_render_y_marg) {
-                if (gReal_graf_data_index == 0) {
-                    gMap_render_y = (gCurrent_graf_data->map_render_y_marg + 1) & ~1;
-                } else {
-                    gMap_render_y = (((gCurrent_graf_data->map_render_y_marg + 1) & ~1) - 40) / 2;
-                }
-            }
-            if (gBack_screen->width - gCurrent_graf_data->map_render_x_marg - gMap_render_width_i < gMap_render_x_i) {
-                if (gReal_graf_data_index == 0) {
-                    gMap_render_x = (gBack_screen->width - gCurrent_graf_data->map_render_x_marg - gMap_render_width_i) & ~3;
-                } else {
-                    gMap_render_x = ((gBack_screen->width - gCurrent_graf_data->map_render_x_marg - gMap_render_width_i) & ~3) / 2;
-                }
-            }
-            if (gBack_screen->height - gCurrent_graf_data->map_render_y_marg - gMap_render_height_i < gMap_render_y_i) {
-                if (gReal_graf_data_index == 0) {
-                    gMap_render_y = (gBack_screen->height - gCurrent_graf_data->map_render_y_marg - gMap_render_height_i) & ~1;
-                } else {
-                    gMap_render_y = (((gBack_screen->height - gCurrent_graf_data->map_render_y_marg - gMap_render_height_i) & ~3) - 40) / 2;
-                }
-            }
-            SetIntegerMapRenders();
-            AdjustRenderScreenSize();
+        if (gMap_render_x == old_x && old_y == gMap_render_y) {
+            return;
         }
+        SetIntegerMapRenders();
+        if (gMap_render_x_i < gCurrent_graf_data->map_render_x_marg) {
+            if (gReal_graf_data_index != 0) {
+                gMap_render_x = ((gCurrent_graf_data->map_render_x_marg + 3) & ~3) / 2;
+            } else {
+                gMap_render_x = (gCurrent_graf_data->map_render_x_marg + 3) & ~3;
+            }
+        }
+        if (gMap_render_y_i < gCurrent_graf_data->map_render_y_marg) {
+            if (gReal_graf_data_index != 0) {
+                gMap_render_y = (((gCurrent_graf_data->map_render_y_marg + 1) & ~1) - 40) / 2;
+            } else {
+                gMap_render_y = (gCurrent_graf_data->map_render_y_marg + 1) & ~1;
+            }
+        }
+        if (gBack_screen->width - gCurrent_graf_data->map_render_x_marg - gMap_render_width_i < gMap_render_x_i) {
+            if (gReal_graf_data_index != 0) {
+                gMap_render_x = ((gBack_screen->width - gCurrent_graf_data->map_render_x_marg - gMap_render_width_i) & ~3) / 2;
+            } else {
+                gMap_render_x = (gBack_screen->width - gCurrent_graf_data->map_render_x_marg - gMap_render_width_i) & ~3;
+            }
+        }
+        if (gBack_screen->height - gCurrent_graf_data->map_render_y_marg - gMap_render_height_i < gMap_render_y_i) {
+            if (gReal_graf_data_index != 0) {
+                gMap_render_y = (((gBack_screen->height - gCurrent_graf_data->map_render_y_marg - gMap_render_height_i) & ~1) - 40) / 2;
+            } else {
+                gMap_render_y = (gBack_screen->height - gCurrent_graf_data->map_render_y_marg - gMap_render_height_i) & ~1;
+            }
+        }
+        SetIntegerMapRenders();
+        AdjustRenderScreenSize();
     }
 }
 


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4a3778,22 +0x466bfb,22 @@
0x4a3778 : mov eax, dword ptr [ebp - 4] 	(controls.c:1448)
0x4a377b : mov dword ptr [ebp - 0x28], eax
0x4a377e : fild dword ptr [ebp - 0x28]
0x4a3781 : fadd dword ptr [gMap_render_x (DATA)]
0x4a3787 : fstp dword ptr [gMap_render_x (DATA)]
0x4a378d : fld dword ptr [gMap_render_x (DATA)] 	(controls.c:1450)
0x4a3793 : fcomp dword ptr [ebp - 0xc]
0x4a3796 : fnstsw ax
0x4a3798 : test ah, 0x40
0x4a379b : je 0x19
0x4a37a1 : -fld dword ptr [ebp - 0x10]
0x4a37a4 : -fcomp dword ptr [gMap_render_y (DATA)]
         : +fld dword ptr [gMap_render_y (DATA)]
         : +fcomp dword ptr [ebp - 0x10]
0x4a37aa : fnstsw ax
0x4a37ac : test ah, 0x40
0x4a37af : je 0x5
0x4a37b5 : jmp 0x20d 	(controls.c:1451)
0x4a37ba : call SetIntegerMapRenders (FUNCTION) 	(controls.c:1453)
0x4a37bf : mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(controls.c:1454)
0x4a37c4 : mov ecx, dword ptr [gMap_render_x_i (DATA)]
0x4a37ca : cmp dword ptr [eax + 0x3a0], ecx
0x4a37d0 : jle 0x51
0x4a37d6 : cmp dword ptr [gReal_graf_data_index (DATA)], 0 	(controls.c:1455)


CheckMapRenderMove is only 99.01% similar to the original, diff above
```

#### Effective match analysis

The changed block only swaps operands in an x87 compare: `fld [a]; fcomp [b]` became `fld [b]; fcomp [a]`. In this code path, the result is used only via `test ah, 0x40`, which checks the x87 equality flag (C3). Equality is symmetric, so swapping operands does not change whether the branch is taken (ignoring NaNs as requested). The x87 stack effect is also the same (`fld` then `fcomp` pops once), so functional behavior is unchanged.

#### Original match

```
---
+++
@@ -0x4a3694,33 +0x466b17,29 @@
0x4a3694 : push ebp 	(controls.c:1429)
0x4a3695 : mov ebp, esp
0x4a3697 : sub esp, 0x48
0x4a369a : push ebx
0x4a369b : push esi
0x4a369c : push edi
         : +mov eax, dword ptr [gMap_render_y (DATA)] 	(controls.c:1435)
         : +mov dword ptr [ebp - 0x10], eax
0x4a369d : mov eax, dword ptr [gMap_render_x (DATA)] 	(controls.c:1436)
0x4a36a2 : mov dword ptr [ebp - 0xc], eax
0x4a36a5 : -mov eax, dword ptr [gMap_render_y (DATA)]
0x4a36aa : -mov dword ptr [ebp - 0x10], eax
0x4a36ad : cmp dword ptr [gMap_mode (DATA)], 0 	(controls.c:1437)
0x4a36b4 : -je 0x30d
         : +je 0x2fb
0x4a36ba : mov eax, dword ptr [gFrame_period (DATA)] 	(controls.c:1438)
0x4a36bf : mov dword ptr [ebp - 0x18], eax
0x4a36c2 : mov dword ptr [ebp - 0x14], 0
0x4a36c9 : fild qword ptr [ebp - 0x18]
0x4a36cc : -fmul qword ptr [0.1 (FLOAT)]
         : +fmul dword ptr [0.10000000149011612 (FLOAT)]
0x4a36d2 : call __ftol (FUNCTION)
0x4a36d7 : mov dword ptr [ebp - 4], eax
0x4a36da : -push 8
0x4a36dc : -call KeyIsDown (FUNCTION)
0x4a36e1 : -add esp, 4
0x4a36e4 : -mov dword ptr [ebp - 8], eax
0x4a36e7 : push 0x1e 	(controls.c:1439)
0x4a36e9 : call KeyIsDown (FUNCTION)
0x4a36ee : add esp, 4
0x4a36f1 : test eax, eax
0x4a36f3 : je 0x1a
0x4a36f9 : mov eax, dword ptr [ebp - 4] 	(controls.c:1440)
0x4a36fc : mov dword ptr [ebp - 0x1c], eax
0x4a36ff : fild dword ptr [ebp - 0x1c]
0x4a3702 : fsubr dword ptr [gMap_render_y (DATA)]
0x4a3708 : fstp dword ptr [gMap_render_y (DATA)]

---
+++
@@ -0x4a3772,136 +0x466be8,143 @@
0x4a3772 : je 0x15
0x4a3778 : mov eax, dword ptr [ebp - 4] 	(controls.c:1447)
0x4a377b : mov dword ptr [ebp - 0x28], eax
0x4a377e : fild dword ptr [ebp - 0x28]
0x4a3781 : fadd dword ptr [gMap_render_x (DATA)]
0x4a3787 : fstp dword ptr [gMap_render_x (DATA)]
0x4a378d : fld dword ptr [gMap_render_x (DATA)] 	(controls.c:1449)
0x4a3793 : fcomp dword ptr [ebp - 0xc]
0x4a3796 : fnstsw ax
0x4a3798 : test ah, 0x40
0x4a379b : -je 0x19
0x4a37a1 : -fld dword ptr [ebp - 0x10]
0x4a37a4 : -fcomp dword ptr [gMap_render_y (DATA)]
         : +je 0x14
         : +fld dword ptr [gMap_render_y (DATA)]
         : +fcomp dword ptr [ebp - 0x10]
0x4a37aa : fnstsw ax
0x4a37ac : test ah, 0x40
0x4a37af : -je 0x5
0x4a37b5 : -jmp 0x20d
         : +jne 0x20d
0x4a37ba : call SetIntegerMapRenders (FUNCTION) 	(controls.c:1450)
0x4a37bf : mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(controls.c:1451)
0x4a37c4 : mov ecx, dword ptr [gMap_render_x_i (DATA)]
0x4a37ca : cmp dword ptr [eax + 0x3a0], ecx
0x4a37d0 : jle 0x51
0x4a37d6 : cmp dword ptr [gReal_graf_data_index (DATA)], 0 	(controls.c:1452)
0x4a37dd : -je 0x27
         : +jne 0x22
         : +mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(controls.c:1453)
         : +mov eax, dword ptr [eax + 0x3a0]
         : +add eax, 3
         : +and eax, 0xfffffffc
         : +mov dword ptr [ebp - 0x2c], eax
         : +fild dword ptr [ebp - 0x2c]
         : +fstp dword ptr [gMap_render_x (DATA)]
         : +jmp 0x22 	(controls.c:1454)
0x4a37e3 : mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(controls.c:1455)
0x4a37e8 : mov eax, dword ptr [eax + 0x3a0]
0x4a37ee : add eax, 3
0x4a37f1 : and eax, 0xfffffffc
0x4a37f4 : cdq 
0x4a37f5 : sub eax, edx
0x4a37f7 : sar eax, 1
0x4a37f9 : -mov dword ptr [ebp - 0x2c], eax
0x4a37fc : -fild dword ptr [ebp - 0x2c]
0x4a37ff : -fstp dword ptr [gMap_render_x (DATA)]
0x4a3805 : -jmp 0x1d
0x4a380a : -mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x4a380f : -mov eax, dword ptr [eax + 0x3a0]
0x4a3815 : -add eax, 3
0x4a3818 : -and eax, 0xfffffffc
0x4a381b : mov dword ptr [ebp - 0x30], eax
0x4a381e : fild dword ptr [ebp - 0x30]
0x4a3821 : fstp dword ptr [gMap_render_x (DATA)]
0x4a3827 : mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(controls.c:1458)
0x4a382c : mov ecx, dword ptr [gMap_render_y_i (DATA)]
0x4a3832 : cmp dword ptr [eax + 0x3a4], ecx
0x4a3838 : jle 0x50
0x4a383e : cmp dword ptr [gReal_graf_data_index (DATA)], 0 	(controls.c:1459)
0x4a3845 : -je 0x28
         : +jne 0x20
         : +mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(controls.c:1460)
         : +mov eax, dword ptr [eax + 0x3a4]
         : +inc eax
         : +and eax, 0xfffffffe
         : +mov dword ptr [ebp - 0x34], eax
         : +fild dword ptr [ebp - 0x34]
         : +fstp dword ptr [gMap_render_y (DATA)]
         : +jmp 0x23 	(controls.c:1461)
0x4a384b : mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(controls.c:1462)
0x4a3850 : mov eax, dword ptr [eax + 0x3a4]
0x4a3856 : inc eax
0x4a3857 : and eax, 0xfffffffe
0x4a385a : sub eax, 0x28
0x4a385d : cdq 
0x4a385e : sub eax, edx
0x4a3860 : sar eax, 1
0x4a3862 : -mov dword ptr [ebp - 0x34], eax
0x4a3865 : -fild dword ptr [ebp - 0x34]
0x4a3868 : -fstp dword ptr [gMap_render_y (DATA)]
0x4a386e : -jmp 0x1b
0x4a3873 : -mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x4a3878 : -mov eax, dword ptr [eax + 0x3a4]
0x4a387e : -inc eax
0x4a387f : -and eax, 0xfffffffe
0x4a3882 : mov dword ptr [ebp - 0x38], eax
0x4a3885 : fild dword ptr [ebp - 0x38]
0x4a3888 : fstp dword ptr [gMap_render_y (DATA)]
0x4a388e : mov eax, dword ptr [gBack_screen (DATA)] 	(controls.c:1465)
0x4a3893 : xor ecx, ecx
0x4a3895 : mov cx, word ptr [eax + 0x34]
0x4a3899 : mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x4a389e : sub ecx, dword ptr [eax + 0x3a0]
0x4a38a4 : sub ecx, dword ptr [gMap_render_width_i (DATA)]
0x4a38aa : cmp ecx, dword ptr [gMap_render_x_i (DATA)]
0x4a38b0 : jge 0x6f
0x4a38b6 : cmp dword ptr [gReal_graf_data_index (DATA)], 0 	(controls.c:1466)
0x4a38bd : -je 0x37
         : +jne 0x30
         : +mov eax, dword ptr [gBack_screen (DATA)] 	(controls.c:1467)
         : +xor ecx, ecx
         : +mov cx, word ptr [eax + 0x34]
         : +mov eax, dword ptr [gCurrent_graf_data (DATA)]
         : +sub ecx, dword ptr [eax + 0x3a0]
         : +sub ecx, dword ptr [gMap_render_width_i (DATA)]
         : +and ecx, 0xfffffffc
         : +mov dword ptr [ebp - 0x3c], ecx
         : +fild dword ptr [ebp - 0x3c]
         : +fstp dword ptr [gMap_render_x (DATA)]
         : +jmp 0x32 	(controls.c:1468)
0x4a38c3 : mov eax, dword ptr [gBack_screen (DATA)] 	(controls.c:1469)
0x4a38c8 : xor ecx, ecx
0x4a38ca : mov cx, word ptr [eax + 0x34]
0x4a38ce : mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x4a38d3 : sub ecx, dword ptr [eax + 0x3a0]
0x4a38d9 : sub ecx, dword ptr [gMap_render_width_i (DATA)]
0x4a38df : and ecx, 0xfffffffc
0x4a38e2 : mov eax, ecx
0x4a38e4 : cdq 
0x4a38e5 : sub eax, edx
0x4a38e7 : sar eax, 1
0x4a38e9 : -mov dword ptr [ebp - 0x3c], eax
0x4a38ec : -fild dword ptr [ebp - 0x3c]
0x4a38ef : -fstp dword ptr [gMap_render_x (DATA)]
0x4a38f5 : -jmp 0x2b
0x4a38fa : -mov eax, dword ptr [gBack_screen (DATA)]
0x4a38ff : -xor ecx, ecx
0x4a3901 : -mov cx, word ptr [eax + 0x34]
0x4a3905 : -mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x4a390a : -sub ecx, dword ptr [eax + 0x3a0]
0x4a3910 : -sub ecx, dword ptr [gMap_render_width_i (DATA)]
0x4a3916 : -and ecx, 0xfffffffc
0x4a3919 : -mov dword ptr [ebp - 0x40], ecx
         : +mov dword ptr [ebp - 0x40], eax
0x4a391c : fild dword ptr [ebp - 0x40]
0x4a391f : fstp dword ptr [gMap_render_x (DATA)]
0x4a3925 : mov eax, dword ptr [gBack_screen (DATA)] 	(controls.c:1472)
0x4a392a : xor ecx, ecx
0x4a392c : mov cx, word ptr [eax + 0x36]
0x4a3930 : mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x4a3935 : sub ecx, dword ptr [eax + 0x3a4]
0x4a393b : sub ecx, dword ptr [gMap_render_height_i (DATA)]
0x4a3941 : cmp ecx, dword ptr [gMap_render_y_i (DATA)]
0x4a3947 : jge 0x70
0x4a394d : cmp dword ptr [gReal_graf_data_index (DATA)], 0 	(controls.c:1473)
0x4a3954 : -je 0x38
         : +jne 0x30
0x4a395a : mov eax, dword ptr [gBack_screen (DATA)] 	(controls.c:1474)
0x4a395f : xor ecx, ecx
0x4a3961 : mov cx, word ptr [eax + 0x36]
0x4a3965 : mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x4a396a : sub ecx, dword ptr [eax + 0x3a4]
0x4a3970 : sub ecx, dword ptr [gMap_render_height_i (DATA)]
0x4a3976 : and ecx, 0xfffffffe
0x4a3979 : -lea eax, [ecx - 0x28]
0x4a397c : -cdq 
0x4a397d : -sub eax, edx
0x4a397f : -sar eax, 1
0x4a3981 : -mov dword ptr [ebp - 0x44], eax
         : +mov dword ptr [ebp - 0x44], ecx
0x4a3984 : fild dword ptr [ebp - 0x44]
0x4a3987 : fstp dword ptr [gMap_render_y (DATA)]
0x4a398d : -jmp 0x2b
         : +jmp 0x33 	(controls.c:1475)
0x4a3992 : mov eax, dword ptr [gBack_screen (DATA)] 	(controls.c:1476)
0x4a3997 : xor ecx, ecx
0x4a3999 : mov cx, word ptr [eax + 0x36]
0x4a399d : mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x4a39a2 : sub ecx, dword ptr [eax + 0x3a4]
0x4a39a8 : sub ecx, dword ptr [gMap_render_height_i (DATA)]
0x4a39ae : -and ecx, 0xfffffffe
0x4a39b1 : -mov dword ptr [ebp - 0x48], ecx
         : +and ecx, 0xfffffffc
         : +lea eax, [ecx - 0x28]
         : +cdq 
         : +sub eax, edx
         : +sar eax, 1
         : +mov dword ptr [ebp - 0x48], eax
0x4a39b4 : fild dword ptr [ebp - 0x48]
         : +fstp dword ptr [gMap_render_y (DATA)]
         : +call SetIntegerMapRenders (FUNCTION) 	(controls.c:1479)
         : +call AdjustRenderScreenSize (FUNCTION) 	(controls.c:1480)
         : +pop edi 	(controls.c:1483)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


CheckMapRenderMove is only 72.26% similar to the original, diff above
```

*AI generated. Time taken: 506s, tokens: 52,504*
