### PR TITLE
CycleCarSimplificationLevel 100% match

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -2436,7 +2436,7 @@ void CycleCarSimplificationLevel(void) {
     char* dst;
 
     gCar_simplification_level++;
-    gCar_simplification_level = (unsigned int)gCar_simplification_level % 5;
+    gCar_simplification_level = gCar_simplification_level % 5u;
     src = GetMiscString(kMiscString_CarSimplificationLevel_D);
     dst = BrMemAllocate(strlen(src) + 21, kMem_simp_level);
     sprintf(dst, src, gCar_simplification_level);

--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -2435,9 +2435,10 @@ void CycleCarSimplificationLevel(void) {
     char* src;
     char* dst;
 
-    gCar_simplification_level = (gCar_simplification_level + 1) % 5;
+    gCar_simplification_level++;
+    gCar_simplification_level = (unsigned int)gCar_simplification_level % 5;
     src = GetMiscString(kMiscString_CarSimplificationLevel_D);
-    dst = BrMemAllocate(strlen(src), kMem_simp_level);
+    dst = BrMemAllocate(strlen(src) + 21, kMem_simp_level);
     sprintf(dst, src, gCar_simplification_level);
     NewTextHeadupSlot(eHeadupSlot_misc, 0, 2000, -kFont_MEDIUMHD, dst);
     BrMemFree(dst);


### PR DESCRIPTION
## Match result

```
0x4a4ec8: CycleCarSimplificationLevel 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4a4ec8,33 +0x46966c,33 @@
0x4a4ec8 : push ebp 	(controls.c:2434)
0x4a4ec9 : mov ebp, esp
0x4a4ecb : sub esp, 8
0x4a4ece : push ebx
0x4a4ecf : push esi
0x4a4ed0 : push edi
0x4a4ed1 : -inc dword ptr [gCar_simplification_level (DATA)]
         : +mov eax, dword ptr [gCar_simplification_level (DATA)] 	(controls.c:2438)
0x4a4ed7 : mov ecx, 5
0x4a4edc : -mov eax, dword ptr [gCar_simplification_level (DATA)]
0x4a4ee1 : -sub edx, edx
0x4a4ee3 : -div ecx
         : +inc eax
         : +cdq 
         : +idiv ecx
0x4a4ee5 : mov dword ptr [gCar_simplification_level (DATA)], edx
0x4a4eeb : push 0x77 	(controls.c:2439)
0x4a4eed : call GetMiscString (FUNCTION)
0x4a4ef2 : add esp, 4
0x4a4ef5 : mov dword ptr [ebp - 8], eax
0x4a4ef8 : push 0x89 	(controls.c:2440)
0x4a4efd : mov edi, dword ptr [ebp - 8]
0x4a4f00 : mov ecx, 0xffffffff
0x4a4f05 : sub eax, eax
0x4a4f07 : repne scasb al, byte ptr es:[edi]
0x4a4f09 : not ecx
0x4a4f0b : -lea eax, [ecx + 0x14]
         : +lea eax, [ecx - 1]
0x4a4f0e : push eax
0x4a4f0f : call BrMemAllocate (FUNCTION)
0x4a4f14 : add esp, 8
0x4a4f17 : mov dword ptr [ebp - 4], eax
0x4a4f1a : mov eax, dword ptr [gCar_simplification_level (DATA)] 	(controls.c:2441)
0x4a4f1f : push eax
0x4a4f20 : mov eax, dword ptr [ebp - 8]
0x4a4f23 : push eax
0x4a4f24 : mov eax, dword ptr [ebp - 4]
0x4a4f27 : push eax

---
+++
@@ -0x4a4f33,10 +0x4696d1,16 @@
0x4a4f33 : push eax
0x4a4f34 : push -4
0x4a4f36 : push 0x7d0
0x4a4f3b : push 0
0x4a4f3d : push 4
0x4a4f3f : call NewTextHeadupSlot (FUNCTION)
0x4a4f44 : add esp, 0x14
0x4a4f47 : mov eax, dword ptr [ebp - 4] 	(controls.c:2443)
0x4a4f4a : push eax
0x4a4f4b : call BrMemFree (FUNCTION)
         : +add esp, 4
         : +pop edi 	(controls.c:2444)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


CycleCarSimplificationLevel is only 83.67% similar to the original, diff above
```

*AI generated. Time taken: 103s, tokens: 15,374*
