### PR TITLE
DisposeJoinList 100% match

### DIFF
--- a/src/DETHRACE/common/newgame.c
+++ b/src/DETHRACE/common/newgame.c
@@ -675,10 +675,7 @@ void DisposeJoinList(int pExemption) {
     int i;
 
     for (i = 0; i < COUNT_OF(gGames_to_join); i++) {
-        if (i == pExemption) {
-            continue;
-        }
-        if (gGames_to_join[i].game != NULL) {
+        if (i != pExemption && gGames_to_join[i].game != NULL) {
             DisposeJoinableGame(i);
         }
     }


### PR DESCRIPTION
## Match result

```
0x4b1297: DisposeJoinList 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b1297,27 +0x48f1c5,28 @@
0x4b1297 : push ebp 	(newgame.c:674)
0x4b1298 : mov ebp, esp
0x4b129a : sub esp, 4
0x4b129d : push ebx
0x4b129e : push esi
0x4b129f : push edi
0x4b12a0 : mov dword ptr [ebp - 4], 0 	(newgame.c:677)
0x4b12a7 : jmp 0x3
0x4b12ac : inc dword ptr [ebp - 4]
0x4b12af : cmp dword ptr [ebp - 4], 6
0x4b12b3 : -jge 0x2e
         : +jge 0x33
0x4b12b9 : mov eax, dword ptr [ebp + 8] 	(newgame.c:678)
0x4b12bc : cmp dword ptr [ebp - 4], eax
0x4b12bf : -je 0x1d
         : +jne 0x5
         : +jmp -0x1e 	(newgame.c:679)
0x4b12c5 : mov eax, dword ptr [ebp - 4] 	(newgame.c:681)
0x4b12c8 : cmp dword ptr [eax*8 + gGames_to_join[0].game (DATA)], 0
0x4b12d0 : je 0xc
0x4b12d6 : mov eax, dword ptr [ebp - 4] 	(newgame.c:682)
0x4b12d9 : push eax
0x4b12da : call DisposeJoinableGame (FUNCTION)
0x4b12df : add esp, 4
0x4b12e2 : -jmp -0x3b
         : +jmp -0x40 	(newgame.c:684)
0x4b12e7 : pop edi 	(newgame.c:685)
0x4b12e8 : pop esi
0x4b12e9 : pop ebx
0x4b12ea : leave 
0x4b12eb : ret 


DisposeJoinList is only 87.27% similar to the original, diff above
```

*AI generated. Time taken: 57s, tokens: 13,798*
