### PR TITLE
CheckSingleFace equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -452,67 +452,92 @@ void CheckSingleFace(tFace_ref* pFace, br_vector3* ray_pos, br_vector3* ray_dir,
     *rt = 100.0;
 
     d = pFace->normal.v[1] * ray_dir->v[1] + ray_dir->v[2] * pFace->normal.v[2] + ray_dir->v[0] * pFace->normal.v[0];
-    if ((this_material == NULL || (this_material->flags & (BR_MATF_TWO_SIDED | BR_MATF_ALWAYS_VISIBLE)) != 0 || d <= 0.0)
-        && (!this_material || !this_material->identifier || *this_material->identifier != '!' || !gPling_materials)
-        && fabs(d) >= 0.00000023841858) {
-        BrVector3Sub(&p, ray_pos, &pFace->v[0]);
-        numerator = BrVector3Dot(&pFace->normal, &p);
-        if (!BadDiv__finteray(numerator, d)) {
-            if (d > 0.0) {
-                if (-numerator < -0.001 || -numerator > d + 0.003) {
-                    return;
-                }
-            } else if (numerator < -0.001 || 0.003 - d < numerator) {
-                return;
-            }
-            t = -(numerator / d);
-            if (t > 1.0) {
-                t = 1.0;
-            }
-            BrVector3Scale(&tv, ray_dir, t);
-            BrVector3Accumulate(&tv, ray_pos);
-            axis_m = fabs(pFace->normal.v[0]) < fabs(pFace->normal.v[1]);
-            if (fabs(pFace->normal.v[2]) > fabs(pFace->normal.v[axis_m])) {
-                axis_m = 2;
-            }
-            if (axis_m) {
-                axis_0 = 0;
-                if (axis_m == 1) {
-                    axis_1 = 2;
-                } else {
-                    axis_1 = 1;
-                }
-            } else {
-                axis_0 = 1;
-                axis_1 = 2;
-            }
-            v0i1 = pFace->v[0].v[axis_0];
-            v0i2 = pFace->v[0].v[axis_1];
-            u0 = pFace->v[1].v[axis_0] - v0i1;
-            u1 = pFace->v[1].v[axis_1] - v0i2;
-            v0 = pFace->v[2].v[axis_0] - v0i1;
-            v1 = pFace->v[2].v[axis_1] - v0i2;
-            u2 = tv.v[axis_0] - v0i1;
-            v2 = tv.v[axis_1] - v0i2;
-            if (fabs(u0) > 0.0000002384185791015625) {
-                f_d = v1 * u0 - u1 * v0;
-                if (f_d == 0) {
-                    return;
-                }
-                alpha = (v2 * u0 - u1 * u2) / f_d;
-                beta = (u2 - alpha * v0) / u0;
-            } else {
-                alpha = u2 / v0;
-                beta = (v2 - alpha * v1) / u1;
-            }
-            if (beta >= -0.0001 && alpha >= -0.0001 && alpha + beta <= 1.0001) {
-                *rt = t;
-                *normal = pFace->normal;
-                if (d > 0.0) {
-                    BrVector3Negate(normal, normal);
-                }
-            }
+    if (this_material != NULL && (this_material->flags & (BR_MATF_TWO_SIDED | BR_MATF_ALWAYS_VISIBLE)) == 0 && d > 0.0f) {
+        return;
+    }
+    if (this_material != NULL && this_material->identifier != NULL && *this_material->identifier == '!' && gPling_materials) {
+        return;
+    }
+    if ((float)fabs(d) < 0.00000023841858f) {
+        return;
+    }
+
+    BrVector3Sub(&tv, ray_pos, &pFace->v[0]);
+    numerator = BrVector3Dot(&pFace->normal, &tv);
+    if (BadDiv__finteray(numerator, d)) {
+        return;
+    }
+
+    if (d <= 0.0f) {
+        if (numerator < -0.001 || numerator > -d + 0.003) {
+            return;
         }
+    } else {
+        if (-numerator < -0.001 || -numerator > d + 0.003) {
+            return;
+        }
+    }
+    t = -(numerator / d);
+    if (t > 1.0f) {
+        t = 1.0f;
+    }
+
+    BrVector3Scale(&p, ray_dir, t);
+    BrVector3Accumulate(&p, ray_pos);
+
+    axis_m = 0;
+    if (fabs(pFace->normal.v[0]) < fabs(pFace->normal.v[1])) {
+        axis_m = 1;
+    }
+    if (fabs(pFace->normal.v[2]) > fabs(pFace->normal.v[axis_m])) {
+        axis_m = 2;
+    }
+    switch (axis_m) {
+    case 0:
+        axis_0 = 1;
+        axis_1 = 2;
+        break;
+    case 1:
+        axis_0 = 0;
+        axis_1 = 2;
+        break;
+    case 2:
+        axis_0 = 0;
+        axis_1 = 1;
+        break;
+    }
+
+    v0i1 = pFace->v[0].v[axis_0];
+    v0i2 = pFace->v[0].v[axis_1];
+    u1 = pFace->v[1].v[axis_0] - v0i1;
+    v1 = pFace->v[1].v[axis_1] - v0i2;
+    u2 = pFace->v[2].v[axis_0] - v0i1;
+    v2 = pFace->v[2].v[axis_1] - v0i2;
+    u0 = p.v[axis_0] - v0i1;
+    v0 = p.v[axis_1] - v0i2;
+    if (fabs(u1) <= 0.0000002384185791015625) {
+        beta = u0 / u2;
+        f_numerator = v0 - v2 * beta;
+        alpha = f_numerator / v1;
+    } else {
+        f_n = v0 * u1 - u0 * v1;
+        f_d = u1 * v2 - v1 * u2;
+        if (f_d == 0) {
+            return;
+        }
+        beta = f_n / f_d;
+        f_numerator = u0 - beta * u2;
+        alpha = f_numerator / u1;
+    }
+    if (alpha < -0.0001 || beta < -0.0001 || alpha + beta > 1.0001) {
+        return;
+    }
+    *rt = t;
+    normal->v[0] = pFace->normal.v[0];
+    normal->v[1] = pFace->normal.v[1];
+    normal->v[2] = pFace->normal.v[2];
+    if (d > 0.0f) {
+        BrVector3Negate(normal, normal);
     }
 }
 

--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -533,9 +533,7 @@ void CheckSingleFace(tFace_ref* pFace, br_vector3* ray_pos, br_vector3* ray_dir,
         return;
     }
     *rt = t;
-    normal->v[0] = pFace->normal.v[0];
-    normal->v[1] = pFace->normal.v[1];
-    normal->v[2] = pFace->normal.v[2];
+    BrVector3Copy(normal, &pFace->normal);
     if (d > 0.0f) {
         BrVector3Negate(normal, normal);
     }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4abf00,24 +0x477435,24 @@
0x4abf00 : mov ebp, esp
0x4abf02 : sub esp, 0x98
0x4abf08 : push ebx
0x4abf09 : push esi
0x4abf0a : push edi
0x4abf0b : mov eax, dword ptr [ebp + 8] 	(finteray.c:451)
0x4abf0e : mov eax, dword ptr [eax]
0x4abf10 : mov dword ptr [ebp - 0x50], eax
0x4abf13 : mov eax, dword ptr [ebp + 0x18] 	(finteray.c:452)
0x4abf16 : mov dword ptr [eax], 0x42c80000
         : +mov eax, dword ptr [ebp + 0x10] 	(finteray.c:454)
         : +fld dword ptr [eax + 4]
0x4abf1c : mov eax, dword ptr [ebp + 8]
0x4abf1f : -fld dword ptr [eax + 0x38]
0x4abf22 : -mov eax, dword ptr [ebp + 0x10]
0x4abf25 : -fmul dword ptr [eax + 4]
         : +fmul dword ptr [eax + 0x38]
0x4abf28 : mov eax, dword ptr [ebp + 0x10]
0x4abf2b : fld dword ptr [eax + 8]
0x4abf2e : mov eax, dword ptr [ebp + 8]
0x4abf31 : fmul dword ptr [eax + 0x3c]
0x4abf34 : faddp st(1)
0x4abf36 : mov eax, dword ptr [ebp + 0x10]
0x4abf39 : fld dword ptr [eax]
0x4abf3b : mov eax, dword ptr [ebp + 8]
0x4abf3e : fmul dword ptr [eax + 0x34]
0x4abf41 : faddp st(1)

---
+++
@@ -0x4ac2a0,22 +0x4777d5,22 @@
0x4ac2a0 : fst qword ptr [ebp - 0x88]
0x4ac2a6 : fdiv qword ptr [ebp - 8] 	(finteray.c:521)
0x4ac2a9 : fstp qword ptr [ebp - 0x28]
0x4ac2ac : jmp 0x56 	(finteray.c:522)
0x4ac2b1 : fld qword ptr [ebp - 0x94] 	(finteray.c:523)
0x4ac2b7 : fmul qword ptr [ebp - 0x6c]
0x4ac2ba : fld qword ptr [ebp - 8]
0x4ac2bd : fmul qword ptr [ebp - 0x64]
0x4ac2c0 : fsubp st(1)
0x4ac2c2 : fstp qword ptr [ebp - 0x20]
0x4ac2c5 : -fld qword ptr [ebp - 0x34]
0x4ac2c8 : -fmul qword ptr [ebp - 0x6c]
         : +fld qword ptr [ebp - 0x6c] 	(finteray.c:524)
         : +fmul qword ptr [ebp - 0x34]
0x4ac2cb : fld qword ptr [ebp - 8]
0x4ac2ce : fmul qword ptr [ebp - 0x74]
0x4ac2d1 : fsubp st(1)
0x4ac2d3 : fcom qword ptr [0.0 (FLOAT)] 	(finteray.c:525)
0x4ac2d9 : fstp qword ptr [ebp - 0x58]
0x4ac2dc : fnstsw ax
0x4ac2de : test ah, 0x40
0x4ac2e1 : je 0x5
0x4ac2e7 : jmp 0xc6 	(finteray.c:526)
0x4ac2ec : fld qword ptr [ebp - 0x20] 	(finteray.c:528)


CheckSingleFace is only 98.52% similar to the original, diff above
```

#### Effective match analysis

Both shown changes only swap the two operands of a floating-point multiplication (`fld A; fmul B` vs `fld B; fmul A`). The surrounding stack usage, subsequent `fsubp`/`faddp`, stores, comparisons, and jumps are unchanged. Since multiplication is commutative (and you asked to ignore NaN behavior and tiny FP rounding effects), these diffs preserve functional results and do not introduce control-flow reshuffling.

#### Original match

```
---
+++
@@ -0x4abeff,299 +0x477434,316 @@
0x4abeff : push ebp 	(finteray.c:427)
0x4abf00 : mov ebp, esp
0x4abf02 : -sub esp, 0x98
         : +sub esp, 0x94
0x4abf08 : push ebx
0x4abf09 : push esi
0x4abf0a : push edi
0x4abf0b : mov eax, dword ptr [ebp + 8] 	(finteray.c:451)
0x4abf0e : mov eax, dword ptr [eax]
0x4abf10 : mov dword ptr [ebp - 0x50], eax
0x4abf13 : mov eax, dword ptr [ebp + 0x18] 	(finteray.c:452)
0x4abf16 : mov dword ptr [eax], 0x42c80000
         : +mov eax, dword ptr [ebp + 0x10] 	(finteray.c:454)
         : +fld dword ptr [eax + 4]
0x4abf1c : mov eax, dword ptr [ebp + 8]
0x4abf1f : -fld dword ptr [eax + 0x38]
0x4abf22 : -mov eax, dword ptr [ebp + 0x10]
0x4abf25 : -fmul dword ptr [eax + 4]
         : +fmul dword ptr [eax + 0x38]
0x4abf28 : mov eax, dword ptr [ebp + 0x10]
0x4abf2b : fld dword ptr [eax + 8]
0x4abf2e : mov eax, dword ptr [ebp + 8]
0x4abf31 : fmul dword ptr [eax + 0x3c]
0x4abf34 : faddp st(1)
0x4abf36 : mov eax, dword ptr [ebp + 0x10]
0x4abf39 : fld dword ptr [eax]
0x4abf3b : mov eax, dword ptr [ebp + 8]
0x4abf3e : fmul dword ptr [eax + 0x34]
0x4abf41 : faddp st(1)
0x4abf43 : fstp dword ptr [ebp - 0x48]
0x4abf46 : cmp dword ptr [ebp - 0x50], 0 	(finteray.c:457)
0x4abf4a : -je 0x26
         : +je 0x21
0x4abf50 : mov eax, dword ptr [ebp - 0x50]
0x4abf53 : test byte ptr [eax + 0x21], 0x18
0x4abf57 : -jne 0x19
         : +jne 0x14
0x4abf5d : fld dword ptr [ebp - 0x48]
0x4abf60 : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x4abf66 : fnstsw ax
0x4abf68 : test ah, 0x41
0x4abf6b : -jne 0x5
0x4abf71 : -jmp 0x43c
         : +je 0x3db
0x4abf76 : cmp dword ptr [ebp - 0x50], 0
0x4abf7a : -je 0x31
         : +je 0x2c
0x4abf80 : mov eax, dword ptr [ebp - 0x50]
0x4abf83 : cmp dword ptr [eax + 4], 0
0x4abf87 : -je 0x24
         : +je 0x1f
0x4abf8d : mov eax, dword ptr [ebp - 0x50]
0x4abf90 : mov eax, dword ptr [eax + 4]
0x4abf93 : movsx eax, byte ptr [eax]
0x4abf96 : cmp eax, 0x21
0x4abf99 : -jne 0x12
         : +jne 0xd
0x4abf9f : cmp dword ptr [gPling_materials (DATA)], 0
0x4abfa6 : -je 0x5
0x4abfac : -jmp 0x401
         : +jne 0x3a5
0x4abfb1 : fld dword ptr [ebp - 0x48]
0x4abfb4 : fabs 
0x4abfb6 : -fcomp dword ptr [2.384185791015625e-07 (FLOAT)]
         : +fcomp qword ptr [2.3841858e-07 (FLOAT)]
0x4abfbc : fnstsw ax
0x4abfbe : test ah, 1
0x4abfc1 : -je 0x5
0x4abfc7 : -jmp 0x3e6
         : +jne 0x38f
0x4abfcc : mov eax, dword ptr [ebp + 0xc] 	(finteray.c:458)
0x4abfcf : fld dword ptr [eax]
0x4abfd1 : mov eax, dword ptr [ebp + 8]
0x4abfd4 : fsub dword ptr [eax + 4]
0x4abfd7 : -fstp dword ptr [ebp - 0x80]
         : +fstp dword ptr [ebp - 0x18]
0x4abfda : mov eax, dword ptr [ebp + 0xc]
0x4abfdd : fld dword ptr [eax + 4]
0x4abfe0 : mov eax, dword ptr [ebp + 8]
0x4abfe3 : fsub dword ptr [eax + 8]
0x4abfe6 : -fstp dword ptr [ebp - 0x7c]
         : +fstp dword ptr [ebp - 0x14]
0x4abfe9 : mov eax, dword ptr [ebp + 0xc]
0x4abfec : fld dword ptr [eax + 8]
0x4abfef : mov eax, dword ptr [ebp + 8]
0x4abff2 : fsub dword ptr [eax + 0xc]
0x4abff5 : -fstp dword ptr [ebp - 0x78]
         : +fstp dword ptr [ebp - 0x10]
0x4abff8 : mov eax, dword ptr [ebp + 8] 	(finteray.c:459)
0x4abffb : fld dword ptr [eax + 0x38]
0x4abffe : -fmul dword ptr [ebp - 0x7c]
         : +fmul dword ptr [ebp - 0x14]
0x4ac001 : mov eax, dword ptr [ebp + 8]
0x4ac004 : fld dword ptr [eax + 0x3c]
0x4ac007 : -fmul dword ptr [ebp - 0x78]
         : +fmul dword ptr [ebp - 0x10]
0x4ac00a : faddp st(1)
0x4ac00c : mov eax, dword ptr [ebp + 8]
0x4ac00f : fld dword ptr [eax + 0x34]
0x4ac012 : -fmul dword ptr [ebp - 0x80]
         : +fmul dword ptr [ebp - 0x18]
0x4ac015 : faddp st(1)
0x4ac017 : fstp dword ptr [ebp - 0x8c]
0x4ac01d : mov eax, dword ptr [ebp - 0x48] 	(finteray.c:460)
0x4ac020 : push eax
0x4ac021 : mov eax, dword ptr [ebp - 0x8c]
0x4ac027 : push eax
0x4ac028 : call BadDiv__finteray (FUNCTION)
0x4ac02d : add esp, 8
0x4ac030 : test eax, eax
0x4ac032 : -je 0x5
0x4ac038 : -jmp 0x375
         : +jne 0x323
0x4ac03d : fld dword ptr [ebp - 0x48] 	(finteray.c:461)
0x4ac040 : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x4ac046 : fnstsw ax
0x4ac048 : test ah, 0x41
0x4ac04b : -je 0x3d
0x4ac051 : -fld dword ptr [ebp - 0x8c]
0x4ac057 : -fcomp qword ptr [-0.001 (FLOAT)]
0x4ac05d : -fnstsw ax
0x4ac05f : -test ah, 1
0x4ac062 : -jne 0x1c
0x4ac068 : -fld dword ptr [ebp - 0x48]
0x4ac06b : -fchs 
0x4ac06d : -fadd qword ptr [0.003 (FLOAT)]
0x4ac073 : -fcomp dword ptr [ebp - 0x8c]
0x4ac079 : -fnstsw ax
0x4ac07b : -test ah, 1
0x4ac07e : -je 0x5
0x4ac084 : -jmp 0x329
0x4ac089 : -jmp 0x3c
         : +jne 0x41
0x4ac08e : fld dword ptr [ebp - 0x8c] 	(finteray.c:462)
0x4ac094 : fchs 
0x4ac096 : fcomp qword ptr [-0.001 (FLOAT)]
0x4ac09c : fnstsw ax
0x4ac09e : test ah, 1
0x4ac0a1 : jne 0x1e
0x4ac0a7 : fld dword ptr [ebp - 0x48]
0x4ac0aa : fadd qword ptr [0.003 (FLOAT)]
0x4ac0b0 : fld dword ptr [ebp - 0x8c]
0x4ac0b6 : fchs 
0x4ac0b8 : fcompp 
0x4ac0ba : fnstsw ax
0x4ac0bc : test ah, 0x41
0x4ac0bf : jne 0x5
0x4ac0c5 : -jmp 0x2e8
         : +jmp 0x2d3 	(finteray.c:463)
         : +jmp 0x36 	(finteray.c:465)
         : +fld dword ptr [ebp - 0x8c]
         : +fcomp qword ptr [-0.001 (FLOAT)]
         : +fnstsw ax
         : +test ah, 1
         : +jne 0x1a
         : +fld qword ptr [0.003 (FLOAT)]
         : +fsub dword ptr [ebp - 0x48]
         : +fcomp dword ptr [ebp - 0x8c]
         : +fnstsw ax
         : +test ah, 1
         : +je 0x5
         : +jmp 0x298 	(finteray.c:466)
0x4ac0ca : fld dword ptr [ebp - 0x8c] 	(finteray.c:468)
0x4ac0d0 : fdiv dword ptr [ebp - 0x48]
0x4ac0d3 : fchs 
0x4ac0d5 : -fcom dword ptr [1.0 (FLOAT)]
         : +fcom qword ptr [1.0 (FLOAT)] 	(finteray.c:469)
0x4ac0db : fstp dword ptr [ebp - 0x4c]
0x4ac0de : fnstsw ax
0x4ac0e0 : test ah, 0x41
0x4ac0e3 : jne 0x7
0x4ac0e9 : mov dword ptr [ebp - 0x4c], 0x3f800000 	(finteray.c:470)
0x4ac0f0 : mov eax, dword ptr [ebp + 0x10] 	(finteray.c:472)
0x4ac0f3 : fld dword ptr [eax]
0x4ac0f5 : fmul dword ptr [ebp - 0x4c]
0x4ac0f8 : -fstp dword ptr [ebp - 0x18]
         : +fstp dword ptr [ebp - 0x80]
0x4ac0fb : mov eax, dword ptr [ebp + 0x10]
0x4ac0fe : fld dword ptr [eax + 4]
0x4ac101 : fmul dword ptr [ebp - 0x4c]
0x4ac104 : -fstp dword ptr [ebp - 0x14]
         : +fstp dword ptr [ebp - 0x7c]
0x4ac107 : mov eax, dword ptr [ebp + 0x10]
0x4ac10a : fld dword ptr [eax + 8]
0x4ac10d : fmul dword ptr [ebp - 0x4c]
0x4ac110 : -fstp dword ptr [ebp - 0x10]
         : +fstp dword ptr [ebp - 0x78]
0x4ac113 : mov eax, dword ptr [ebp + 0xc] 	(finteray.c:473)
0x4ac116 : fld dword ptr [eax]
0x4ac118 : -fadd dword ptr [ebp - 0x18]
0x4ac11b : -fstp dword ptr [ebp - 0x18]
         : +fadd dword ptr [ebp - 0x80]
         : +fstp dword ptr [ebp - 0x80]
0x4ac11e : mov eax, dword ptr [ebp + 0xc]
0x4ac121 : fld dword ptr [eax + 4]
0x4ac124 : -fadd dword ptr [ebp - 0x14]
0x4ac127 : -fstp dword ptr [ebp - 0x14]
         : +fadd dword ptr [ebp - 0x7c]
         : +fstp dword ptr [ebp - 0x7c]
0x4ac12a : mov eax, dword ptr [ebp + 0xc]
0x4ac12d : fld dword ptr [eax + 8]
0x4ac130 : -fadd dword ptr [ebp - 0x10]
0x4ac133 : -fstp dword ptr [ebp - 0x10]
0x4ac136 : -mov dword ptr [ebp - 0xc], 0
         : +fadd dword ptr [ebp - 0x78]
         : +fstp dword ptr [ebp - 0x78]
0x4ac13d : mov eax, dword ptr [ebp + 8] 	(finteray.c:474)
0x4ac140 : fld dword ptr [eax + 0x38]
0x4ac143 : fabs 
0x4ac145 : mov eax, dword ptr [ebp + 8]
0x4ac148 : fld dword ptr [eax + 0x34]
0x4ac14b : fabs 
0x4ac14d : fcompp 
0x4ac14f : fnstsw ax
0x4ac151 : test ah, 1
0x4ac154 : -je 0x7
         : +je 0xc
0x4ac15a : mov dword ptr [ebp - 0xc], 1
         : +jmp 0x7
         : +mov dword ptr [ebp - 0xc], 0
0x4ac161 : mov eax, dword ptr [ebp - 0xc] 	(finteray.c:475)
0x4ac164 : mov ecx, dword ptr [ebp + 8]
0x4ac167 : fld dword ptr [ecx + eax*4 + 0x34]
0x4ac16b : fabs 
0x4ac16d : mov eax, dword ptr [ebp + 8]
0x4ac170 : fld dword ptr [eax + 0x3c]
0x4ac173 : fabs 
0x4ac175 : fcompp 
0x4ac177 : fnstsw ax
0x4ac179 : test ah, 0x41
0x4ac17c : jne 0x7
0x4ac182 : mov dword ptr [ebp - 0xc], 2 	(finteray.c:476)
0x4ac189 : -mov eax, dword ptr [ebp - 0xc]
0x4ac18c : -mov dword ptr [ebp - 0x98], eax
0x4ac192 : -jmp 0x3e
         : +cmp dword ptr [ebp - 0xc], 0 	(finteray.c:478)
         : +je 0x29
         : +mov dword ptr [ebp - 0x5c], 0 	(finteray.c:479)
         : +cmp dword ptr [ebp - 0xc], 1 	(finteray.c:480)
         : +jne 0xc
         : +mov dword ptr [ebp - 0x44], 2 	(finteray.c:481)
         : +jmp 0x7 	(finteray.c:482)
         : +mov dword ptr [ebp - 0x44], 1 	(finteray.c:483)
         : +jmp 0xe 	(finteray.c:485)
0x4ac197 : mov dword ptr [ebp - 0x5c], 1 	(finteray.c:486)
0x4ac19e : mov dword ptr [ebp - 0x44], 2 	(finteray.c:487)
0x4ac1a5 : -jmp 0x57
0x4ac1aa : -mov dword ptr [ebp - 0x5c], 0
0x4ac1b1 : -mov dword ptr [ebp - 0x44], 2
0x4ac1b8 : -jmp 0x44
0x4ac1bd : -mov dword ptr [ebp - 0x5c], 0
0x4ac1c4 : -mov dword ptr [ebp - 0x44], 1
0x4ac1cb : -jmp 0x31
0x4ac1d0 : -jmp 0x2c
0x4ac1d5 : -cmp dword ptr [ebp - 0x98], 0
0x4ac1dc : -je -0x4b
0x4ac1e2 : -cmp dword ptr [ebp - 0x98], 1
0x4ac1e9 : -je -0x45
0x4ac1ef : -cmp dword ptr [ebp - 0x98], 2
0x4ac1f6 : -je -0x3f
0x4ac1fc : -jmp 0x0
0x4ac201 : mov eax, dword ptr [ebp - 0x5c] 	(finteray.c:489)
0x4ac204 : mov ecx, dword ptr [ebp + 8]
0x4ac207 : mov eax, dword ptr [ecx + eax*4 + 4]
0x4ac20b : mov dword ptr [ebp - 0x2c], eax
0x4ac20e : mov eax, dword ptr [ebp - 0x44] 	(finteray.c:490)
0x4ac211 : mov ecx, dword ptr [ebp + 8]
0x4ac214 : mov eax, dword ptr [ecx + eax*4 + 4]
0x4ac218 : mov dword ptr [ebp - 0x40], eax
0x4ac21b : mov eax, dword ptr [ebp - 0x5c] 	(finteray.c:491)
0x4ac21e : mov ecx, dword ptr [ebp + 8]
0x4ac221 : fld dword ptr [ecx + eax*4 + 0x10]
0x4ac225 : fsub dword ptr [ebp - 0x2c]
0x4ac228 : -fstp qword ptr [ebp - 0x6c]
         : +fstp qword ptr [ebp - 0x64]
0x4ac22b : mov eax, dword ptr [ebp - 0x44] 	(finteray.c:492)
0x4ac22e : mov ecx, dword ptr [ebp + 8]
0x4ac231 : fld dword ptr [ecx + eax*4 + 0x10]
0x4ac235 : fsub dword ptr [ebp - 0x40]
0x4ac238 : -fstp qword ptr [ebp - 8]
         : +fstp qword ptr [ebp - 0x6c]
0x4ac23b : mov eax, dword ptr [ebp - 0x5c] 	(finteray.c:493)
0x4ac23e : mov ecx, dword ptr [ebp + 8]
0x4ac241 : fld dword ptr [ecx + eax*4 + 0x1c]
0x4ac245 : fsub dword ptr [ebp - 0x2c]
0x4ac248 : -fstp qword ptr [ebp - 0x74]
         : +fstp qword ptr [ebp - 0x94]
0x4ac24b : mov eax, dword ptr [ebp - 0x44] 	(finteray.c:494)
0x4ac24e : mov ecx, dword ptr [ebp + 8]
0x4ac251 : fld dword ptr [ecx + eax*4 + 0x1c]
0x4ac255 : fsub dword ptr [ebp - 0x40]
         : +fstp qword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp - 0x5c] 	(finteray.c:495)
         : +fld dword ptr [ebp + eax*4 - 0x80]
         : +fsub dword ptr [ebp - 0x2c]
         : +fstp qword ptr [ebp - 0x74]
         : +mov eax, dword ptr [ebp - 0x44] 	(finteray.c:496)
         : +fld dword ptr [ebp + eax*4 - 0x80]
         : +fsub dword ptr [ebp - 0x40]
0x4ac258 : fstp qword ptr [ebp - 0x34]
0x4ac25b : -mov eax, dword ptr [ebp - 0x5c]
0x4ac25e : -fld dword ptr [ebp + eax*4 - 0x18]
0x4ac262 : -fsub dword ptr [ebp - 0x2c]
0x4ac265 : -fstp qword ptr [ebp - 0x64]
0x4ac268 : -mov eax, dword ptr [ebp - 0x44]
0x4ac26b : -fld dword ptr [ebp + eax*4 - 0x18]
0x4ac26f : -fsub dword ptr [ebp - 0x40]
0x4ac272 : -fstp qword ptr [ebp - 0x94]
0x4ac278 : -fld qword ptr [ebp - 0x6c]
         : +fld qword ptr [ebp - 0x64] 	(finteray.c:497)
0x4ac27b : fabs 
0x4ac27d : fcomp qword ptr [2.384185791015625e-07 (FLOAT)]
0x4ac283 : fnstsw ax
0x4ac285 : test ah, 0x41
0x4ac288 : -je 0x23
0x4ac28e : -fld qword ptr [ebp - 0x64]
0x4ac291 : -fdiv qword ptr [ebp - 0x74]
0x4ac294 : -fst qword ptr [ebp - 0x3c]
0x4ac297 : -fmul qword ptr [ebp - 0x34]
0x4ac29a : -fsubr qword ptr [ebp - 0x94]
0x4ac2a0 : -fst qword ptr [ebp - 0x88]
0x4ac2a6 : -fdiv qword ptr [ebp - 8]
0x4ac2a9 : -fstp qword ptr [ebp - 0x28]
0x4ac2ac : -jmp 0x56
         : +jne 0x52
         : +fld qword ptr [ebp - 8] 	(finteray.c:498)
         : +fmul qword ptr [ebp - 0x64]
0x4ac2b1 : fld qword ptr [ebp - 0x94]
0x4ac2b7 : fmul qword ptr [ebp - 0x6c]
0x4ac2ba : -fld qword ptr [ebp - 8]
0x4ac2bd : -fmul qword ptr [ebp - 0x64]
0x4ac2c0 : -fsubp st(1)
0x4ac2c2 : -fstp qword ptr [ebp - 0x20]
0x4ac2c5 : -fld qword ptr [ebp - 0x34]
0x4ac2c8 : -fmul qword ptr [ebp - 0x6c]
0x4ac2cb : -fld qword ptr [ebp - 8]
0x4ac2ce : -fmul qword ptr [ebp - 0x74]
0x4ac2d1 : fsubp st(1)
0x4ac2d3 : fcom qword ptr [0.0 (FLOAT)] 	(finteray.c:499)
0x4ac2d9 : fstp qword ptr [ebp - 0x58]
0x4ac2dc : fnstsw ax
0x4ac2de : test ah, 0x40
0x4ac2e1 : je 0x5
0x4ac2e7 : -jmp 0xc6
0x4ac2ec : -fld qword ptr [ebp - 0x20]
         : +jmp 0xdc 	(finteray.c:500)
         : +fld qword ptr [ebp - 0x64] 	(finteray.c:502)
         : +fmul qword ptr [ebp - 0x34]
         : +fld qword ptr [ebp - 0x74]
         : +fmul qword ptr [ebp - 0x6c]
         : +fsubp st(1)
0x4ac2ef : fdiv qword ptr [ebp - 0x58]
0x4ac2f2 : -fst qword ptr [ebp - 0x3c]
0x4ac2f5 : -fmul qword ptr [ebp - 0x74]
0x4ac2f8 : -fsubr qword ptr [ebp - 0x64]
0x4ac2fb : -fst qword ptr [ebp - 0x88]
         : +fst qword ptr [ebp - 0x28]
         : +fmul qword ptr [ebp - 0x94] 	(finteray.c:503)
         : +fsubr qword ptr [ebp - 0x74]
         : +fdiv qword ptr [ebp - 0x64]
         : +fstp qword ptr [ebp - 0x3c]
         : +jmp 0x18 	(finteray.c:504)
         : +fld qword ptr [ebp - 0x74] 	(finteray.c:505)
         : +fdiv qword ptr [ebp - 0x94]
         : +fst qword ptr [ebp - 0x28]
         : +fmul qword ptr [ebp - 8] 	(finteray.c:506)
         : +fsubr qword ptr [ebp - 0x34]
0x4ac301 : fdiv qword ptr [ebp - 0x6c]
0x4ac304 : -fstp qword ptr [ebp - 0x28]
         : +fstp qword ptr [ebp - 0x3c]
         : +fld qword ptr [ebp - 0x3c] 	(finteray.c:508)
         : +fcomp qword ptr [-0.0001 (FLOAT)]
         : +fnstsw ax
         : +test ah, 1
         : +jne 0x88
0x4ac307 : fld qword ptr [ebp - 0x28]
0x4ac30a : fcomp qword ptr [-0.0001 (FLOAT)]
0x4ac310 : fnstsw ax
0x4ac312 : test ah, 1
0x4ac315 : -jne 0x2b
0x4ac31b : -fld qword ptr [ebp - 0x3c]
0x4ac31e : -fcomp qword ptr [-0.0001 (FLOAT)]
0x4ac324 : -fnstsw ax
0x4ac326 : -test ah, 1
0x4ac329 : -jne 0x17
         : +jne 0x74
0x4ac32f : fld qword ptr [ebp - 0x3c]
0x4ac332 : fadd qword ptr [ebp - 0x28]
0x4ac335 : fcomp qword ptr [1.0001 (FLOAT)]
0x4ac33b : fnstsw ax
0x4ac33d : test ah, 0x41
0x4ac340 : -jne 0x5
0x4ac346 : -jmp 0x67
         : +je 0x5d
0x4ac34b : mov eax, dword ptr [ebp + 0x18] 	(finteray.c:509)
0x4ac34e : mov ecx, dword ptr [ebp - 0x4c]
         : +mov dword ptr [eax], ecx
         : +mov eax, dword ptr [ebp + 8] 	(finteray.c:510)
         : +add eax, 0x34
         : +mov ecx, dword ptr [ebp + 0x14]
         : +mov edx, dword ptr [eax]
         : +mov dword ptr [ecx], edx
         : +mov edx, dword ptr [eax + 4]
         : +mov dword ptr [ecx + 4], edx
         : +mov eax, dword ptr [eax + 8]
         : +mov dword ptr [ecx + 8], eax
         : +fld dword ptr [ebp - 0x48] 	(finteray.c:511)
         : +fcomp qword ptr [0.0 (FLOAT)]
         : +fnstsw ax
         : +test ah, 0x41
         : +jne 0x28
         : +mov eax, dword ptr [ebp + 0x14] 	(finteray.c:512)
         : +fld dword ptr [eax]
         : +fchs 
         : +mov eax, dword ptr [ebp + 0x14]
         : +fstp dword ptr [eax]
         : +mov eax, dword ptr [ebp + 0x14]
         : +fld dword ptr [eax + 4]
         : +fchs 
         : +mov eax, dword ptr [ebp + 0x14]
         : +fstp dword ptr [eax + 4]
         : +mov eax, dword ptr [ebp + 0x14]
         : +fld dword ptr [eax + 8]
         : +fchs 
         : +mov eax, dword ptr [ebp + 0x14]
         : +fstp dword ptr [eax + 8]
         : +pop edi 	(finteray.c:517)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


CheckSingleFace is only 59.19% similar to the original, diff above
```

*AI generated. Time taken: 1867s, tokens: 117,386*
