### PR TITLE
FastFloatCos equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/trig.c
+++ b/src/DETHRACE/common/trig.c
@@ -137,22 +137,21 @@ float FastFloatSin(int pAngle_in_degrees) {
 // FUNCTION: CARM95 0x004aa18c
 float FastFloatCos(int pAngle_in_degrees) {
 
-    if (pAngle_in_degrees >= 0) {
-        pAngle_in_degrees = pAngle_in_degrees % 360;
-    } else {
+    if (pAngle_in_degrees < 0) {
         pAngle_in_degrees = 360 - -pAngle_in_degrees % 360;
+    } else {
+        pAngle_in_degrees = pAngle_in_degrees % 360;
     }
 
     if (pAngle_in_degrees > 270) {
         return gFloat_sine_table[pAngle_in_degrees - 270];
-    }
-    if (pAngle_in_degrees > 180) {
+    } else if (pAngle_in_degrees > 180) {
         return -gFloat_sine_table[270 - pAngle_in_degrees];
-    }
-    if (pAngle_in_degrees <= 90) {
+    } else if (pAngle_in_degrees > 90) {
+        return -gFloat_sine_table[pAngle_in_degrees - 90];
+    } else {
         return gFloat_sine_table[90 - pAngle_in_degrees];
     }
-    return -gFloat_sine_table[pAngle_in_degrees - 90];
 }
 
 // IDA: float __usercall FastFloatTan@<ST0>(int pAngle_in_degrees@<EAX>)


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4aa1b0,35 +0x4b7e21,35 @@
0x4aa1b0 : mov dword ptr [ebp + 8], ecx
0x4aa1b3 : jmp 0xe 	(trig.c:142)
0x4aa1b8 : mov ecx, 0x168 	(trig.c:143)
0x4aa1bd : mov eax, dword ptr [ebp + 8]
0x4aa1c0 : cdq 
0x4aa1c1 : idiv ecx
0x4aa1c3 : mov dword ptr [ebp + 8], edx
0x4aa1c6 : cmp dword ptr [ebp + 8], 0x10e 	(trig.c:146)
0x4aa1cd : jle 0x14
0x4aa1d3 : mov eax, dword ptr [ebp + 8] 	(trig.c:147)
0x4aa1d6 : -fld dword ptr [eax*4 + "*******************************************" (STRING)]
         : +fld dword ptr [eax*4 + "%s %s" (STRING)]
0x4aa1dd : jmp 0x61
0x4aa1e2 : jmp 0x5c 	(trig.c:148)
0x4aa1e7 : cmp dword ptr [ebp + 8], 0xb4
0x4aa1ee : jle 0x1b
0x4aa1f4 : mov eax, 0x10e 	(trig.c:149)
0x4aa1f9 : sub eax, dword ptr [ebp + 8]
0x4aa1fc : fld dword ptr [eax*4 + gFloat_sine_table[0] (DATA)]
0x4aa203 : fchs 
0x4aa205 : jmp 0x39
0x4aa20a : jmp 0x34 	(trig.c:150)
0x4aa20f : cmp dword ptr [ebp + 8], 0x5a
0x4aa213 : jle 0x16
0x4aa219 : mov eax, dword ptr [ebp + 8] 	(trig.c:151)
0x4aa21c : -fld dword ptr [eax*4 + "ruce." (STRING)]
         : +fld dword ptr [eax*4 + "BLEND50.TAB" (STRING)]
0x4aa223 : fchs 
0x4aa225 : jmp 0x19
0x4aa22a : jmp 0x14 	(trig.c:152)
0x4aa22f : mov eax, 0x5a 	(trig.c:153)
0x4aa234 : sub eax, dword ptr [ebp + 8]
0x4aa237 : fld dword ptr [eax*4 + gFloat_sine_table[0] (DATA)]
0x4aa23e : jmp 0x0
0x4aa243 : pop edi 	(trig.c:155)
0x4aa244 : pop esi
0x4aa245 : pop ebx


FastFloatCos is only 96.08% similar to the original, diff above
```

#### Effective match analysis

The control flow, comparisons, jumps, arithmetic (`idiv`, `sub`), sign flips (`fchs`), and overall branch structure are unchanged. The only shown differences are the symbolic labels attached to two `fld [eax*4 + ...]` memory operands (different string names), which indicates differing address annotation/placement in data rather than a logic change in the function body. Given this diff, there is no evidence of changed functional computation path; it appears functionally equivalent.

#### Original match

```
---
+++
@@ -0x4aa18c,44 +0x4b7dfd,48 @@
0x4aa18c : push ebp 	(trig.c:138)
0x4aa18d : mov ebp, esp
0x4aa18f : push ebx
0x4aa190 : push esi
0x4aa191 : push edi
0x4aa192 : cmp dword ptr [ebp + 8], 0 	(trig.c:140)
0x4aa196 : -jge 0x1c
         : +jl 0x13
         : +mov ecx, 0x168 	(trig.c:141)
         : +mov eax, dword ptr [ebp + 8]
         : +cdq 
         : +idiv ecx
         : +mov dword ptr [ebp + 8], edx
         : +jmp 0x17 	(trig.c:142)
0x4aa19c : mov ecx, 0x168 	(trig.c:143)
0x4aa1a1 : mov eax, dword ptr [ebp + 8]
0x4aa1a4 : neg eax
0x4aa1a6 : mov ebx, 0x168
0x4aa1ab : cdq 
0x4aa1ac : idiv ebx
0x4aa1ae : sub ecx, edx
0x4aa1b0 : mov dword ptr [ebp + 8], ecx
0x4aa1b3 : -jmp 0xe
0x4aa1b8 : -mov ecx, 0x168
         : +cmp dword ptr [ebp + 8], 0x10e 	(trig.c:146)
         : +jle 0xf
0x4aa1bd : mov eax, dword ptr [ebp + 8] 	(trig.c:147)
0x4aa1c0 : -cdq 
0x4aa1c1 : -idiv ecx
0x4aa1c3 : -mov dword ptr [ebp + 8], edx
0x4aa1c6 : -cmp dword ptr [ebp + 8], 0x10e
0x4aa1cd : -jle 0x14
0x4aa1d3 : -mov eax, dword ptr [ebp + 8]
0x4aa1d6 : -fld dword ptr [eax*4 + "*******************************************" (STRING)]
0x4aa1dd : -jmp 0x61
0x4aa1e2 : -jmp 0x5c
         : +fld dword ptr [eax*4 + "%s %s" (STRING)]
         : +jmp 0x52
0x4aa1e7 : cmp dword ptr [ebp + 8], 0xb4 	(trig.c:149)
0x4aa1ee : -jle 0x1b
         : +jle 0x16
0x4aa1f4 : mov eax, 0x10e 	(trig.c:150)
0x4aa1f9 : sub eax, dword ptr [ebp + 8]
0x4aa1fc : fld dword ptr [eax*4 + gFloat_sine_table[0] (DATA)]
0x4aa203 : fchs 
0x4aa205 : -jmp 0x39
0x4aa20a : -jmp 0x34
         : +jmp 0x2f
0x4aa20f : cmp dword ptr [ebp + 8], 0x5a 	(trig.c:152)
0x4aa213 : -jle 0x16
0x4aa219 : -mov eax, dword ptr [ebp + 8]
0x4aa21c : -fld dword ptr [eax*4 + "ruce." (STRING)]
0x4aa223 : -fchs 
0x4aa225 : -jmp 0x19
0x4aa22a : -jmp 0x14
         : +jg 0x14
0x4aa22f : mov eax, 0x5a 	(trig.c:153)
0x4aa234 : sub eax, dword ptr [ebp + 8]
         : +fld dword ptr [eax*4 + gFloat_sine_table[0] (DATA)]
         : +jmp 0x11
         : +mov eax, dword ptr [ebp + 8] 	(trig.c:155)
         : +fld dword ptr [eax*4 + "BLEND50.TAB" (STRING)]
         : +fchs 
         : +jmp 0x0
         : +pop edi 	(trig.c:156)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


FastFloatCos is only 50.00% similar to the original, diff above
```

*AI generated. Time taken: 998s, tokens: 163,654*
