### PR TITLE
NewNetGameDown 100% match

### DIFF
--- a/src/DETHRACE/common/newgame.c
+++ b/src/DETHRACE/common/newgame.c
@@ -496,28 +496,24 @@ int NewNetGameDown(int* pCurrent_choice, int* pCurrent_mode) {
     }
 
     new_sel = -1;
-    for (i = gLast_graph_sel__newgame - 1; i < COUNT_OF(gGames_to_join); i++) {
-        gLast_graph_sel__newgame = i;
-        if (gGames_to_join[i].game == NULL) {
-            continue;
+    for (i = gLast_graph_sel__newgame + 1; i < COUNT_OF(gGames_to_join); i++) {
+        if (gGames_to_join[i].game != NULL) {
+            if (gGames_to_join[i].game->options.open_game || gGames_to_join[i].game->no_races_yet) {
+                if (gGames_to_join[i].game->num_players < 6) {
+                    new_sel = i;
+                    break;
+                }
+            }
         }
-        if (!gGames_to_join[i].game->options.open_game && !gGames_to_join[i].game->no_races_yet) {
-            continue;
-        }
-        if (gGames_to_join[i].game->num_players > 5) {
-            continue;
-        }
-        new_sel = i;
-        break;
     }
-    if (new_sel < 0) {
-        gLast_graph_sel__newgame = -1;
-        *pCurrent_choice = 0;
-        *pCurrent_mode = 0;
-    } else {
+    if (new_sel >= 0) {
         gLast_graph_sel__newgame = new_sel;
         *pCurrent_choice = 2;
         *pCurrent_mode = 1;
+    } else {
+        *pCurrent_choice = 0;
+        *pCurrent_mode = 0;
+        gLast_graph_sel__newgame = -1;
     }
     return 1;
 }


### PR DESCRIPTION
## Match result

```
0x4b0589: NewNetGameDown 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b0597,56 +0x48e815,61 @@
0x4b0597 : mov eax, dword ptr [gEffects_outlet (DATA)]
0x4b059c : push eax
0x4b059d : call DRS3StartSound (FUNCTION)
0x4b05a2 : add esp, 8
0x4b05a5 : mov eax, dword ptr [ebp + 0xc] 	(newgame.c:494)
0x4b05a8 : cmp dword ptr [eax], 0
0x4b05ab : jne 0xa
0x4b05b1 : mov dword ptr [gLast_graph_sel__newgame (DATA)], 0xffffffff 	(newgame.c:495)
0x4b05bb : mov dword ptr [ebp - 4], 0xffffffff 	(newgame.c:498)
0x4b05c2 : mov eax, dword ptr [gLast_graph_sel__newgame (DATA)] 	(newgame.c:499)
0x4b05c7 : -inc eax
         : +dec eax
0x4b05c8 : mov dword ptr [ebp - 8], eax
0x4b05cb : jmp 0x3
0x4b05d0 : inc dword ptr [ebp - 8]
0x4b05d3 : cmp dword ptr [ebp - 8], 6
0x4b05d7 : -jge 0x5d
         : +jge 0x74
         : +mov eax, dword ptr [ebp - 8] 	(newgame.c:500)
         : +mov dword ptr [gLast_graph_sel__newgame (DATA)], eax
0x4b05dd : mov eax, dword ptr [ebp - 8] 	(newgame.c:501)
0x4b05e0 : cmp dword ptr [eax*8 + gGames_to_join[0].game (DATA)], 0
0x4b05e8 : -je 0x47
         : +jne 0x5
         : +jmp -0x2b 	(newgame.c:502)
0x4b05ee : mov eax, dword ptr [ebp - 8] 	(newgame.c:504)
0x4b05f1 : mov eax, dword ptr [eax*8 + gGames_to_join[0].game (DATA)]
0x4b05f8 : cmp dword ptr [eax + 0x58], 0
0x4b05fc : -jne 0x14
         : +jne 0x19
0x4b0602 : mov eax, dword ptr [ebp - 8]
0x4b0605 : mov eax, dword ptr [eax*8 + gGames_to_join[0].game (DATA)]
0x4b060c : cmp dword ptr [eax + 0x3c], 0
0x4b0610 : -je 0x1f
         : +jne 0x5
         : +jmp -0x58 	(newgame.c:505)
0x4b0616 : mov eax, dword ptr [ebp - 8] 	(newgame.c:507)
0x4b0619 : mov eax, dword ptr [eax*8 + gGames_to_join[0].game (DATA)]
0x4b0620 : -cmp dword ptr [eax + 0x34], 6
0x4b0624 : -jge 0xb
         : +cmp dword ptr [eax + 0x34], 5
         : +jle 0x5
         : +jmp -0x71 	(newgame.c:508)
0x4b062a : mov eax, dword ptr [ebp - 8] 	(newgame.c:510)
0x4b062d : mov dword ptr [ebp - 4], eax
0x4b0630 : jmp 0x5 	(newgame.c:511)
0x4b0635 : -jmp -0x6a
         : +jmp -0x81 	(newgame.c:512)
0x4b063a : cmp dword ptr [ebp - 4], 0 	(newgame.c:513)
0x4b063e : -jl 0x1f
         : +jge 0x21
         : +mov dword ptr [gLast_graph_sel__newgame (DATA)], 0xffffffff 	(newgame.c:514)
         : +mov eax, dword ptr [ebp + 8] 	(newgame.c:515)
         : +mov dword ptr [eax], 0
         : +mov eax, dword ptr [ebp + 0xc] 	(newgame.c:516)
         : +mov dword ptr [eax], 0
         : +jmp 0x1a 	(newgame.c:517)
0x4b0644 : mov eax, dword ptr [ebp - 4] 	(newgame.c:518)
0x4b0647 : mov dword ptr [gLast_graph_sel__newgame (DATA)], eax
0x4b064c : mov eax, dword ptr [ebp + 8] 	(newgame.c:519)
0x4b064f : mov dword ptr [eax], 2
0x4b0655 : mov eax, dword ptr [ebp + 0xc] 	(newgame.c:520)
0x4b0658 : mov dword ptr [eax], 1
0x4b065e : -jmp 0x1c
0x4b0663 : -mov eax, dword ptr [ebp + 8]
0x4b0666 : -mov dword ptr [eax], 0
0x4b066c : -mov eax, dword ptr [ebp + 0xc]
0x4b066f : -mov dword ptr [eax], 0
0x4b0675 : -mov dword ptr [gLast_graph_sel__newgame (DATA)], 0xffffffff
0x4b067f : mov eax, 1 	(newgame.c:522)
0x4b0684 : jmp 0x0
0x4b0689 : pop edi 	(newgame.c:523)
0x4b068a : pop esi
0x4b068b : pop ebx
0x4b068c : leave 
0x4b068d : ret 


NewNetGameDown is only 73.28% similar to the original, diff above
```

*AI generated. Time taken: 99s, tokens: 17,729*
