### PR TITLE
DRSetPalette3 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -903,7 +903,16 @@ void DRSetPaletteEntries(br_pixelmap* pPalette, int pFirst_colour, int pCount) {
 void DRSetPalette3(br_pixelmap* pThe_palette, int pSet_current_palette) {
 
     if (pSet_current_palette) {
+#ifdef DETHRACE_FIX_BUGS
+        if ((char*)gCurrent_palette_pixels < (char*)pThe_palette->pixels + 0x400u
+            && (char*)pThe_palette->pixels < (char*)gCurrent_palette_pixels + 0x400u) {
+            memmove(gCurrent_palette_pixels, pThe_palette->pixels, 0x400u);
+        } else {
+            memcpy(gCurrent_palette_pixels, pThe_palette->pixels, 0x400u);
+        }
+#else
         memcpy(gCurrent_palette_pixels, pThe_palette->pixels, 0x400u);
+#endif
 #ifdef DETHRACE_3DFX_PATCH
         g16bit_palette_valid = 0;
 #endif

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -912,7 +912,8 @@ void DRSetPalette3(br_pixelmap* pThe_palette, int pSet_current_palette) {
         PDSetPalette(pThe_palette);
     }
     if (pThe_palette != gRender_palette) {
-        gPalette_munged |= 1u;
+        gPalette_munged |= 1;
+    } else {
     }
 }
 

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -906,7 +906,7 @@ void DRSetPalette3(br_pixelmap* pThe_palette, int pSet_current_palette) {
 #ifdef DETHRACE_FIX_BUGS
         memmove(gCurrent_palette_pixels, pThe_palette->pixels, 4 * 256);
 #else
-        memcpy(gCurrent_palette_pixels, pThe_palette->pixels, 0x400u);
+        memcpy(gCurrent_palette_pixels, pThe_palette->pixels, 4 * 256);
 #endif
 #ifdef DETHRACE_3DFX_PATCH
         g16bit_palette_valid = 0;

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -904,12 +904,7 @@ void DRSetPalette3(br_pixelmap* pThe_palette, int pSet_current_palette) {
 
     if (pSet_current_palette) {
 #ifdef DETHRACE_FIX_BUGS
-        if ((char*)gCurrent_palette_pixels < (char*)pThe_palette->pixels + 0x400u
-            && (char*)pThe_palette->pixels < (char*)gCurrent_palette_pixels + 0x400u) {
-            memmove(gCurrent_palette_pixels, pThe_palette->pixels, 0x400u);
-        } else {
-            memcpy(gCurrent_palette_pixels, pThe_palette->pixels, 0x400u);
-        }
+        memmove(gCurrent_palette_pixels, pThe_palette->pixels, 4 * 256);
 #else
         memcpy(gCurrent_palette_pixels, pThe_palette->pixels, 0x400u);
 #endif


### PR DESCRIPTION
## Match result

```
0x4b3af8: DRSetPalette3 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b3b14,18 +0x47ed66,19 @@
0x4b3b14 : mov ecx, 0x100
0x4b3b19 : rep movsd dword ptr es:[edi], dword ptr [esi]
0x4b3b1b : cmp dword ptr [gFaded_palette (DATA)], 0 	(graphics.c:911)
0x4b3b22 : jne 0xc
0x4b3b28 : mov eax, dword ptr [ebp + 8] 	(graphics.c:912)
0x4b3b2b : push eax
0x4b3b2c : call PDSetPalette (FUNCTION)
0x4b3b31 : add esp, 4
0x4b3b34 : mov eax, dword ptr [gRender_palette (DATA)] 	(graphics.c:914)
0x4b3b39 : cmp dword ptr [ebp + 8], eax
0x4b3b3c : -je 0xc
0x4b3b42 : -or dword ptr [gPalette_munged (DATA)], 1
0x4b3b49 : -jmp 0x0
         : +je 0xd
         : +mov eax, dword ptr [gPalette_munged (DATA)] 	(graphics.c:915)
         : +or eax, 1
         : +mov dword ptr [gPalette_munged (DATA)], eax
0x4b3b4e : pop edi 	(graphics.c:917)
0x4b3b4f : pop esi
0x4b3b50 : pop ebx
0x4b3b51 : leave 
0x4b3b52 : ret 


DRSetPalette3 is only 87.72% similar to the original, diff above
```

*AI generated. Time taken: 111s, tokens: 18,000*
