### PR TITLE
Disable werror in builds

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -14,13 +14,13 @@ jobs:
     strategy:
       matrix:
         platform:
-          - { name: "Linux", arch: "x64", os: ubuntu-latest, werror: true }
-          - { name: "Linux", arch: "arm64", os: ubuntu-24.04-arm, werror: true }
+          - { name: "Linux", arch: "x64", os: ubuntu-latest, werror: false }
+          - { name: "Linux", arch: "arm64", os: ubuntu-24.04-arm, werror: false }
           - {
               name: "MacOS",
               arch: "arm64-x64",
               os: macos-latest,
-              werror: true,
+              werror: false,
               cmake-args: '-DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"',
             }
           - {


### PR DESCRIPTION
Before https://github.com/dethrace-labs/dethrace/pull/901, we weren't building properly with warnings-as-errors. Now we are, we have warnings for uninitialized things.

With the asm-match stuff going on, I'd rather keep this off to avoid lots of PRs failing, and do separate clean-up work to fix uninitialized vars etc 