### PR TITLE
NewNetGameUp 100% match

### DIFF
--- a/src/DETHRACE/common/newgame.c
+++ b/src/DETHRACE/common/newgame.c
@@ -459,27 +459,23 @@ int NewNetGameUp(int* pCurrent_choice, int* pCurrent_mode) {
     }
     new_sel = -1;
     for (i = gLast_graph_sel__newgame - 1; i >= 0; i--) {
-        gLast_graph_sel__newgame = i;
-        if (gGames_to_join[i].game == NULL) {
-            continue;
+        if (gGames_to_join[i].game != NULL) {
+            if (gGames_to_join[i].game->options.open_game || gGames_to_join[i].game->no_races_yet) {
+                if (gGames_to_join[i].game->num_players < 6) {
+                    new_sel = i;
+                    break;
+                }
+            }
         }
-        if (!gGames_to_join[i].game->options.open_game && !gGames_to_join[i].game->no_races_yet) {
-            continue;
-        }
-        if (gGames_to_join[i].game->num_players > 5) {
-            continue;
-        }
-        new_sel = i;
-        break;
     }
-    if (new_sel < 0) {
-        gLast_graph_sel__newgame = -1;
-        *pCurrent_choice = 0;
-        *pCurrent_mode = 0;
-    } else {
+    if (new_sel >= 0) {
         gLast_graph_sel__newgame = new_sel;
         *pCurrent_choice = 2;
         *pCurrent_mode = 1;
+    } else {
+        gLast_graph_sel__newgame = -1;
+        *pCurrent_choice = 0;
+        *pCurrent_mode = 0;
     }
     return 1;
 }


### PR DESCRIPTION
## Match result

```
0x4b0484: NewNetGameUp 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b04a3,51 +0x48e70a,56 @@
0x4b04a3 : cmp dword ptr [eax], 0
0x4b04a6 : jne 0xa
0x4b04ac : mov dword ptr [gLast_graph_sel__newgame (DATA)], 6 	(newgame.c:458)
0x4b04b6 : mov dword ptr [ebp - 4], 0xffffffff 	(newgame.c:460)
0x4b04bd : mov eax, dword ptr [gLast_graph_sel__newgame (DATA)] 	(newgame.c:461)
0x4b04c2 : dec eax
0x4b04c3 : mov dword ptr [ebp - 8], eax
0x4b04c6 : jmp 0x3
0x4b04cb : dec dword ptr [ebp - 8]
0x4b04ce : cmp dword ptr [ebp - 8], 0
0x4b04d2 : -jl 0x5d
         : +jl 0x74
         : +mov eax, dword ptr [ebp - 8] 	(newgame.c:462)
         : +mov dword ptr [gLast_graph_sel__newgame (DATA)], eax
0x4b04d8 : mov eax, dword ptr [ebp - 8] 	(newgame.c:463)
0x4b04db : cmp dword ptr [eax*8 + gGames_to_join[0].game (DATA)], 0
0x4b04e3 : -je 0x47
         : +jne 0x5
         : +jmp -0x2b 	(newgame.c:464)
0x4b04e9 : mov eax, dword ptr [ebp - 8] 	(newgame.c:466)
0x4b04ec : mov eax, dword ptr [eax*8 + gGames_to_join[0].game (DATA)]
0x4b04f3 : cmp dword ptr [eax + 0x58], 0
0x4b04f7 : -jne 0x14
         : +jne 0x19
0x4b04fd : mov eax, dword ptr [ebp - 8]
0x4b0500 : mov eax, dword ptr [eax*8 + gGames_to_join[0].game (DATA)]
0x4b0507 : cmp dword ptr [eax + 0x3c], 0
0x4b050b : -je 0x1f
         : +jne 0x5
         : +jmp -0x58 	(newgame.c:467)
0x4b0511 : mov eax, dword ptr [ebp - 8] 	(newgame.c:469)
0x4b0514 : mov eax, dword ptr [eax*8 + gGames_to_join[0].game (DATA)]
0x4b051b : -cmp dword ptr [eax + 0x34], 6
0x4b051f : -jge 0xb
         : +cmp dword ptr [eax + 0x34], 5
         : +jle 0x5
         : +jmp -0x71 	(newgame.c:470)
0x4b0525 : mov eax, dword ptr [ebp - 8] 	(newgame.c:472)
0x4b0528 : mov dword ptr [ebp - 4], eax
0x4b052b : jmp 0x5 	(newgame.c:473)
0x4b0530 : -jmp -0x6a
         : +jmp -0x81 	(newgame.c:474)
0x4b0535 : cmp dword ptr [ebp - 4], 0 	(newgame.c:475)
0x4b0539 : -jl 0x1f
         : +jge 0x21
         : +mov dword ptr [gLast_graph_sel__newgame (DATA)], 0xffffffff 	(newgame.c:476)
         : +mov eax, dword ptr [ebp + 8] 	(newgame.c:477)
         : +mov dword ptr [eax], 0
         : +mov eax, dword ptr [ebp + 0xc] 	(newgame.c:478)
         : +mov dword ptr [eax], 0
         : +jmp 0x1a 	(newgame.c:479)
0x4b053f : mov eax, dword ptr [ebp - 4] 	(newgame.c:480)
0x4b0542 : mov dword ptr [gLast_graph_sel__newgame (DATA)], eax
0x4b0547 : mov eax, dword ptr [ebp + 8] 	(newgame.c:481)
0x4b054a : mov dword ptr [eax], 2
0x4b0550 : mov eax, dword ptr [ebp + 0xc] 	(newgame.c:482)
0x4b0553 : mov dword ptr [eax], 1
0x4b0559 : -jmp 0x1c
0x4b055e : -mov dword ptr [gLast_graph_sel__newgame (DATA)], 0xffffffff
0x4b0568 : -mov eax, dword ptr [ebp + 8]
0x4b056b : -mov dword ptr [eax], 0
0x4b0571 : -mov eax, dword ptr [ebp + 0xc]
0x4b0574 : -mov dword ptr [eax], 0
0x4b057a : mov eax, 1 	(newgame.c:484)
0x4b057f : jmp 0x0
0x4b0584 : pop edi 	(newgame.c:485)
0x4b0585 : pop esi
0x4b0586 : pop ebx
0x4b0587 : leave 
0x4b0588 : ret 


NewNetGameUp is only 74.81% similar to the original, diff above
```

*AI generated. Time taken: 103s, tokens: 19,196*
