### PR TITLE
LineBoxCollWithSphere 100% match

### DIFF
--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -1264,18 +1264,19 @@ int LineBoxCollWithSphere(br_vector3* o, br_vector3* p, br_bounds* pB, br_vector
     if (plane != 0) {
         return plane;
     }
-    if (!SphereBoxIntersection(pB, p, 2.5e-5f, pHit_point)) {
+    if (SphereBoxIntersection(pB, p, 2.5e-5f, pHit_point)) {
+        for (i = 0; i < 3; i++) {
+            if (pB->max.v[i] == pHit_point->v[i] && p->v[i] <= o->v[i]) {
+                return i + 1;
+            }
+            if (pHit_point->v[i] == pB->min.v[i] && p->v[i] >= o->v[i]) {
+                return i + 5;
+            }
+        }
+        return 0;
+    } else {
         return 0;
     }
-    for (i = 0; i < 3; i++) {
-        if (pB->max.v[i] == pHit_point->v[i] && p->v[i] <= o->v[i]) {
-            return i + 1;
-        }
-        if (pHit_point->v[i] == pB->min.v[i] && p->v[i] >= o->v[i]) {
-            return i + 5;
-        }
-    }
-    return 0;
 }
 
 // IDA: int __usercall CompVert@<EAX>(int v1@<EAX>, int v2@<EDX>)


### PR DESCRIPTION
## Match result

```
0x4af4d2: LineBoxCollWithSphere 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4af4e3,32 +0x47a6bc,34 @@
0x4af4e3 : mov eax, dword ptr [ebp + 0xc]
0x4af4e6 : push eax
0x4af4e7 : mov eax, dword ptr [ebp + 8]
0x4af4ea : push eax
0x4af4eb : call LineBoxColl (FUNCTION)
0x4af4f0 : add esp, 0x10
0x4af4f3 : mov dword ptr [ebp - 4], eax
0x4af4f6 : cmp dword ptr [ebp - 4], 0 	(finteray.c:1264)
0x4af4fa : je 0x8
0x4af500 : mov eax, dword ptr [ebp - 4] 	(finteray.c:1265)
0x4af503 : -jmp 0xdb
         : +jmp 0xd6
0x4af508 : mov eax, dword ptr [ebp + 0x14] 	(finteray.c:1267)
0x4af50b : push eax
0x4af50c : push 0x37d1b717
0x4af511 : mov eax, dword ptr [ebp + 0xc]
0x4af514 : push eax
0x4af515 : mov eax, dword ptr [ebp + 0x10]
0x4af518 : push eax
0x4af519 : call SphereBoxIntersection (FUNCTION)
0x4af51e : add esp, 0x10
0x4af521 : test eax, eax
0x4af523 : -je 0xb3
         : +jne 0x7
         : +xor eax, eax 	(finteray.c:1268)
         : +jmp 0xae
0x4af529 : mov dword ptr [ebp - 8], 0 	(finteray.c:1270)
0x4af530 : jmp 0x3
0x4af535 : inc dword ptr [ebp - 8]
0x4af538 : cmp dword ptr [ebp - 8], 3
0x4af53c : jge 0x8e
0x4af542 : mov eax, dword ptr [ebp - 8] 	(finteray.c:1271)
0x4af545 : mov ecx, dword ptr [ebp + 0x10]
0x4af548 : fld dword ptr [ecx + eax*4 + 0xc]
0x4af54c : mov eax, dword ptr [ebp - 8]
0x4af54f : mov ecx, dword ptr [ebp + 0x14]

---
+++
@@ -0x4af563,38 +0x47a743,40 @@
0x4af563 : mov ecx, dword ptr [ebp + 0xc]
0x4af566 : fld dword ptr [ecx + eax*4]
0x4af569 : mov eax, dword ptr [ebp - 8]
0x4af56c : mov ecx, dword ptr [ebp + 8]
0x4af56f : fcomp dword ptr [ecx + eax*4]
0x4af572 : fnstsw ax
0x4af574 : test ah, 0x41
0x4af577 : je 0x9
0x4af57d : mov eax, dword ptr [ebp - 8] 	(finteray.c:1272)
0x4af580 : inc eax
0x4af581 : -jmp 0x5d
         : +jmp 0x51
0x4af586 : mov eax, dword ptr [ebp - 8] 	(finteray.c:1274)
0x4af589 : mov ecx, dword ptr [ebp + 0x14]
0x4af58c : fld dword ptr [ecx + eax*4]
0x4af58f : mov eax, dword ptr [ebp - 8]
0x4af592 : mov ecx, dword ptr [ebp + 0x10]
0x4af595 : fcomp dword ptr [ecx + eax*4]
0x4af598 : fnstsw ax
0x4af59a : test ah, 0x40
0x4af59d : je 0x28
0x4af5a3 : mov eax, dword ptr [ebp - 8]
0x4af5a6 : mov ecx, dword ptr [ebp + 0xc]
0x4af5a9 : fld dword ptr [ecx + eax*4]
0x4af5ac : mov eax, dword ptr [ebp - 8]
0x4af5af : mov ecx, dword ptr [ebp + 8]
0x4af5b2 : fcomp dword ptr [ecx + eax*4]
0x4af5b5 : fnstsw ax
0x4af5b7 : test ah, 1
0x4af5ba : jne 0xb
0x4af5c0 : mov eax, dword ptr [ebp - 8] 	(finteray.c:1275)
0x4af5c3 : add eax, 5
0x4af5c6 : -jmp 0x18
         : +jmp 0xc
0x4af5cb : jmp -0x9b 	(finteray.c:1277)
0x4af5d0 : xor eax, eax 	(finteray.c:1278)
0x4af5d2 : -jmp 0xc
0x4af5d7 : -jmp 0x7
0x4af5dc : -xor eax, eax
0x4af5de : jmp 0x0
         : +pop edi 	(finteray.c:1279)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


LineBoxCollWithSphere is only 89.66% similar to the original, diff above
```

*AI generated. Time taken: 286s, tokens: 44,848*
