### PR TITLE
BoundsTransformTest equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -1159,9 +1159,9 @@ int BoundsTransformTest(br_bounds* b1, br_bounds* b2, br_matrix34* M) {
         < b2->min.v[1]) {
         return 0;
     }
-    if ((M->m[0][1] < 0.0 ? M->m[0][1] * o.v[0] : 0.0)
-            + (M->m[1][1] < 0.0 ? M->m[1][1] * o.v[1] : 0.0)
-            + (M->m[2][1] < 0.0 ? M->m[2][1] * o.v[2] : 0.0)
+    if ((M->m[0][1] < 0.0f ? M->m[0][1] * o.v[0] : 0.0f)
+            + (M->m[1][1] < 0.0f ? M->m[1][1] * o.v[1] : 0.0f)
+            + (M->m[2][1] < 0.0f ? M->m[2][1] * o.v[2] : 0.0f)
             + val
         > b2->max.v[1]) {
         return 0;


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4aecb1,23 +0x479e50,23 @@
0x4aecb1 : fmul dword ptr [ebp - 0x10]
0x4aecb4 : fstp dword ptr [ebp - 0x14]
0x4aecb7 : jmp 0x7
0x4aecbc : mov dword ptr [ebp - 0x14], 0
0x4aecc3 : mov eax, dword ptr [ebp + 0x10]
0x4aecc6 : fld dword ptr [eax + 0xc]
0x4aecc9 : fcomp dword ptr [0.0 (FLOAT)]
0x4aeccf : fnstsw ax
0x4aecd1 : test ah, 0x41
0x4aecd4 : jne 0x11
0x4aecda : -fld dword ptr [ebp - 0xc]
0x4aecdd : mov eax, dword ptr [ebp + 0x10]
0x4aece0 : -fmul dword ptr [eax + 0xc]
         : +fld dword ptr [eax + 0xc]
         : +fmul dword ptr [ebp - 0xc]
0x4aece3 : fstp dword ptr [ebp - 0x18]
0x4aece6 : jmp 0x7
0x4aeceb : mov dword ptr [ebp - 0x18], 0
0x4aecf2 : mov eax, dword ptr [ebp + 0x10]
0x4aecf5 : fld dword ptr [eax + 0x18]
0x4aecf8 : fcomp dword ptr [0.0 (FLOAT)]
0x4aecfe : fnstsw ax
0x4aed00 : test ah, 0x41
0x4aed03 : jne 0x11
0x4aed09 : mov eax, dword ptr [ebp + 0x10]

---
+++
@@ -0x4aed6b,23 +0x479f0a,23 @@
0x4aed6b : fmul dword ptr [ebp - 0x10]
0x4aed6e : fstp dword ptr [ebp - 0x20]
0x4aed71 : mov eax, dword ptr [ebp + 0x10]
0x4aed74 : fld dword ptr [eax + 0xc]
0x4aed77 : fcomp dword ptr [0.0 (FLOAT)]
0x4aed7d : fnstsw ax
0x4aed7f : test ah, 1
0x4aed82 : jne 0xc
0x4aed88 : mov dword ptr [ebp - 0x24], 0
0x4aed8f : jmp 0xc
0x4aed94 : -fld dword ptr [ebp - 0xc]
0x4aed97 : mov eax, dword ptr [ebp + 0x10]
0x4aed9a : -fmul dword ptr [eax + 0xc]
         : +fld dword ptr [eax + 0xc]
         : +fmul dword ptr [ebp - 0xc]
0x4aed9d : fstp dword ptr [ebp - 0x24]
0x4aeda0 : mov eax, dword ptr [ebp + 0x10]
0x4aeda3 : fld dword ptr [eax + 0x18]
0x4aeda6 : fcomp dword ptr [0.0 (FLOAT)]
0x4aedac : fnstsw ax
0x4aedae : test ah, 1
0x4aedb1 : jne 0xc
0x4aedb7 : mov dword ptr [ebp - 0x28], 0
0x4aedbe : jmp 0xc
0x4aedc3 : mov eax, dword ptr [ebp + 0x10]

---
+++
@@ -0x4aedee,24 +0x479f8d,24 @@
0x4aedee : jmp 0x32e
0x4aedf3 : mov eax, dword ptr [ebp + 0x10] 	(finteray.c:1138)
0x4aedf6 : fld dword ptr [eax + 0x14]
0x4aedf9 : mov eax, dword ptr [ebp + 8]
0x4aedfc : fmul dword ptr [eax + 4]
0x4aedff : mov eax, dword ptr [ebp + 8]
0x4aee02 : fld dword ptr [eax + 8]
0x4aee05 : mov eax, dword ptr [ebp + 0x10]
0x4aee08 : fmul dword ptr [eax + 0x20]
0x4aee0b : faddp st(1)
         : +mov eax, dword ptr [ebp + 8]
         : +fld dword ptr [eax]
0x4aee0d : mov eax, dword ptr [ebp + 0x10]
0x4aee10 : -fld dword ptr [eax + 8]
0x4aee13 : -mov eax, dword ptr [ebp + 8]
0x4aee16 : -fmul dword ptr [eax]
         : +fmul dword ptr [eax + 8]
0x4aee18 : faddp st(1)
0x4aee1a : mov eax, dword ptr [ebp + 0x10]
0x4aee1d : fadd dword ptr [eax + 0x2c]
0x4aee20 : fstp dword ptr [ebp - 4]
0x4aee23 : mov eax, dword ptr [ebp + 0x10] 	(finteray.c:1143)
0x4aee26 : fld dword ptr [eax + 8]
0x4aee29 : fcomp dword ptr [0.0 (FLOAT)]
0x4aee2f : fnstsw ax
0x4aee31 : test ah, 0x41
0x4aee34 : jne 0x11

---
+++
@@ -0x4aefd2,23 +0x47a171,23 @@
0x4aefd2 : fmul dword ptr [ebp - 0x10]
0x4aefd5 : fstp dword ptr [ebp - 0x44]
0x4aefd8 : jmp 0x7
0x4aefdd : mov dword ptr [ebp - 0x44], 0
0x4aefe4 : mov eax, dword ptr [ebp + 0x10]
0x4aefe7 : fld dword ptr [eax + 0x10]
0x4aefea : fcomp dword ptr [0.0 (FLOAT)]
0x4aeff0 : fnstsw ax
0x4aeff2 : test ah, 0x41
0x4aeff5 : jne 0x11
0x4aeffb : -fld dword ptr [ebp - 0xc]
0x4aeffe : mov eax, dword ptr [ebp + 0x10]
0x4af001 : -fmul dword ptr [eax + 0x10]
         : +fld dword ptr [eax + 0x10]
         : +fmul dword ptr [ebp - 0xc]
0x4af004 : fstp dword ptr [ebp - 0x48]
0x4af007 : jmp 0x7
0x4af00c : mov dword ptr [ebp - 0x48], 0
0x4af013 : mov eax, dword ptr [ebp + 0x10]
0x4af016 : fld dword ptr [eax + 0x1c]
0x4af019 : fcomp dword ptr [0.0 (FLOAT)]
0x4af01f : fnstsw ax
0x4af021 : test ah, 0x41
0x4af024 : jne 0x11
0x4af02a : mov eax, dword ptr [ebp + 0x10]

---
+++
@@ -0x4af08f,23 +0x47a22e,23 @@
0x4af08f : fmul dword ptr [ebp - 0x10]
0x4af092 : fstp dword ptr [ebp - 0x50]
0x4af095 : mov eax, dword ptr [ebp + 0x10]
0x4af098 : fld dword ptr [eax + 0x10]
0x4af09b : fcomp dword ptr [0.0 (FLOAT)]
0x4af0a1 : fnstsw ax
0x4af0a3 : test ah, 1
0x4af0a6 : jne 0xc
0x4af0ac : mov dword ptr [ebp - 0x54], 0
0x4af0b3 : jmp 0xc
0x4af0b8 : -fld dword ptr [ebp - 0xc]
0x4af0bb : mov eax, dword ptr [ebp + 0x10]
0x4af0be : -fmul dword ptr [eax + 0x10]
         : +fld dword ptr [eax + 0x10]
         : +fmul dword ptr [ebp - 0xc]
0x4af0c1 : fstp dword ptr [ebp - 0x54]
0x4af0c4 : mov eax, dword ptr [ebp + 0x10]
0x4af0c7 : fld dword ptr [eax + 0x1c]
0x4af0ca : fcomp dword ptr [0.0 (FLOAT)]
0x4af0d0 : fnstsw ax
0x4af0d2 : test ah, 1
0x4af0d5 : jne 0xc
0x4af0db : mov dword ptr [ebp - 0x58], 0
0x4af0e2 : jmp 0xc
0x4af0e7 : mov eax, dword ptr [ebp + 0x10]


BoundsTransformTest is only 96.95% similar to the original, diff above
```

#### Effective match analysis

All shown diffs keep the same branch structure and conditions, and the arithmetic changes are only operand-order swaps for `fmul` (e.g., `fld a; fmul b` vs `fld b; fmul a`) followed by the same stores/adds. Since multiplication is commutative (and you asked to ignore NaN and tiny FP effects), these produce the same functional results. I do not see a control-flow reshuffle in the provided hunks.

#### Original match

```
---
+++
@@ -0x4aec32,13 +0x479dd1,13 @@
0x4aec32 : push ebp 	(finteray.c:1116)
0x4aec33 : mov ebp, esp
0x4aec35 : -sub esp, 0x58
         : +sub esp, 0x64
0x4aec38 : push ebx
0x4aec39 : push esi
0x4aec3a : push edi
0x4aec3b : mov eax, dword ptr [ebp + 8] 	(finteray.c:1120)
0x4aec3e : fld dword ptr [eax + 0xc]
0x4aec41 : mov eax, dword ptr [ebp + 8]
0x4aec44 : fsub dword ptr [eax]
0x4aec46 : fstp dword ptr [ebp - 0x10]
0x4aec49 : mov eax, dword ptr [ebp + 8]
0x4aec4c : fld dword ptr [eax + 0x10]

---
+++
@@ -0x4aecb1,23 +0x479e50,23 @@
0x4aecb1 : fmul dword ptr [ebp - 0x10]
0x4aecb4 : fstp dword ptr [ebp - 0x14]
0x4aecb7 : jmp 0x7
0x4aecbc : mov dword ptr [ebp - 0x14], 0
0x4aecc3 : mov eax, dword ptr [ebp + 0x10]
0x4aecc6 : fld dword ptr [eax + 0xc]
0x4aecc9 : fcomp dword ptr [0.0 (FLOAT)]
0x4aeccf : fnstsw ax
0x4aecd1 : test ah, 0x41
0x4aecd4 : jne 0x11
0x4aecda : -fld dword ptr [ebp - 0xc]
0x4aecdd : mov eax, dword ptr [ebp + 0x10]
0x4aece0 : -fmul dword ptr [eax + 0xc]
         : +fld dword ptr [eax + 0xc]
         : +fmul dword ptr [ebp - 0xc]
0x4aece3 : fstp dword ptr [ebp - 0x18]
0x4aece6 : jmp 0x7
0x4aeceb : mov dword ptr [ebp - 0x18], 0
0x4aecf2 : mov eax, dword ptr [ebp + 0x10]
0x4aecf5 : fld dword ptr [eax + 0x18]
0x4aecf8 : fcomp dword ptr [0.0 (FLOAT)]
0x4aecfe : fnstsw ax
0x4aed00 : test ah, 0x41
0x4aed03 : jne 0x11
0x4aed09 : mov eax, dword ptr [ebp + 0x10]

---
+++
@@ -0x4aed21,44 +0x479ec0,44 @@
0x4aed21 : fld dword ptr [ebp - 0x14]
0x4aed24 : fadd dword ptr [ebp - 0x18]
0x4aed27 : fadd dword ptr [ebp - 0x1c]
0x4aed2a : fadd dword ptr [ebp - 4]
0x4aed2d : mov eax, dword ptr [ebp + 0xc]
0x4aed30 : fcomp dword ptr [eax]
0x4aed32 : fnstsw ax
0x4aed34 : test ah, 1
0x4aed37 : je 0x7
0x4aed3d : xor eax, eax 	(finteray.c:1128)
0x4aed3f : -jmp 0x3dd
         : +jmp 0x3f2
0x4aed44 : mov eax, dword ptr [ebp + 0x10] 	(finteray.c:1134)
0x4aed47 : fld dword ptr [eax]
0x4aed49 : fcomp dword ptr [0.0 (FLOAT)]
0x4aed4f : fnstsw ax
0x4aed51 : test ah, 1
0x4aed54 : jne 0xc
0x4aed5a : mov dword ptr [ebp - 0x20], 0
0x4aed61 : jmp 0xb
0x4aed66 : mov eax, dword ptr [ebp + 0x10]
0x4aed69 : fld dword ptr [eax]
0x4aed6b : fmul dword ptr [ebp - 0x10]
0x4aed6e : fstp dword ptr [ebp - 0x20]
0x4aed71 : mov eax, dword ptr [ebp + 0x10]
0x4aed74 : fld dword ptr [eax + 0xc]
0x4aed77 : fcomp dword ptr [0.0 (FLOAT)]
0x4aed7d : fnstsw ax
0x4aed7f : test ah, 1
0x4aed82 : jne 0xc
0x4aed88 : mov dword ptr [ebp - 0x24], 0
0x4aed8f : jmp 0xc
0x4aed94 : -fld dword ptr [ebp - 0xc]
0x4aed97 : mov eax, dword ptr [ebp + 0x10]
0x4aed9a : -fmul dword ptr [eax + 0xc]
         : +fld dword ptr [eax + 0xc]
         : +fmul dword ptr [ebp - 0xc]
0x4aed9d : fstp dword ptr [ebp - 0x24]
0x4aeda0 : mov eax, dword ptr [ebp + 0x10]
0x4aeda3 : fld dword ptr [eax + 0x18]
0x4aeda6 : fcomp dword ptr [0.0 (FLOAT)]
0x4aedac : fnstsw ax
0x4aedae : test ah, 1
0x4aedb1 : jne 0xc
0x4aedb7 : mov dword ptr [ebp - 0x28], 0
0x4aedbe : jmp 0xc
0x4aedc3 : mov eax, dword ptr [ebp + 0x10]

---
+++
@@ -0x4aedcf,34 +0x479f6e,34 @@
0x4aedcf : fld dword ptr [ebp - 0x20]
0x4aedd2 : fadd dword ptr [ebp - 0x24]
0x4aedd5 : fadd dword ptr [ebp - 0x28]
0x4aedd8 : fadd dword ptr [ebp - 4]
0x4aeddb : mov eax, dword ptr [ebp + 0xc]
0x4aedde : fcomp dword ptr [eax + 0xc]
0x4aede1 : fnstsw ax
0x4aede3 : test ah, 0x41
0x4aede6 : jne 0x7
0x4aedec : xor eax, eax 	(finteray.c:1135)
0x4aedee : -jmp 0x32e
         : +jmp 0x343
0x4aedf3 : mov eax, dword ptr [ebp + 0x10] 	(finteray.c:1138)
0x4aedf6 : fld dword ptr [eax + 0x14]
0x4aedf9 : mov eax, dword ptr [ebp + 8]
0x4aedfc : fmul dword ptr [eax + 4]
0x4aedff : mov eax, dword ptr [ebp + 8]
0x4aee02 : fld dword ptr [eax + 8]
0x4aee05 : mov eax, dword ptr [ebp + 0x10]
0x4aee08 : fmul dword ptr [eax + 0x20]
0x4aee0b : faddp st(1)
         : +mov eax, dword ptr [ebp + 8]
         : +fld dword ptr [eax]
0x4aee0d : mov eax, dword ptr [ebp + 0x10]
0x4aee10 : -fld dword ptr [eax + 8]
0x4aee13 : -mov eax, dword ptr [ebp + 8]
0x4aee16 : -fmul dword ptr [eax]
         : +fmul dword ptr [eax + 8]
0x4aee18 : faddp st(1)
0x4aee1a : mov eax, dword ptr [ebp + 0x10]
0x4aee1d : fadd dword ptr [eax + 0x2c]
0x4aee20 : fstp dword ptr [ebp - 4]
0x4aee23 : mov eax, dword ptr [ebp + 0x10] 	(finteray.c:1143)
0x4aee26 : fld dword ptr [eax + 8]
0x4aee29 : fcomp dword ptr [0.0 (FLOAT)]
0x4aee2f : fnstsw ax
0x4aee31 : test ah, 0x41
0x4aee34 : jne 0x11

---
+++
@@ -0x4aeeb0,21 +0x47a04f,21 @@
0x4aeeb0 : fld dword ptr [ebp - 0x2c]
0x4aeeb3 : fadd dword ptr [ebp - 0x30]
0x4aeeb6 : fadd dword ptr [ebp - 0x34]
0x4aeeb9 : fadd dword ptr [ebp - 4]
0x4aeebc : mov eax, dword ptr [ebp + 0xc]
0x4aeebf : fcomp dword ptr [eax + 8]
0x4aeec2 : fnstsw ax
0x4aeec4 : test ah, 1
0x4aeec7 : je 0x7
0x4aeecd : xor eax, eax 	(finteray.c:1144)
0x4aeecf : -jmp 0x24d
         : +jmp 0x262
0x4aeed4 : mov eax, dword ptr [ebp + 0x10] 	(finteray.c:1150)
0x4aeed7 : fld dword ptr [eax + 8]
0x4aeeda : fcomp dword ptr [0.0 (FLOAT)]
0x4aeee0 : fnstsw ax
0x4aeee2 : test ah, 1
0x4aeee5 : jne 0xc
0x4aeeeb : mov dword ptr [ebp - 0x38], 0
0x4aeef2 : jmp 0xc
0x4aeef7 : mov eax, dword ptr [ebp + 0x10]
0x4aeefa : fld dword ptr [eax + 8]

---
+++
@@ -0x4aef61,21 +0x47a100,21 @@
0x4aef61 : fld dword ptr [ebp - 0x38]
0x4aef64 : fadd dword ptr [ebp - 0x3c]
0x4aef67 : fadd dword ptr [ebp - 0x40]
0x4aef6a : fadd dword ptr [ebp - 4]
0x4aef6d : mov eax, dword ptr [ebp + 0xc]
0x4aef70 : fcomp dword ptr [eax + 0x14]
0x4aef73 : fnstsw ax
0x4aef75 : test ah, 0x41
0x4aef78 : jne 0x7
0x4aef7e : xor eax, eax 	(finteray.c:1151)
0x4aef80 : -jmp 0x19c
         : +jmp 0x1b1
0x4aef85 : mov eax, dword ptr [ebp + 8] 	(finteray.c:1154)
0x4aef88 : fld dword ptr [eax + 8]
0x4aef8b : mov eax, dword ptr [ebp + 0x10]
0x4aef8e : fmul dword ptr [eax + 0x1c]
0x4aef91 : mov eax, dword ptr [ebp + 8]
0x4aef94 : fld dword ptr [eax + 4]
0x4aef97 : mov eax, dword ptr [ebp + 0x10]
0x4aef9a : fmul dword ptr [eax + 0x10]
0x4aef9d : faddp st(1)
0x4aef9f : mov eax, dword ptr [ebp + 0x10]

---
+++
@@ -0x4aefd2,23 +0x47a171,23 @@
0x4aefd2 : fmul dword ptr [ebp - 0x10]
0x4aefd5 : fstp dword ptr [ebp - 0x44]
0x4aefd8 : jmp 0x7
0x4aefdd : mov dword ptr [ebp - 0x44], 0
0x4aefe4 : mov eax, dword ptr [ebp + 0x10]
0x4aefe7 : fld dword ptr [eax + 0x10]
0x4aefea : fcomp dword ptr [0.0 (FLOAT)]
0x4aeff0 : fnstsw ax
0x4aeff2 : test ah, 0x41
0x4aeff5 : jne 0x11
0x4aeffb : -fld dword ptr [ebp - 0xc]
0x4aeffe : mov eax, dword ptr [ebp + 0x10]
0x4af001 : -fmul dword ptr [eax + 0x10]
         : +fld dword ptr [eax + 0x10]
         : +fmul dword ptr [ebp - 0xc]
0x4af004 : fstp dword ptr [ebp - 0x48]
0x4af007 : jmp 0x7
0x4af00c : mov dword ptr [ebp - 0x48], 0
0x4af013 : mov eax, dword ptr [ebp + 0x10]
0x4af016 : fld dword ptr [eax + 0x1c]
0x4af019 : fcomp dword ptr [0.0 (FLOAT)]
0x4af01f : fnstsw ax
0x4af021 : test ah, 0x41
0x4af024 : jne 0x11
0x4af02a : mov eax, dword ptr [ebp + 0x10]

---
+++
@@ -0x4af042,60 +0x47a1e1,63 @@
0x4af042 : fld dword ptr [ebp - 0x44]
0x4af045 : fadd dword ptr [ebp - 0x48]
0x4af048 : fadd dword ptr [ebp - 0x4c]
0x4af04b : fadd dword ptr [ebp - 4]
0x4af04e : mov eax, dword ptr [ebp + 0xc]
0x4af051 : fcomp dword ptr [eax + 4]
0x4af054 : fnstsw ax
0x4af056 : test ah, 1
0x4af059 : je 0x7
0x4af05f : xor eax, eax 	(finteray.c:1160)
0x4af061 : -jmp 0xbb
         : +jmp 0xd0
0x4af066 : mov eax, dword ptr [ebp + 0x10] 	(finteray.c:1166)
0x4af069 : fld dword ptr [eax + 4]
0x4af06c : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x4af072 : fnstsw ax
0x4af074 : test ah, 1
0x4af077 : -jne 0xc
         : +jne 0x13
         : +mov dword ptr [ebp - 0x54], 0
0x4af07d : mov dword ptr [ebp - 0x50], 0
0x4af084 : jmp 0xc
0x4af089 : mov eax, dword ptr [ebp + 0x10]
0x4af08c : fld dword ptr [eax + 4]
0x4af08f : fmul dword ptr [ebp - 0x10]
0x4af092 : -fstp dword ptr [ebp - 0x50]
         : +fstp qword ptr [ebp - 0x54]
0x4af095 : mov eax, dword ptr [ebp + 0x10]
0x4af098 : fld dword ptr [eax + 0x10]
0x4af09b : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x4af0a1 : fnstsw ax
0x4af0a3 : test ah, 1
0x4af0a6 : -jne 0xc
0x4af0ac : -mov dword ptr [ebp - 0x54], 0
         : +jne 0x13
         : +mov dword ptr [ebp - 0x5c], 0
         : +mov dword ptr [ebp - 0x58], 0
0x4af0b3 : jmp 0xc
0x4af0b8 : -fld dword ptr [ebp - 0xc]
0x4af0bb : mov eax, dword ptr [ebp + 0x10]
0x4af0be : -fmul dword ptr [eax + 0x10]
0x4af0c1 : -fstp dword ptr [ebp - 0x54]
         : +fld dword ptr [eax + 0x10]
         : +fmul dword ptr [ebp - 0xc]
         : +fstp qword ptr [ebp - 0x5c]
0x4af0c4 : mov eax, dword ptr [ebp + 0x10]
0x4af0c7 : fld dword ptr [eax + 0x1c]
0x4af0ca : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x4af0d0 : fnstsw ax
0x4af0d2 : test ah, 1
0x4af0d5 : -jne 0xc
0x4af0db : -mov dword ptr [ebp - 0x58], 0
         : +jne 0x13
         : +mov dword ptr [ebp - 0x64], 0
         : +mov dword ptr [ebp - 0x60], 0
0x4af0e2 : jmp 0xc
0x4af0e7 : mov eax, dword ptr [ebp + 0x10]
0x4af0ea : fld dword ptr [eax + 0x1c]
0x4af0ed : fmul dword ptr [ebp - 8]
0x4af0f0 : -fstp dword ptr [ebp - 0x58]
0x4af0f3 : -fld dword ptr [ebp - 0x50]
0x4af0f6 : -fadd dword ptr [ebp - 0x54]
0x4af0f9 : -fadd dword ptr [ebp - 0x58]
         : +fstp qword ptr [ebp - 0x64]
         : +fld qword ptr [ebp - 0x54]
         : +fadd qword ptr [ebp - 0x5c]
         : +fadd qword ptr [ebp - 0x64]
0x4af0fc : fadd dword ptr [ebp - 4]
0x4af0ff : mov eax, dword ptr [ebp + 0xc]
0x4af102 : fcomp dword ptr [eax + 0x10]
0x4af105 : fnstsw ax
0x4af107 : test ah, 0x41
0x4af10a : jne 0x7
0x4af110 : xor eax, eax 	(finteray.c:1167)
0x4af112 : jmp 0xa
0x4af117 : mov eax, 1 	(finteray.c:1170)
0x4af11c : jmp 0x0


BoundsTransformTest is only 91.03% similar to the original, diff above
```

*AI generated. Time taken: 426s, tokens: 59,733*
