### PR TITLE
AddToLollipopQueue 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -452,16 +452,17 @@ void ResetLollipopQueue(void) {
 // FUNCTION: CARM95 0x004b305f
 int AddToLollipopQueue(br_actor* pActor, int pIndex) {
 
-    if (pIndex >= 0) {
-        gLollipops[pIndex] = pActor;
-    } else if (gNumber_of_lollipops >= 100) {
-        pIndex = -1;
+    if (pIndex < 0) {
+        if (gNumber_of_lollipops < 100) {
+            gLollipops[gNumber_of_lollipops] = pActor;
+            gNumber_of_lollipops++;
+            return gNumber_of_lollipops - 1;
+        }
+        return -1;
     } else {
-        gLollipops[gNumber_of_lollipops] = pActor;
-        pIndex = gNumber_of_lollipops;
-        gNumber_of_lollipops++;
+        gLollipops[pIndex] = pActor;
+        return pIndex;
     }
-    return pIndex;
 }
 
 // IDA: void __cdecl RenderLollipops()

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -453,7 +453,7 @@ void ResetLollipopQueue(void) {
 int AddToLollipopQueue(br_actor* pActor, int pIndex) {
 
     if (pIndex < 0) {
-        if (gNumber_of_lollipops < 100) {
+        if (gNumber_of_lollipops < COUNT_OF(gLollipops)) {
             gLollipops[gNumber_of_lollipops] = pActor;
             gNumber_of_lollipops++;
             return gNumber_of_lollipops - 1;


### PR DESCRIPTION
## Match result

```
0x4b305f: AddToLollipopQueue 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b305f,28 +0x47decf,28 @@
0x4b305f : push ebp 	(graphics.c:453)
0x4b3060 : mov ebp, esp
0x4b3062 : push ebx
0x4b3063 : push esi
0x4b3064 : push edi
0x4b3065 : cmp dword ptr [ebp + 0xc], 0 	(graphics.c:455)
0x4b3069 : -jge 0x3d
         : +jl 0x12
         : +mov eax, dword ptr [ebp + 8] 	(graphics.c:456)
         : +mov ecx, dword ptr [ebp + 0xc]
         : +mov dword ptr [ecx*4 + gLollipops[0] (DATA)], eax
         : +jmp 0x37 	(graphics.c:457)
0x4b306f : cmp dword ptr [gNumber_of_lollipops (DATA)], 0x64
0x4b3076 : -jge 0x21
         : +jl 0xc
         : +mov dword ptr [ebp + 0xc], 0xffffffff 	(graphics.c:458)
         : +jmp 0x1e 	(graphics.c:459)
0x4b307c : mov eax, dword ptr [ebp + 8] 	(graphics.c:460)
0x4b307f : mov ecx, dword ptr [gNumber_of_lollipops (DATA)]
0x4b3085 : mov dword ptr [ecx*4 + gLollipops[0] (DATA)], eax
         : +mov eax, dword ptr [gNumber_of_lollipops (DATA)] 	(graphics.c:461)
         : +mov dword ptr [ebp + 0xc], eax
0x4b308c : inc dword ptr [gNumber_of_lollipops (DATA)] 	(graphics.c:462)
0x4b3092 : -mov eax, dword ptr [gNumber_of_lollipops (DATA)]
0x4b3097 : -dec eax
0x4b3098 : -jmp 0x24
0x4b309d : -mov eax, 0xffffffff
0x4b30a2 : -jmp 0x1a
0x4b30a7 : -jmp 0x15
0x4b30ac : -mov eax, dword ptr [ebp + 8]
0x4b30af : -mov ecx, dword ptr [ebp + 0xc]
0x4b30b2 : -mov dword ptr [ecx*4 + gLollipops[0] (DATA)], eax
0x4b30b9 : mov eax, dword ptr [ebp + 0xc] 	(graphics.c:464)
0x4b30bc : jmp 0x0
0x4b30c1 : pop edi 	(graphics.c:465)
0x4b30c2 : pop esi
0x4b30c3 : pop ebx
0x4b30c4 : leave 
         : +ret 


AddToLollipopQueue is only 60.71% similar to the original, diff above
```

*AI generated. Time taken: 661s, tokens: 40,240*
