### PR TITLE
ClipToPlaneGE equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -1013,12 +1013,13 @@ void ClipToPlaneGE(br_vector3* p, int* nv, int i, br_scalar limit) {
     for (vertex = 0; *nv > vertex; ++vertex) {
         if ((p[last_vertex].v[i] > limit) != (p[vertex].v[i] > limit)) {
             for (k = 0; k < 3; ++k) {
-                if (i != k) {
-                    p2[j].v[k] = (p[vertex].v[k] - p[last_vertex].v[k])
-                            * (limit - p[last_vertex].v[i])
-                            / (p[vertex].v[i] - p[last_vertex].v[i])
-                        + p[last_vertex].v[k];
+                if (k == i) {
+                    continue;
                 }
+                p2[j].v[k] = (p[vertex].v[k] - p[last_vertex].v[k])
+                        * (limit - p[last_vertex].v[i])
+                        / (p[vertex].v[i] - p[last_vertex].v[i])
+                    + p[last_vertex].v[k];
             }
             p2[j++].v[i] = limit;
         }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4ae63f,34 +0x47978b,34 @@
0x4ae63f : fnstsw ax
0x4ae641 : test ah, 0x41
0x4ae644 : sete dl
0x4ae647 : cmp ecx, edx
0x4ae649 : je 0x119
0x4ae64f : mov dword ptr [ebp - 0x9c], 0 	(finteray.c:1015)
0x4ae659 : jmp 0x6
0x4ae65e : inc dword ptr [ebp - 0x9c]
0x4ae664 : cmp dword ptr [ebp - 0x9c], 3
0x4ae66b : jge 0xd5
0x4ae671 : -mov eax, dword ptr [ebp - 0x9c]
0x4ae677 : -cmp dword ptr [ebp + 0x10], eax
         : +mov eax, dword ptr [ebp + 0x10] 	(finteray.c:1016)
         : +cmp dword ptr [ebp - 0x9c], eax
0x4ae67a : jne 0x5
0x4ae680 : jmp -0x27 	(finteray.c:1017)
0x4ae685 : mov eax, dword ptr [ebp - 0x9c] 	(finteray.c:1022)
0x4ae68b : mov ecx, dword ptr [ebp - 0x94]
0x4ae691 : lea ecx, [ecx + ecx*2]
0x4ae694 : shl ecx, 2
0x4ae697 : lea eax, [ecx + eax*4]
0x4ae69a : mov ecx, dword ptr [ebp + 8]
0x4ae69d : fld dword ptr [eax + ecx]
0x4ae6a0 : -mov eax, dword ptr [ebp - 0xa0]
0x4ae6a6 : -lea eax, [eax + eax*2]
0x4ae6a9 : -mov ecx, dword ptr [ebp - 0x9c]
         : +mov eax, dword ptr [ebp - 0x9c]
         : +mov ecx, dword ptr [ebp - 0xa0]
         : +lea ecx, [ecx + ecx*2]
0x4ae6af : shl ecx, 2
0x4ae6b2 : lea eax, [ecx + eax*4]
0x4ae6b5 : mov ecx, dword ptr [ebp + 8]
0x4ae6b8 : fsub dword ptr [eax + ecx]
0x4ae6bb : fld dword ptr [ebp + 0x14]
0x4ae6be : mov eax, dword ptr [ebp + 0x10]
0x4ae6c1 : mov ecx, dword ptr [ebp - 0xa0]
0x4ae6c7 : lea ecx, [ecx + ecx*2]
0x4ae6ca : shl ecx, 2
0x4ae6cd : lea eax, [ecx + eax*4]

---
+++
@@ -0x4ae6ea,23 +0x479836,23 @@
0x4ae6ea : mov ecx, dword ptr [ebp + 8]
0x4ae6ed : fld dword ptr [eax + ecx]
0x4ae6f0 : mov eax, dword ptr [ebp + 0x10]
0x4ae6f3 : mov ecx, dword ptr [ebp - 0xa0]
0x4ae6f9 : lea ecx, [ecx + ecx*2]
0x4ae6fc : shl ecx, 2
0x4ae6ff : lea eax, [ecx + eax*4]
0x4ae702 : mov ecx, dword ptr [ebp + 8]
0x4ae705 : fsub dword ptr [eax + ecx]
0x4ae708 : fdivp st(1)
0x4ae70a : -mov eax, dword ptr [ebp - 0xa0]
0x4ae710 : -lea eax, [eax + eax*2]
0x4ae713 : -mov ecx, dword ptr [ebp - 0x9c]
         : +mov eax, dword ptr [ebp - 0x9c]
         : +mov ecx, dword ptr [ebp - 0xa0]
         : +lea ecx, [ecx + ecx*2]
0x4ae719 : shl ecx, 2
0x4ae71c : lea eax, [ecx + eax*4]
0x4ae71f : mov ecx, dword ptr [ebp + 8]
0x4ae722 : fadd dword ptr [eax + ecx]
0x4ae725 : mov eax, dword ptr [ebp - 0x9c]
0x4ae72b : mov ecx, dword ptr [ebp - 0x98]
0x4ae731 : lea ecx, [ecx + ecx*2]
0x4ae734 : shl ecx, 2
0x4ae737 : lea eax, [ecx + eax*4]
0x4ae73a : fstp dword ptr [ebp + eax - 0x90]


ClipToPlaneGE is only 95.68% similar to the original, diff above
```

#### Effective match analysis

All shown changes preserve semantics. The `cmp` operand swap (`cmp [ebp+0x10], eax` vs `cmp [ebp-0x9c], eax`) is followed only by `jne`, which depends on ZF (equality) and is unchanged by operand order. The other edits only reshuffle register usage while computing the same effective addresses: both old and new forms compute `base + (4*idx + 12*plane)` (or equivalent term ordering) before the same `fld/fsub/fadd` memory accesses. No branch structure changes are introduced in the shown diff.

#### Original match

```
---
+++
@@ -0x4ae5c4,21 +0x479710,21 @@
0x4ae5c4 : mov eax, dword ptr [eax]
0x4ae5c6 : dec eax
0x4ae5c7 : mov dword ptr [ebp - 0xa0], eax
0x4ae5cd : mov dword ptr [ebp - 0x98], 0 	(finteray.c:1012)
0x4ae5d7 : mov dword ptr [ebp - 0x94], 0 	(finteray.c:1013)
0x4ae5e1 : jmp 0x6
0x4ae5e6 : inc dword ptr [ebp - 0x94]
0x4ae5ec : mov eax, dword ptr [ebp + 0xc]
0x4ae5ef : mov ecx, dword ptr [ebp - 0x94]
0x4ae5f5 : cmp dword ptr [eax], ecx
0x4ae5f7 : -jle 0x207
         : +jle 0x202
0x4ae5fd : mov eax, dword ptr [ebp + 0x10] 	(finteray.c:1014)
0x4ae600 : mov ecx, dword ptr [ebp - 0xa0]
0x4ae606 : lea ecx, [ecx + ecx*2]
0x4ae609 : shl ecx, 2
0x4ae60c : lea eax, [ecx + eax*4]
0x4ae60f : mov ecx, dword ptr [ebp + 8]
0x4ae612 : fld dword ptr [eax + ecx]
0x4ae615 : xor ecx, ecx
0x4ae617 : fcomp dword ptr [ebp + 0x14]
0x4ae61a : fnstsw ax

---
+++
@@ -0x4ae62e,40 +0x47977a,39 @@
0x4ae62e : shl edx, 2
0x4ae631 : lea eax, [edx + eax*4]
0x4ae634 : mov edx, dword ptr [ebp + 8]
0x4ae637 : fld dword ptr [eax + edx]
0x4ae63a : xor edx, edx
0x4ae63c : fcomp dword ptr [ebp + 0x14]
0x4ae63f : fnstsw ax
0x4ae641 : test ah, 0x41
0x4ae644 : sete dl
0x4ae647 : cmp ecx, edx
0x4ae649 : -je 0x119
         : +je 0x114
0x4ae64f : mov dword ptr [ebp - 0x9c], 0 	(finteray.c:1015)
0x4ae659 : jmp 0x6
0x4ae65e : inc dword ptr [ebp - 0x9c]
0x4ae664 : cmp dword ptr [ebp - 0x9c], 3
0x4ae66b : -jge 0xd5
0x4ae671 : -mov eax, dword ptr [ebp - 0x9c]
0x4ae677 : -cmp dword ptr [ebp + 0x10], eax
0x4ae67a : -jne 0x5
0x4ae680 : -jmp -0x27
         : +jge 0xd0
         : +mov eax, dword ptr [ebp + 0x10] 	(finteray.c:1016)
         : +cmp dword ptr [ebp - 0x9c], eax
         : +je 0xbc
0x4ae685 : mov eax, dword ptr [ebp - 0x9c] 	(finteray.c:1020)
0x4ae68b : mov ecx, dword ptr [ebp - 0x94]
0x4ae691 : lea ecx, [ecx + ecx*2]
0x4ae694 : shl ecx, 2
0x4ae697 : lea eax, [ecx + eax*4]
0x4ae69a : mov ecx, dword ptr [ebp + 8]
0x4ae69d : fld dword ptr [eax + ecx]
0x4ae6a0 : -mov eax, dword ptr [ebp - 0xa0]
0x4ae6a6 : -lea eax, [eax + eax*2]
0x4ae6a9 : -mov ecx, dword ptr [ebp - 0x9c]
         : +mov eax, dword ptr [ebp - 0x9c]
         : +mov ecx, dword ptr [ebp - 0xa0]
         : +lea ecx, [ecx + ecx*2]
0x4ae6af : shl ecx, 2
0x4ae6b2 : lea eax, [ecx + eax*4]
0x4ae6b5 : mov ecx, dword ptr [ebp + 8]
0x4ae6b8 : fsub dword ptr [eax + ecx]
0x4ae6bb : fld dword ptr [ebp + 0x14]
0x4ae6be : mov eax, dword ptr [ebp + 0x10]
0x4ae6c1 : mov ecx, dword ptr [ebp - 0xa0]
0x4ae6c7 : lea ecx, [ecx + ecx*2]
0x4ae6ca : shl ecx, 2
0x4ae6cd : lea eax, [ecx + eax*4]

---
+++
@@ -0x4ae6ea,34 +0x479831,34 @@
0x4ae6ea : mov ecx, dword ptr [ebp + 8]
0x4ae6ed : fld dword ptr [eax + ecx]
0x4ae6f0 : mov eax, dword ptr [ebp + 0x10]
0x4ae6f3 : mov ecx, dword ptr [ebp - 0xa0]
0x4ae6f9 : lea ecx, [ecx + ecx*2]
0x4ae6fc : shl ecx, 2
0x4ae6ff : lea eax, [ecx + eax*4]
0x4ae702 : mov ecx, dword ptr [ebp + 8]
0x4ae705 : fsub dword ptr [eax + ecx]
0x4ae708 : fdivp st(1)
0x4ae70a : -mov eax, dword ptr [ebp - 0xa0]
0x4ae710 : -lea eax, [eax + eax*2]
0x4ae713 : -mov ecx, dword ptr [ebp - 0x9c]
         : +mov eax, dword ptr [ebp - 0x9c]
         : +mov ecx, dword ptr [ebp - 0xa0]
         : +lea ecx, [ecx + ecx*2]
0x4ae719 : shl ecx, 2
0x4ae71c : lea eax, [ecx + eax*4]
0x4ae71f : mov ecx, dword ptr [ebp + 8]
0x4ae722 : fadd dword ptr [eax + ecx]
0x4ae725 : mov eax, dword ptr [ebp - 0x9c]
0x4ae72b : mov ecx, dword ptr [ebp - 0x98]
0x4ae731 : lea ecx, [ecx + ecx*2]
0x4ae734 : shl ecx, 2
0x4ae737 : lea eax, [ecx + eax*4]
0x4ae73a : fstp dword ptr [ebp + eax - 0x90]
0x4ae741 : -jmp -0xe8
         : +jmp -0xe3 	(finteray.c:1022)
0x4ae746 : mov eax, dword ptr [ebp + 0x10] 	(finteray.c:1023)
0x4ae749 : mov ecx, dword ptr [ebp - 0x98]
0x4ae74f : lea ecx, [ecx + ecx*2]
0x4ae752 : shl ecx, 2
0x4ae755 : lea eax, [ecx + eax*4]
0x4ae758 : mov ecx, dword ptr [ebp + 0x14]
0x4ae75b : mov dword ptr [ebp + eax - 0x90], ecx
0x4ae762 : inc dword ptr [ebp - 0x98]
0x4ae768 : mov eax, dword ptr [ebp + 0x10] 	(finteray.c:1025)
0x4ae76b : mov ecx, dword ptr [ebp - 0x94]

---
+++
@@ -0x4ae7cd,21 +0x479914,21 @@
0x4ae7cd : mov eax, dword ptr [ebp - 0x94]
0x4ae7d3 : lea eax, [eax + eax*2]
0x4ae7d6 : mov ecx, dword ptr [ebp + 8]
0x4ae7d9 : mov edx, dword ptr [ebp - 0x98]
0x4ae7df : lea edx, [edx + edx*2]
0x4ae7e2 : mov eax, dword ptr [ecx + eax*4 + 8]
0x4ae7e6 : mov dword ptr [ebp + edx*4 - 0x88], eax
0x4ae7ed : inc dword ptr [ebp - 0x98] 	(finteray.c:1027)
0x4ae7f3 : mov eax, dword ptr [ebp - 0x94] 	(finteray.c:1029)
0x4ae7f9 : mov dword ptr [ebp - 0xa0], eax
0x4ae7ff : -jmp -0x21e
         : +jmp -0x219 	(finteray.c:1030)
0x4ae804 : mov eax, dword ptr [ebp - 0x98] 	(finteray.c:1031)
0x4ae80a : mov ecx, dword ptr [ebp + 0xc]
0x4ae80d : mov dword ptr [ecx], eax
0x4ae80f : mov dword ptr [ebp - 0x9c], 0 	(finteray.c:1032)
0x4ae819 : jmp 0x6
0x4ae81e : inc dword ptr [ebp - 0x9c]
0x4ae824 : mov eax, dword ptr [ebp - 0x98]
0x4ae82a : cmp dword ptr [ebp - 0x9c], eax
0x4ae830 : jge 0x64
0x4ae836 : mov eax, dword ptr [ebp - 0x9c] 	(finteray.c:1033)

---
+++
@@ -0x4ae86a,10 +0x4799b1,15 @@
0x4ae86a : mov eax, dword ptr [ebp + eax*4 - 0x8c]
0x4ae871 : mov dword ptr [edx + ecx*4 + 4], eax
0x4ae875 : mov eax, dword ptr [ebp - 0x9c]
0x4ae87b : lea eax, [eax + eax*2]
0x4ae87e : mov ecx, dword ptr [ebp - 0x9c]
0x4ae884 : lea ecx, [ecx + ecx*2]
0x4ae887 : mov edx, dword ptr [ebp + 8]
0x4ae88a : mov eax, dword ptr [ebp + eax*4 - 0x88]
0x4ae891 : mov dword ptr [edx + ecx*4 + 8], eax
0x4ae895 : jmp -0x7c 	(finteray.c:1034)
         : +pop edi 	(finteray.c:1035)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


ClipToPlaneGE is only 90.66% similar to the original, diff above
```

*AI generated. Time taken: 1432s, tokens: 114,860*
