### PR TITLE
Match FindNonCarsCB

### DIFF
--- a/src/DETHRACE/common/brucetrk.c
+++ b/src/DETHRACE/common/brucetrk.c
@@ -169,17 +169,23 @@ br_uintptr_t FindNonCarsCB(br_actor* pActor, tTrack_spec* pTrack_spec) {
 
     if (pActor->identifier != NULL && pActor->identifier[0] == '&' && pActor->identifier[1] >= '0' && pActor->identifier[1] <= '9') {
 
-        i = (pActor->identifier[5] - '0') * 100
-            + (pActor->identifier[6] - '0') * 10
+        i = (pActor->identifier[6] - '0') * 10
+            + (pActor->identifier[5] - '0') * 100
             + pActor->identifier[7] - '0'
             + (pActor->identifier[4] - '0') * 1000;
 
         if (i < 0 || pTrack_spec->ampersand_digits <= i) {
             return 1;
         }
-        r1 = BR_SQR3(pActor->t.t.mat.m[0][2], pActor->t.t.mat.m[0][1], pActor->t.t.mat.m[0][0]);
-        r2 = BR_SQR3(pActor->t.t.mat.m[1][2], pActor->t.t.mat.m[1][0], pActor->t.t.mat.m[1][1]);
-        r3 = BR_SQR3(pActor->t.t.mat.m[2][2], pActor->t.t.mat.m[2][0], pActor->t.t.mat.m[2][1]);
+        r1 = pActor->t.t.mat.m[0][1] * pActor->t.t.mat.m[0][1]
+            + pActor->t.t.mat.m[0][2] * pActor->t.t.mat.m[0][2]
+            + pActor->t.t.mat.m[0][0] * pActor->t.t.mat.m[0][0];
+        r2 = pActor->t.t.mat.m[1][2] * pActor->t.t.mat.m[1][2]
+            + pActor->t.t.mat.m[1][1] * pActor->t.t.mat.m[1][1]
+            + pActor->t.t.mat.m[1][0] * pActor->t.t.mat.m[1][0];
+        r3 = pActor->t.t.mat.m[2][0] * pActor->t.t.mat.m[2][0]
+            + pActor->t.t.mat.m[2][1] * pActor->t.t.mat.m[2][1]
+            + pActor->t.t.mat.m[2][2] * pActor->t.t.mat.m[2][2];
         if (r1 < .999 || r2 < .999 || r3 < .999) {
             dr_dprintf("non car was scaled down %s", pActor->identifier);
             pActor->t.t.translate.t.v[0] += 2000.f;


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4a90ff,57 +0x445ab8,56 @@
0x4a90ff : push ebp 	(brucetrk.c:164)
0x4a9100 : mov ebp, esp
0x4a9102 : sub esp, 0x10
0x4a9105 : push ebx
0x4a9106 : push esi
0x4a9107 : push edi
0x4a9108 : mov eax, dword ptr [ebp + 8] 	(brucetrk.c:170)
0x4a910b : cmp dword ptr [eax + 0x14], 0
0x4a910f : -je 0x2ca
         : +je 0x2c8
0x4a9115 : mov eax, dword ptr [ebp + 8]
0x4a9118 : mov eax, dword ptr [eax + 0x14]
0x4a911b : movsx eax, byte ptr [eax]
0x4a911e : cmp eax, 0x26
0x4a9121 : -jne 0x2b8
         : +jne 0x2b6
0x4a9127 : mov eax, dword ptr [ebp + 8]
0x4a912a : mov eax, dword ptr [eax + 0x14]
0x4a912d : movsx eax, byte ptr [eax + 1]
0x4a9131 : cmp eax, 0x30
0x4a9134 : -jl 0x2a5
         : +jl 0x2a3
0x4a913a : mov eax, dword ptr [ebp + 8]
0x4a913d : mov eax, dword ptr [eax + 0x14]
0x4a9140 : movsx eax, byte ptr [eax + 1]
0x4a9144 : cmp eax, 0x39
0x4a9147 : -jg 0x292
         : +jg 0x290
0x4a914d : mov eax, dword ptr [ebp + 8] 	(brucetrk.c:175)
0x4a9150 : mov eax, dword ptr [eax + 0x14]
0x4a9153 : -movsx eax, byte ptr [eax + 5]
0x4a9157 : -lea eax, [eax*4 - 0xc0]
0x4a915e : -lea eax, [eax + eax*4]
0x4a9161 : -lea eax, [eax + eax*4]
         : +movsx eax, byte ptr [eax + 6]
         : +lea eax, [eax + eax*4 - 0xf0]
0x4a9164 : mov ecx, dword ptr [ebp + 8]
0x4a9167 : mov ecx, dword ptr [ecx + 0x14]
0x4a916a : -movsx ecx, byte ptr [ecx + 6]
0x4a916e : -lea ecx, [ecx + ecx*4 - 0xf0]
0x4a9175 : -lea eax, [eax + ecx*2]
         : +movsx ecx, byte ptr [ecx + 5]
         : +lea ecx, [ecx*4 - 0xc0]
         : +lea ecx, [ecx + ecx*4]
         : +lea ecx, [ecx + ecx*4]
         : +lea eax, [ecx + eax*2]
0x4a9178 : mov ecx, dword ptr [ebp + 8]
0x4a917b : mov ecx, dword ptr [ecx + 0x14]
0x4a917e : movsx ecx, byte ptr [ecx + 7]
0x4a9182 : -sub ecx, 0x30
0x4a9185 : add eax, ecx
0x4a9187 : mov ecx, dword ptr [ebp + 8]
0x4a918a : mov ecx, dword ptr [ecx + 0x14]
0x4a918d : movsx ecx, byte ptr [ecx + 4]
0x4a9191 : lea ecx, [ecx + ecx*4 - 0xf0]
0x4a9198 : lea ecx, [ecx + ecx*4]
0x4a919b : lea ecx, [ecx + ecx*4]
0x4a919e : -lea eax, [eax + ecx*8]
         : +lea eax, [eax + ecx*8 - 0x30]
0x4a91a1 : mov dword ptr [ebp - 0x10], eax
0x4a91a4 : cmp dword ptr [ebp - 0x10], 0 	(brucetrk.c:177)
0x4a91a8 : jl 0xf
0x4a91ae : mov eax, dword ptr [ebp + 0xc]
0x4a91b1 : mov ecx, dword ptr [ebp - 0x10]
0x4a91b4 : cmp dword ptr [eax + 0x24], ecx
0x4a91b7 : jg 0xa
0x4a91bd : mov eax, 1 	(brucetrk.c:178)
0x4a91c2 : jmp 0x27e
0x4a91c7 : mov eax, dword ptr [ebp + 8] 	(brucetrk.c:182)

---
+++
@@ -0x4a91d9,47 +0x445b90,47 @@
0x4a91d9 : mov eax, dword ptr [ebp + 8]
0x4a91dc : fmul dword ptr [eax + 0x30]
0x4a91df : faddp st(1)
0x4a91e1 : mov eax, dword ptr [ebp + 8]
0x4a91e4 : fld dword ptr [eax + 0x2c]
0x4a91e7 : mov eax, dword ptr [ebp + 8]
0x4a91ea : fmul dword ptr [eax + 0x2c]
0x4a91ed : faddp st(1)
0x4a91ef : fstp dword ptr [ebp - 4]
0x4a91f2 : mov eax, dword ptr [ebp + 8] 	(brucetrk.c:185)
         : +fld dword ptr [eax + 0x38]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 0x38]
         : +mov eax, dword ptr [ebp + 8]
0x4a91f5 : fld dword ptr [eax + 0x40]
0x4a91f8 : mov eax, dword ptr [ebp + 8]
0x4a91fb : fmul dword ptr [eax + 0x40]
         : +faddp st(1)
0x4a91fe : mov eax, dword ptr [ebp + 8]
0x4a9201 : fld dword ptr [eax + 0x3c]
0x4a9204 : mov eax, dword ptr [ebp + 8]
0x4a9207 : fmul dword ptr [eax + 0x3c]
0x4a920a : faddp st(1)
         : +fstp dword ptr [ebp - 8]
0x4a920c : mov eax, dword ptr [ebp + 8] 	(brucetrk.c:188)
0x4a920f : -fld dword ptr [eax + 0x38]
         : +fld dword ptr [eax + 0x4c]
0x4a9212 : mov eax, dword ptr [ebp + 8]
0x4a9215 : -fmul dword ptr [eax + 0x38]
0x4a9218 : -faddp st(1)
0x4a921a : -fstp dword ptr [ebp - 8]
         : +fmul dword ptr [eax + 0x4c]
0x4a921d : mov eax, dword ptr [ebp + 8]
0x4a9220 : fld dword ptr [eax + 0x44]
0x4a9223 : mov eax, dword ptr [ebp + 8]
0x4a9226 : fmul dword ptr [eax + 0x44]
         : +faddp st(1)
0x4a9229 : mov eax, dword ptr [ebp + 8]
0x4a922c : fld dword ptr [eax + 0x48]
0x4a922f : mov eax, dword ptr [ebp + 8]
0x4a9232 : fmul dword ptr [eax + 0x48]
0x4a9235 : -faddp st(1)
0x4a9237 : -mov eax, dword ptr [ebp + 8]
0x4a923a : -fld dword ptr [eax + 0x4c]
0x4a923d : -mov eax, dword ptr [ebp + 8]
0x4a9240 : -fmul dword ptr [eax + 0x4c]
0x4a9243 : faddp st(1)
0x4a9245 : fstp dword ptr [ebp - 0xc]
0x4a9248 : fld dword ptr [ebp - 4] 	(brucetrk.c:189)
0x4a924b : fcomp qword ptr [0.999 (FLOAT)]
0x4a9251 : fnstsw ax
0x4a9253 : test ah, 1
0x4a9256 : jne 0x28
0x4a925c : fld dword ptr [ebp - 8]
0x4a925f : fcomp qword ptr [0.999 (FLOAT)]
0x4a9265 : fnstsw ax

---
+++
@@ -0x4a93b7,21 +0x445d6e,21 @@
0x4a93b7 : add esp, 8
0x4a93ba : mov eax, dword ptr [ebp + 8] 	(brucetrk.c:208)
0x4a93bd : mov ecx, dword ptr [ebp + 0xc]
0x4a93c0 : mov ecx, dword ptr [ecx + 0x28]
0x4a93c3 : mov edx, dword ptr [ebp - 0x10]
0x4a93c6 : mov dword ptr [ecx + edx*4], eax
0x4a93c9 : mov eax, dword ptr [ebp + 8] 	(brucetrk.c:209)
0x4a93cc : mov dword ptr [eax + 0x5c], 0
0x4a93d3 : xor eax, eax 	(brucetrk.c:210)
0x4a93d5 : jmp 0x6b
0x4a93da : -jmp 0x4c
         : +jmp 0x66 	(brucetrk.c:211)
0x4a93df : mov eax, dword ptr [ebp + 8] 	(brucetrk.c:212)
0x4a93e2 : cmp dword ptr [eax + 0x18], 0
0x4a93e6 : je 0x3f
0x4a93ec : cmp dword ptr [gAusterity_mode (DATA)], 0
0x4a93f3 : jne 0x32
0x4a93f9 : mov eax, dword ptr [ebp + 8]
0x4a93fc : cmp dword ptr [eax + 0x14], 0
0x4a9400 : je 0x25
0x4a9406 : mov eax, dword ptr [ebp + 8]
0x4a9409 : mov eax, dword ptr [eax + 0x14]

---
+++
@@ -0x4a942e,10 +0x445de5,12 @@
0x4a942e : push eax
0x4a942f : push FindNonCarsCB (FUNCTION)
0x4a9434 : mov eax, dword ptr [ebp + 8]
0x4a9437 : push eax
0x4a9438 : call BrActorEnum (FUNCTION)
0x4a943d : add esp, 0xc
0x4a9440 : jmp 0x0
0x4a9445 : pop edi 	(brucetrk.c:217)
0x4a9446 : pop esi
0x4a9447 : pop ebx
         : +leave 
         : +ret 


FindNonCarsCB is only 90.58% similar to the original, diff above
```

#### Effective match analysis

The diffs shown are algebraic/instruction-scheduling rewrites, not functional logic changes. In the index-parsing block, bytes `[+5]`/`[+6]` are computed in swapped order but combined with the same weights, and the removed `sub ecx, 0x30` is exactly compensated by `-0x30` folded into the final `lea`, yielding the same final integer. In the floating-point blocks, squared-term accumulation order is changed (including moving the `+0x38` and `+0x4c` term positions), but the same terms are summed into the same locals; under your stated tolerance (ignore FP finite-precision micro-effects and NaN behavior), this is equivalent. The jump-distance differences are consistent with layout/encoding size changes rather than a different branch structure in the shown regions.

#### Original match

```
---
+++
@@ -0x4a90ff,109 +0x445ab8,108 @@
0x4a90ff : push ebp 	(brucetrk.c:164)
0x4a9100 : mov ebp, esp
0x4a9102 : sub esp, 0x10
0x4a9105 : push ebx
0x4a9106 : push esi
0x4a9107 : push edi
0x4a9108 : mov eax, dword ptr [ebp + 8] 	(brucetrk.c:170)
0x4a910b : cmp dword ptr [eax + 0x14], 0
0x4a910f : -je 0x2ca
         : +je 0x2c8
0x4a9115 : mov eax, dword ptr [ebp + 8]
0x4a9118 : mov eax, dword ptr [eax + 0x14]
0x4a911b : movsx eax, byte ptr [eax]
0x4a911e : cmp eax, 0x26
0x4a9121 : -jne 0x2b8
         : +jne 0x2b6
0x4a9127 : mov eax, dword ptr [ebp + 8]
0x4a912a : mov eax, dword ptr [eax + 0x14]
0x4a912d : movsx eax, byte ptr [eax + 1]
0x4a9131 : cmp eax, 0x30
0x4a9134 : -jl 0x2a5
         : +jl 0x2a3
0x4a913a : mov eax, dword ptr [ebp + 8]
0x4a913d : mov eax, dword ptr [eax + 0x14]
0x4a9140 : movsx eax, byte ptr [eax + 1]
0x4a9144 : cmp eax, 0x39
0x4a9147 : -jg 0x292
         : +jg 0x290
0x4a914d : mov eax, dword ptr [ebp + 8] 	(brucetrk.c:175)
0x4a9150 : mov eax, dword ptr [eax + 0x14]
0x4a9153 : -movsx eax, byte ptr [eax + 5]
0x4a9157 : -lea eax, [eax*4 - 0xc0]
0x4a915e : -lea eax, [eax + eax*4]
0x4a9161 : -lea eax, [eax + eax*4]
         : +movsx eax, byte ptr [eax + 6]
         : +lea eax, [eax + eax*4 - 0xf0]
0x4a9164 : mov ecx, dword ptr [ebp + 8]
0x4a9167 : mov ecx, dword ptr [ecx + 0x14]
0x4a916a : -movsx ecx, byte ptr [ecx + 6]
0x4a916e : -lea ecx, [ecx + ecx*4 - 0xf0]
0x4a9175 : -lea eax, [eax + ecx*2]
         : +movsx ecx, byte ptr [ecx + 5]
         : +lea ecx, [ecx*4 - 0xc0]
         : +lea ecx, [ecx + ecx*4]
         : +lea ecx, [ecx + ecx*4]
         : +lea eax, [ecx + eax*2]
0x4a9178 : mov ecx, dword ptr [ebp + 8]
0x4a917b : mov ecx, dword ptr [ecx + 0x14]
0x4a917e : movsx ecx, byte ptr [ecx + 7]
0x4a9182 : -sub ecx, 0x30
0x4a9185 : add eax, ecx
0x4a9187 : mov ecx, dword ptr [ebp + 8]
0x4a918a : mov ecx, dword ptr [ecx + 0x14]
0x4a918d : movsx ecx, byte ptr [ecx + 4]
0x4a9191 : lea ecx, [ecx + ecx*4 - 0xf0]
0x4a9198 : lea ecx, [ecx + ecx*4]
0x4a919b : lea ecx, [ecx + ecx*4]
0x4a919e : -lea eax, [eax + ecx*8]
         : +lea eax, [eax + ecx*8 - 0x30]
0x4a91a1 : mov dword ptr [ebp - 0x10], eax
0x4a91a4 : cmp dword ptr [ebp - 0x10], 0 	(brucetrk.c:177)
0x4a91a8 : jl 0xf
0x4a91ae : mov eax, dword ptr [ebp + 0xc]
0x4a91b1 : mov ecx, dword ptr [ebp - 0x10]
0x4a91b4 : cmp dword ptr [eax + 0x24], ecx
0x4a91b7 : jg 0xa
0x4a91bd : mov eax, 1 	(brucetrk.c:178)
0x4a91c2 : jmp 0x27e
0x4a91c7 : mov eax, dword ptr [ebp + 8] 	(brucetrk.c:180)
         : +fld dword ptr [eax + 0x30]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 0x30]
         : +mov eax, dword ptr [ebp + 8]
0x4a91ca : fld dword ptr [eax + 0x34]
0x4a91cd : mov eax, dword ptr [ebp + 8]
0x4a91d0 : fmul dword ptr [eax + 0x34]
0x4a91d3 : -mov eax, dword ptr [ebp + 8]
0x4a91d6 : -fld dword ptr [eax + 0x30]
0x4a91d9 : -mov eax, dword ptr [ebp + 8]
0x4a91dc : -fmul dword ptr [eax + 0x30]
0x4a91df : faddp st(1)
0x4a91e1 : mov eax, dword ptr [ebp + 8]
0x4a91e4 : fld dword ptr [eax + 0x2c]
0x4a91e7 : mov eax, dword ptr [ebp + 8]
0x4a91ea : fmul dword ptr [eax + 0x2c]
0x4a91ed : faddp st(1)
0x4a91ef : fstp dword ptr [ebp - 4]
0x4a91f2 : mov eax, dword ptr [ebp + 8] 	(brucetrk.c:181)
0x4a91f5 : fld dword ptr [eax + 0x40]
0x4a91f8 : mov eax, dword ptr [ebp + 8]
0x4a91fb : fmul dword ptr [eax + 0x40]
0x4a91fe : mov eax, dword ptr [ebp + 8]
         : +fld dword ptr [eax + 0x38]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 0x38]
         : +faddp st(1)
         : +mov eax, dword ptr [ebp + 8]
