### PR TITLE
GetTilingLimits 100% match

### DIFF
--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -1335,15 +1335,16 @@ void GetTilingLimits(br_vector2* min, br_vector2* max) {
     BrVector2Set(min, 32000.f, 32000.f);
     BrVector2Set(max, -32000.f, -32000.f);
     for (f = 0; f < gSelected_model->nfaces; f++) {
-        if (faces[f].material == gSub_material) {
-            for (i = 0; i < 3; i++) {
-                for (j = 0; j < 2; j++) {
-                    if (verts[faces[f].vertices[i]].map.v[j] < min->v[j]) {
-                        min->v[j] = verts[faces[f].vertices[i]].map.v[j];
-                    }
-                    if (verts[faces[f].vertices[i]].map.v[j] > max->v[j]) {
-                        max->v[j] = verts[faces[f].vertices[i]].map.v[j];
-                    }
+        if (faces[f].material != gSub_material) {
+            continue;
+        }
+        for (i = 0; i < 3; i++) {
+            for (j = 0; j < 2; j++) {
+                if (verts[faces[f].vertices[0 + i]].map.v[j] < min->v[j]) {
+                    min->v[j] = verts[faces[f].vertices[0 + i]].map.v[j];
+                }
+                if (verts[faces[f].vertices[0 + i]].map.v[j] > max->v[j]) {
+                    max->v[j] = verts[faces[f].vertices[0 + i]].map.v[j];
                 }
             }
         }

--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -1340,11 +1340,11 @@ void GetTilingLimits(br_vector2* min, br_vector2* max) {
         }
         for (i = 0; i < 3; i++) {
             for (j = 0; j < 2; j++) {
-                if (verts[faces[f].vertices[0 + i]].map.v[j] < min->v[j]) {
-                    min->v[j] = verts[faces[f].vertices[0 + i]].map.v[j];
+                if (verts[faces[f].vertices[DR_FF(i)]].map.v[j] < min->v[j]) {
+                    min->v[j] = verts[faces[f].vertices[DR_FF(i)]].map.v[j];
                 }
-                if (verts[faces[f].vertices[0 + i]].map.v[j] > max->v[j]) {
-                    max->v[j] = verts[faces[f].vertices[0 + i]].map.v[j];
+                if (verts[faces[f].vertices[DR_FF(i)]].map.v[j] > max->v[j]) {
+                    max->v[j] = verts[faces[f].vertices[DR_FF(i)]].map.v[j];
                 }
             }
         }

--- a/src/DETHRACE/macros.h
+++ b/src/DETHRACE/macros.h
@@ -103,15 +103,18 @@
 #ifdef DETHRACE_FIX_BUGS
 // Fixes ubsan runtime errors related to memcpy arguments:
 // e.g. null pointer passed as argument 2, which is declared to never be null
-#define DR_SAFE_MEMCPY(DST, SRC, N) \
-    do { \
-        if ((N) != 0) { \
+#define DR_SAFE_MEMCPY(DST, SRC, N)    \
+    do {                               \
+        if ((N) != 0) {                \
             memcpy((DST), (SRC), (N)); \
-        } \
+        }                              \
     } while (0)
 #else
 #define DR_SAFE_MEMCPY(DST, SRC, N) memcpy((DST), (SRC), (N))
 #endif
+
+// "Force first" - for asm matching it can be helpful to try and force one branch/operation to be evaluated first
+#define DR_FF(x) (x * 1)
 
 // MACROS_H
 #endif


### PR DESCRIPTION
## Match result

```
0x4afa2a: GetTilingLimits 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4afa5f,104 +0x47a933,109 @@
0x4afa5f : mov dword ptr [eax], 0xc6fa0000
0x4afa65 : mov eax, dword ptr [ebp + 0xc]
0x4afa68 : mov dword ptr [eax + 4], 0xc6fa0000
0x4afa6f : mov dword ptr [ebp - 0xc], 0 	(finteray.c:1337)
0x4afa76 : jmp 0x3
0x4afa7b : inc dword ptr [ebp - 0xc]
0x4afa7e : mov eax, dword ptr [gSelected_model (DATA)]
0x4afa83 : xor ecx, ecx
0x4afa85 : mov cx, word ptr [eax + 0x12]
0x4afa89 : cmp ecx, dword ptr [ebp - 0xc]
0x4afa8c : -jle 0x145
         : +jle 0x13c
0x4afa92 : mov eax, dword ptr [ebp - 0xc] 	(finteray.c:1338)
0x4afa95 : lea eax, [eax + eax*4]
0x4afa98 : mov ecx, dword ptr [ebp - 4]
0x4afa9b : mov edx, dword ptr [gSub_material (DATA)]
0x4afaa1 : cmp dword ptr [ecx + eax*8 + 8], edx
0x4afaa5 : -je 0x5
0x4afaab : -jmp -0x35
         : +jne 0x11e
0x4afab0 : mov dword ptr [ebp - 0x10], 0 	(finteray.c:1339)
0x4afab7 : jmp 0x3
0x4afabc : inc dword ptr [ebp - 0x10]
0x4afabf : cmp dword ptr [ebp - 0x10], 3
0x4afac3 : -jge 0x109
         : +jge 0x105
0x4afac9 : mov dword ptr [ebp - 0x14], 0 	(finteray.c:1340)
0x4afad0 : jmp 0x3
0x4afad5 : inc dword ptr [ebp - 0x14]
0x4afad8 : cmp dword ptr [ebp - 0x14], 2
0x4afadc : -jge 0xeb
0x4afae2 : -mov eax, dword ptr [ebp - 0x10]
0x4afae5 : -mov ecx, dword ptr [ebp - 0xc]
0x4afae8 : -lea ecx, [ecx + ecx*4]
0x4afaeb : -shl ecx, 3
0x4afaee : -lea eax, [ecx + eax*2]
         : +jge 0xe7
         : +mov eax, dword ptr [ebp - 0xc] 	(finteray.c:1341)
         : +lea eax, [eax + eax*4]
         : +mov ecx, dword ptr [ebp - 0x10]
         : +add ecx, ecx
         : +lea eax, [ecx + eax*8]
0x4afaf1 : mov ecx, dword ptr [ebp - 4]
0x4afaf4 : xor edx, edx
0x4afaf6 : mov dx, word ptr [eax + ecx]
0x4afafa : lea eax, [edx + edx*4]
0x4afafd : mov ecx, dword ptr [ebp - 0x14]
0x4afb00 : shl ecx, 2
0x4afb03 : lea eax, [ecx + eax*8]
0x4afb06 : mov ecx, dword ptr [ebp - 8]
0x4afb09 : fld dword ptr [eax + ecx + 0xc]
0x4afb0d : mov eax, dword ptr [ebp - 0x14]
0x4afb10 : mov ecx, dword ptr [ebp + 8]
0x4afb13 : fcomp dword ptr [ecx + eax*4]
0x4afb16 : fnstsw ax
0x4afb18 : test ah, 1
0x4afb1b : -je 0x34
0x4afb21 : -mov eax, dword ptr [ebp - 0x10]
0x4afb24 : -mov ecx, dword ptr [ebp - 0xc]
0x4afb27 : -lea ecx, [ecx + ecx*4]
0x4afb2a : -shl ecx, 3
0x4afb2d : -lea eax, [ecx + eax*2]
         : +je 0x33
         : +mov eax, dword ptr [ebp - 0xc] 	(finteray.c:1342)
         : +lea eax, [eax + eax*4]
         : +mov ecx, dword ptr [ebp - 0x10]
         : +add ecx, ecx
         : +lea eax, [ecx + eax*8]
0x4afb30 : mov ecx, dword ptr [ebp - 4]
0x4afb33 : xor edx, edx
0x4afb35 : mov dx, word ptr [eax + ecx]
0x4afb39 : lea eax, [edx + edx*4]
0x4afb3c : mov ecx, dword ptr [ebp - 0x14]
0x4afb3f : shl ecx, 2
0x4afb42 : lea eax, [ecx + eax*8]
0x4afb45 : mov ecx, dword ptr [ebp - 8]
0x4afb48 : mov edx, dword ptr [ebp - 0x14]
0x4afb4b : mov ebx, dword ptr [ebp + 8]
0x4afb4e : mov eax, dword ptr [eax + ecx + 0xc]
0x4afb52 : mov dword ptr [ebx + edx*4], eax
0x4afb55 : -mov eax, dword ptr [ebp - 0x10]
0x4afb58 : -mov ecx, dword ptr [ebp - 0xc]
0x4afb5b : -lea ecx, [ecx + ecx*4]
0x4afb5e : -shl ecx, 3
0x4afb61 : -lea eax, [ecx + eax*2]
         : +mov eax, dword ptr [ebp - 0xc] 	(finteray.c:1344)
         : +lea eax, [eax + eax*4]
         : +mov ecx, dword ptr [ebp - 0x10]
         : +add ecx, ecx
         : +lea eax, [ecx + eax*8]
0x4afb64 : mov ecx, dword ptr [ebp - 4]
0x4afb67 : xor edx, edx
0x4afb69 : mov dx, word ptr [eax + ecx]
0x4afb6d : lea eax, [edx + edx*4]
0x4afb70 : mov ecx, dword ptr [ebp - 0x14]
0x4afb73 : shl ecx, 2
0x4afb76 : lea eax, [ecx + eax*8]
0x4afb79 : mov ecx, dword ptr [ebp - 8]
0x4afb7c : fld dword ptr [eax + ecx + 0xc]
0x4afb80 : mov eax, dword ptr [ebp - 0x14]
0x4afb83 : mov ecx, dword ptr [ebp + 0xc]
0x4afb86 : fcomp dword ptr [ecx + eax*4]
0x4afb89 : fnstsw ax
0x4afb8b : test ah, 0x41
0x4afb8e : -jne 0x34
0x4afb94 : -mov eax, dword ptr [ebp - 0x10]
0x4afb97 : -mov ecx, dword ptr [ebp - 0xc]
0x4afb9a : -lea ecx, [ecx + ecx*4]
0x4afb9d : -shl ecx, 3
0x4afba0 : -lea eax, [ecx + eax*2]
         : +jne 0x33
         : +mov eax, dword ptr [ebp - 0xc] 	(finteray.c:1345)
         : +lea eax, [eax + eax*4]
         : +mov ecx, dword ptr [ebp - 0x10]
         : +add ecx, ecx
         : +lea eax, [ecx + eax*8]
0x4afba3 : mov ecx, dword ptr [ebp - 4]
0x4afba6 : xor edx, edx
0x4afba8 : mov dx, word ptr [eax + ecx]
0x4afbac : lea eax, [edx + edx*4]
0x4afbaf : mov ecx, dword ptr [ebp - 0x14]
0x4afbb2 : shl ecx, 2
0x4afbb5 : lea eax, [ecx + eax*8]
0x4afbb8 : mov ecx, dword ptr [ebp - 8]
0x4afbbb : mov edx, dword ptr [ebp - 0x14]
0x4afbbe : mov ebx, dword ptr [ebp + 0xc]
0x4afbc1 : mov eax, dword ptr [eax + ecx + 0xc]
0x4afbc5 : mov dword ptr [ebx + edx*4], eax
0x4afbc8 : -jmp -0xf8
0x4afbcd : -jmp -0x116
         : +jmp -0xf4 	(finteray.c:1347)
         : +jmp -0x112 	(finteray.c:1348)
         : +jmp -0x153 	(finteray.c:1350)
         : +pop edi 	(finteray.c:1351)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


GetTilingLimits is only 74.49% similar to the original, diff above
```

*AI generated. Time taken: 275s, tokens: 34,299*
