### PR TITLE
CycleRoadTexturingLevel 100% match

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -2354,10 +2354,13 @@ void CycleRoadTexturingLevel(void) {
     new_level = (GetRoadTexturingLevel() + 1) % 3;
     ReallySetRoadTexturingLevel(new_level);
     SetRoadTexturingLevel(new_level);
-    if (new_level == eRTL_none) {
+    switch (new_level) {
+    case eRTL_none:
         NewTextHeadupSlot(eHeadupSlot_misc, 0, 2000, -kFont_MEDIUMHD, GetMiscString(kMiscString_NoRoadTextures));
-    } else if (new_level == eRTL_full) {
+        break;
+    case eRTL_full:
         NewTextHeadupSlot(eHeadupSlot_misc, 0, 2000, -kFont_MEDIUMHD, GetMiscString(kMiscString_RoadTextures));
+        break;
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4a4bfb: CycleRoadTexturingLevel 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4a4bfb,47 +0x4693b9,50 @@
0x4a4bfb : push ebp 	(controls.c:2351)
0x4a4bfc : mov ebp, esp
0x4a4bfe : -sub esp, 8
         : +sub esp, 4
0x4a4c01 : push ebx
0x4a4c02 : push esi
0x4a4c03 : push edi
0x4a4c04 : call GetRoadTexturingLevel (FUNCTION) 	(controls.c:2354)
0x4a4c09 : inc eax
0x4a4c0a : mov ecx, 3
0x4a4c0f : cdq 
0x4a4c10 : idiv ecx
0x4a4c12 : mov dword ptr [ebp - 4], edx
0x4a4c15 : mov eax, dword ptr [ebp - 4] 	(controls.c:2355)
0x4a4c18 : push eax
0x4a4c19 : call ReallySetRoadTexturingLevel (FUNCTION)
0x4a4c1e : add esp, 4
0x4a4c21 : mov eax, dword ptr [ebp - 4] 	(controls.c:2356)
0x4a4c24 : push eax
0x4a4c25 : call SetRoadTexturingLevel (FUNCTION)
0x4a4c2a : add esp, 4
0x4a4c2d : -mov eax, dword ptr [ebp - 4]
0x4a4c30 : -mov dword ptr [ebp - 8], eax
0x4a4c33 : -jmp 0x4b
         : +cmp dword ptr [ebp - 4], 0 	(controls.c:2357)
         : +jne 0x23
0x4a4c38 : push 0x35 	(controls.c:2358)
0x4a4c3a : call GetMiscString (FUNCTION)
0x4a4c3f : add esp, 4
0x4a4c42 : push eax
0x4a4c43 : push -4
0x4a4c45 : push 0x7d0
0x4a4c4a : push 0
0x4a4c4c : push 4
0x4a4c4e : call NewTextHeadupSlot (FUNCTION)
0x4a4c53 : add esp, 0x14
0x4a4c56 : -jmp 0x41
         : +jmp 0x28 	(controls.c:2359)
         : +cmp dword ptr [ebp - 4], 1
         : +jne 0x1e
0x4a4c5b : push 0x36 	(controls.c:2360)
0x4a4c5d : call GetMiscString (FUNCTION)
0x4a4c62 : add esp, 4
0x4a4c65 : push eax
0x4a4c66 : push -4
0x4a4c68 : push 0x7d0
0x4a4c6d : push 0
0x4a4c6f : push 4
0x4a4c71 : call NewTextHeadupSlot (FUNCTION)
0x4a4c76 : add esp, 0x14
0x4a4c79 : -jmp 0x1e
0x4a4c7e : -jmp 0x19
0x4a4c83 : -cmp dword ptr [ebp - 8], 0
         : +pop edi 	(controls.c:2362)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


CycleRoadTexturingLevel is only 80.41% similar to the original, diff above
```

*AI generated. Time taken: 71s, tokens: 19,352*
