### PR TITLE
ActorRayPick2D 100% match

### DIFF
--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -162,19 +162,30 @@ int ActorRayPick2D(br_actor* ap, br_vector3* pPosition, br_vector3* pDir, br_mod
         pPosition = &pos;
         pDir = &dir;
     }
-    if (ap->type == BR_ACTOR_MODEL) {
+    switch (ap->type) {
+    case BR_ACTOR_MODEL:
         if (PickBoundsTestRay__finteray(&this_model->bounds, pPosition, pDir, t_near, t_far, &t_near, &t_far)) {
             t_near = 0.0;
             t_far = MIN(1.f, gNearest_T);
             r = callback(ap, this_model, this_material, pPosition, pDir, t_near, t_far, arg);
             if (r) {
-                return r;
+                break;
             }
         }
         if (r) {
-            return r;
+            break;
         }
-    } else if (ap->type >= BR_ACTOR_BOUNDS && ap->type <= BR_ACTOR_BOUNDS_CORRECT) {
+        /* fall through */
+    default:
+        for (a = ap->children; a != NULL; a = a->next) {
+            r = ActorRayPick2D(a, pPosition, pDir, this_model, this_material, callback);
+            if (r) {
+                break;
+            }
+        }
+        break;
+    case BR_ACTOR_BOUNDS:
+    case BR_ACTOR_BOUNDS_CORRECT:
         if (PickBoundsTestRay__finteray((br_bounds*)ap->type_data, pPosition, pDir, t_near, t_far, &t_near, &t_far)) {
             for (a = ap->children; a != NULL; a = a->next) {
                 r = ActorRayPick2D(a, pPosition, pDir, this_model, this_material, callback);
@@ -183,13 +194,7 @@ int ActorRayPick2D(br_actor* ap, br_vector3* pPosition, br_vector3* pDir, br_mod
                 }
             }
         }
-        return r;
-    }
-    for (a = ap->children; a != NULL; a = a->next) {
-        r = ActorRayPick2D(a, pPosition, pDir, this_model, this_material, callback);
-        if (r) {
-            break;
-        }
+        break;
     }
     return r;
 }


### PR DESCRIPTION
## Match result

