### PR TITLE
InitAbuseomatic equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -2705,14 +2705,13 @@ void InitAbuseomatic(void) {
         if (fgets(s, COUNT_OF(s) - 1, f) == NULL) {
             break;
         }
-        len = strlen(s);
-        if (len > 63) {
+        if (strlen(s) > 63) {
             s[63] = '\0';
         }
         len = strlen(s);
         while (len != 0 && s[len - 1] < ' ') {
-            s[len - 1] = '\0';
             len--;
+            s[len] = '\0';
         }
         gAbuse_text[i] = BrMemAllocate(strlen(s) + 1, kMem_abuse_text);
         strcpy(gAbuse_text[i], s);


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4a56eb,35 +0x469ffc,36 @@
0x4a56eb : mov dword ptr [eax*4 + gAbuse_text[0] (DATA)], 0
0x4a56f6 : jmp -0x29 	(controls.c:2699)
0x4a56fb : push "rt" (STRING) 	(controls.c:2700)
0x4a5700 : lea eax, [ebp - 0x200]
0x4a5706 : push eax
0x4a5707 : call fopen (FUNCTION)
0x4a570c : add esp, 8
0x4a570f : mov dword ptr [ebp - 0x204], eax
0x4a5715 : cmp dword ptr [ebp - 0x204], 0 	(controls.c:2701)
0x4a571c : jne 0x5
0x4a5722 : -jmp 0x13c
         : +jmp 0x137 	(controls.c:2702)
0x4a5727 : mov dword ptr [ebp - 0x208], 0 	(controls.c:2704)
0x4a5731 : jmp 0x6
0x4a5736 : inc dword ptr [ebp - 0x208]
0x4a573c : cmp dword ptr [ebp - 0x208], 0xa
0x4a5743 : -jge 0x10b
         : +jge 0x106
0x4a5749 : mov eax, dword ptr [ebp - 0x204] 	(controls.c:2705)
0x4a574f : push eax
0x4a5750 : push 0xff
0x4a5755 : lea eax, [ebp - 0x100]
0x4a575b : push eax
0x4a575c : call fgets (FUNCTION)
0x4a5761 : add esp, 0xc
0x4a5764 : test eax, eax
0x4a5766 : -je 0xde
         : +jne 0x5
         : +jmp 0xde 	(controls.c:2706)
0x4a576c : lea edi, [ebp - 0x100] 	(controls.c:2708)
0x4a5772 : mov ecx, 0xffffffff
0x4a5777 : sub eax, eax
0x4a5779 : repne scasb al, byte ptr es:[edi]
0x4a577b : not ecx
0x4a577d : lea eax, [ecx - 1]
0x4a5780 : cmp eax, 0x3f
0x4a5783 : jbe 0x7
0x4a5789 : mov byte ptr [ebp - 0xc1], 0 	(controls.c:2709)
0x4a5790 : lea edi, [ebp - 0x100] 	(controls.c:2711)

---
+++
@@ -0x4a5826,17 +0x46a13c,20 @@
0x4a5826 : mov eax, ecx
0x4a5828 : mov edx, edi
0x4a582a : mov ebx, dword ptr [ebp - 0x208]
0x4a5830 : mov edi, dword ptr [ebx*4 + gAbuse_text[0] (DATA)]
0x4a5837 : mov esi, edx
0x4a5839 : shr ecx, 2
0x4a583c : rep movsd dword ptr es:[edi], dword ptr [esi]
0x4a583e : mov ecx, eax
0x4a5840 : and ecx, 3
0x4a5843 : rep movsb byte ptr es:[edi], byte ptr [esi]
0x4a5845 : -jmp 0x5
0x4a584a : -jmp 0x5
0x4a584f : -jmp -0x11e
         : +jmp -0x119 	(controls.c:2718)
0x4a5854 : mov eax, dword ptr [ebp - 0x204] 	(controls.c:2719)
0x4a585a : push eax
0x4a585b : call fclose (FUNCTION)
0x4a5860 : add esp, 4
         : +pop edi 	(controls.c:2720)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


InitAbuseomatic is only 93.10% similar to the original, diff above
```

#### Effective match analysis

The shown changes are control-transfer refactorings that preserve outcomes: adjusted jump displacements are consistent with address/layout shifts, `je target` was rewritten as `jne skip; jmp target` (logically identical), and removed/added short jumps appear to be jump-threading/alignment cleanup with the same loop/exit destinations. Data operations (`fopen`/`fgets` checks, buffer handling, copy, `fclose`) are unchanged, and no new state mutations are introduced.

#### Original match

```
---
+++
@@ -0x4a56eb,60 +0x469ffc,62 @@
0x4a56eb : mov dword ptr [eax*4 + gAbuse_text[0] (DATA)], 0
0x4a56f6 : jmp -0x29 	(controls.c:2699)
0x4a56fb : push "rt" (STRING) 	(controls.c:2700)
0x4a5700 : lea eax, [ebp - 0x200]
0x4a5706 : push eax
0x4a5707 : call fopen (FUNCTION)
0x4a570c : add esp, 8
0x4a570f : mov dword ptr [ebp - 0x204], eax
0x4a5715 : cmp dword ptr [ebp - 0x204], 0 	(controls.c:2701)
0x4a571c : jne 0x5
0x4a5722 : -jmp 0x13c
         : +jmp 0x141 	(controls.c:2702)
0x4a5727 : mov dword ptr [ebp - 0x208], 0 	(controls.c:2704)
0x4a5731 : jmp 0x6
0x4a5736 : inc dword ptr [ebp - 0x208]
0x4a573c : cmp dword ptr [ebp - 0x208], 0xa
0x4a5743 : -jge 0x10b
         : +jge 0x110
0x4a5749 : mov eax, dword ptr [ebp - 0x204] 	(controls.c:2705)
0x4a574f : push eax
0x4a5750 : push 0xff
0x4a5755 : lea eax, [ebp - 0x100]
0x4a575b : push eax
0x4a575c : call fgets (FUNCTION)
0x4a5761 : add esp, 0xc
0x4a5764 : test eax, eax
0x4a5766 : -je 0xde
         : +jne 0x5
         : +jmp 0xe8 	(controls.c:2706)
0x4a576c : lea edi, [ebp - 0x100] 	(controls.c:2708)
0x4a5772 : mov ecx, 0xffffffff
0x4a5777 : sub eax, eax
0x4a5779 : repne scasb al, byte ptr es:[edi]
0x4a577b : not ecx
0x4a577d : lea eax, [ecx - 1]
0x4a5780 : -cmp eax, 0x3f
0x4a5783 : -jbe 0x7
         : +mov dword ptr [ebp - 0x20c], eax
         : +cmp dword ptr [ebp - 0x20c], 0x3f 	(controls.c:2709)
         : +jle 0x7
0x4a5789 : mov byte ptr [ebp - 0xc1], 0 	(controls.c:2710)
0x4a5790 : lea edi, [ebp - 0x100] 	(controls.c:2712)
0x4a5796 : mov ecx, 0xffffffff
0x4a579b : sub eax, eax
0x4a579d : repne scasb al, byte ptr es:[edi]
0x4a579f : not ecx
0x4a57a1 : lea eax, [ecx - 1]
0x4a57a4 : mov dword ptr [ebp - 0x20c], eax
0x4a57aa : cmp dword ptr [ebp - 0x20c], 0 	(controls.c:2713)
0x4a57b1 : je 0x30
0x4a57b7 : mov eax, dword ptr [ebp - 0x20c]
0x4a57bd : movsx eax, byte ptr [ebp + eax - 0x101]
0x4a57c5 : cmp eax, 0x20
0x4a57c8 : jge 0x19
         : +mov eax, dword ptr [ebp - 0x20c] 	(controls.c:2714)
         : +mov byte ptr [ebp + eax - 0x101], 0
0x4a57ce : dec dword ptr [ebp - 0x20c] 	(controls.c:2715)
0x4a57d4 : -mov eax, dword ptr [ebp - 0x20c]
0x4a57da : -mov byte ptr [ebp + eax - 0x100], 0
0x4a57e2 : jmp -0x3d 	(controls.c:2716)
0x4a57e7 : push 0xf3 	(controls.c:2717)
0x4a57ec : lea edi, [ebp - 0x100]
0x4a57f2 : mov ecx, 0xffffffff
0x4a57f7 : sub eax, eax
0x4a57f9 : repne scasb al, byte ptr es:[edi]
0x4a57fb : not ecx
0x4a57fd : push ecx
0x4a57fe : call BrMemAllocate (FUNCTION)
0x4a5803 : add esp, 8

---
+++
@@ -0x4a5826,22 +0x46a146,20 @@
0x4a5826 : mov eax, ecx
0x4a5828 : mov edx, edi
0x4a582a : mov ebx, dword ptr [ebp - 0x208]
0x4a5830 : mov edi, dword ptr [ebx*4 + gAbuse_text[0] (DATA)]
0x4a5837 : mov esi, edx
0x4a5839 : shr ecx, 2
0x4a583c : rep movsd dword ptr es:[edi], dword ptr [esi]
0x4a583e : mov ecx, eax
0x4a5840 : and ecx, 3
0x4a5843 : rep movsb byte ptr es:[edi], byte ptr [esi]
0x4a5845 : -jmp 0x5
0x4a584a : -jmp 0x5
0x4a584f : -jmp -0x11e
         : +jmp -0x123 	(controls.c:2719)
0x4a5854 : mov eax, dword ptr [ebp - 0x204] 	(controls.c:2720)
0x4a585a : push eax
0x4a585b : call fclose (FUNCTION)
0x4a5860 : add esp, 4
0x4a5863 : pop edi 	(controls.c:2721)
0x4a5864 : pop esi
0x4a5865 : pop ebx
0x4a5866 : leave 
0x4a5867 : ret 


InitAbuseomatic is only 91.60% similar to the original, diff above
```

*AI generated. Time taken: 208s*
