### PR TITLE
DRSceneRayPick2D 100% match

### DIFF
--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -200,7 +200,7 @@ int DRSceneRayPick2D(br_actor* world, br_vector3* pPosition, br_vector3* pDir, d
 
     BrMatrix34Inverse(&gPick_model_to_view__finteray, &world->t.t.mat);
     // LOG_WARN_ONCE("Missing material and model pointers to ActorRayPick2D");
-    return ActorRayPick2D(world, pPosition, pDir, NULL, NULL, callback);
+    return ActorRayPick2D(world, pPosition, pDir, model_unk1, material_unk1, callback);
 }
 
 // IDA: int __usercall DRModelPick2D@<EAX>(br_model *model@<EAX>, br_material *material@<EDX>, br_vector3 *ray_pos@<EBX>, br_vector3 *ray_dir@<ECX>, br_scalar t_near, br_scalar t_far, dr_modelpick2d_cbfn *callback, void *arg)


### PR DESCRIPTION
## Match result

```
0x4aaf10: DRSceneRayPick2D 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4aaf15,22 +0x476af2,26 @@
0x4aaf15 : push edi
0x4aaf16 : mov eax, dword ptr [ebp + 8] 	(finteray.c:201)
0x4aaf19 : add eax, 0x2c
0x4aaf1c : push eax
0x4aaf1d : push gPick_model_to_view__finteray (DATA)
0x4aaf22 : call BrMatrix34Inverse (FUNCTION)
0x4aaf27 : add esp, 8
0x4aaf2a : fstp st(0)
0x4aaf2c : mov eax, dword ptr [ebp + 0x14] 	(finteray.c:203)
0x4aaf2f : push eax
0x4aaf30 : -mov eax, dword ptr [material_unk1 (DATA)]
0x4aaf35 : -push eax
0x4aaf36 : -mov eax, dword ptr [model_unk1 (DATA)]
0x4aaf3b : -push eax
         : +push 0
         : +push 0
0x4aaf3c : mov eax, dword ptr [ebp + 0x10]
0x4aaf3f : push eax
0x4aaf40 : mov eax, dword ptr [ebp + 0xc]
0x4aaf43 : push eax
0x4aaf44 : mov eax, dword ptr [ebp + 8]
0x4aaf47 : push eax
0x4aaf48 : call ActorRayPick2D (FUNCTION)
0x4aaf4d : add esp, 0x18
         : +jmp 0x0
         : +pop edi 	(finteray.c:204)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRSceneRayPick2D is only 78.57% similar to the original, diff above
```

*AI generated. Time taken: 69s, tokens: 34,251*
