### PR TITLE
SortOutRecover 100% match

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -1743,9 +1743,7 @@ void SortOutRecover(tCar_spec* pCar) {
         gPalette_fade_time = 0;
         old_time = 0;
     }
-    if (the_time < 500) {
-        val = 256 - (the_time * 256) / 500;
-    } else {
+    if (the_time >= 500) {
         if (old_time < 500) {
             FlipUpCar(pCar);
             PipeSingleSpecial(ePipe_special_fade);
@@ -1758,10 +1756,10 @@ void SortOutRecover(tCar_spec* pCar) {
             old_time = 0;
             pCar->doing_nothing_flag = 0;
         }
+    } else {
+        val = 256 - (the_time * 256) / 500;
     }
-    if (val <= 0) {
-        val = 0;
-    }
+    val = val > 0 ? val : 0;
     SetFadedPalette(val);
     old_time = the_time;
 }


### PR DESCRIPTION
## Match result

```
0x4a3a33: SortOutRecover 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4a3a3a,21 +0x467a9c,30 @@
0x4a3a3a : push esi
0x4a3a3b : push edi
0x4a3a3c : call GetRaceTime (FUNCTION) 	(controls.c:1741)
0x4a3a41 : sub eax, dword ptr [gPalette_fade_time (DATA)]
0x4a3a47 : mov dword ptr [ebp - 8], eax
0x4a3a4a : cmp dword ptr [ebp - 8], 0 	(controls.c:1742)
0x4a3a4e : jge 0x14
0x4a3a54 : mov dword ptr [gPalette_fade_time (DATA)], 0 	(controls.c:1743)
0x4a3a5e : mov dword ptr [old_time (DATA)], 0 	(controls.c:1744)
0x4a3a68 : cmp dword ptr [ebp - 8], 0x1f4 	(controls.c:1746)
0x4a3a6f : -jl 0x83
         : +jge 0x1d
         : +mov ecx, 0x100 	(controls.c:1747)
         : +mov eax, dword ptr [ebp - 8]
         : +shl eax, 8
         : +mov ebx, 0x1f4
         : +cdq 
         : +idiv ebx
         : +sub ecx, eax
         : +mov dword ptr [ebp - 4], ecx
         : +jmp 0x7e 	(controls.c:1748)
0x4a3a75 : cmp dword ptr [old_time (DATA)], 0x1f4 	(controls.c:1749)
0x4a3a7f : jge 0x16
0x4a3a85 : mov eax, dword ptr [ebp + 8] 	(controls.c:1750)
0x4a3a88 : push eax
0x4a3a89 : call FlipUpCar (FUNCTION)
0x4a3a8e : add esp, 4
0x4a3a91 : push 0 	(controls.c:1751)
0x4a3a93 : call PipeSingleSpecial (FUNCTION)
0x4a3a98 : add esp, 4
0x4a3a9b : mov eax, dword ptr [ebp + 8] 	(controls.c:1753)

---
+++
@@ -0x4a3ab8,34 +0x467b37,23 @@
0x4a3ab8 : cdq 
0x4a3ab9 : idiv ecx
0x4a3abb : mov dword ptr [ebp - 4], eax
0x4a3abe : cmp dword ptr [ebp - 4], 0x100 	(controls.c:1755)
0x4a3ac5 : jl 0x28
0x4a3acb : mov dword ptr [ebp - 4], 0x100 	(controls.c:1756)
0x4a3ad2 : mov dword ptr [gPalette_fade_time (DATA)], 0 	(controls.c:1757)
0x4a3adc : mov dword ptr [old_time (DATA)], 0 	(controls.c:1758)
0x4a3ae6 : mov eax, dword ptr [ebp + 8] 	(controls.c:1759)
0x4a3ae9 : mov dword ptr [eax + 0x228], 0
0x4a3af3 : -jmp 0x18
0x4a3af8 : -mov ecx, 0x100
0x4a3afd : -mov eax, dword ptr [ebp - 8]
0x4a3b00 : -shl eax, 8
0x4a3b03 : -mov ebx, 0x1f4
0x4a3b08 : -cdq 
0x4a3b09 : -idiv ebx
0x4a3b0b : -sub ecx, eax
0x4a3b0d : -mov dword ptr [ebp - 4], ecx
0x4a3b10 : -mov eax, dword ptr [ebp - 4]
0x4a3b13 : -test eax, eax
0x4a3b15 : -jg 0x2
0x4a3b1b : -xor eax, eax
0x4a3b1d : -mov dword ptr [ebp - 4], eax
         : +cmp dword ptr [ebp - 4], 0 	(controls.c:1762)
         : +jg 0x7
         : +mov dword ptr [ebp - 4], 0 	(controls.c:1763)
0x4a3b20 : mov eax, dword ptr [ebp - 4] 	(controls.c:1765)
0x4a3b23 : push eax
0x4a3b24 : call SetFadedPalette (FUNCTION)
0x4a3b29 : add esp, 4
0x4a3b2c : mov eax, dword ptr [ebp - 8] 	(controls.c:1766)
0x4a3b2f : mov dword ptr [old_time (DATA)], eax
0x4a3b34 : pop edi 	(controls.c:1767)
0x4a3b35 : pop esi
0x4a3b36 : pop ebx
0x4a3b37 : leave 


SortOutRecover is only 78.12% similar to the original, diff above
```

*AI generated. Time taken: 100s, tokens: 17,090*
