### PR TITLE
FastFloatArcTan2 100% match

### DIFF
--- a/src/DETHRACE/common/trig.c
+++ b/src/DETHRACE/common/trig.c
@@ -258,37 +258,37 @@ float FastFloatArcTan2(float pY, float pX) {
     if (pX == 0.0f) {
         if (pY < 0.0f) {
             return 270.0;
-        } else if (pY == 0.0f) {
-            return 0.0f;
-        } else {
+        } else if (pY > 0.0f) {
             return 90.0f;
+        } else {
+            return 0.0f;
         }
-    } else if (pX > 0.0f) {
-        if (pY >= 0.0) {
-            if (abs_y <= abs_x) {
-                return abs_y / abs_x * 45.0f;
+    } else if (pX < 0.0f) {
+        if (pY < 0.0f) {
+            if (abs_y > abs_x) {
+                return (6.0f - abs_x / abs_y) * 45.0;
             } else {
-                return (2.0f - abs_x / abs_y) * 45.0f;
+                return (abs_y / abs_x + 4.0f) * 45.0;
             }
         } else {
-            if (abs_y <= abs_x) {
-                return (8.0f - abs_y / abs_x) * 45.0f;
+            if (abs_y > abs_x) {
+                return (abs_x / abs_y + 2.0f) * 45.0;
             } else {
-                return (abs_x / abs_y + 6.0f) * 45.0f;
+                return (4.0f - abs_y / abs_x) * 45.0;
             }
         }
     } else {
-        if (pY >= 0.0f) {
-            if (abs_y <= abs_x) {
-                return (4.0f - abs_y / abs_x) * 45.0f;
+        if (pY < 0.0f) {
+            if (abs_y > abs_x) {
+                return (abs_x / abs_y + 6.0f) * 45.0;
             } else {
-                return (abs_x / abs_y + 2.0f) * 45.0f;
+                return (8.0f - abs_y / abs_x) * 45.0;
             }
         } else {
-            if (abs_y <= abs_x) {
-                return (abs_y / abs_x + 4.0f) * 45.0f;
+            if (abs_y > abs_x) {
+                return (2.0f - abs_x / abs_y) * 45.0;
             } else {
-                return (6.0f - abs_x / abs_y) * 45.0f;
+                return abs_y / abs_x * 45.0;
             }
         }
     }


### PR DESCRIPTION
## Match result

```
0x4aa4c0: FastFloatArcTan2 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4aa4f0,104 +0x4b8152,104 @@
0x4aa4f0 : fcomp dword ptr [0.0 (FLOAT)]
0x4aa4f6 : fnstsw ax
0x4aa4f8 : test ah, 1
0x4aa4fb : je 0x10
0x4aa501 : fld dword ptr [270.0 (FLOAT)] 	(trig.c:260)
0x4aa507 : jmp 0x18e
0x4aa50c : jmp 0x2f 	(trig.c:261)
0x4aa511 : fld dword ptr [ebp + 8]
0x4aa514 : fcomp dword ptr [0.0 (FLOAT)]
0x4aa51a : fnstsw ax
0x4aa51c : -test ah, 0x41
0x4aa51f : -jne 0x10
0x4aa525 : -fld dword ptr [90.0 (FLOAT)]
         : +test ah, 0x40
         : +je 0x10
         : +fld dword ptr [0.0 (FLOAT)] 	(trig.c:262)
0x4aa52b : jmp 0x16a
0x4aa530 : jmp 0xb 	(trig.c:263)
0x4aa535 : -fld dword ptr [0.0 (FLOAT)]
         : +fld dword ptr [90.0 (FLOAT)] 	(trig.c:264)
0x4aa53b : jmp 0x15a
0x4aa540 : jmp 0x155 	(trig.c:266)
0x4aa545 : fld dword ptr [ebp + 0xc]
0x4aa548 : fcomp dword ptr [0.0 (FLOAT)]
0x4aa54e : fnstsw ax
0x4aa550 : -test ah, 1
0x4aa553 : -je 0xa6
         : +test ah, 0x41
         : +jne 0xa0
0x4aa559 : fld dword ptr [ebp + 8] 	(trig.c:267)
0x4aa55c : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x4aa562 : fnstsw ax
0x4aa564 : test ah, 1
0x4aa567 : -je 0x49
         : +jne 0x43
0x4aa56d : fld dword ptr [ebp - 8] 	(trig.c:268)
0x4aa570 : fcomp dword ptr [ebp - 4]
0x4aa573 : fnstsw ax
0x4aa575 : test ah, 0x41
0x4aa578 : -jne 0x1c
         : +je 0x16
         : +fld dword ptr [ebp - 8] 	(trig.c:269)
         : +fdiv dword ptr [ebp - 4]
         : +fmul dword ptr [45.0 (FLOAT)]
         : +jmp 0x10b
         : +jmp 0x17 	(trig.c:270)
0x4aa57e : fld dword ptr [ebp - 4] 	(trig.c:271)
0x4aa581 : fdiv dword ptr [ebp - 8]
0x4aa584 : -fsubr dword ptr [6.0 (FLOAT)]
0x4aa58a : -fmul qword ptr [45.0 (FLOAT)]
0x4aa590 : -jmp 0x105
0x4aa595 : -jmp 0x17
0x4aa59a : -fld dword ptr [ebp - 8]
0x4aa59d : -fdiv dword ptr [ebp - 4]
0x4aa5a0 : -fadd dword ptr [4.0 (FLOAT)]
0x4aa5a6 : -fmul qword ptr [45.0 (FLOAT)]
0x4aa5ac : -jmp 0xe9
         : +fsubr dword ptr [2.0 (FLOAT)]
         : +fmul dword ptr [45.0 (FLOAT)]
         : +jmp 0xef
0x4aa5b1 : jmp 0x44 	(trig.c:273)
0x4aa5b6 : fld dword ptr [ebp - 8] 	(trig.c:274)
0x4aa5b9 : fcomp dword ptr [ebp - 4]
0x4aa5bc : fnstsw ax
0x4aa5be : test ah, 0x41
0x4aa5c1 : -jne 0x1c
         : +je 0x1c
         : +fld dword ptr [ebp - 8] 	(trig.c:275)
         : +fdiv dword ptr [ebp - 4]
         : +fsubr dword ptr [8.0 (FLOAT)]
         : +fmul dword ptr [45.0 (FLOAT)]
         : +jmp 0xc2
         : +jmp 0x17 	(trig.c:276)
0x4aa5c7 : fld dword ptr [ebp - 4] 	(trig.c:277)
0x4aa5ca : fdiv dword ptr [ebp - 8]
0x4aa5cd : -fadd dword ptr [2.0 (FLOAT)]
0x4aa5d3 : -fmul qword ptr [45.0 (FLOAT)]
0x4aa5d9 : -jmp 0xbc
0x4aa5de : -jmp 0x17
0x4aa5e3 : -fld dword ptr [ebp - 8]
0x4aa5e6 : -fdiv dword ptr [ebp - 4]
0x4aa5e9 : -fsubr dword ptr [4.0 (FLOAT)]
0x4aa5ef : -fmul qword ptr [45.0 (FLOAT)]
0x4aa5f5 : -jmp 0xa0
0x4aa5fa : -jmp 0x9b
         : +fadd dword ptr [6.0 (FLOAT)]
         : +fmul dword ptr [45.0 (FLOAT)]
         : +jmp 0xa6
         : +jmp 0xa1 	(trig.c:280)
0x4aa5ff : fld dword ptr [ebp + 8] 	(trig.c:281)
0x4aa602 : fcomp dword ptr [0.0 (FLOAT)]
0x4aa608 : fnstsw ax
0x4aa60a : test ah, 1
0x4aa60d : -je 0x49
         : +jne 0x49
0x4aa613 : fld dword ptr [ebp - 8] 	(trig.c:282)
0x4aa616 : fcomp dword ptr [ebp - 4]
0x4aa619 : fnstsw ax
0x4aa61b : test ah, 0x41
0x4aa61e : -jne 0x1c
         : +je 0x1c
         : +fld dword ptr [ebp - 8] 	(trig.c:283)
         : +fdiv dword ptr [ebp - 4]
         : +fsubr dword ptr [4.0 (FLOAT)]
         : +fmul dword ptr [45.0 (FLOAT)]
         : +jmp 0x65
         : +jmp 0x17 	(trig.c:284)
0x4aa624 : fld dword ptr [ebp - 4] 	(trig.c:285)
0x4aa627 : fdiv dword ptr [ebp - 8]
0x4aa62a : -fadd dword ptr [6.0 (FLOAT)]
0x4aa630 : -fmul qword ptr [45.0 (FLOAT)]
0x4aa636 : -jmp 0x5f
0x4aa63b : -jmp 0x17
0x4aa640 : -fld dword ptr [ebp - 8]
0x4aa643 : -fdiv dword ptr [ebp - 4]
0x4aa646 : -fsubr dword ptr [8.0 (FLOAT)]
0x4aa64c : -fmul qword ptr [45.0 (FLOAT)]
0x4aa652 : -jmp 0x43
0x4aa657 : -jmp 0x3e
         : +fadd dword ptr [2.0 (FLOAT)]
         : +fmul dword ptr [45.0 (FLOAT)]
         : +jmp 0x49
         : +jmp 0x44 	(trig.c:287)
0x4aa65c : fld dword ptr [ebp - 8] 	(trig.c:288)
0x4aa65f : fcomp dword ptr [ebp - 4]
0x4aa662 : fnstsw ax
0x4aa664 : test ah, 0x41
0x4aa667 : -jne 0x1c
         : +je 0x1c
         : +fld dword ptr [ebp - 8] 	(trig.c:289)
         : +fdiv dword ptr [ebp - 4]
         : +fadd dword ptr [4.0 (FLOAT)]
         : +fmul dword ptr [45.0 (FLOAT)]
         : +jmp 0x1c
         : +jmp 0x17 	(trig.c:290)
0x4aa66d : fld dword ptr [ebp - 4] 	(trig.c:291)
0x4aa670 : fdiv dword ptr [ebp - 8]
0x4aa673 : -fsubr dword ptr [2.0 (FLOAT)]
0x4aa679 : -fmul qword ptr [45.0 (FLOAT)]
0x4aa67f : -jmp 0x16
0x4aa684 : -jmp 0x11
0x4aa689 : -fld dword ptr [ebp - 8]
0x4aa68c : -fdiv dword ptr [ebp - 4]
0x4aa68f : -fmul qword ptr [45.0 (FLOAT)]
         : +fsubr dword ptr [6.0 (FLOAT)]
         : +fmul dword ptr [45.0 (FLOAT)]
0x4aa695 : jmp 0x0
0x4aa69a : pop edi 	(trig.c:295)
0x4aa69b : pop esi
0x4aa69c : pop ebx
0x4aa69d : leave 
0x4aa69e : ret 


FastFloatArcTan2 is only 59.84% similar to the original, diff above
```

*AI generated. Time taken: 285s, tokens: 51,994*