0x4a9201 : fld dword ptr [eax + 0x3c]
0x4a9204 : mov eax, dword ptr [ebp + 8]
0x4a9207 : fmul dword ptr [eax + 0x3c]
0x4a920a : faddp st(1)
0x4a920c : -mov eax, dword ptr [ebp + 8]
0x4a920f : -fld dword ptr [eax + 0x38]
0x4a9212 : -mov eax, dword ptr [ebp + 8]
0x4a9215 : -fmul dword ptr [eax + 0x38]
0x4a9218 : -faddp st(1)
0x4a921a : fstp dword ptr [ebp - 8]
0x4a921d : mov eax, dword ptr [ebp + 8] 	(brucetrk.c:182)
0x4a9220 : -fld dword ptr [eax + 0x44]
         : +fld dword ptr [eax + 0x4c]
0x4a9223 : mov eax, dword ptr [ebp + 8]
0x4a9226 : -fmul dword ptr [eax + 0x44]
         : +fmul dword ptr [eax + 0x4c]
0x4a9229 : mov eax, dword ptr [ebp + 8]
0x4a922c : fld dword ptr [eax + 0x48]
0x4a922f : mov eax, dword ptr [ebp + 8]
0x4a9232 : fmul dword ptr [eax + 0x48]
0x4a9235 : faddp st(1)
0x4a9237 : mov eax, dword ptr [ebp + 8]
0x4a923a : -fld dword ptr [eax + 0x4c]
         : +fld dword ptr [eax + 0x44]
