### PR TITLE
NetOptGoAhead 100% match

### DIFF
--- a/src/DETHRACE/common/newgame.c
+++ b/src/DETHRACE/common/newgame.c
@@ -1183,16 +1183,16 @@ void DefaultNetSettings(void) {
 // FUNCTION: CARM95 0x004b1a34
 int NetOptGoAhead(int* pCurrent_choice, int* pCurrent_mode) {
 
-    if (*pCurrent_mode == 0) {
+    if (*pCurrent_mode != 0) {
+        NetOptRight(pCurrent_choice, pCurrent_mode);
+        return 0;
+    } else {
         if (*pCurrent_choice == 2) {
             RevertToDefaults();
             return 0;
         } else {
             return 1;
         }
-    } else {
-        NetOptRight(pCurrent_choice, pCurrent_mode);
-        return 0;
     }
 }
 

--- a/src/DETHRACE/common/newgame.c
+++ b/src/DETHRACE/common/newgame.c
@@ -1182,17 +1182,14 @@ void DefaultNetSettings(void) {
 // IDA: int __usercall NetOptGoAhead@<EAX>(int *pCurrent_choice@<EAX>, int *pCurrent_mode@<EDX>)
 // FUNCTION: CARM95 0x004b1a34
 int NetOptGoAhead(int* pCurrent_choice, int* pCurrent_mode) {
-
     if (*pCurrent_mode != 0) {
         NetOptRight(pCurrent_choice, pCurrent_mode);
         return 0;
+    } else if (*pCurrent_choice == 2) {
+        RevertToDefaults();
+        return 0;
     } else {
-        if (*pCurrent_choice == 2) {
-            RevertToDefaults();
-            return 0;
-        } else {
-            return 1;
-        }
+        return 1;
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4b1a34: NetOptGoAhead 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b1a34,31 +0x48fef1,31 @@
0x4b1a34 : push ebp 	(newgame.c:1184)
0x4b1a35 : mov ebp, esp
0x4b1a37 : push ebx
0x4b1a38 : push esi
0x4b1a39 : push edi
0x4b1a3a : mov eax, dword ptr [ebp + 0xc] 	(newgame.c:1186)
0x4b1a3d : cmp dword ptr [eax], 0
0x4b1a40 : -je 0x1c
         : +jne 0x2c
         : +mov eax, dword ptr [ebp + 8] 	(newgame.c:1187)
         : +cmp dword ptr [eax], 2
         : +jne 0x11
         : +call RevertToDefaults (FUNCTION) 	(newgame.c:1188)
         : +xor eax, eax 	(newgame.c:1189)
         : +jmp 0x2b
         : +jmp 0xa 	(newgame.c:1190)
         : +mov eax, 1 	(newgame.c:1191)
         : +jmp 0x1c
         : +jmp 0x17 	(newgame.c:1193)
0x4b1a46 : mov eax, dword ptr [ebp + 0xc] 	(newgame.c:1194)
0x4b1a49 : push eax
0x4b1a4a : mov eax, dword ptr [ebp + 8]
0x4b1a4d : push eax
0x4b1a4e : call NetOptRight (FUNCTION)
0x4b1a53 : add esp, 8
0x4b1a56 : xor eax, eax 	(newgame.c:1195)
0x4b1a58 : -jmp 0x2c
0x4b1a5d : -jmp 0x27
0x4b1a62 : -mov eax, dword ptr [ebp + 8]
0x4b1a65 : -cmp dword ptr [eax], 2
0x4b1a68 : -jne 0x11
0x4b1a6e : -call RevertToDefaults (FUNCTION)
0x4b1a73 : -xor eax, eax
0x4b1a75 : -jmp 0xf
0x4b1a7a : -jmp 0xa
0x4b1a7f : -mov eax, 1
0x4b1a84 : jmp 0x0
0x4b1a89 : pop edi 	(newgame.c:1197)
0x4b1a8a : pop esi
0x4b1a8b : pop ebx
0x4b1a8c : leave 
0x4b1a8d : ret 


NetOptGoAhead is only 64.52% similar to the original, diff above
```

*AI generated. Time taken: 111s, tokens: 11,668*
