### PR TITLE
DistanceFromPlane equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -1378,7 +1378,7 @@ void TryThisEdge(tCar_spec* pCar, br_vector3* pLight, int pIndex_1, br_scalar pS
 br_scalar DistanceFromPlane(br_vector3* pPos, br_scalar pA, br_scalar pB, br_scalar pC, br_scalar pD) {
     br_vector3 normal;
 
-    return fabs((pPos->v[1] * pB + pPos->v[0] * pA + pPos->v[2] * pC + pD) / (pA * pA + pC * pC + pB * pB));
+    return fabs(((pPos->v[1] * pB + pPos->v[0] * pA) + pPos->v[2] * pC + pD) / ((pA * pA - -(pC * pC)) + pB * pB));
 }
 
 // IDA: void __cdecl DisableLights()

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -1399,7 +1399,6 @@ void TryThisEdge(tCar_spec* pCar, br_vector3* pLight, int pIndex_1, br_scalar pS
 br_scalar DistanceFromPlane(br_vector3* pPos, br_scalar pA, br_scalar pB, br_scalar pC, br_scalar pD) {
     br_vector3 normal;
 
-    // return fabs(((pPos->v[1] * pB + pPos->v[0] * pA) + pPos->v[2] * pC + pD) / (((pA * pA) + pC * pC) + pB * pB));
     return fabs((pPos->v[0] * pA + pPos->v[1] * pB + pPos->v[2] * pC + pD) / (pA * pA + pB * pB + pC * pC));
 }
 

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -168,7 +168,7 @@ char* gFont_names[21] = {
 
 // GLOBAL: CARM95 0x005201a0
 br_colour gRGB_colours[9] = {
-    BR_COLOUR_RGB(0x00 ,0x00, 0x00),
+    BR_COLOUR_RGB(0x00, 0x00, 0x00),
     BR_COLOUR_RGB(0xff, 0xff, 0xff),
     BR_COLOUR_RGB(0xff, 0x00, 0x00),
     BR_COLOUR_RGB(0x00, 0xff, 0x00),
@@ -1378,7 +1378,7 @@ void TryThisEdge(tCar_spec* pCar, br_vector3* pLight, int pIndex_1, br_scalar pS
 br_scalar DistanceFromPlane(br_vector3* pPos, br_scalar pA, br_scalar pB, br_scalar pC, br_scalar pD) {
     br_vector3 normal;
 
-    return fabs(((pPos->v[1] * pB + pPos->v[0] * pA) + pPos->v[2] * pC + pD) / ((pA * pA - -(pC * pC)) + pB * pB));
+    return fabs(((pPos->v[1] * pB + pPos->v[0] * pA) + pPos->v[2] * pC + pD) / ((pA * pA + (pC * pC)) + pB * pB));
 }
 
 // IDA: void __cdecl DisableLights()

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -1378,7 +1378,7 @@ void TryThisEdge(tCar_spec* pCar, br_vector3* pLight, int pIndex_1, br_scalar pS
 br_scalar DistanceFromPlane(br_vector3* pPos, br_scalar pA, br_scalar pB, br_scalar pC, br_scalar pD) {
     br_vector3 normal;
 
-    return fabs(((pPos->v[1] * pB + pPos->v[0] * pA) + pPos->v[2] * pC + pD) / ((pA * pA + (pC * pC)) + pB * pB));
+    return fabs(((pPos->v[1] * pB + pPos->v[0] * pA) + pPos->v[2] * pC + pD) / (((pA * pA) + pC * pC) + pB * pB));
 }
 
 // IDA: void __cdecl DisableLights()

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -1399,7 +1399,8 @@ void TryThisEdge(tCar_spec* pCar, br_vector3* pLight, int pIndex_1, br_scalar pS
 br_scalar DistanceFromPlane(br_vector3* pPos, br_scalar pA, br_scalar pB, br_scalar pC, br_scalar pD) {
     br_vector3 normal;
 
-    return fabs(((pPos->v[1] * pB + pPos->v[0] * pA) + pPos->v[2] * pC + pD) / (((pA * pA) + pC * pC) + pB * pB));
+    // return fabs(((pPos->v[1] * pB + pPos->v[0] * pA) + pPos->v[2] * pC + pD) / (((pA * pA) + pC * pC) + pB * pB));
+    return fabs((pPos->v[0] * pA + pPos->v[1] * pB + pPos->v[2] * pC + pD) / (pA * pA + pB * pB + pC * pC));
 }
 
 // IDA: void __cdecl DisableLights()


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4b401d,26 +0x4803b2,26 @@
0x4b401d : fmul dword ptr [ebp + 0x10]
0x4b4020 : mov eax, dword ptr [ebp + 8]
0x4b4023 : fld dword ptr [eax]
0x4b4025 : fmul dword ptr [ebp + 0xc]
0x4b4028 : faddp st(1)
0x4b402a : mov eax, dword ptr [ebp + 8]
0x4b402d : fld dword ptr [eax + 8]
0x4b4030 : fmul dword ptr [ebp + 0x14]
0x4b4033 : faddp st(1)
0x4b4035 : fadd dword ptr [ebp + 0x18]
         : +fld dword ptr [ebp + 0x10]
         : +fmul dword ptr [ebp + 0x10]
0x4b4038 : fld dword ptr [ebp + 0xc]
0x4b403b : fmul dword ptr [ebp + 0xc]
         : +faddp st(1)
0x4b403e : fld dword ptr [ebp + 0x14]
0x4b4041 : fmul dword ptr [ebp + 0x14]
0x4b4044 : -faddp st(1)
0x4b4046 : -fld dword ptr [ebp + 0x10]
0x4b4049 : -fmul dword ptr [ebp + 0x10]
0x4b404c : faddp st(1)
0x4b404e : fdivp st(1)
0x4b4050 : fabs 
0x4b4052 : jmp 0x0
0x4b4057 : pop edi 	(graphics.c:1404)
0x4b4058 : pop esi
0x4b4059 : pop ebx
0x4b405a : leave 
0x4b405b : ret 


DistanceFromPlane is only 91.18% similar to the original, diff above
```

#### Effective match analysis

The diff only changes the order of accumulating the three squared terms on the x87 stack: original computes (c^2 + z^2) + y^2, while new computes (y^2 + c^2) + z^2 before the same `fdivp st(1)` and `fabs`. Control flow is unchanged (same jump structure/targets in this snippet), and the final mathematical result is the same apart from possible floating-point rounding-order effects, which you said to ignore.

#### Original match

```
---
+++
@@ -0x4b400e,34 +0x4800a1,34 @@
0x4b400e : push ebp 	(graphics.c:1378)
0x4b400f : mov ebp, esp
0x4b4011 : sub esp, 0xc
0x4b4014 : push ebx
0x4b4015 : push esi
0x4b4016 : push edi
0x4b4017 : mov eax, dword ptr [ebp + 8] 	(graphics.c:1381)
         : +fld dword ptr [eax + 8]
         : +fmul dword ptr [ebp + 0x14]
         : +mov eax, dword ptr [ebp + 8]
0x4b401a : fld dword ptr [eax + 4]
0x4b401d : fmul dword ptr [ebp + 0x10]
         : +faddp st(1)
0x4b4020 : mov eax, dword ptr [ebp + 8]
0x4b4023 : fld dword ptr [eax]
0x4b4025 : fmul dword ptr [ebp + 0xc]
0x4b4028 : faddp st(1)
0x4b402a : -mov eax, dword ptr [ebp + 8]
0x4b402d : -fld dword ptr [eax + 8]
         : +fadd dword ptr [ebp + 0x18]
         : +fld dword ptr [ebp + 0x14]
0x4b4030 : fmul dword ptr [ebp + 0x14]
         : +fld dword ptr [ebp + 0x10]
         : +fmul dword ptr [ebp + 0x10]
0x4b4033 : faddp st(1)
0x4b4035 : -fadd dword ptr [ebp + 0x18]
0x4b4038 : fld dword ptr [ebp + 0xc]
0x4b403b : fmul dword ptr [ebp + 0xc]
0x4b403e : -fld dword ptr [ebp + 0x14]
0x4b4041 : -fmul dword ptr [ebp + 0x14]
0x4b4044 : -faddp st(1)
0x4b4046 : -fld dword ptr [ebp + 0x10]
0x4b4049 : -fmul dword ptr [ebp + 0x10]
0x4b404c : faddp st(1)
0x4b404e : fdivp st(1)
0x4b4050 : fabs 
0x4b4052 : jmp 0x0
0x4b4057 : pop edi 	(graphics.c:1382)
0x4b4058 : pop esi
0x4b4059 : pop ebx
0x4b405a : leave 
0x4b405b : ret 


DistanceFromPlane is only 76.47% similar to the original, diff above
```

*AI generated. Time taken: 1445s, tokens: 121,404*
