### PR TITLE
SelectFace 100% match

### DIFF
--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -2,6 +2,7 @@
 #include "brender.h"
 #include "brucetrk.h"
 #include "car.h"
+#include "depth.h"
 #include "formats.h"
 #include "globvars.h"
 #include "harness/trace.h"
@@ -1318,7 +1319,50 @@ void SelectFace(br_vector3* pDir) {
     br_scalar t;
     br_model* old_model;
     int i;
-    NOT_IMPLEMENTED();
+
+    c = &gProgram_state.current_car;
+    old_model = gSelected_model;
+
+    if (gSub_material == NULL) {
+        gSub_material = BrMaterialAllocate("");
+        if (gSub_material == NULL) {
+            return;
+        }
+        gSub_material->index_shade = gAcid_shade_table;
+        BrMaterialAdd(gSub_material);
+    }
+
+    if (gSelected_model != NULL && gSelected_model->nfaces == gNfaces) {
+        for (i = 0; i < gSelected_model->nfaces; i++) {
+            if (gSelected_model->faces[(unsigned short)i].material == gSub_material) {
+                gSelected_model->faces[(unsigned short)i].material = gReal_material;
+            }
+        }
+        BrModelUpdate(gSelected_model, 0x7fff);
+    }
+
+    gSelected_model = NULL;
+
+    dir.v[0] = pDir->v[0];
+    dir.v[1] = pDir->v[1];
+    dir.v[2] = pDir->v[2];
+
+    FindFace(&c->pos, &dir, &normal, &t, &gReal_material);
+    if (t > 1.f) {
+        return;
+    }
+
+    if (gNearest_model == old_model) {
+        return;
+    }
+
+    gSelected_model = gNearest_model;
+    gNfaces = gSelected_model->nfaces;
+    gSub_material->colour_map = gReal_material->colour_map;
+    gSub_material->flags = gReal_material->flags | 0x5;
+    BrMaterialUpdate(gSub_material, 0x7fff);
+    SetFacesGroup(gNearest_face);
+    BrModelUpdate(gSelected_model, 0x7fff);
 }
 
 // IDA: void __usercall GetTilingLimits(br_vector2 *min@<EAX>, br_vector2 *max@<EDX>)

