### PR TITLE
Scale equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -1361,10 +1361,7 @@ void Scale(int pD, int factor) {
     br_vertex* verts;
     br_face* faces;
 
-    if (gSelected_model == NULL) {
-        return;
-    }
-    if (gSelected_model->nfaces != gNfaces) {
+    if (gSelected_model == NULL || gSelected_model->nfaces != gNfaces) {
         return;
     }
     verts = gSelected_model->vertices;
@@ -1378,7 +1375,7 @@ void Scale(int pD, int factor) {
         for (f = 0; f < gSelected_model->nfaces; f++) {
             if (faces[f].material == gSub_material
                 && (faces[f].vertices[0] == v || faces[f].vertices[1] == v || faces[f].vertices[2] == v)) {
-                verts[v].map.v[pD] = (factor + d) / d * verts[v].map.v[pD];
+                verts[v].map.v[pD] *= (factor + d) / d;
                 break;
             }
         }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4afd25,32 +0x47abd9,32 @@
0x4afd25 : mov ecx, dword ptr [ebp - 4]
0x4afd28 : xor edx, edx
0x4afd2a : mov dx, word ptr [ecx + eax*8 + 4]
0x4afd2f : cmp edx, dword ptr [ebp - 0x18]
0x4afd32 : jne 0x40
0x4afd38 : mov eax, dword ptr [ebp + 0xc] 	(finteray.c:1378)
0x4afd3b : mov dword ptr [ebp - 0x2c], eax
0x4afd3e : fild dword ptr [ebp - 0x2c]
0x4afd41 : fadd dword ptr [ebp - 8]
0x4afd44 : fdiv dword ptr [ebp - 8]
0x4afd47 : -mov eax, dword ptr [ebp - 0x18]
0x4afd4a : -lea eax, [eax + eax*4]
0x4afd4d : -mov ecx, dword ptr [ebp + 8]
0x4afd50 : -shl ecx, 2
0x4afd53 : -lea eax, [ecx + eax*8]
         : +mov eax, dword ptr [ebp + 8]
         : +mov ecx, dword ptr [ebp - 0x18]
         : +lea ecx, [ecx + ecx*4]
         : +shl ecx, 3
         : +lea eax, [ecx + eax*4]
0x4afd56 : mov ecx, dword ptr [ebp - 0xc]
0x4afd59 : fmul dword ptr [eax + ecx + 0xc]
0x4afd5d : -mov eax, dword ptr [ebp - 0x18]
0x4afd60 : -lea eax, [eax + eax*4]
0x4afd63 : -mov ecx, dword ptr [ebp + 8]
0x4afd66 : -shl ecx, 2
0x4afd69 : -lea eax, [ecx + eax*8]
         : +mov eax, dword ptr [ebp + 8]
         : +mov ecx, dword ptr [ebp - 0x18]
         : +lea ecx, [ecx + ecx*4]
         : +shl ecx, 3
         : +lea eax, [ecx + eax*4]
0x4afd6c : mov ecx, dword ptr [ebp - 0xc]
0x4afd6f : fstp dword ptr [eax + ecx + 0xc]
0x4afd73 : jmp 0x5 	(finteray.c:1379)
0x4afd78 : jmp -0xbf 	(finteray.c:1381)
0x4afd7d : jmp -0xe7 	(finteray.c:1382)
0x4afd82 : push 0x7fff 	(finteray.c:1383)
0x4afd87 : mov eax, dword ptr [gSelected_model (DATA)]
0x4afd8c : push eax
0x4afd8d : call BrModelUpdate (FUNCTION)
0x4afd92 : add esp, 8


Scale is only 91.60% similar to the original, diff above
```

#### Effective match analysis

The changed blocks compute the same effective address in a different instruction order: original computes `eax = 40*[ebp-0x18] + 4*[ebp+8]`, and new computes `eax = 40*[ebp-0x18] + 4*[ebp+8]` via `ecx` then combines with `eax`. Both uses (the `fmul` load and `fstp` store at `[eax + [ebp-0xc] + 0xc]`) therefore target the same memory location. No branch conditions or jump structure changed in this diff, so functional control flow is unchanged.

#### Original match

```
---
+++
@@ -0x4afbf3,18 +0x47aaa7,19 @@
0x4afbf3 : push ebp 	(finteray.c:1355)
0x4afbf4 : mov ebp, esp
0x4afbf6 : sub esp, 0x2c
0x4afbf9 : push ebx
0x4afbfa : push esi
0x4afbfb : push edi
0x4afbfc : cmp dword ptr [gSelected_model (DATA)], 0 	(finteray.c:1364)
0x4afc03 : -je 0x17
         : +jne 0x5
         : +jmp 0x18c 	(finteray.c:1365)
0x4afc09 : mov eax, dword ptr [gSelected_model (DATA)] 	(finteray.c:1367)
0x4afc0e : xor ecx, ecx
0x4afc10 : mov cx, word ptr [eax + 0x12]
0x4afc14 : cmp ecx, dword ptr [gNfaces (DATA)]
0x4afc1a : je 0x5
0x4afc20 : jmp 0x170 	(finteray.c:1368)
0x4afc25 : mov eax, dword ptr [gSelected_model (DATA)] 	(finteray.c:1370)
0x4afc2a : mov eax, dword ptr [eax + 8]
0x4afc2d : mov dword ptr [ebp - 0xc], eax
0x4afc30 : mov eax, dword ptr [gSelected_model (DATA)] 	(finteray.c:1371)

---
+++
@@ -0x4afd25,32 +0x47abde,32 @@
0x4afd25 : mov ecx, dword ptr [ebp - 4]
0x4afd28 : xor edx, edx
0x4afd2a : mov dx, word ptr [ecx + eax*8 + 4]
0x4afd2f : cmp edx, dword ptr [ebp - 0x18]
0x4afd32 : jne 0x40
0x4afd38 : mov eax, dword ptr [ebp + 0xc] 	(finteray.c:1381)
0x4afd3b : mov dword ptr [ebp - 0x2c], eax
0x4afd3e : fild dword ptr [ebp - 0x2c]
0x4afd41 : fadd dword ptr [ebp - 8]
0x4afd44 : fdiv dword ptr [ebp - 8]
0x4afd47 : -mov eax, dword ptr [ebp - 0x18]
0x4afd4a : -lea eax, [eax + eax*4]
0x4afd4d : -mov ecx, dword ptr [ebp + 8]
0x4afd50 : -shl ecx, 2
0x4afd53 : -lea eax, [ecx + eax*8]
         : +mov eax, dword ptr [ebp + 8]
         : +mov ecx, dword ptr [ebp - 0x18]
         : +lea ecx, [ecx + ecx*4]
         : +shl ecx, 3
         : +lea eax, [ecx + eax*4]
0x4afd56 : mov ecx, dword ptr [ebp - 0xc]
0x4afd59 : fmul dword ptr [eax + ecx + 0xc]
0x4afd5d : -mov eax, dword ptr [ebp - 0x18]
0x4afd60 : -lea eax, [eax + eax*4]
0x4afd63 : -mov ecx, dword ptr [ebp + 8]
0x4afd66 : -shl ecx, 2
0x4afd69 : -lea eax, [ecx + eax*8]
         : +mov eax, dword ptr [ebp + 8]
         : +mov ecx, dword ptr [ebp - 0x18]
         : +lea ecx, [ecx + ecx*4]
         : +shl ecx, 3
         : +lea eax, [ecx + eax*4]
0x4afd6c : mov ecx, dword ptr [ebp - 0xc]
0x4afd6f : fstp dword ptr [eax + ecx + 0xc]
0x4afd73 : jmp 0x5 	(finteray.c:1382)
0x4afd78 : jmp -0xbf 	(finteray.c:1384)
0x4afd7d : jmp -0xe7 	(finteray.c:1385)
0x4afd82 : push 0x7fff 	(finteray.c:1386)
0x4afd87 : mov eax, dword ptr [gSelected_model (DATA)]
0x4afd8c : push eax
0x4afd8d : call BrModelUpdate (FUNCTION)
0x4afd92 : add esp, 8


Scale is only 90.38% similar to the original, diff above
```

*AI generated. Time taken: 591s, tokens: 70,351*
