### PR TITLE
CompVert equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -1285,10 +1285,10 @@ int CompVert(int v1, int v2) {
     br_vector3 tv;
     br_vector2 tv2;
 
+    vl = gSelected_model->vertices;
     if (v1 == v2) {
         return 1;
     }
-    vl = gSelected_model->vertices;
     BrVector3Sub(&tv, &vl[v1].p, &vl[v2].p);
     if (BrVector3LengthSquared(&tv) > 1e-5f) {
         return 0;


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4af96d,24 +0x47a81b,24 @@
0x4af96d : fstp dword ptr [ebp - 0x14]
0x4af970 : mov eax, dword ptr [ebp + 8]
0x4af973 : lea eax, [eax + eax*4]
0x4af976 : mov ecx, dword ptr [ebp - 0xc]
0x4af979 : fld dword ptr [ecx + eax*8 + 8]
0x4af97d : mov eax, dword ptr [ebp + 0xc]
0x4af980 : lea eax, [eax + eax*4]
0x4af983 : mov ecx, dword ptr [ebp - 0xc]
0x4af986 : fsub dword ptr [ecx + eax*8 + 8]
0x4af98a : fstp dword ptr [ebp - 0x10]
         : +fld dword ptr [ebp - 0x10] 	(finteray.c:1293)
         : +fmul dword ptr [ebp - 0x10]
0x4af98d : fld dword ptr [ebp - 0x14]
0x4af990 : fmul dword ptr [ebp - 0x14]
0x4af993 : -fld dword ptr [ebp - 0x10]
0x4af996 : -fmul dword ptr [ebp - 0x10]
0x4af999 : faddp st(1)
0x4af99b : fld dword ptr [ebp - 0x18]
0x4af99e : fmul dword ptr [ebp - 0x18]
0x4af9a1 : faddp st(1)
0x4af9a3 : fcomp dword ptr [9.999999747378752e-06 (FLOAT)]
0x4af9a9 : fnstsw ax
0x4af9ab : test ah, 0x41
0x4af9ae : jne 0x7
0x4af9b4 : xor eax, eax 	(finteray.c:1294)
0x4af9b6 : jmp 0x6a


CompVert is only 97.80% similar to the original, diff above
```

#### Effective match analysis

The diff only changes when the `[ebp-0x10]^2` term is loaded/multiplied relative to `[ebp-0x14]^2`. Both versions still compute the same sum of squares: `[ebp-0x10]^2 + [ebp-0x14]^2 + [ebp-0x18]^2`, then compare it against the same constant and branch the same way. No control-flow restructuring is introduced; this is just stack-operation reordering with equivalent functional result under the stated ignore rules.

#### Original match

```
---
+++
@@ -0x4af90e,24 +0x47a7bc,24 @@
0x4af90e : push ebp 	(finteray.c:1283)
0x4af90f : mov ebp, esp
0x4af911 : sub esp, 0x18
0x4af914 : push ebx
0x4af915 : push esi
0x4af916 : push edi
0x4af917 : -mov eax, dword ptr [gSelected_model (DATA)]
0x4af91c : -mov eax, dword ptr [eax + 8]
0x4af91f : -mov dword ptr [ebp - 0xc], eax
0x4af922 : mov eax, dword ptr [ebp + 8] 	(finteray.c:1288)
0x4af925 : cmp dword ptr [ebp + 0xc], eax
0x4af928 : jne 0xa
0x4af92e : mov eax, 1 	(finteray.c:1289)
0x4af933 : -jmp 0xed
         : +jmp 0xf8
         : +mov eax, dword ptr [gSelected_model (DATA)] 	(finteray.c:1291)
         : +mov eax, dword ptr [eax + 8]
         : +mov dword ptr [ebp - 0xc], eax
0x4af938 : mov eax, dword ptr [ebp + 8] 	(finteray.c:1292)
0x4af93b : lea eax, [eax + eax*4]
0x4af93e : mov ecx, dword ptr [ebp - 0xc]
0x4af941 : fld dword ptr [ecx + eax*8]
0x4af944 : mov eax, dword ptr [ebp + 0xc]
0x4af947 : lea eax, [eax + eax*4]
0x4af94a : mov ecx, dword ptr [ebp - 0xc]
0x4af94d : fsub dword ptr [ecx + eax*8]
0x4af950 : fstp dword ptr [ebp - 0x18]
0x4af953 : mov eax, dword ptr [ebp + 8]

---
+++
@@ -0x4af96d,24 +0x47a81b,24 @@
0x4af96d : fstp dword ptr [ebp - 0x14]
0x4af970 : mov eax, dword ptr [ebp + 8]
0x4af973 : lea eax, [eax + eax*4]
0x4af976 : mov ecx, dword ptr [ebp - 0xc]
0x4af979 : fld dword ptr [ecx + eax*8 + 8]
0x4af97d : mov eax, dword ptr [ebp + 0xc]
0x4af980 : lea eax, [eax + eax*4]
0x4af983 : mov ecx, dword ptr [ebp - 0xc]
0x4af986 : fsub dword ptr [ecx + eax*8 + 8]
0x4af98a : fstp dword ptr [ebp - 0x10]
         : +fld dword ptr [ebp - 0x10] 	(finteray.c:1293)
         : +fmul dword ptr [ebp - 0x10]
0x4af98d : fld dword ptr [ebp - 0x14]
0x4af990 : fmul dword ptr [ebp - 0x14]
0x4af993 : -fld dword ptr [ebp - 0x10]
0x4af996 : -fmul dword ptr [ebp - 0x10]
0x4af999 : faddp st(1)
0x4af99b : fld dword ptr [ebp - 0x18]
0x4af99e : fmul dword ptr [ebp - 0x18]
0x4af9a1 : faddp st(1)
0x4af9a3 : fcomp dword ptr [9.999999747378752e-06 (FLOAT)]
0x4af9a9 : fnstsw ax
0x4af9ab : test ah, 0x41
0x4af9ae : jne 0x7
0x4af9b4 : xor eax, eax 	(finteray.c:1294)
0x4af9b6 : jmp 0x6a


CompVert is only 93.41% similar to the original, diff above
```

*AI generated. Time taken: 273s, tokens: 35,608*
