### PR TITLE
DefaultNetSettings 100% match

### DIFF
--- a/src/DETHRACE/common/newgame.c
+++ b/src/DETHRACE/common/newgame.c
@@ -1168,15 +1168,14 @@ void DefaultNetSettings(void) {
 
     PathCat(the_path, gApplication_path, "NETDEFLT.TXT");
     f = DRfopen(the_path, "rt");
-    if (f == NULL) {
-        return;
+    if (f != NULL) {
+        ReadNetworkSettings(f, gNet_settings);
+        rewind(f);
+        for (i = 0; i < COUNT_OF(gNet_settings) - 1; i++) {
+            ReadNetworkSettings(f, &gNet_settings[i] + 1);
+        }
+        fclose(f);
     }
-    ReadNetworkSettings(f, gNet_settings);
-    rewind(f);
-    for (i = 0; i < COUNT_OF(gNet_settings) - 1; i++) {
-        ReadNetworkSettings(f, &gNet_settings[i + 1]);
-    }
-    fclose(f);
 }
 
 // IDA: int __usercall NetOptGoAhead@<EAX>(int *pCurrent_choice@<EAX>, int *pCurrent_mode@<EDX>)


### PR DESCRIPTION
## Match result

```
0x4b1984: DefaultNetSettings 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b19a0,45 +0x48fe5a,46 @@
0x4b19a0 : push eax
0x4b19a1 : call PathCat (FUNCTION)
0x4b19a6 : add esp, 0xc
0x4b19a9 : push "rt" (STRING) 	(newgame.c:1170)
0x4b19ae : lea eax, [ebp - 0x108]
0x4b19b4 : push eax
0x4b19b5 : call DRfopen (FUNCTION)
0x4b19ba : add esp, 8
0x4b19bd : mov dword ptr [ebp - 4], eax
0x4b19c0 : cmp dword ptr [ebp - 4], 0 	(newgame.c:1171)
0x4b19c4 : -je 0x65
         : +jne 0x5
         : +jmp 0x63 	(newgame.c:1172)
0x4b19ca : push gNet_settings[0].show_players_on_map (DATA) 	(newgame.c:1174)
0x4b19cf : mov eax, dword ptr [ebp - 4]
0x4b19d2 : push eax
0x4b19d3 : call ReadNetworkSettings (FUNCTION)
0x4b19d8 : add esp, 8
0x4b19db : mov eax, dword ptr [ebp - 4] 	(newgame.c:1175)
0x4b19de : push eax
0x4b19df : call rewind (FUNCTION)
0x4b19e4 : add esp, 4
0x4b19e7 : mov dword ptr [ebp - 8], 0 	(newgame.c:1176)
0x4b19ee : jmp 0x3
0x4b19f3 : inc dword ptr [ebp - 8]
0x4b19f6 : cmp dword ptr [ebp - 8], 7
0x4b19fa : -jge 0x23
         : +jge 0x21
0x4b1a00 : mov eax, dword ptr [ebp - 8] 	(newgame.c:1177)
         : +inc eax
0x4b1a03 : shl eax, 4
0x4b1a06 : lea eax, [eax + eax*2]
0x4b1a09 : add eax, gNet_settings[0].show_players_on_map (DATA)
0x4b1a0e : -add eax, 0x30
0x4b1a11 : push eax
0x4b1a12 : mov eax, dword ptr [ebp - 4]
0x4b1a15 : push eax
0x4b1a16 : call ReadNetworkSettings (FUNCTION)
0x4b1a1b : add esp, 8
0x4b1a1e : -jmp -0x30
         : +jmp -0x2e 	(newgame.c:1178)
0x4b1a23 : mov eax, dword ptr [ebp - 4] 	(newgame.c:1179)
0x4b1a26 : push eax
0x4b1a27 : call fclose (FUNCTION)
0x4b1a2c : add esp, 4
0x4b1a2f : pop edi 	(newgame.c:1180)
0x4b1a30 : pop esi
0x4b1a31 : pop ebx
0x4b1a32 : leave 
0x4b1a33 : ret 


DefaultNetSettings is only 91.74% similar to the original, diff above
```

*AI generated. Time taken: 188s, tokens: 19,982*
