### PR TITLE
DisplayUserMessage 100% match

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -2651,8 +2651,8 @@ void DisplayUserMessage(void) {
     int len;
     tDR_font* font;
 
-    font = &gFonts[FONT_NEWHITE];
     the_message = &gString[20];
+    font = &gFonts[FONT_NEWHITE];
     if (!gEntering_message || gNet_mode == eNet_mode_none) {
         return;
     }
@@ -2669,7 +2669,7 @@ void DisplayUserMessage(void) {
         gCurrent_graf_data->net_message_enter_y + 6 * font->height,
         1);
 
-    TransDRPixelmapText(gBack_screen, 20 * gBack_screen->width / 100, gCurrent_graf_data->net_message_enter_y, font, GetMiscString(kMiscString_ENTER_MESSAGE), 100);
+    TransDRPixelmapText(gBack_screen, 20 * gBack_screen->width / 100, gCurrent_graf_data->net_message_enter_y, &gFonts[FONT_NEWHITE], GetMiscString(kMiscString_ENTER_MESSAGE), 100);
     OoerrIveGotTextInMeBoxMissus(
         FONT_NEWHITE,
         the_message,


### PR DESCRIPTION
## Match result

```
0x4a54a9: DisplayUserMessage 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4a54a9,27 +0x469dc1,27 @@
0x4a54a9 : push ebp 	(controls.c:2649)
0x4a54aa : mov ebp, esp
0x4a54ac : sub esp, 0xc
0x4a54af : push ebx
0x4a54b0 : push esi
0x4a54b1 : push edi
         : +mov eax, gFonts[0].images (DATA) 	(controls.c:2654)
         : +add eax, 0x15a8
         : +mov dword ptr [ebp - 4], eax
0x4a54b2 : mov eax, gString[0] (DATA) 	(controls.c:2655)
0x4a54b7 : add eax, 0x14
0x4a54ba : mov dword ptr [ebp - 8], eax
0x4a54bd : -mov eax, gFonts[0].images (DATA)
0x4a54c2 : -add eax, 0x15a8
0x4a54c7 : -mov dword ptr [ebp - 4], eax
0x4a54ca : cmp dword ptr [gEntering_message (DATA)], 0 	(controls.c:2656)
0x4a54d1 : je 0xd
0x4a54d7 : cmp dword ptr [gNet_mode (DATA)], 0
0x4a54de : jne 0x5
0x4a54e4 : -jmp 0x18c
         : +jmp 0x185 	(controls.c:2657)
0x4a54e9 : mov edi, dword ptr [ebp - 8] 	(controls.c:2660)
0x4a54ec : mov ecx, 0xffffffff
0x4a54f1 : sub eax, eax
0x4a54f3 : repne scasb al, byte ptr es:[edi]
0x4a54f5 : not ecx
0x4a54f7 : lea eax, [ecx - 1]
0x4a54fa : mov dword ptr [ebp - 0xc], eax
0x4a54fd : cmp dword ptr [ebp - 0xc], 0x3f 	(controls.c:2661)
0x4a5501 : jge 0x23
0x4a5507 : call PDGetTotalTime (FUNCTION)

---
+++
@@ -0x4a558e,22 +0x469ea6,21 @@
0x4a558e : push eax
0x4a558f : mov eax, dword ptr [gBack_screen (DATA)]
0x4a5594 : push eax
0x4a5595 : call DimRectangle (FUNCTION)
0x4a559a : add esp, 0x18
0x4a559d : push 0x64 	(controls.c:2672)
0x4a559f : push 0xe3
0x4a55a4 : call GetMiscString (FUNCTION)
0x4a55a9 : add esp, 4
0x4a55ac : push eax
0x4a55ad : -mov eax, gFonts[0].images (DATA)
0x4a55b2 : -add eax, 0x15a8
         : +mov eax, dword ptr [ebp - 4]
0x4a55b7 : push eax
0x4a55b8 : mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x4a55bd : mov eax, dword ptr [eax + 0x46c]
0x4a55c3 : push eax
0x4a55c4 : mov eax, dword ptr [gBack_screen (DATA)]
0x4a55c9 : xor ecx, ecx
0x4a55cb : mov cx, word ptr [eax + 0x34]
0x4a55cf : lea eax, [ecx*4]
0x4a55d6 : lea eax, [eax + eax*4]
0x4a55d9 : mov ecx, 0x64

---
+++
@@ -0x4a5656,10 +0x469f67,16 @@
0x4a5656 : push eax
0x4a5657 : mov eax, dword ptr [gBack_screen (DATA)]
0x4a565c : push eax
0x4a565d : mov eax, dword ptr [ebp - 8]
0x4a5660 : push eax
0x4a5661 : push 6
0x4a5663 : call OoerrIveGotTextInMeBoxMissus (FUNCTION)
0x4a5668 : add esp, 0x20
0x4a566b : mov eax, dword ptr [ebp - 0xc] 	(controls.c:2682)
0x4a566e : mov ecx, dword ptr [ebp - 8]
         : +mov byte ptr [eax + ecx], 0
         : +pop edi 	(controls.c:2683)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DisplayUserMessage is only 93.91% similar to the original, diff above
```

*AI generated. Time taken: 126s, tokens: 11,357*
