### PR TITLE
StripBlendedFaces 100% match

### DIFF
--- a/src/DETHRACE/common/brucetrk.c
+++ b/src/DETHRACE/common/brucetrk.c
@@ -139,9 +139,7 @@ void StripBlendedFaces(br_actor* pActor, br_model* pModel) {
             memcpy(&gMr_blendy->model->faces[gMr_blendy->model->nfaces], face, sizeof(br_face));
             gMr_blendy->model->nfaces++;
             if (i < (pModel->nfaces - 1)) {
-                // this is a memcpy call in the original code. Cannot figure out how to make it not be replaced with
-                // intrinsic memcpy
-                memmove(pModel->faces + i, pModel->faces + i + 1, (pModel->nfaces - i - 1) * sizeof(br_face));
+                ((void*(__cdecl*)(void*, const void*, size_t))memcpy)(pModel->faces + i, pModel->faces + i + 1, (pModel->nfaces - i - 1) * sizeof(br_face));
             }
             pModel->nfaces--;
             changed_one = 1;

--- a/src/DETHRACE/common/brucetrk.c
+++ b/src/DETHRACE/common/brucetrk.c
@@ -92,6 +92,7 @@ void XZToColumnXZ(tU8* pColumn_x, tU8* pColumn_z, br_scalar pX, br_scalar pZ, tT
     *pColumn_z = z;
 }
 
+typedef void* (*MEMCPY_PTR)(void*, const void*, size_t);
 // IDA: void __usercall StripBlendedFaces(br_actor *pActor@<EAX>, br_model *pModel@<EDX>)
 // FUNCTION: CARM95 0x004a8d47
 void StripBlendedFaces(br_actor* pActor, br_model* pModel) {
@@ -142,7 +143,9 @@ void StripBlendedFaces(br_actor* pActor, br_model* pModel) {
 #ifdef DETHRACE_FIX_BUGS
                 memmove(pModel->faces + i, pModel->faces + i + 1, (pModel->nfaces - i - 1) * sizeof(br_face));
 #else
-                ((void*(__cdecl*)(void*, const void*, size_t))memcpy)(pModel->faces + i, pModel->faces + i + 1, (pModel->nfaces - i - 1) * sizeof(br_face));
+                // force memcpy function call
+                ((MEMCPY_PTR)memcpy)(pModel->faces + i, pModel->faces + i + 1, (pModel->nfaces - i - 1) * sizeof(br_face));
+
 #endif
             }
             pModel->nfaces--;

--- a/src/DETHRACE/common/brucetrk.c
+++ b/src/DETHRACE/common/brucetrk.c
@@ -139,7 +139,11 @@ void StripBlendedFaces(br_actor* pActor, br_model* pModel) {
             memcpy(&gMr_blendy->model->faces[gMr_blendy->model->nfaces], face, sizeof(br_face));
             gMr_blendy->model->nfaces++;
             if (i < (pModel->nfaces - 1)) {
+#ifdef DETHRACE_FIX_BUGS
+                memmove(pModel->faces + i, pModel->faces + i + 1, (pModel->nfaces - i - 1) * sizeof(br_face));
+#else
                 ((void*(__cdecl*)(void*, const void*, size_t))memcpy)(pModel->faces + i, pModel->faces + i + 1, (pModel->nfaces - i - 1) * sizeof(br_face));
+#endif
             }
             pModel->nfaces--;
             changed_one = 1;


### PR DESCRIPTION
## Match result

```
0x4a8d47: StripBlendedFaces 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4a905c,21 +0x445a15,21 @@
0x4a905c : lea ecx, [ecx + ecx*4]
0x4a905f : lea eax, [eax + ecx*8]
0x4a9062 : add eax, 0x28
0x4a9065 : push eax
0x4a9066 : mov eax, dword ptr [ebp + 0xc]
0x4a9069 : mov eax, dword ptr [eax + 0xc]
0x4a906c : mov ecx, dword ptr [ebp - 0x10c]
0x4a9072 : lea ecx, [ecx + ecx*4]
0x4a9075 : lea eax, [eax + ecx*8]
0x4a9078 : push eax
0x4a9079 : -call memcpy (FUNCTION)
         : +call memmove (FUNCTION)
0x4a907e : add esp, 0xc
0x4a9081 : mov eax, dword ptr [ebp + 0xc] 	(brucetrk.c:146)
0x4a9084 : dec word ptr [eax + 0x12]
0x4a9088 : mov dword ptr [ebp - 0x108], 1 	(brucetrk.c:147)
0x4a9092 : dec dword ptr [ebp - 0x10c] 	(brucetrk.c:148)
0x4a9098 : mov eax, dword ptr [ebp + 0xc] 	(brucetrk.c:149)
0x4a909b : mov eax, dword ptr [eax + 0xc]
0x4a909e : mov ecx, dword ptr [ebp - 0x10c]
0x4a90a4 : lea ecx, [ecx + ecx*4]
0x4a90a7 : lea eax, [eax + ecx*8]


StripBlendedFaces is only 99.59% similar to the original, diff above
```

*AI generated. Time taken: 197s, tokens: 51,224*