--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -1343,9 +1343,7 @@ void SelectFace(br_vector3* pDir) {
 
     gSelected_model = NULL;
 
-    dir.v[0] = pDir->v[0];
-    dir.v[1] = pDir->v[1];
-    dir.v[2] = pDir->v[2];
+    BrVector3Copy(&dir, pDir);
 
     FindFace(&c->pos, &dir, &normal, &t, &gReal_material);
     if (t > 1.f) {

--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -1334,11 +1334,11 @@ void SelectFace(br_vector3* pDir) {
 
     if (gSelected_model != NULL && gSelected_model->nfaces == gNfaces) {
         for (i = 0; i < gSelected_model->nfaces; i++) {
-            if (gSelected_model->faces[(unsigned short)i].material == gSub_material) {
-                gSelected_model->faces[(unsigned short)i].material = gReal_material;
+            if (gSelected_model->faces[i].material == gSub_material) {
+                gSelected_model->faces[i].material = gReal_material;
             }
         }
-        BrModelUpdate(gSelected_model, 0x7fff);
+        BrModelUpdate(gSelected_model, BR_MODU_ALL);
     }
 
     gSelected_model = NULL;
@@ -1357,10 +1357,10 @@ void SelectFace(br_vector3* pDir) {
     gSelected_model = gNearest_model;
     gNfaces = gSelected_model->nfaces;
     gSub_material->colour_map = gReal_material->colour_map;
-    gSub_material->flags = gReal_material->flags | 0x5;
-    BrMaterialUpdate(gSub_material, 0x7fff);
+    gSub_material->flags = gReal_material->flags | BR_MODF_GENERATE_TAGS | BR_MODF_DONT_WELD;
+    BrMaterialUpdate(gSub_material, BR_MATU_ALL);
     SetFacesGroup(gNearest_face);
-    BrModelUpdate(gSelected_model, 0x7fff);
+    BrModelUpdate(gSelected_model, BR_MODU_ALL);
 }
 
 // IDA: void __usercall GetTilingLimits(br_vector2 *min@<EAX>, br_vector2 *max@<EDX>)

--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -1334,8 +1334,8 @@ void SelectFace(br_vector3* pDir) {
 
     if (gSelected_model != NULL && gSelected_model->nfaces == gNfaces) {
         for (i = 0; i < gSelected_model->nfaces; i++) {
-            if (gSelected_model->faces[i].material == gSub_material) {
-                gSelected_model->faces[i].material = gReal_material;
+            if (gSelected_model->faces[i * 1].material == gSub_material) {
+                gSelected_model->faces[i * 1].material = gReal_material;
             }
         }
         BrModelUpdate(gSelected_model, BR_MODU_ALL);


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4af5fe,57 +0x47a908,59 @@
0x4af5fe : mov eax, dword ptr [gSelected_model (DATA)] 	(finteray.c:1324)
0x4af603 : mov dword ptr [ebp - 0x10], eax
0x4af606 : cmp dword ptr [gSub_material (DATA)], 0 	(finteray.c:1326)
0x4af60d : jne 0x40
0x4af613 : push <OFFSET4> 	(finteray.c:1327)
0x4af618 : call BrMaterialAllocate (FUNCTION)
0x4af61d : add esp, 4
0x4af620 : mov dword ptr [gSub_material (DATA)], eax
0x4af625 : cmp dword ptr [gSub_material (DATA)], 0 	(finteray.c:1328)
0x4af62c : jne 0x5
0x4af632 : -jmp 0x198
         : +jmp 0x1a3 	(finteray.c:1329)
0x4af637 : mov eax, dword ptr [gAcid_shade_table (DATA)] 	(finteray.c:1331)
0x4af63c : mov ecx, dword ptr [gSub_material (DATA)]
0x4af642 : mov dword ptr [ecx + 0x48], eax
0x4af645 : mov eax, dword ptr [gSub_material (DATA)] 	(finteray.c:1332)
0x4af64a : push eax
0x4af64b : call BrMaterialAdd (FUNCTION)
0x4af650 : add esp, 4
0x4af653 : cmp dword ptr [gSelected_model (DATA)], 0 	(finteray.c:1335)
0x4af65a : -je 0x89
         : +je 0x94
0x4af660 : mov eax, dword ptr [gSelected_model (DATA)]
0x4af665 : xor ecx, ecx
0x4af667 : mov cx, word ptr [eax + 0x12]
0x4af66b : cmp ecx, dword ptr [gNfaces (DATA)]
0x4af671 : -jne 0x72
         : +jne 0x7d
0x4af677 : mov dword ptr [ebp - 0xc], 0 	(finteray.c:1336)
0x4af67e : jmp 0x3
0x4af683 : inc dword ptr [ebp - 0xc]
0x4af686 : mov eax, dword ptr [gSelected_model (DATA)]
0x4af68b : xor ecx, ecx
0x4af68d : mov cx, word ptr [eax + 0x12]
0x4af691 : cmp ecx, dword ptr [ebp - 0xc]
0x4af694 : -jle 0x3c
         : +jle 0x47
0x4af69a : mov eax, dword ptr [ebp - 0xc] 	(finteray.c:1337)
         : +and eax, 0xffff
0x4af69d : lea eax, [eax + eax*4]
0x4af6a0 : mov ecx, dword ptr [gSelected_model (DATA)]
0x4af6a6 : mov ecx, dword ptr [ecx + 0xc]
0x4af6a9 : mov edx, dword ptr [gSub_material (DATA)]
0x4af6af : cmp dword ptr [ecx + eax*8 + 8], edx
0x4af6b3 : -jne 0x18
         : +jne 0x1e
0x4af6b9 : mov eax, dword ptr [gReal_material (DATA)] 	(finteray.c:1338)
0x4af6be : mov ecx, dword ptr [ebp - 0xc]
         : +and ecx, 0xffff
0x4af6c1 : lea ecx, [ecx + ecx*4]
0x4af6c4 : mov edx, dword ptr [gSelected_model (DATA)]
0x4af6ca : mov edx, dword ptr [edx + 0xc]
0x4af6cd : mov dword ptr [edx + ecx*8 + 8], eax
0x4af6d1 : -jmp -0x53
         : +jmp -0x5e 	(finteray.c:1340)
0x4af6d6 : push 0x7fff 	(finteray.c:1341)
0x4af6db : mov eax, dword ptr [gSelected_model (DATA)]
0x4af6e0 : push eax
0x4af6e1 : call BrModelUpdate (FUNCTION)
0x4af6e6 : add esp, 8
0x4af6e9 : mov dword ptr [gSelected_model (DATA)], 0 	(finteray.c:1344)
0x4af6f3 : mov eax, dword ptr [ebp + 8] 	(finteray.c:1346)
0x4af6f6 : mov eax, dword ptr [eax]
0x4af6f8 : mov dword ptr [ebp - 0x1c], eax
0x4af6fb : mov eax, dword ptr [ebp + 8] 	(finteray.c:1347)


SelectFace is only 94.53% similar to the original, diff above
```

#### Effective match analysis

The diff appears functionally equivalent. All conditional branches keep the same predicates and logical destinations; the changed jump displacements are consistent with code size shifts from inserted instructions. The only semantic-looking additions are `and eax, 0xffff` / `and ecx, 0xffff` before face-index address calculations, but the loop index is locally initialized to 0 and incremented while bounded by a zero-extended 16-bit face count, so those masks are redundant in normal execution. No meaningful control-flow restructuring or result-changing dataflow differences are evident.

#### Original match

```
---
+++
@@ -0x4af5e8,8 +0x47a8eb,12 @@
0x4af5e8 : push ebp 	(finteray.c:1314)
0x4af5e9 : mov ebp, esp
0x4af5eb : sub esp, 0x28
0x4af5ee : push ebx
0x4af5ef : push esi
0x4af5f0 : push edi
0x4af5f1 : -mov eax, gProgram_state (DATA)
0x4af5f6 : -add eax, 0xb0
         : +call abort (FUNCTION) 	(finteray.c:1321)
         : +pop edi 	(finteray.c:1322)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


SelectFace is only 60.00% similar to the original, diff above
```

*AI generated. Time taken: 974s, tokens: 178,762*
