### PR TITLE
LineBoxColl equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -1184,53 +1184,50 @@ int LineBoxColl(br_vector3* o, br_vector3* p, br_bounds* pB, br_vector3* pHit_po
     inside = 1;
     BrVector3Sub(&dir, p, o);
     for (i = 0; i < 3; ++i) {
-        if (pB->min.v[i] <= o->v[i]) {
-            if (pB->max.v[i] >= o->v[i]) {
-                quad[i] = 2;
-            } else {
-                quad[i] = 0;
-                max_t[i] = pB->max.v[i];
-                inside = 0;
-            }
-        } else {
+        if (pB->min.v[i] > o->v[i]) {
             quad[i] = 1;
-            max_t[i] = pB->min.v[i];
+            cp[i] = pB->min.v[i];
             inside = 0;
+        } else if (pB->max.v[i] < o->v[i]) {
+            quad[i] = 0;
+            cp[i] = pB->max.v[i];
+            inside = 0;
+        } else {
+            quad[i] = 2;
         }
     }
     if (inside) {
         BrVector3Copy(pHit_point, o);
         return 8;
-    } else {
-        for (i = 0; i < 3; ++i) {
-            if (quad[i] == 2 || dir.v[i] == 0.0) {
-                cp[i] = -1.0;
-            } else {
-                cp[i] = (max_t[i] - o->v[i]) / dir.v[i];
-            }
-        }
-        which_plane = 0;
-        for (i = 1; i < 3; ++i) {
-            if (cp[which_plane] < cp[i]) {
-                which_plane = i;
-            }
-        }
-        if (cp[which_plane] >= 0.0 && cp[which_plane] <= 1.0) {
-            for (i = 0; i < 3; ++i) {
-                if (which_plane == i) {
-                    pHit_point->v[i] = max_t[i];
-                } else {
-                    pHit_point->v[i] = dir.v[i] * cp[which_plane] + o->v[i];
-                    if (pHit_point->v[i] < pB->min.v[i] || pB->max.v[i] < pHit_point->v[i]) {
-                        return 0;
-                    }
-                }
-            }
-            return which_plane + 4 * quad[which_plane] + 1;
+    }
+
+    for (i = 0; i < 3; ++i) {
+        if (quad[i] != 2 && dir.v[i] != 0.0f) {
+            max_t[i] = (cp[i] - o->v[i]) / dir.v[i];
         } else {
-            return 0;
+            max_t[i] = -1.0f;
         }
     }
+    which_plane = 0;
+    for (i = 1; i < 3; ++i) {
+        if (max_t[i] > max_t[which_plane]) {
+            which_plane = i;
+        }
+    }
+    if (max_t[which_plane] < 0.0f || max_t[which_plane] > 1.0f) {
+        return 0;
+    }
+    for (i = 0; i < 3; ++i) {
+        if (which_plane != i) {
+            pHit_point->v[i] = dir.v[i] * max_t[which_plane] + o->v[i];
+            if (pHit_point->v[i] < pB->min.v[i] || pB->max.v[i] < pHit_point->v[i]) {
+                return 0;
+            }
+        } else {
+            pHit_point->v[i] = cp[i];
+        }
+    }
+    return which_plane + 4 * quad[which_plane] + 1;
 }
 
 // IDA: int __usercall SphereBoxIntersection@<EAX>(br_bounds *pB@<EAX>, br_vector3 *pC@<EDX>, br_scalar pR_squared, br_vector3 *pHit_point)


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4af2a7,27 +0x47a45b,27 @@
0x4af2a7 : jmp 0xb 	(finteray.c:1207)
0x4af2ac : mov eax, dword ptr [ebp - 0x30] 	(finteray.c:1208)
0x4af2af : mov dword ptr [ebp + eax*4 - 0xc], 0xbf800000
0x4af2b7 : jmp -0x66 	(finteray.c:1210)
0x4af2bc : mov dword ptr [ebp - 0x2c], 0 	(finteray.c:1211)
0x4af2c3 : mov dword ptr [ebp - 0x30], 1 	(finteray.c:1212)
0x4af2ca : jmp 0x3
0x4af2cf : inc dword ptr [ebp - 0x30]
0x4af2d2 : cmp dword ptr [ebp - 0x30], 3
0x4af2d6 : jge 0x24
         : +mov eax, dword ptr [ebp - 0x30] 	(finteray.c:1213)
         : +fld dword ptr [ebp + eax*4 - 0xc]
0x4af2dc : mov eax, dword ptr [ebp - 0x2c]
0x4af2df : -fld dword ptr [ebp + eax*4 - 0xc]
0x4af2e3 : -mov eax, dword ptr [ebp - 0x30]
0x4af2e6 : fcomp dword ptr [ebp + eax*4 - 0xc]
0x4af2ea : fnstsw ax
0x4af2ec : -test ah, 1
0x4af2ef : -je 0x6
         : +test ah, 0x41
         : +jne 0x6
0x4af2f5 : mov eax, dword ptr [ebp - 0x30] 	(finteray.c:1214)
0x4af2f8 : mov dword ptr [ebp - 0x2c], eax
0x4af2fb : jmp -0x31 	(finteray.c:1216)
0x4af300 : mov eax, dword ptr [ebp - 0x2c] 	(finteray.c:1217)
0x4af303 : fld dword ptr [ebp + eax*4 - 0xc]
0x4af307 : fcomp dword ptr [0.0 (FLOAT)]
0x4af30d : fnstsw ax
0x4af30f : test ah, 1
0x4af312 : jne 0x18
0x4af318 : mov eax, dword ptr [ebp - 0x2c]


LineBoxColl is only 97.94% similar to the original, diff above
```

#### Effective match analysis

Yes for normal (non-NaN) inputs. The new code swaps the `fld`/operand roles in the `fcomp`, then adjusts the condition check accordingly: old logic updated the index when `arr[current_best] < arr[i]` (via `test ah,1` after comparing best vs candidate), while new logic updates only when `arr[i] > arr[current_best]` (via `test ah,0x41` after comparing candidate vs best). Those are functionally the same strict-greater selection. The only behavioral difference is unordered/NaN handling, which you explicitly said to ignore.

#### Original match

```
---
+++
@@ -0x4af170,136 +0x47a324,141 @@
0x4af170 : cmp dword ptr [ebp - 0x30], 3
0x4af174 : jge 0x9a
0x4af17a : mov eax, dword ptr [ebp - 0x30] 	(finteray.c:1187)
0x4af17d : mov ecx, dword ptr [ebp + 0x10]
0x4af180 : fld dword ptr [ecx + eax*4]
0x4af183 : mov eax, dword ptr [ebp - 0x30]
0x4af186 : mov ecx, dword ptr [ebp + 8]
0x4af189 : fcomp dword ptr [ecx + eax*4]
0x4af18c : fnstsw ax
0x4af18e : test ah, 0x41
0x4af191 : -jne 0x27
0x4af197 : -mov eax, dword ptr [ebp - 0x30]
0x4af19a : -mov dword ptr [ebp + eax*4 - 0x18], 1
0x4af1a2 : -mov eax, dword ptr [ebp - 0x30]
0x4af1a5 : -mov ecx, dword ptr [ebp + 0x10]
0x4af1a8 : -mov edx, dword ptr [ebp - 0x30]
0x4af1ab : -mov eax, dword ptr [ecx + eax*4]
0x4af1ae : -mov dword ptr [ebp + edx*4 - 0x28], eax
0x4af1b2 : -mov dword ptr [ebp - 0x1c], 0
0x4af1b9 : -jmp 0x51
         : +je 0x56
0x4af1be : mov eax, dword ptr [ebp - 0x30] 	(finteray.c:1188)
0x4af1c1 : mov ecx, dword ptr [ebp + 0x10]
0x4af1c4 : fld dword ptr [ecx + eax*4 + 0xc]
0x4af1c8 : mov eax, dword ptr [ebp - 0x30]
0x4af1cb : mov ecx, dword ptr [ebp + 8]
0x4af1ce : fcomp dword ptr [ecx + eax*4]
0x4af1d1 : fnstsw ax
0x4af1d3 : test ah, 1
0x4af1d6 : -je 0x28
         : +jne 0x10
         : +mov eax, dword ptr [ebp - 0x30] 	(finteray.c:1189)
         : +mov dword ptr [ebp + eax*4 - 0x18], 2
         : +jmp 0x23 	(finteray.c:1190)
0x4af1dc : mov eax, dword ptr [ebp - 0x30] 	(finteray.c:1191)
0x4af1df : mov dword ptr [ebp + eax*4 - 0x18], 0
0x4af1e7 : mov eax, dword ptr [ebp - 0x30] 	(finteray.c:1192)
0x4af1ea : mov ecx, dword ptr [ebp + 0x10]
0x4af1ed : mov edx, dword ptr [ebp - 0x30]
0x4af1f0 : mov eax, dword ptr [ecx + eax*4 + 0xc]
0x4af1f4 : -mov dword ptr [ebp + edx*4 - 0x28], eax
         : +mov dword ptr [ebp + edx*4 - 0xc], eax
0x4af1f8 : mov dword ptr [ebp - 0x1c], 0 	(finteray.c:1193)
0x4af1ff : -jmp 0xb
         : +jmp 0x22 	(finteray.c:1195)
0x4af204 : mov eax, dword ptr [ebp - 0x30] 	(finteray.c:1196)
0x4af207 : -mov dword ptr [ebp + eax*4 - 0x18], 2
         : +mov dword ptr [ebp + eax*4 - 0x18], 1
         : +mov eax, dword ptr [ebp - 0x30] 	(finteray.c:1197)
         : +mov ecx, dword ptr [ebp + 0x10]
         : +mov edx, dword ptr [ebp - 0x30]
         : +mov eax, dword ptr [ecx + eax*4]
         : +mov dword ptr [ebp + edx*4 - 0xc], eax
         : +mov dword ptr [ebp - 0x1c], 0 	(finteray.c:1198)
0x4af20f : jmp -0xa7 	(finteray.c:1200)
0x4af214 : cmp dword ptr [ebp - 0x1c], 0 	(finteray.c:1201)
0x4af218 : -je 0x2c
         : +je 0x31
0x4af21e : mov eax, dword ptr [ebp + 8] 	(finteray.c:1202)
0x4af221 : mov ecx, dword ptr [ebp + 0x14]
0x4af224 : mov eax, dword ptr [eax]
0x4af226 : mov dword ptr [ecx], eax
0x4af228 : mov eax, dword ptr [ebp + 8]
0x4af22b : mov ecx, dword ptr [ebp + 0x14]
0x4af22e : mov eax, dword ptr [eax + 4]
0x4af231 : mov dword ptr [ecx + 4], eax
0x4af234 : mov eax, dword ptr [ebp + 8]
0x4af237 : mov ecx, dword ptr [ebp + 0x14]
0x4af23a : mov eax, dword ptr [eax + 8]
0x4af23d : mov dword ptr [ecx + 8], eax
0x4af240 : mov eax, 8 	(finteray.c:1203)
0x4af245 : -jmp 0x1a1
         : +jmp 0x1ab
         : +jmp 0x1a6 	(finteray.c:1204)
0x4af24a : mov dword ptr [ebp - 0x30], 0 	(finteray.c:1205)
0x4af251 : jmp 0x3
0x4af256 : inc dword ptr [ebp - 0x30]
0x4af259 : cmp dword ptr [ebp - 0x30], 3
0x4af25d : jge 0x59
0x4af263 : mov eax, dword ptr [ebp - 0x30] 	(finteray.c:1206)
0x4af266 : cmp dword ptr [ebp + eax*4 - 0x18], 2
0x4af26b : -je 0x3b
         : +je 0x18
0x4af271 : mov eax, dword ptr [ebp - 0x30]
0x4af274 : fld dword ptr [ebp + eax*4 - 0x3c]
0x4af278 : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x4af27e : fnstsw ax
0x4af280 : test ah, 0x40
0x4af283 : -jne 0x23
         : +je 0x10
0x4af289 : mov eax, dword ptr [ebp - 0x30] 	(finteray.c:1207)
0x4af28c : -fld dword ptr [ebp + eax*4 - 0x28]
         : +mov dword ptr [ebp + eax*4 - 0x28], 0xbf800000
         : +jmp 0x1e 	(finteray.c:1208)
         : +mov eax, dword ptr [ebp - 0x30] 	(finteray.c:1209)
         : +fld dword ptr [ebp + eax*4 - 0xc]
0x4af290 : mov eax, dword ptr [ebp - 0x30]
0x4af293 : mov ecx, dword ptr [ebp + 8]
0x4af296 : fsub dword ptr [ecx + eax*4]
0x4af299 : mov eax, dword ptr [ebp - 0x30]
0x4af29c : fdiv dword ptr [ebp + eax*4 - 0x3c]
0x4af2a0 : mov eax, dword ptr [ebp - 0x30]
0x4af2a3 : -fstp dword ptr [ebp + eax*4 - 0xc]
0x4af2a7 : -jmp 0xb
0x4af2ac : -mov eax, dword ptr [ebp - 0x30]
0x4af2af : -mov dword ptr [ebp + eax*4 - 0xc], 0xbf800000
         : +fstp dword ptr [ebp + eax*4 - 0x28]
0x4af2b7 : jmp -0x66 	(finteray.c:1211)
0x4af2bc : mov dword ptr [ebp - 0x2c], 0 	(finteray.c:1212)
0x4af2c3 : mov dword ptr [ebp - 0x30], 1 	(finteray.c:1213)
0x4af2ca : jmp 0x3
0x4af2cf : inc dword ptr [ebp - 0x30]
0x4af2d2 : cmp dword ptr [ebp - 0x30], 3
0x4af2d6 : jge 0x24
0x4af2dc : mov eax, dword ptr [ebp - 0x2c] 	(finteray.c:1214)
0x4af2df : -fld dword ptr [ebp + eax*4 - 0xc]
         : +fld dword ptr [ebp + eax*4 - 0x28]
0x4af2e3 : mov eax, dword ptr [ebp - 0x30]
0x4af2e6 : -fcomp dword ptr [ebp + eax*4 - 0xc]
         : +fcomp dword ptr [ebp + eax*4 - 0x28]
0x4af2ea : fnstsw ax
0x4af2ec : test ah, 1
0x4af2ef : je 0x6
0x4af2f5 : mov eax, dword ptr [ebp - 0x30] 	(finteray.c:1215)
0x4af2f8 : mov dword ptr [ebp - 0x2c], eax
0x4af2fb : jmp -0x31 	(finteray.c:1217)
0x4af300 : mov eax, dword ptr [ebp - 0x2c] 	(finteray.c:1218)
0x4af303 : -fld dword ptr [ebp + eax*4 - 0xc]
0x4af307 : -fcomp dword ptr [0.0 (FLOAT)]
         : +fld dword ptr [ebp + eax*4 - 0x28]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x4af30d : fnstsw ax
0x4af30f : test ah, 1
0x4af312 : -jne 0x18
         : +jne 0xd1
0x4af318 : mov eax, dword ptr [ebp - 0x2c]
0x4af31b : -fld dword ptr [ebp + eax*4 - 0xc]
0x4af31f : -fcomp dword ptr [1.0 (FLOAT)]
         : +fld dword ptr [ebp + eax*4 - 0x28]
         : +fcomp qword ptr [1.0 (FLOAT)]
0x4af325 : fnstsw ax
0x4af327 : test ah, 0x41
0x4af32a : -jne 0x7
0x4af330 : -xor eax, eax
0x4af332 : -jmp 0xb4
         : +je 0xb9
0x4af337 : mov dword ptr [ebp - 0x30], 0 	(finteray.c:1219)
0x4af33e : jmp 0x3
0x4af343 : inc dword ptr [ebp - 0x30]
0x4af346 : cmp dword ptr [ebp - 0x30], 3
0x4af34a : jge 0x88
0x4af350 : mov eax, dword ptr [ebp - 0x30] 	(finteray.c:1220)
0x4af353 : cmp dword ptr [ebp - 0x2c], eax
0x4af356 : -je 0x67
         : +jne 0x15
         : +mov eax, dword ptr [ebp - 0x30] 	(finteray.c:1221)
         : +mov ecx, dword ptr [ebp - 0x30]
         : +mov edx, dword ptr [ebp + 0x14]
         : +mov eax, dword ptr [ebp + eax*4 - 0xc]
         : +mov dword ptr [edx + ecx*4], eax
         : +jmp 0x62 	(finteray.c:1222)
0x4af35c : mov eax, dword ptr [ebp - 0x30] 	(finteray.c:1223)
0x4af35f : fld dword ptr [ebp + eax*4 - 0x3c]
0x4af363 : mov eax, dword ptr [ebp - 0x2c]
0x4af366 : -fmul dword ptr [ebp + eax*4 - 0xc]
         : +fmul dword ptr [ebp + eax*4 - 0x28]
0x4af36a : mov eax, dword ptr [ebp - 0x30]
0x4af36d : mov ecx, dword ptr [ebp + 8]
0x4af370 : fadd dword ptr [ecx + eax*4]
0x4af373 : mov eax, dword ptr [ebp - 0x30]
0x4af376 : mov ecx, dword ptr [ebp + 0x14]
0x4af379 : fstp dword ptr [ecx + eax*4]
0x4af37c : mov eax, dword ptr [ebp - 0x30] 	(finteray.c:1224)
0x4af37f : mov ecx, dword ptr [ebp + 0x14]
0x4af382 : fld dword ptr [ecx + eax*4]
0x4af385 : mov eax, dword ptr [ebp - 0x30]

---
+++
@@ -0x4af399,28 +0x47a560,25 @@
0x4af399 : mov eax, dword ptr [ebp - 0x30]
0x4af39c : mov ecx, dword ptr [ebp + 0x10]
0x4af39f : fld dword ptr [ecx + eax*4 + 0xc]
0x4af3a3 : mov eax, dword ptr [ebp - 0x30]
0x4af3a6 : mov ecx, dword ptr [ebp + 0x14]
0x4af3a9 : fcomp dword ptr [ecx + eax*4]
0x4af3ac : fnstsw ax
0x4af3ae : test ah, 1
0x4af3b1 : je 0x7
0x4af3b7 : xor eax, eax 	(finteray.c:1225)
0x4af3b9 : -jmp 0x2d
0x4af3be : -jmp 0x10
0x4af3c3 : -mov eax, dword ptr [ebp - 0x30]
0x4af3c6 : -mov ecx, dword ptr [ebp - 0x30]
0x4af3c9 : -mov edx, dword ptr [ebp + 0x14]
0x4af3cc : -mov eax, dword ptr [ebp + eax*4 - 0x28]
0x4af3d0 : -mov dword ptr [edx + ecx*4], eax
         : +jmp 0x24
0x4af3d3 : jmp -0x95 	(finteray.c:1228)
0x4af3d8 : mov eax, dword ptr [ebp - 0x2c] 	(finteray.c:1229)
0x4af3db : mov eax, dword ptr [ebp + eax*4 - 0x18]
0x4af3df : mov ecx, dword ptr [ebp - 0x2c]
0x4af3e2 : lea eax, [ecx + eax*4 + 1]
         : +jmp 0xc
         : +jmp 0x7 	(finteray.c:1230)
         : +xor eax, eax 	(finteray.c:1231)
0x4af3e6 : jmp 0x0
0x4af3eb : pop edi 	(finteray.c:1234)
0x4af3ec : pop esi
0x4af3ed : pop ebx
0x4af3ee : leave 
0x4af3ef : ret 


LineBoxColl is only 77.44% similar to the original, diff above
```

*AI generated. Time taken: 612s, tokens: 110,280*
