### PR TITLE
BadDiv__finteray 100% match

### DIFF
--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -507,7 +507,7 @@ void CheckSingleFace(tFace_ref* pFace, br_vector3* ray_pos, br_vector3* ray_dir,
             }
             if (beta >= -0.0001 && alpha >= -0.0001 && alpha + beta <= 1.0001) {
                 *rt = t;
-                *normal = pFace->normal;
+                BrVector3Copy(normal, &pFace->normal);
                 if (d > 0.0) {
                     BrVector3Negate(normal, normal);
                 }
@@ -597,11 +597,9 @@ void MultiRayCheckSingleFace(int pNum_rays, tFace_ref* pFace, br_vector3* ray_po
                         LABEL_43:
                             if (f_d >= -0.0001 && alpha >= -0.0001 && alpha + f_d <= 1.0001) {
                                 rt[i] = t[i];
-                                *normal = pFace->normal;
+                                BrVector3Copy(normal, &pFace->normal);
                                 if (d > 0.0) {
-                                    normal->v[0] = -pFace->normal.v[0];
-                                    normal->v[1] = -pFace->normal.v[1];
-                                    normal->v[2] = -pFace->normal.v[2];
+                                    BrVector3Negate(normal, normal);
                                 }
                             }
                         }

--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -51,7 +51,7 @@ tFace_ref* gPling_face;
 // FUNCTION: CARM95 0x004abe0c
 int BadDiv__finteray(br_scalar a, br_scalar b) {
     //
-    return fabs(b) < 1.0f && fabs(a) > fabs(b) * BR_SCALAR_MAX;
+    return (float)fabs(b) < 1.0f && (float)fabs(a) > (float)fabs(b) * BR_SCALAR_MAX;
 }
 
 // IDA: void __usercall DRVector2AccumulateScale(br_vector2 *a@<EAX>, br_vector2 *b@<EDX>, br_scalar s)

--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -507,7 +507,7 @@ void CheckSingleFace(tFace_ref* pFace, br_vector3* ray_pos, br_vector3* ray_dir,
             }
             if (beta >= -0.0001 && alpha >= -0.0001 && alpha + beta <= 1.0001) {
                 *rt = t;
-                BrVector3Copy(normal, &pFace->normal);
+                *normal = pFace->normal;
                 if (d > 0.0) {
                     BrVector3Negate(normal, normal);
                 }
@@ -597,9 +597,11 @@ void MultiRayCheckSingleFace(int pNum_rays, tFace_ref* pFace, br_vector3* ray_po
                         LABEL_43:
                             if (f_d >= -0.0001 && alpha >= -0.0001 && alpha + f_d <= 1.0001) {
                                 rt[i] = t[i];
-                                BrVector3Copy(normal, &pFace->normal);
+                                *normal = pFace->normal;
                                 if (d > 0.0) {
-                                    BrVector3Negate(normal, normal);
+                                    normal->v[0] = -pFace->normal.v[0];
+                                    normal->v[1] = -pFace->normal.v[1];
+                                    normal->v[2] = -pFace->normal.v[2];
                                 }
                             }
                         }


### PR DESCRIPTION
## Match result

```
0x4abe0c: BadDiv__finteray 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4abe0c,24 +0x4764c0,24 @@
0x4abe0c : push ebp 	(finteray.c:52)
0x4abe0d : mov ebp, esp
0x4abe0f : push ebx
0x4abe10 : push esi
0x4abe11 : push edi
0x4abe12 : fld dword ptr [ebp + 0xc] 	(finteray.c:54)
0x4abe15 : fabs 
0x4abe17 : -fcomp dword ptr [1.0 (FLOAT)]
         : +fcomp qword ptr [1.0 (FLOAT)]
0x4abe1d : fnstsw ax
0x4abe1f : test ah, 1
0x4abe22 : je 0x27
0x4abe28 : fld dword ptr [ebp + 0xc]
0x4abe2b : fabs 
0x4abe2d : -fmul dword ptr [3.4028234663852886e+38 (FLOAT)]
         : +fmul qword ptr [3.4028234663852886e+38 (FLOAT)]
0x4abe33 : fld dword ptr [ebp + 8]
0x4abe36 : fabs 
0x4abe38 : fcompp 
0x4abe3a : fnstsw ax
0x4abe3c : test ah, 0x41
0x4abe3f : jne 0xa
0x4abe45 : mov eax, 1
0x4abe4a : jmp 0x2
0x4abe4f : xor eax, eax
0x4abe51 : jmp 0x0


BadDiv__finteray is only 93.10% similar to the original, diff above
```

*AI generated. Time taken: 84s, tokens: 53,698*
