### PR TITLE
OppositeColour 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -1175,19 +1175,21 @@ int OppositeColour(int pColour) {
     int brightness;
 
     if (pColour < 224) {
-        if ((pColour & 0x7) < 4) {
-            brightness = 255;
+        brightness = pColour & 0x7;
+        if (brightness < 4) {
+            pColour = 255;
         } else {
-            brightness = 0;
+            pColour = 0;
         }
     } else {
-        if ((pColour & 0xf) < 8) {
-            brightness = 255;
+        brightness = pColour & 0xf;
+        if (brightness < 8) {
+            pColour = 255;
         } else {
-            brightness = 0;
+            pColour = 0;
         }
     }
-    return brightness;
+    return pColour;
 }
 
 // IDA: void __usercall DrawMapBlip(tCar_spec *pCar@<EAX>, tU32 pTime@<EDX>, br_matrix34 *pTrans@<EBX>, br_vector3 *pPos@<ECX>, int pColour)


### PR DESCRIPTION
## Match result

```
0x4b764f: OppositeColour 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b764f,25 +0x47f794,30 @@
0x4b764f : push ebp 	(graphics.c:1174)
0x4b7650 : mov ebp, esp
0x4b7652 : sub esp, 4
0x4b7655 : push ebx
0x4b7656 : push esi
0x4b7657 : push edi
0x4b7658 : cmp dword ptr [ebp + 8], 0xe0 	(graphics.c:1177)
0x4b765f : -jge 0x2b
         : +jge 0x25
0x4b7665 : mov eax, dword ptr [ebp + 8] 	(graphics.c:1178)
0x4b7668 : -and eax, 7
0x4b766b : -mov dword ptr [ebp - 4], eax
0x4b766e : -cmp dword ptr [ebp - 4], 4
0x4b7672 : -jge 0xc
0x4b7678 : -mov dword ptr [ebp + 8], 0xff
         : +and al, 7
         : +cmp al, 4
         : +jae 0xc
         : +mov dword ptr [ebp - 4], 0xff 	(graphics.c:1179)
0x4b767f : jmp 0x7 	(graphics.c:1180)
0x4b7684 : -mov dword ptr [ebp + 8], 0
0x4b768b : -jmp 0x26
         : +mov dword ptr [ebp - 4], 0 	(graphics.c:1181)
         : +jmp 0x20 	(graphics.c:1183)
0x4b7690 : mov eax, dword ptr [ebp + 8] 	(graphics.c:1184)
0x4b7693 : -and eax, 0xf
0x4b7696 : -mov dword ptr [ebp - 4], eax
0x4b7699 : -cmp dword ptr [ebp - 4], 8
0x4b769d : -jge 0xc
0x4b76a3 : -mov dword ptr [ebp + 8], 0xff
         : +and al, 0xf
         : +cmp al, 8
         : +jae 0xc
         : +mov dword ptr [ebp - 4], 0xff 	(graphics.c:1185)
0x4b76aa : jmp 0x7 	(graphics.c:1186)
0x4b76af : -mov dword ptr [ebp + 8], 0
         : +mov dword ptr [ebp - 4], 0 	(graphics.c:1187)
         : +mov eax, dword ptr [ebp - 4] 	(graphics.c:1190)
         : +jmp 0x0
         : +pop edi 	(graphics.c:1191)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


OppositeColour is only 40.00% similar to the original, diff above
```

*AI generated. Time taken: 72s, tokens: 8,192*
