### PR TITLE
SetScreenWobble 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -1045,8 +1045,8 @@ void NewScreenWobble(double pAmplitude_x, double pAmplitude_y, double pPeriod) {
 // FUNCTION: CARM95 0x004b3f3a
 void SetScreenWobble(int pWobble_x, int pWobble_y) {
 
-    gScreen_wobble_y = pWobble_y;
     gScreen_wobble_x = pWobble_x;
+    gScreen_wobble_y = pWobble_y;
 }
 
 // IDA: void __cdecl ResetScreenWobble()


### PR DESCRIPTION
## Match result

```
0x4b3f3a: SetScreenWobble 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b3f3a,14 +0x47f18a,14 @@
0x4b3f3a : push ebp 	(graphics.c:1046)
0x4b3f3b : mov ebp, esp
0x4b3f3d : push ebx
0x4b3f3e : push esi
0x4b3f3f : push edi
         : +mov eax, dword ptr [ebp + 0xc] 	(graphics.c:1048)
         : +mov dword ptr [gScreen_wobble_y (DATA)], eax
0x4b3f40 : mov eax, dword ptr [ebp + 8] 	(graphics.c:1049)
0x4b3f43 : mov dword ptr [gScreen_wobble_x (DATA)], eax
0x4b3f48 : -mov eax, dword ptr [ebp + 0xc]
0x4b3f4b : -mov dword ptr [gScreen_wobble_y (DATA)], eax
0x4b3f50 : pop edi 	(graphics.c:1050)
0x4b3f51 : pop esi
0x4b3f52 : pop ebx
0x4b3f53 : leave 
0x4b3f54 : ret 


SetScreenWobble is only 85.71% similar to the original, diff above
```

*AI generated. Time taken: 65s, tokens: 13,306*