```
0x4aaf5a: ActorRayPick2D 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4aaf5a,13 +0x47680b,13 @@
0x4aaf5a : push ebp 	(finteray.c:127)
0x4aaf5b : mov ebp, esp
0x4aaf5d : -sub esp, 0x98
         : +sub esp, 0x94
0x4aaf63 : push ebx
0x4aaf64 : push esi
0x4aaf65 : push edi
0x4aaf66 : mov dword ptr [ebp - 0x48], 0 	(finteray.c:140)
0x4aaf6d : mov dword ptr [ebp - 0x3c], 0x3f800000 	(finteray.c:141)
0x4aaf74 : mov dword ptr [ebp - 0x38], 0 	(finteray.c:142)
0x4aaf7b : mov dword ptr [ebp - 0x40], 0 	(finteray.c:143)
0x4aaf82 : mov eax, dword ptr [ebp + 8] 	(finteray.c:144)
0x4aaf85 : cmp dword ptr [eax + 0x18], 0
0x4aaf89 : je 0x11

---
+++
@@ -0x4aafbc,21 +0x47686d,21 @@
0x4aafbc : mov dword ptr [ebp - 0x44], eax
0x4aafbf : jmp 0x6 	(finteray.c:151)
0x4aafc4 : mov eax, dword ptr [ebp + 0x18] 	(finteray.c:152)
0x4aafc7 : mov dword ptr [ebp - 0x44], eax
0x4aafca : mov eax, dword ptr [ebp + 8] 	(finteray.c:154)
0x4aafcd : xor ecx, ecx
0x4aafcf : mov cl, byte ptr [eax + 0x20]
0x4aafd2 : cmp ecx, 1
0x4aafd5 : jne 0x7
0x4aafdb : xor eax, eax 	(finteray.c:155)
0x4aafdd : -jmp 0x25d
         : +jmp 0x255
0x4aafe2 : mov eax, dword ptr [ebp + 8] 	(finteray.c:157)
0x4aafe5 : cmp dword ptr [eax + 0x14], 0
0x4aafe9 : je 0x74
0x4aafef : mov eax, dword ptr [ebp + 8]
0x4aaff2 : mov eax, dword ptr [eax + 0x14]
0x4aaff5 : movsx eax, byte ptr [eax]
0x4aaff8 : cmp eax, 0x26
0x4aaffb : jne 0x62
0x4ab001 : mov eax, dword ptr [ebp + 8] 	(finteray.c:158)
0x4ab004 : add eax, 0x28

---
+++
@@ -0x4ab04e,41 +0x4768ff,41 @@
0x4ab04e : push eax
0x4ab04f : call BrMatrix34ApplyV (FUNCTION)
0x4ab054 : add esp, 0xc
0x4ab057 : lea eax, [ebp - 0x60] 	(finteray.c:162)
0x4ab05a : mov dword ptr [ebp + 0xc], eax
0x4ab05d : lea eax, [ebp - 0x54] 	(finteray.c:163)
0x4ab060 : mov dword ptr [ebp + 0x10], eax
0x4ab063 : mov eax, dword ptr [ebp + 8] 	(finteray.c:165)
0x4ab066 : xor ecx, ecx
0x4ab068 : mov cl, byte ptr [eax + 0x12]
0x4ab06b : -mov dword ptr [ebp - 0x98], ecx
0x4ab071 : -jmp 0x195
         : +cmp ecx, 1
         : +jne 0xae
0x4ab076 : lea eax, [ebp - 0x3c] 	(finteray.c:166)
0x4ab079 : push eax
0x4ab07a : lea eax, [ebp - 0x48]
0x4ab07d : push eax
0x4ab07e : mov eax, dword ptr [ebp - 0x3c]
0x4ab081 : push eax
0x4ab082 : mov eax, dword ptr [ebp - 0x48]
0x4ab085 : push eax
0x4ab086 : mov eax, dword ptr [ebp + 0x10]
0x4ab089 : push eax
0x4ab08a : mov eax, dword ptr [ebp + 0xc]
0x4ab08d : push eax
0x4ab08e : mov eax, dword ptr [ebp - 0x94]
0x4ab094 : add eax, 0x34
0x4ab097 : push eax
0x4ab098 : call PickBoundsTestRay__finteray (FUNCTION)
0x4ab09d : add esp, 0x1c
0x4ab0a0 : test eax, eax
0x4ab0a2 : -je 0x62
         : +je 0x65
0x4ab0a8 : mov dword ptr [ebp - 0x48], 0 	(finteray.c:167)
0x4ab0af : fld dword ptr [gNearest_T (DATA)] 	(finteray.c:168)
0x4ab0b5 : fld dword ptr [1.0 (FLOAT)]
0x4ab0bb : fcom st(1)
0x4ab0bd : fnstsw ax
0x4ab0bf : test ah, 0x41
0x4ab0c2 : je 0x2
0x4ab0c8 : fxch st(1)
0x4ab0ca : fstp st(0)
0x4ab0cc : fstp dword ptr [ebp - 0x3c]

---
+++
@@ -0x4ab0e3,54 +0x476992,38 @@
0x4ab0e3 : mov eax, dword ptr [ebp - 0x44]
0x4ab0e6 : push eax
0x4ab0e7 : mov eax, dword ptr [ebp - 0x94]
0x4ab0ed : push eax
0x4ab0ee : mov eax, dword ptr [ebp + 8]
0x4ab0f1 : push eax
0x4ab0f2 : call dword ptr [ebp + 0x1c]
0x4ab0f5 : add esp, 0x20
0x4ab0f8 : mov dword ptr [ebp - 0x38], eax
0x4ab0fb : cmp dword ptr [ebp - 0x38], 0 	(finteray.c:170)
0x4ab0ff : -je 0x5
0x4ab105 : -jmp 0x12d
         : +je 0x8
         : +mov eax, dword ptr [ebp - 0x38] 	(finteray.c:171)
         : +jmp 0x12c
0x4ab10a : cmp dword ptr [ebp - 0x38], 0 	(finteray.c:174)
0x4ab10e : -je 0x5
0x4ab114 : -jmp 0x11e
         : +je 0x8
         : +mov eax, dword ptr [ebp - 0x38] 	(finteray.c:175)
         : +jmp 0x11a
         : +jmp 0xb3 	(finteray.c:177)
0x4ab119 : mov eax, dword ptr [ebp + 8]
0x4ab11c : -mov eax, dword ptr [eax + 8]
0x4ab11f : -mov dword ptr [ebp - 0x34], eax
0x4ab122 : -jmp 0x8
0x4ab127 : -mov eax, dword ptr [ebp - 0x34]
0x4ab12a : -mov eax, dword ptr [eax]
0x4ab12c : -mov dword ptr [ebp - 0x34], eax
0x4ab12f : -cmp dword ptr [ebp - 0x34], 0
0x4ab133 : -je 0x3a
0x4ab139 : -mov eax, dword ptr [ebp + 0x1c]
0x4ab13c : -push eax
0x4ab13d : -mov eax, dword ptr [ebp - 0x44]
0x4ab140 : -push eax
0x4ab141 : -mov eax, dword ptr [ebp - 0x94]
0x4ab147 : -push eax
0x4ab148 : -mov eax, dword ptr [ebp + 0x10]
0x4ab14b : -push eax
0x4ab14c : -mov eax, dword ptr [ebp + 0xc]
0x4ab14f : -push eax
0x4ab150 : -mov eax, dword ptr [ebp - 0x34]
0x4ab153 : -push eax
0x4ab154 : -call ActorRayPick2D (FUNCTION)
0x4ab159 : -add esp, 0x18
0x4ab15c : -mov dword ptr [ebp - 0x38], eax
0x4ab15f : -cmp dword ptr [ebp - 0x38], 0
0x4ab163 : -je 0x5
0x4ab169 : -jmp 0x5
0x4ab16e : -jmp -0x4c
0x4ab173 : -jmp 0xbf
         : +xor ecx, ecx
         : +mov cl, byte ptr [eax + 0x12]
         : +cmp ecx, 5
         : +jl 0xa2
         : +mov eax, dword ptr [ebp + 8]
         : +xor ecx, ecx
         : +mov cl, byte ptr [eax + 0x12]
         : +cmp ecx, 6
         : +jg 0x91
0x4ab178 : lea eax, [ebp - 0x3c] 	(finteray.c:178)
0x4ab17b : push eax
0x4ab17c : lea eax, [ebp - 0x48]
0x4ab17f : push eax
0x4ab180 : mov eax, dword ptr [ebp - 0x3c]
0x4ab183 : push eax
0x4ab184 : mov eax, dword ptr [ebp - 0x48]
0x4ab187 : push eax
0x4ab188 : mov eax, dword ptr [ebp + 0x10]
0x4ab18b : push eax

---
+++
@@ -0x4ab1dd,20 +0x476a5a,47 @@
0x4ab1dd : push eax
0x4ab1de : mov eax, dword ptr [ebp - 0x34]
0x4ab1e1 : push eax
0x4ab1e2 : call ActorRayPick2D (FUNCTION)
0x4ab1e7 : add esp, 0x18
0x4ab1ea : mov dword ptr [ebp - 0x38], eax
0x4ab1ed : cmp dword ptr [ebp - 0x38], 0 	(finteray.c:181)
0x4ab1f1 : je 0x5
0x4ab1f7 : jmp 0x5 	(finteray.c:182)
0x4ab1fc : jmp -0x4c 	(finteray.c:184)
0x4ab201 : -jmp 0x31
0x4ab206 : -jmp 0x2c
0x4ab20b : -cmp dword ptr [ebp - 0x98], 1
0x4ab212 : -je -0x1a2
0x4ab218 : -cmp dword ptr [ebp - 0x98], 5
0x4ab21f : -jl -0x10c
0x4ab225 : -cmp dword ptr [ebp - 0x98], 6
0x4ab22c : -jle -0xba
0x4ab232 : -jmp -0x11e
0x4ab237 : mov eax, dword ptr [ebp - 0x38] 	(finteray.c:186)
         : +jmp 0x62
         : +mov eax, dword ptr [ebp + 8] 	(finteray.c:188)
         : +mov eax, dword ptr [eax + 8]
         : +mov dword ptr [ebp - 0x34], eax
         : +jmp 0x8
         : +mov eax, dword ptr [ebp - 0x34]
         : +mov eax, dword ptr [eax]
         : +mov dword ptr [ebp - 0x34], eax
         : +cmp dword ptr [ebp - 0x34], 0
         : +je 0x3a
         : +mov eax, dword ptr [ebp + 0x1c] 	(finteray.c:189)
         : +push eax
         : +mov eax, dword ptr [ebp - 0x44]
         : +push eax
         : +mov eax, dword ptr [ebp - 0x94]
         : +push eax
         : +mov eax, dword ptr [ebp + 0x10]
         : +push eax
         : +mov eax, dword ptr [ebp + 0xc]
         : +push eax
         : +mov eax, dword ptr [ebp - 0x34]
         : +push eax
         : +call ActorRayPick2D (FUNCTION)
         : +add esp, 0x18
         : +mov dword ptr [ebp - 0x38], eax
         : +cmp dword ptr [ebp - 0x38], 0 	(finteray.c:190)
         : +je 0x5
         : +jmp 0x5 	(finteray.c:191)
         : +jmp -0x4c 	(finteray.c:193)
         : +mov eax, dword ptr [ebp - 0x38] 	(finteray.c:194)
         : +jmp 0x0
         : +pop edi 	(finteray.c:195)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


ActorRayPick2D is only 77.36% similar to the original, diff above
```

*AI generated. Time taken: 247s, tokens: 27,914*
