### PR TITLE
FindHighestPolyCallBack__finteray 100% match

### DIFF
--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -367,7 +367,7 @@ int DRModelPick2D__finteray(br_model* model, br_material* material, br_vector3* 
 // FUNCTION: CARM95 0x004abe8d
 int FindHighestPolyCallBack__finteray(br_model* pModel, br_material* pMaterial, br_vector3* pRay_pos, br_vector3* pRay_dir, br_scalar pT, int pF, int pE, int pV, br_vector3* pPoint, br_vector2* pMap, void* pArg) {
 
-    if (pT < (double)gNearest_T) {
+    if ((+pT) < gNearest_T) {
         gNearest_T = pT;
         gNearest_model = pModel;
         gNearest_face = pF;

--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -367,7 +367,7 @@ int DRModelPick2D__finteray(br_model* model, br_material* material, br_vector3* 
 // FUNCTION: CARM95 0x004abe8d
 int FindHighestPolyCallBack__finteray(br_model* pModel, br_material* pMaterial, br_vector3* pRay_pos, br_vector3* pRay_dir, br_scalar pT, int pF, int pE, int pV, br_vector3* pPoint, br_vector2* pMap, void* pArg) {
 
-    if ((+pT) < gNearest_T) {
+    if ((pT) < gNearest_T) {
         gNearest_T = pT;
         gNearest_model = pModel;
         gNearest_face = pF;


### PR DESCRIPTION
## Match result

```
0x4abe8d: FindHighestPolyCallBack__finteray 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4abe8d,20 +0x47729b,20 @@
0x4abe8d : push ebp 	(finteray.c:368)
0x4abe8e : mov ebp, esp
0x4abe90 : push ebx
0x4abe91 : push esi
0x4abe92 : push edi
0x4abe93 : -fld dword ptr [ebp + 0x18]
0x4abe96 : -fcomp dword ptr [gNearest_T (DATA)]
         : +fld dword ptr [gNearest_T (DATA)] 	(finteray.c:370)
         : +fcomp dword ptr [ebp + 0x18]
0x4abe9c : fnstsw ax
0x4abe9e : -test ah, 1
0x4abea1 : -je 0x22
         : +test ah, 0x41
         : +jne 0x22
0x4abea7 : mov eax, dword ptr [ebp + 0x18] 	(finteray.c:371)
0x4abeaa : mov dword ptr [gNearest_T (DATA)], eax
0x4abeaf : mov eax, dword ptr [ebp + 8] 	(finteray.c:372)
0x4abeb2 : mov dword ptr [gNearest_model (DATA)], eax
0x4abeb7 : mov eax, dword ptr [ebp + 0x1c] 	(finteray.c:373)
0x4abeba : mov dword ptr [gNearest_face (DATA)], eax
0x4abebf : mov eax, dword ptr [gTemp_group (DATA)] 	(finteray.c:374)
0x4abec4 : mov dword ptr [gNearest_face_group (DATA)], eax
0x4abec9 : xor eax, eax 	(finteray.c:376)
0x4abecb : jmp 0x0


FindHighestPolyCallBack__finteray is only 84.00% similar to the original, diff above
```

*AI generated. Time taken: 321s, tokens: 45,110*
