### PR TITLE
NetChooseGoAhead 100% match

### DIFF
--- a/src/DETHRACE/common/newgame.c
+++ b/src/DETHRACE/common/newgame.c
@@ -1379,9 +1379,7 @@ void DrawNetChooseInitial(void) {
 // FUNCTION: CARM95 0x004b1d9c
 int NetChooseGoAhead(int* pCurrent_choice, int* pCurrent_mode) {
 
-    if (*pCurrent_mode == 0) {
-        return 1;
-    } else {
+    if (*pCurrent_mode != 0) {
         if (*pCurrent_choice - 4 != gCurrent_game_selection) {
             RemoveTransientBitmaps(1);
             DontLetFlicFuckWithPalettes();
@@ -1402,6 +1400,8 @@ int NetChooseGoAhead(int* pCurrent_choice, int* pCurrent_mode) {
             }
         }
         return 0;
+    } else {
+        return 1;
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4b1d9c: NetChooseGoAhead 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b1d9c,18 +0x49024c,21 @@
0x4b1d9c : push ebp 	(newgame.c:1380)
0x4b1d9d : mov ebp, esp
0x4b1d9f : push ebx
0x4b1da0 : push esi
0x4b1da1 : push edi
0x4b1da2 : mov eax, dword ptr [ebp + 0xc] 	(newgame.c:1382)
0x4b1da5 : cmp dword ptr [eax], 0
0x4b1da8 : -je 0xd8
         : +jne 0xf
         : +mov eax, 1 	(newgame.c:1383)
         : +jmp 0xd8
         : +jmp 0xd3 	(newgame.c:1384)
0x4b1dae : mov eax, dword ptr [ebp + 8] 	(newgame.c:1385)
0x4b1db1 : mov eax, dword ptr [eax]
0x4b1db3 : sub eax, 4
0x4b1db6 : cmp eax, dword ptr [gCurrent_game_selection (DATA)]
0x4b1dbc : je 0xb8
0x4b1dc2 : push 1 	(newgame.c:1386)
0x4b1dc4 : call RemoveTransientBitmaps (FUNCTION)
0x4b1dc9 : add esp, 4
0x4b1dcc : call DontLetFlicFuckWithPalettes (FUNCTION) 	(newgame.c:1387)
0x4b1dd1 : call TurnFlicTransparencyOn (FUNCTION) 	(newgame.c:1388)

---
+++
@@ -0x4b1e4e,19 +0x49030d,16 @@
0x4b1e4e : call PickNetRace (FUNCTION)
0x4b1e53 : add esp, 8
0x4b1e56 : mov dword ptr [gRace_index (DATA)], eax
0x4b1e5b : cmp dword ptr [gMouse_in_use (DATA)], 0 	(newgame.c:1399)
0x4b1e62 : jne 0x12
0x4b1e68 : mov eax, dword ptr [ebp + 0xc] 	(newgame.c:1400)
0x4b1e6b : mov dword ptr [eax], 0
0x4b1e71 : mov eax, dword ptr [ebp + 8] 	(newgame.c:1401)
0x4b1e74 : mov dword ptr [eax], 0
0x4b1e7a : xor eax, eax 	(newgame.c:1404)
0x4b1e7c : -jmp 0xf
0x4b1e81 : -jmp 0xa
0x4b1e86 : -mov eax, 1
0x4b1e8b : jmp 0x0
0x4b1e90 : pop edi 	(newgame.c:1406)
0x4b1e91 : pop esi
0x4b1e92 : pop ebx
0x4b1e93 : leave 
0x4b1e94 : ret 


NetChooseGoAhead is only 94.20% similar to the original, diff above
```

*AI generated. Time taken: 1397s, tokens: 24,699*
