### PR TITLE
SphereBoxIntersection 100% match

### DIFF
--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -1241,16 +1241,14 @@ int SphereBoxIntersection(br_bounds* pB, br_vector3* pC, br_scalar pR_squared, b
 
     d = 0.f;
     for (i = 0; i < 3; i++) {
-        if (pC->v[i] <= pB->min.v[i]) {
-            pHit_point->v[i] = pB->min.v[i];
-        } else if (pC->v[i] > pB->max.v[i]) {
-            pHit_point->v[i] = pB->max.v[i];
+        if (pC->v[i] > pB->min.v[i]) {
+            pHit_point->v[i] = pB->max.v[i] < pC->v[i] ? pB->max.v[i] : pC->v[i];
         } else {
-            pHit_point->v[i] = pC->v[i];
+            pHit_point->v[i] = pB->min.v[i];
         }
         d += (pC->v[i] - pHit_point->v[i]) * (pC->v[i] - pHit_point->v[i]);
     }
-    return d <= pR_squared;
+    return (pR_squared + 0.f) >= d;
 }
 
 // IDA: int __usercall LineBoxCollWithSphere@<EAX>(br_vector3 *o@<EAX>, br_vector3 *p@<EDX>, br_bounds *pB@<EBX>, br_vector3 *pHit_point@<ECX>)

--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -1238,16 +1238,18 @@ int LineBoxColl(br_vector3* o, br_vector3* p, br_bounds* pB, br_vector3* pHit_po
 int SphereBoxIntersection(br_bounds* pB, br_vector3* pC, br_scalar pR_squared, br_vector3* pHit_point) {
     int i;
     br_scalar d;
+    br_vector3 hit_point;
 
     d = 0.f;
     for (i = 0; i < 3; i++) {
         if (pC->v[i] > pB->min.v[i]) {
-            pHit_point->v[i] = pB->max.v[i] < pC->v[i] ? pB->max.v[i] : pC->v[i];
+            hit_point.v[i] = pB->max.v[i] < pC->v[i] ? pB->max.v[i] : pC->v[i];
         } else {
-            pHit_point->v[i] = pB->min.v[i];
+            hit_point.v[i] = pB->min.v[i];
         }
-        d += (pC->v[i] - pHit_point->v[i]) * (pC->v[i] - pHit_point->v[i]);
+        d += (pC->v[i] - hit_point.v[i]) * (pC->v[i] - hit_point.v[i]);
     }
+    BrVector3Copy(pHit_point, &hit_point);
     return (pR_squared + 0.f) >= d;
 }
 


### PR DESCRIPTION
## Match result

```
0x4af3f0: SphereBoxIntersection 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4af3f1,72 +0x47a5af,79 @@
0x4af3f1 : mov ebp, esp
0x4af3f3 : sub esp, 8
0x4af3f6 : push ebx
0x4af3f7 : push esi
0x4af3f8 : push edi
0x4af3f9 : mov dword ptr [ebp - 4], 0 	(finteray.c:1242)
0x4af400 : mov dword ptr [ebp - 8], 0 	(finteray.c:1243)
0x4af407 : jmp 0x3
0x4af40c : inc dword ptr [ebp - 8]
0x4af40f : cmp dword ptr [ebp - 8], 3
0x4af413 : -jge 0x92
         : +jge 0xad
0x4af419 : mov eax, dword ptr [ebp - 8] 	(finteray.c:1244)
0x4af41c : mov ecx, dword ptr [ebp + 0xc]
0x4af41f : fld dword ptr [ecx + eax*4]
0x4af422 : mov eax, dword ptr [ebp - 8]
0x4af425 : mov ecx, dword ptr [ebp + 8]
0x4af428 : fcomp dword ptr [ecx + eax*4]
0x4af42b : fnstsw ax
0x4af42d : test ah, 0x41
0x4af430 : -jne 0x32
         : +je 0x17
         : +mov eax, dword ptr [ebp - 8] 	(finteray.c:1245)
         : +mov ecx, dword ptr [ebp + 8]
         : +mov edx, dword ptr [ebp - 8]
         : +mov ebx, dword ptr [ebp + 0x14]
         : +mov eax, dword ptr [ecx + eax*4]
         : +mov dword ptr [ebx + edx*4], eax
         : +jmp 0x48 	(finteray.c:1246)
0x4af436 : mov eax, dword ptr [ebp - 8]
0x4af439 : mov ecx, dword ptr [ebp + 8]
0x4af43c : fld dword ptr [ecx + eax*4 + 0xc]
0x4af440 : mov eax, dword ptr [ebp - 8]
0x4af443 : mov ecx, dword ptr [ebp + 0xc]
0x4af446 : -fld dword ptr [ecx + eax*4]
0x4af449 : -fcom st(1)
         : +fcomp dword ptr [ecx + eax*4]
0x4af44b : fnstsw ax
0x4af44d : -test ah, 0x41
0x4af450 : -je 0x2
0x4af456 : -fxch st(1)
0x4af458 : -fstp st(0)
         : +test ah, 1
         : +je 0x18
0x4af45a : mov eax, dword ptr [ebp - 8] 	(finteray.c:1247)
0x4af45d : -mov ecx, dword ptr [ebp + 0x14]
0x4af460 : -fstp dword ptr [ecx + eax*4]
         : +mov ecx, dword ptr [ebp + 8]
         : +mov edx, dword ptr [ebp - 8]
         : +mov ebx, dword ptr [ebp + 0x14]
         : +mov eax, dword ptr [ecx + eax*4 + 0xc]
         : +mov dword ptr [ebx + edx*4], eax
0x4af463 : jmp 0x12 	(finteray.c:1248)
0x4af468 : mov eax, dword ptr [ebp - 8] 	(finteray.c:1249)
0x4af46b : -mov ecx, dword ptr [ebp + 8]
         : +mov ecx, dword ptr [ebp + 0xc]
0x4af46e : mov edx, dword ptr [ebp - 8]
0x4af471 : mov ebx, dword ptr [ebp + 0x14]
0x4af474 : mov eax, dword ptr [ecx + eax*4]
0x4af477 : mov dword ptr [ebx + edx*4], eax
0x4af47a : mov eax, dword ptr [ebp - 8] 	(finteray.c:1251)
0x4af47d : mov ecx, dword ptr [ebp + 0xc]
0x4af480 : fld dword ptr [ecx + eax*4]
0x4af483 : mov eax, dword ptr [ebp - 8]
0x4af486 : mov ecx, dword ptr [ebp + 0x14]
0x4af489 : fsub dword ptr [ecx + eax*4]
0x4af48c : mov eax, dword ptr [ebp - 8]
0x4af48f : mov ecx, dword ptr [ebp + 0xc]
0x4af492 : fld dword ptr [ecx + eax*4]
0x4af495 : mov eax, dword ptr [ebp - 8]
0x4af498 : mov ecx, dword ptr [ebp + 0x14]
0x4af49b : fsub dword ptr [ecx + eax*4]
0x4af49e : fmulp st(1)
0x4af4a0 : fadd dword ptr [ebp - 4]
0x4af4a3 : fstp dword ptr [ebp - 4]
0x4af4a6 : -jmp -0x9f
0x4af4ab : -fld dword ptr [ebp + 0x10]
0x4af4ae : -fcomp dword ptr [ebp - 4]
         : +jmp -0xba 	(finteray.c:1252)
         : +fld dword ptr [ebp - 4] 	(finteray.c:1253)
         : +fcomp dword ptr [ebp + 0x10]
0x4af4b1 : fnstsw ax
0x4af4b3 : -test ah, 1
0x4af4b6 : -jne 0xa
         : +test ah, 0x41
         : +je 0xa
0x4af4bc : mov eax, 1
0x4af4c1 : jmp 0x2
0x4af4c6 : xor eax, eax
0x4af4c8 : jmp 0x0
0x4af4cd : pop edi 	(finteray.c:1254)
0x4af4ce : pop esi
0x4af4cf : pop ebx
0x4af4d0 : leave 
0x4af4d1 : ret 


SphereBoxIntersection is only 74.51% similar to the original, diff above
```

*AI generated. Time taken: 418s, tokens: 56,969*
