### PR TITLE
DRSetPalette2 100% effective match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -921,7 +921,18 @@ void DRSetPalette3(br_pixelmap* pThe_palette, int pSet_current_palette) {
 void DRSetPalette2(br_pixelmap* pThe_palette, int pSet_current_palette) {
     ((br_int_32*)pThe_palette->pixels)[0] = 0;
     if (pSet_current_palette) {
-        memcpy(gCurrent_palette_pixels, pThe_palette->pixels, 0x400u);
+        size_t palette_size = 0x400u;
+        char* dst = gCurrent_palette_pixels;
+        char* src = pThe_palette->pixels;
+#ifdef DETHRACE_FIX_BUGS
+        if ((dst < src + palette_size) && (src < dst + palette_size)) {
+            memmove(dst, src, palette_size);
+        } else {
+            memcpy(dst, src, palette_size);
+        }
+#else
+        memcpy(dst, src, palette_size);
+#endif
 #ifdef DETHRACE_3DFX_PATCH
         g16bit_palette_valid = 0;
 #endif

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -929,8 +929,7 @@ void DRSetPalette2(br_pixelmap* pThe_palette, int pSet_current_palette) {
     if (!gFaded_palette) {
         PDSetPalette(pThe_palette);
     }
-    if (pThe_palette != gRender_palette) {
-        gPalette_munged |= 1u;
+    if (gRender_palette == pThe_palette || (gPalette_munged |= 1, 0)) {
     }
 }
 

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -925,11 +925,7 @@ void DRSetPalette2(br_pixelmap* pThe_palette, int pSet_current_palette) {
         char* dst = gCurrent_palette_pixels;
         char* src = pThe_palette->pixels;
 #ifdef DETHRACE_FIX_BUGS
-        if ((dst < src + palette_size) && (src < dst + palette_size)) {
-            memmove(dst, src, palette_size);
-        } else {
-            memcpy(dst, src, palette_size);
-        }
+        memmove(dst, src, palette_size);
 #else
         memcpy(dst, src, palette_size);
 #endif

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -927,13 +927,10 @@ void DRSetPalette3(br_pixelmap* pThe_palette, int pSet_current_palette) {
 void DRSetPalette2(br_pixelmap* pThe_palette, int pSet_current_palette) {
     ((br_int_32*)pThe_palette->pixels)[0] = 0;
     if (pSet_current_palette) {
-        size_t palette_size = 0x400u;
-        char* dst = gCurrent_palette_pixels;
-        char* src = pThe_palette->pixels;
 #ifdef DETHRACE_FIX_BUGS
-        memmove(dst, src, palette_size);
+        memmove(gCurrent_palette_pixels, pThe_palette->pixels, 4 * 256);
 #else
-        memcpy(dst, src, palette_size);
+        memcpy(gCurrent_palette_pixels, pThe_palette->pixels, 4 * 256);
 #endif
 #ifdef DETHRACE_3DFX_PATCH
         g16bit_palette_valid = 0;
@@ -942,7 +939,9 @@ void DRSetPalette2(br_pixelmap* pThe_palette, int pSet_current_palette) {
     if (!gFaded_palette) {
         PDSetPalette(pThe_palette);
     }
-    if (gRender_palette == pThe_palette || (gPalette_munged |= 1, 0)) {
+    if (gRender_palette != pThe_palette) {
+        gPalette_munged |= 1;
+    } else {
     }
 }
 


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4b3b72,20 +0x47edc5,20 @@
0x4b3b72 : mov edi, dword ptr [gCurrent_palette_pixels (DATA)]
0x4b3b78 : mov esi, dword ptr [eax + 8]
0x4b3b7b : mov ecx, 0x100
0x4b3b80 : rep movsd dword ptr es:[edi], dword ptr [esi]
0x4b3b82 : cmp dword ptr [gFaded_palette (DATA)], 0 	(graphics.c:929)
0x4b3b89 : jne 0xc
0x4b3b8f : mov eax, dword ptr [ebp + 8] 	(graphics.c:930)
0x4b3b92 : push eax
0x4b3b93 : call PDSetPalette (FUNCTION)
0x4b3b98 : add esp, 4
0x4b3b9b : -mov eax, dword ptr [gRender_palette (DATA)]
0x4b3ba0 : -cmp dword ptr [ebp + 8], eax
         : +mov eax, dword ptr [ebp + 8] 	(graphics.c:932)
         : +cmp dword ptr [gRender_palette (DATA)], eax
0x4b3ba3 : je 0xc
0x4b3ba9 : or dword ptr [gPalette_munged (DATA)], 1
0x4b3bb0 : jmp 0x0
0x4b3bb5 : pop edi 	(graphics.c:934)
0x4b3bb6 : pop esi
0x4b3bb7 : pop ebx
0x4b3bb8 : leave 
0x4b3bb9 : ret 


0x4b3b53: DRSetPalette2 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x4b3b72,20 +0x47edc5,21 @@
0x4b3b72 : mov edi, dword ptr [gCurrent_palette_pixels (DATA)]
0x4b3b78 : mov esi, dword ptr [eax + 8]
0x4b3b7b : mov ecx, 0x100
0x4b3b80 : rep movsd dword ptr es:[edi], dword ptr [esi]
0x4b3b82 : cmp dword ptr [gFaded_palette (DATA)], 0 	(graphics.c:929)
0x4b3b89 : jne 0xc
0x4b3b8f : mov eax, dword ptr [ebp + 8] 	(graphics.c:930)
0x4b3b92 : push eax
0x4b3b93 : call PDSetPalette (FUNCTION)
0x4b3b98 : add esp, 4
0x4b3b9b : -mov eax, dword ptr [gRender_palette (DATA)]
0x4b3ba0 : -cmp dword ptr [ebp + 8], eax
0x4b3ba3 : -je 0xc
0x4b3ba9 : -or dword ptr [gPalette_munged (DATA)], 1
0x4b3bb0 : -jmp 0x0
         : +mov eax, dword ptr [ebp + 8] 	(graphics.c:932)
         : +cmp dword ptr [gRender_palette (DATA)], eax
         : +je 0xd
         : +mov eax, dword ptr [gPalette_munged (DATA)] 	(graphics.c:933)
         : +or eax, 1
         : +mov dword ptr [gPalette_munged (DATA)], eax
0x4b3bb5 : pop edi 	(graphics.c:935)
0x4b3bb6 : pop esi
0x4b3bb7 : pop ebx
0x4b3bb8 : leave 
0x4b3bb9 : ret 


DRSetPalette2 is only 82.54% similar to the original, diff above
```

*AI generated. Time taken: 969s, tokens: 81,058*
