### PR TITLE
BuildColourTable equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -538,14 +538,12 @@ void DrawNumberAt(br_pixelmap* gImage, int pX, int pY, int pX_pitch, int pY_pitc
 void BuildColourTable(br_pixelmap* pPalette) {
     int i;
     int j;
-    int nearest_index = 0;
+    int nearest_index;
     int red;
     int green;
     int blue;
     float nearest_distance;
     float distance;
-
-#define SQR(i) i* i
 
     for (i = 0; i < COUNT_OF(gRGB_colours); i++) {
         nearest_distance = 196608.f;
@@ -553,12 +551,12 @@ void BuildColourTable(br_pixelmap* pPalette) {
         green = (gRGB_colours[i] >> 8) & 0xFF;
         blue = gRGB_colours[i] & 0xFF;
         for (j = 0; j < 256; j++) {
-            distance = SQR((double)(signed int)(*((br_uint_8*)pPalette->pixels + 4 * j + 2) - red));
-            distance += SQR((double)(signed int)(*((br_uint_8*)pPalette->pixels + 4 * j) - blue));
-            distance += SQR((double)(signed int)(*((br_uint_8*)pPalette->pixels + 4 * j + 1) - green));
-            if (distance < nearest_distance) {
-                nearest_index = j;
+            if ((distance = (sqr((double)(signed int)(((br_uint_8*)pPalette->pixels)[4 * j + 2] - red))
+                             + sqr((double)(signed int)(((br_uint_8*)pPalette->pixels)[4 * j] - blue)))
+                                + sqr((double)(signed int)(((br_uint_8*)pPalette->pixels)[4 * j + 1] - green)))
+                < nearest_distance) {
                 nearest_distance = distance;
+                nearest_index = j;
             }
         }
         gColours[i] = nearest_index;

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -551,10 +551,11 @@ void BuildColourTable(br_pixelmap* pPalette) {
         green = (gRGB_colours[i] >> 8) & 0xFF;
         blue = gRGB_colours[i] & 0xFF;
         for (j = 0; j < 256; j++) {
-            if ((distance = (sqr((double)(signed int)(((br_uint_8*)pPalette->pixels)[4 * j + 2] - red))
-                             + sqr((double)(signed int)(((br_uint_8*)pPalette->pixels)[4 * j] - blue)))
-                                + sqr((double)(signed int)(((br_uint_8*)pPalette->pixels)[4 * j + 1] - green)))
-                < nearest_distance) {
+            distance = sqr(((br_uint_8*)pPalette->pixels)[4 * j + 2] - red)
+                + sqr(((br_uint_8*)pPalette->pixels)[4 * j + 1] - green)
+                + sqr(((br_uint_8*)pPalette->pixels)[4 * j] - blue);
+
+            if (distance < nearest_distance) {
                 nearest_distance = distance;
                 nearest_index = j;
             }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4b3251,36 +0x47e448,36 @@
0x4b3251 : fild dword ptr [ebp - 0x24]
0x4b3254 : sub esp, 8
0x4b3257 : fstp qword ptr [esp]
0x4b325a : call sqr (FUNCTION)
0x4b325f : add esp, 8
0x4b3262 : fstp qword ptr [ebp - 0x2c]
0x4b3265 : mov eax, dword ptr [ebp - 0x1c]
0x4b3268 : mov ecx, dword ptr [ebp + 8]
0x4b326b : mov ecx, dword ptr [ecx + 8]
0x4b326e : xor edx, edx
0x4b3270 : -mov dl, byte ptr [ecx + eax*4]
0x4b3273 : -sub edx, dword ptr [ebp - 0x20]
         : +mov dl, byte ptr [ecx + eax*4 + 1]
         : +sub edx, dword ptr [ebp - 0x18]
0x4b3276 : mov dword ptr [ebp - 0x30], edx
0x4b3279 : fild dword ptr [ebp - 0x30]
0x4b327c : sub esp, 8
0x4b327f : fstp qword ptr [esp]
0x4b3282 : call sqr (FUNCTION)
0x4b3287 : add esp, 8
0x4b328a : fadd qword ptr [ebp - 0x2c]
0x4b328d : fstp qword ptr [ebp - 0x38]
0x4b3290 : mov eax, dword ptr [ebp - 0x1c]
0x4b3293 : mov ecx, dword ptr [ebp + 8]
0x4b3296 : mov ecx, dword ptr [ecx + 8]
0x4b3299 : xor edx, edx
0x4b329b : -mov dl, byte ptr [ecx + eax*4 + 1]
0x4b329f : -sub edx, dword ptr [ebp - 0x18]
         : +mov dl, byte ptr [ecx + eax*4]
         : +sub edx, dword ptr [ebp - 0x20]
0x4b32a2 : mov dword ptr [ebp - 0x3c], edx
0x4b32a5 : fild dword ptr [ebp - 0x3c]
0x4b32a8 : sub esp, 8
0x4b32ab : fstp qword ptr [esp]
0x4b32ae : call sqr (FUNCTION)
0x4b32b3 : add esp, 8
0x4b32b6 : fadd qword ptr [ebp - 0x38]
0x4b32b9 : fcom dword ptr [ebp - 8] 	(graphics.c:558)
0x4b32bc : fstp dword ptr [ebp - 4]
0x4b32bf : fnstsw ax


BuildColourTable is only 95.56% similar to the original, diff above
```

#### Effective match analysis

The diff swaps the two per-axis difference calculations: one now uses `[ecx + eax*4 + 1] - [ebp - 0x18]` where the other used to, and vice versa for `[ecx + eax*4] - [ebp - 0x20]`. Each difference is squared via `sqr`, then the two squared results are added. Since `a^2 + b^2` is unchanged by swapping `a` and `b`, the final computed value and comparison outcome are the same (ignoring NaN/FP edge cases as requested). Control flow is unchanged.

#### Original match

```
---
+++
@@ -0x4b31bb,90 +0x47e113,106 @@
0x4b31bb : push ebp 	(graphics.c:538)
0x4b31bc : mov ebp, esp
0x4b31be : -sub esp, 0x3c
         : +sub esp, 0x38
0x4b31c1 : push ebx
0x4b31c2 : push esi
0x4b31c3 : push edi
         : +mov dword ptr [ebp - 0x10], 0 	(graphics.c:541)
0x4b31c4 : mov dword ptr [ebp - 0x14], 0 	(graphics.c:550)
0x4b31cb : jmp 0x3
0x4b31d0 : inc dword ptr [ebp - 0x14]
0x4b31d3 : cmp dword ptr [ebp - 0x14], 9
0x4b31d7 : -jge 0x110
         : +jge 0x133
0x4b31dd : mov dword ptr [ebp - 8], 0x48400000 	(graphics.c:551)
0x4b31e4 : mov eax, dword ptr [ebp - 0x14] 	(graphics.c:552)
0x4b31e7 : mov eax, dword ptr [eax*4 + gRGB_colours[0] (DATA)]
0x4b31ee : shr eax, 0x10
0x4b31f1 : and eax, 0xff
0x4b31f6 : mov dword ptr [ebp - 0xc], eax
0x4b31f9 : mov eax, dword ptr [ebp - 0x14] 	(graphics.c:553)
0x4b31fc : mov eax, dword ptr [eax*4 + gRGB_colours[0] (DATA)]
0x4b3203 : shr eax, 8
0x4b3206 : and eax, 0xff
0x4b320b : mov dword ptr [ebp - 0x18], eax
0x4b320e : mov eax, dword ptr [ebp - 0x14] 	(graphics.c:554)
0x4b3211 : mov eax, dword ptr [eax*4 + gRGB_colours[0] (DATA)]
0x4b3218 : and eax, 0xff
0x4b321d : mov dword ptr [ebp - 0x20], eax
0x4b3220 : mov dword ptr [ebp - 0x1c], 0 	(graphics.c:555)
0x4b3227 : jmp 0x3
0x4b322c : inc dword ptr [ebp - 0x1c]
0x4b322f : cmp dword ptr [ebp - 0x1c], 0x100
0x4b3236 : -jge 0x9f
         : +jge 0xc2
0x4b323c : mov eax, dword ptr [ebp - 0x1c] 	(graphics.c:556)
0x4b323f : mov ecx, dword ptr [ebp + 8]
0x4b3242 : mov ecx, dword ptr [ecx + 8]
0x4b3245 : xor edx, edx
0x4b3247 : mov dl, byte ptr [ecx + eax*4 + 2]
0x4b324b : sub edx, dword ptr [ebp - 0xc]
0x4b324e : mov dword ptr [ebp - 0x24], edx
0x4b3251 : fild dword ptr [ebp - 0x24]
0x4b3254 : -sub esp, 8
0x4b3257 : -fstp qword ptr [esp]
0x4b325a : -call sqr (FUNCTION)
0x4b325f : -add esp, 8
0x4b3262 : -fstp qword ptr [ebp - 0x2c]
         : +mov eax, dword ptr [ebp - 0x1c]
         : +mov ecx, dword ptr [ebp + 8]
         : +mov ecx, dword ptr [ecx + 8]
         : +xor edx, edx
         : +mov dl, byte ptr [ecx + eax*4 + 2]
         : +sub edx, dword ptr [ebp - 0xc]
         : +mov dword ptr [ebp - 0x28], edx
         : +fild dword ptr [ebp - 0x28]
         : +fmulp st(1)
         : +fstp dword ptr [ebp - 4]
         : +mov eax, dword ptr [ebp - 0x1c] 	(graphics.c:557)
         : +mov ecx, dword ptr [ebp + 8]
         : +mov ecx, dword ptr [ecx + 8]
         : +xor edx, edx
         : +mov dl, byte ptr [ecx + eax*4]
         : +sub edx, dword ptr [ebp - 0x20]
         : +mov dword ptr [ebp - 0x2c], edx
         : +fild dword ptr [ebp - 0x2c]
0x4b3265 : mov eax, dword ptr [ebp - 0x1c]
0x4b3268 : mov ecx, dword ptr [ebp + 8]
0x4b326b : mov ecx, dword ptr [ecx + 8]
0x4b326e : xor edx, edx
0x4b3270 : mov dl, byte ptr [ecx + eax*4]
0x4b3273 : sub edx, dword ptr [ebp - 0x20]
0x4b3276 : mov dword ptr [ebp - 0x30], edx
0x4b3279 : fild dword ptr [ebp - 0x30]
0x4b327c : -sub esp, 8
0x4b327f : -fstp qword ptr [esp]
0x4b3282 : -call sqr (FUNCTION)
0x4b3287 : -add esp, 8
0x4b328a : -fadd qword ptr [ebp - 0x2c]
0x4b328d : -fstp qword ptr [ebp - 0x38]
         : +fmulp st(1)
         : +fadd dword ptr [ebp - 4]
         : +fstp dword ptr [ebp - 4]
0x4b3290 : mov eax, dword ptr [ebp - 0x1c] 	(graphics.c:558)
0x4b3293 : mov ecx, dword ptr [ebp + 8]
0x4b3296 : mov ecx, dword ptr [ecx + 8]
0x4b3299 : xor edx, edx
0x4b329b : mov dl, byte ptr [ecx + eax*4 + 1]
0x4b329f : sub edx, dword ptr [ebp - 0x18]
0x4b32a2 : -mov dword ptr [ebp - 0x3c], edx
0x4b32a5 : -fild dword ptr [ebp - 0x3c]
0x4b32a8 : -sub esp, 8
0x4b32ab : -fstp qword ptr [esp]
0x4b32ae : -call sqr (FUNCTION)
0x4b32b3 : -add esp, 8
0x4b32b6 : -fadd qword ptr [ebp - 0x38]
0x4b32b9 : -fcom dword ptr [ebp - 8]
0x4b32bc : -fstp dword ptr [ebp - 4]
         : +mov dword ptr [ebp - 0x34], edx
         : +fild dword ptr [ebp - 0x34]
         : +mov eax, dword ptr [ebp - 0x1c]
         : +mov ecx, dword ptr [ebp + 8]
         : +mov ecx, dword ptr [ecx + 8]
         : +xor edx, edx
         : +mov dl, byte ptr [ecx + eax*4 + 1]
         : +sub edx, dword ptr [ebp - 0x18]
         : +mov dword ptr [ebp - 0x38], edx
         : +fild dword ptr [ebp - 0x38]
         : +fmulp st(1)
         : +fadd dword ptr [ebp - 4]
         : +fst dword ptr [ebp - 4]
         : +fcomp dword ptr [ebp - 8] 	(graphics.c:559)
0x4b32bf : fnstsw ax
0x4b32c1 : test ah, 1
0x4b32c4 : je 0xc
         : +mov eax, dword ptr [ebp - 0x1c] 	(graphics.c:560)
         : +mov dword ptr [ebp - 0x10], eax
0x4b32ca : mov eax, dword ptr [ebp - 4] 	(graphics.c:561)
0x4b32cd : mov dword ptr [ebp - 8], eax
0x4b32d0 : -mov eax, dword ptr [ebp - 0x1c]
0x4b32d3 : -mov dword ptr [ebp - 0x10], eax
0x4b32d6 : -jmp -0xaf
         : +jmp -0xd2 	(graphics.c:563)
0x4b32db : mov eax, dword ptr [ebp - 0x10] 	(graphics.c:564)
0x4b32de : mov ecx, dword ptr [ebp - 0x14]
0x4b32e1 : mov dword ptr [ecx*4 + gColours[0] (DATA)], eax
0x4b32e8 : -jmp -0x11d
         : +jmp -0x140 	(graphics.c:565)
0x4b32ed : pop edi 	(graphics.c:566)
0x4b32ee : pop esi
0x4b32ef : pop ebx
0x4b32f0 : leave 
0x4b32f1 : ret 


BuildColourTable is only 64.29% similar to the original, diff above
```

*AI generated. Time taken: 485s, tokens: 47,388*
