### PR TITLE
FastFloatArcTan2Angle 100% match

### DIFF
--- a/src/DETHRACE/common/trig.c
+++ b/src/DETHRACE/common/trig.c
@@ -311,38 +311,40 @@ br_angle FastFloatArcTan2Angle(float pY, float pX) {
 
     abs_x = fabs(pX);
     abs_y = fabs(pY);
-    if (pX == 0.0) {
-        if (pY >= 0.0) {
-            if (pY <= 0.0) {
-                return 0;
-            } else {
-                return 16380;
-            }
-        } else {
+    if (pX == 0.0f) {
+        if (pY < 0.0f) {
             return -16396;
+        } else if (pY > 0.0f) {
+            return 16380;
+        } else {
+            return 0;
         }
-    } else if (pX >= 0.0) {
-        if (pY >= 0.0) {
-            if (abs_y <= (double)abs_x) {
-                return (abs_y / abs_x * 8192.0);
+    } else if (pX < 0.0f) {
+        if (pY < 0.0f) {
+            if (abs_y > abs_x) {
+                return ((6.0f - abs_x / abs_y) * 8192.0f);
             } else {
-                return ((2.0 - abs_x / abs_y) * 8192.0f);
+                return ((abs_y / abs_x + 4.0f) * 8192.0f);
             }
-        } else if (abs_y <= abs_x) {
-            return ((8.0 - abs_y / abs_x) * 8192.0f);
+        } else if (abs_y > abs_x) {
+            return ((abs_x / abs_y + 2.0f) * 8192.0f);
         } else {
-            return ((abs_x / abs_y + 6.0) * 8192.0f);
+            return ((4.0f - abs_y / abs_x) * 8192.0f);
         }
-    } else if (pY >= 0.0) {
-        if (abs_y <= abs_x) {
-            return ((4.0 - abs_y / abs_x) * 8192.0f);
-        } else {
-            return ((abs_x / abs_y + 2.0) * 8192.0f);
-        }
-    } else if (abs_y <= abs_x) {
-        return ((abs_y / abs_x + 4.0) * 8192.0f);
     } else {
-        return ((6.0 - abs_x / abs_y) * 8192.0f);
+        if (pY < 0.0f) {
+            if (abs_y > abs_x) {
+                return ((abs_x / abs_y + 6.0f) * 8192.0f);
+            } else {
+                return ((8.0f - abs_y / abs_x) * 8192.0f);
+            }
+        } else {
+            if (abs_y > abs_x) {
+                return ((2.0f - abs_x / abs_y) * 8192.0f);
+            } else {
+                return (abs_y / abs_x * 8192.0f);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4aa6c2: FastFloatArcTan2Angle 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4aa6c8,127 +0x4b832a,127 @@
0x4aa6c8 : push ebx
0x4aa6c9 : push esi
0x4aa6ca : push edi
0x4aa6cb : fld dword ptr [ebp + 0xc] 	(trig.c:312)
0x4aa6ce : fabs 
0x4aa6d0 : fstp dword ptr [ebp - 4]
0x4aa6d3 : fld dword ptr [ebp + 8] 	(trig.c:313)
0x4aa6d6 : fabs 
0x4aa6d8 : fstp dword ptr [ebp - 8]
0x4aa6db : fld dword ptr [ebp + 0xc] 	(trig.c:314)
0x4aa6de : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x4aa6e4 : fnstsw ax
0x4aa6e6 : test ah, 0x40
0x4aa6e9 : je 0x51
0x4aa6ef : fld dword ptr [ebp + 8] 	(trig.c:315)
0x4aa6f2 : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x4aa6f8 : fnstsw ax
0x4aa6fa : test ah, 1
0x4aa6fd : -je 0xe
0x4aa703 : -mov ax, 0xbff4
0x4aa707 : -jmp 0x1b1
0x4aa70c : -jmp 0x2a
         : +jne 0x2f
0x4aa711 : fld dword ptr [ebp + 8] 	(trig.c:316)
0x4aa714 : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x4aa71a : fnstsw ax
0x4aa71c : test ah, 0x41
0x4aa71f : -jne 0xe
         : +je 0xd
         : +xor ax, ax 	(trig.c:317)
         : +jmp 0x19e
         : +jmp 0x9 	(trig.c:318)
0x4aa725 : mov ax, 0x3ffc 	(trig.c:319)
0x4aa729 : -jmp 0x18f
0x4aa72e : -jmp 0x8
0x4aa733 : -xor ax, ax
         : +jmp 0x190
         : +jmp 0x9 	(trig.c:321)
         : +mov ax, 0xbff4 	(trig.c:322)
0x4aa736 : jmp 0x182
0x4aa73b : jmp 0x17d 	(trig.c:324)
0x4aa740 : fld dword ptr [ebp + 0xc]
0x4aa743 : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x4aa749 : fnstsw ax
0x4aa74b : test ah, 1
0x4aa74e : -je 0xba
         : +jne 0xb4
0x4aa754 : fld dword ptr [ebp + 8] 	(trig.c:325)
0x4aa757 : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x4aa75d : fnstsw ax
0x4aa75f : test ah, 1
0x4aa762 : -je 0x53
         : +jne 0x4d
0x4aa768 : fld dword ptr [ebp - 8] 	(trig.c:326)
0x4aa76b : fcomp dword ptr [ebp - 4]
0x4aa76e : fnstsw ax
0x4aa770 : test ah, 0x41
0x4aa773 : -jne 0x21
         : +je 0x1b
         : +fld dword ptr [ebp - 8] 	(trig.c:327)
         : +fdiv dword ptr [ebp - 4]
         : +fmul qword ptr [8192.0 (FLOAT)]
         : +call __ftol (FUNCTION)
         : +jmp 0x12e
         : +jmp 0x1c 	(trig.c:328)
0x4aa779 : fld dword ptr [ebp - 4] 	(trig.c:329)
0x4aa77c : fdiv dword ptr [ebp - 8]
0x4aa77f : -fsubr dword ptr [6.0 (FLOAT)]
0x4aa785 : -fmul dword ptr [8192.0 (FLOAT)]
         : +fsubr qword ptr [2.0 (FLOAT)]
         : +fmul qword ptr [8192.0 (FLOAT)]
0x4aa78b : call __ftol (FUNCTION)
0x4aa790 : -jmp 0x128
0x4aa795 : -jmp 0x1c
0x4aa79a : -fld dword ptr [ebp - 8]
0x4aa79d : -fdiv dword ptr [ebp - 4]
0x4aa7a0 : -fadd dword ptr [4.0 (FLOAT)]
0x4aa7a6 : -fmul dword ptr [8192.0 (FLOAT)]
0x4aa7ac : -call __ftol (FUNCTION)
0x4aa7b1 : -jmp 0x107
         : +jmp 0x10d
0x4aa7b6 : jmp 0x4e 	(trig.c:331)
0x4aa7bb : fld dword ptr [ebp - 8]
0x4aa7be : fcomp dword ptr [ebp - 4]
0x4aa7c1 : fnstsw ax
0x4aa7c3 : test ah, 0x41
0x4aa7c6 : -jne 0x21
         : +je 0x21
         : +fld dword ptr [ebp - 8] 	(trig.c:332)
         : +fdiv dword ptr [ebp - 4]
         : +fsubr qword ptr [8.0 (FLOAT)]
         : +fmul qword ptr [8192.0 (FLOAT)]
         : +call __ftol (FUNCTION)
         : +jmp 0xdb
         : +jmp 0x1c 	(trig.c:333)
0x4aa7cc : fld dword ptr [ebp - 4] 	(trig.c:334)
0x4aa7cf : fdiv dword ptr [ebp - 8]
0x4aa7d2 : -fadd dword ptr [2.0 (FLOAT)]
0x4aa7d8 : -fmul dword ptr [8192.0 (FLOAT)]
         : +fadd qword ptr [6.0 (FLOAT)]
         : +fmul qword ptr [8192.0 (FLOAT)]
0x4aa7de : call __ftol (FUNCTION)
0x4aa7e3 : -jmp 0xd5
0x4aa7e8 : -jmp 0x1c
0x4aa7ed : -fld dword ptr [ebp - 8]
0x4aa7f0 : -fdiv dword ptr [ebp - 4]
0x4aa7f3 : -fsubr dword ptr [4.0 (FLOAT)]
0x4aa7f9 : -fmul dword ptr [8192.0 (FLOAT)]
0x4aa7ff : -call __ftol (FUNCTION)
0x4aa804 : -jmp 0xb4
0x4aa809 : -jmp 0xaf
         : +jmp 0xba
         : +jmp 0xb5 	(trig.c:336)
0x4aa80e : fld dword ptr [ebp + 8]
0x4aa811 : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x4aa817 : fnstsw ax
0x4aa819 : test ah, 1
0x4aa81c : -je 0x53
         : +jne 0x53
0x4aa822 : fld dword ptr [ebp - 8] 	(trig.c:337)
0x4aa825 : fcomp dword ptr [ebp - 4]
0x4aa828 : fnstsw ax
0x4aa82a : test ah, 0x41
0x4aa82d : -jne 0x21
         : +je 0x21
         : +fld dword ptr [ebp - 8] 	(trig.c:338)
         : +fdiv dword ptr [ebp - 4]
         : +fsubr qword ptr [4.0 (FLOAT)]
         : +fmul qword ptr [8192.0 (FLOAT)]
         : +call __ftol (FUNCTION)
         : +jmp 0x74
         : +jmp 0x1c 	(trig.c:339)
0x4aa833 : fld dword ptr [ebp - 4] 	(trig.c:340)
0x4aa836 : fdiv dword ptr [ebp - 8]
0x4aa839 : -fadd dword ptr [6.0 (FLOAT)]
0x4aa83f : -fmul dword ptr [8192.0 (FLOAT)]
         : +fadd qword ptr [2.0 (FLOAT)]
         : +fmul qword ptr [8192.0 (FLOAT)]
0x4aa845 : call __ftol (FUNCTION)
0x4aa84a : -jmp 0x6e
0x4aa84f : -jmp 0x1c
0x4aa854 : -fld dword ptr [ebp - 8]
0x4aa857 : -fdiv dword ptr [ebp - 4]
0x4aa85a : -fsubr dword ptr [8.0 (FLOAT)]
0x4aa860 : -fmul dword ptr [8192.0 (FLOAT)]
0x4aa866 : -call __ftol (FUNCTION)
0x4aa86b : -jmp 0x4d
0x4aa870 : -jmp 0x48
         : +jmp 0x53
         : +jmp 0x4e 	(trig.c:342)
0x4aa875 : fld dword ptr [ebp - 8]
0x4aa878 : fcomp dword ptr [ebp - 4]
0x4aa87b : fnstsw ax
0x4aa87d : test ah, 0x41
0x4aa880 : -jne 0x21
         : +je 0x21
         : +fld dword ptr [ebp - 8] 	(trig.c:343)
         : +fdiv dword ptr [ebp - 4]
         : +fadd qword ptr [4.0 (FLOAT)]
         : +fmul qword ptr [8192.0 (FLOAT)]
         : +call __ftol (FUNCTION)
         : +jmp 0x21
         : +jmp 0x1c 	(trig.c:344)
0x4aa886 : fld dword ptr [ebp - 4] 	(trig.c:345)
0x4aa889 : fdiv dword ptr [ebp - 8]
0x4aa88c : -fsubr dword ptr [2.0 (FLOAT)]
0x4aa892 : -fmul dword ptr [8192.0 (FLOAT)]
0x4aa898 : -call __ftol (FUNCTION)
0x4aa89d : -jmp 0x1b
0x4aa8a2 : -jmp 0x16
0x4aa8a7 : -fld dword ptr [ebp - 8]
0x4aa8aa : -fdiv dword ptr [ebp - 4]
0x4aa8ad : -fmul dword ptr [8192.0 (FLOAT)]
         : +fsubr qword ptr [6.0 (FLOAT)]
         : +fmul qword ptr [8192.0 (FLOAT)]
0x4aa8b3 : call __ftol (FUNCTION)
0x4aa8b8 : jmp 0x0
0x4aa8bd : pop edi 	(trig.c:347)
0x4aa8be : pop esi
0x4aa8bf : pop ebx
0x4aa8c0 : leave 
0x4aa8c1 : ret 


FastFloatArcTan2Angle is only 53.08% similar to the original, diff above
```

*AI generated. Time taken: 1365s, tokens: 338,121*