0x4a923d : mov eax, dword ptr [ebp + 8]
0x4a9240 : -fmul dword ptr [eax + 0x4c]
         : +fmul dword ptr [eax + 0x44]
0x4a9243 : faddp st(1)
0x4a9245 : fstp dword ptr [ebp - 0xc]
0x4a9248 : fld dword ptr [ebp - 4] 	(brucetrk.c:183)
0x4a924b : fcomp qword ptr [0.999 (FLOAT)]
0x4a9251 : fnstsw ax
0x4a9253 : test ah, 1
0x4a9256 : jne 0x28
0x4a925c : fld dword ptr [ebp - 8]
0x4a925f : fcomp qword ptr [0.999 (FLOAT)]
0x4a9265 : fnstsw ax

---
+++
@@ -0x4a93b7,21 +0x445d6e,21 @@
0x4a93b7 : add esp, 8
0x4a93ba : mov eax, dword ptr [ebp + 8] 	(brucetrk.c:202)
0x4a93bd : mov ecx, dword ptr [ebp + 0xc]
0x4a93c0 : mov ecx, dword ptr [ecx + 0x28]
0x4a93c3 : mov edx, dword ptr [ebp - 0x10]
0x4a93c6 : mov dword ptr [ecx + edx*4], eax
0x4a93c9 : mov eax, dword ptr [ebp + 8] 	(brucetrk.c:203)
0x4a93cc : mov dword ptr [eax + 0x5c], 0
0x4a93d3 : xor eax, eax 	(brucetrk.c:204)
0x4a93d5 : jmp 0x6b
0x4a93da : -jmp 0x4c
         : +jmp 0x66 	(brucetrk.c:205)
0x4a93df : mov eax, dword ptr [ebp + 8] 	(brucetrk.c:206)
0x4a93e2 : cmp dword ptr [eax + 0x18], 0
0x4a93e6 : je 0x3f
0x4a93ec : cmp dword ptr [gAusterity_mode (DATA)], 0
0x4a93f3 : jne 0x32
0x4a93f9 : mov eax, dword ptr [ebp + 8]
0x4a93fc : cmp dword ptr [eax + 0x14], 0
0x4a9400 : je 0x25
0x4a9406 : mov eax, dword ptr [ebp + 8]
0x4a9409 : mov eax, dword ptr [eax + 0x14]

---
+++
@@ -0x4a942e,10 +0x445de5,12 @@
0x4a942e : push eax
0x4a942f : push FindNonCarsCB (FUNCTION)
0x4a9434 : mov eax, dword ptr [ebp + 8]
0x4a9437 : push eax
0x4a9438 : call BrActorEnum (FUNCTION)
0x4a943d : add esp, 0xc
0x4a9440 : jmp 0x0
0x4a9445 : pop edi 	(brucetrk.c:211)
0x4a9446 : pop esi
0x4a9447 : pop ebx
         : +leave 
         : +ret 


FindNonCarsCB is only 88.98% similar to the original, diff above
```

*AI generated. Time taken: 841s, tokens: 252,307*
