### PR TITLE
DrawMapSmallBlip 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -1301,7 +1301,8 @@ void DrawMapSmallBlip(tU32 pTime, br_vector3* pPos, int pColour) {
     int offset;
     tU32 time_diff;
 
-    if ((pTime & 0x100) == 0) {
+    if (pTime & 0x100) {
+    } else {
         BrMatrix34ApplyP(&map_pos, pPos, &gCurrent_race.map_transformation);
         if (gReal_graf_data_index != 0) {
             map_pos.v[0] = 2.f * map_pos.v[0];
@@ -1316,8 +1317,7 @@ void DrawMapSmallBlip(tU32 pTime, br_vector3* pPos, int pColour) {
         } else
 #endif
         {
-            offset = (int)map_pos.v[0] + gBack_screen->row_bytes * (int)map_pos.v[1];
-            ((br_uint_8*)gBack_screen->pixels)[offset] = pColour;
+            ((br_uint_8*)gBack_screen->pixels)[(int)map_pos.v[0] + gBack_screen->row_bytes * (int)map_pos.v[1]] = pColour;
         }
     }
 }

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -1323,23 +1323,24 @@ void DrawMapSmallBlip(tU32 pTime, br_vector3* pPos, int pColour) {
     tU32 time_diff;
 
     if (pTime & 0x100) {
-    } else {
-        BrMatrix34ApplyP(&map_pos, pPos, &gCurrent_race.map_transformation);
-        if (gReal_graf_data_index != 0) {
-            map_pos.v[0] = 2.f * map_pos.v[0];
-            map_pos.v[1] = 2.f * map_pos.v[1] + HIRES_Y_OFFSET;
-        }
+        return;
+    }
+
+    BrMatrix34ApplyP(&map_pos, pPos, &gCurrent_race.map_transformation);
+    if (gReal_graf_data_index != 0) {
+        map_pos.v[0] = 2.f * map_pos.v[0];
+        map_pos.v[1] = 2.f * map_pos.v[1] + HIRES_Y_OFFSET;
+    }
 #ifdef DETHRACE_3DFX_PATCH
-        if (gBack_screen->type == BR_PMT_RGB_565) {
-            offset = ((int)map_pos.v[0] * 2) + gBack_screen->row_bytes * (int)map_pos.v[1];
-            pColour = PaletteEntry16Bit(gRender_palette, pColour);
-            tU8* p1 = &(((tU8*)gBack_screen->pixels)[offset]);
-            *((br_uint_16*)(p1)) = pColour;
-        } else
+    if (gBack_screen->type == BR_PMT_RGB_565) {
+        offset = ((int)map_pos.v[0] * 2) + gBack_screen->row_bytes * (int)map_pos.v[1];
+        pColour = PaletteEntry16Bit(gRender_palette, pColour);
+        tU8* p1 = &(((tU8*)gBack_screen->pixels)[offset]);
+        *((br_uint_16*)(p1)) = pColour;
+    } else
 #endif
-        {
-            ((br_uint_8*)gBack_screen->pixels)[(int)map_pos.v[0] + gBack_screen->row_bytes * (int)map_pos.v[1]] = pColour;
-        }
+    {
+        ((br_uint_8*)gBack_screen->pixels)[(int)map_pos.v[0] + gBack_screen->row_bytes * (int)map_pos.v[1]] = pColour;
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4b76c3: DrawMapSmallBlip 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b76c3,45 +0x47fcee,46 @@
0x4b76c3 : push ebp 	(graphics.c:1299)
0x4b76c4 : mov ebp, esp
0x4b76c6 : sub esp, 0x14
0x4b76c9 : push ebx
0x4b76ca : push esi
0x4b76cb : push edi
0x4b76cc : test byte ptr [ebp + 9], 1 	(graphics.c:1304)
0x4b76d0 : -je 0x5
0x4b76d6 : -jmp 0x74
         : +jne 0x7b
0x4b76db : mov eax, gCurrent_race (DATA) 	(graphics.c:1305)
0x4b76e0 : add eax, 0xf88
0x4b76e5 : push eax
0x4b76e6 : mov eax, dword ptr [ebp + 0xc]
0x4b76e9 : push eax
0x4b76ea : lea eax, [ebp - 0x10]
0x4b76ed : push eax
0x4b76ee : call BrMatrix34ApplyP (FUNCTION)
0x4b76f3 : add esp, 0xc
0x4b76f6 : cmp dword ptr [gReal_graf_data_index (DATA)], 0 	(graphics.c:1306)
0x4b76fd : je 0x1e
0x4b7703 : fld dword ptr [ebp - 0x10] 	(graphics.c:1307)
0x4b7706 : fmul dword ptr [2.0 (FLOAT)]
0x4b770c : fstp dword ptr [ebp - 0x10]
0x4b770f : fld dword ptr [ebp - 0xc] 	(graphics.c:1308)
0x4b7712 : fmul dword ptr [2.0 (FLOAT)]
0x4b7718 : fadd dword ptr [40.0 (FLOAT)]
0x4b771e : fstp dword ptr [ebp - 0xc]
0x4b7721 : -mov bl, byte ptr [ebp + 0x10]
0x4b7724 : fld dword ptr [ebp - 0xc] 	(graphics.c:1319)
0x4b7727 : call __ftol (FUNCTION)
0x4b772c : -mov esi, eax
         : +mov ebx, eax
0x4b772e : mov eax, dword ptr [gBack_screen (DATA)]
0x4b7733 : movsx eax, word ptr [eax + 0x28]
0x4b7737 : -imul esi, eax
         : +imul ebx, eax
0x4b773a : fld dword ptr [ebp - 0x10]
0x4b773d : call __ftol (FUNCTION)
0x4b7742 : -add esi, eax
0x4b7744 : -mov eax, dword ptr [gBack_screen (DATA)]
0x4b7749 : -mov eax, dword ptr [eax + 8]
0x4b774c : -mov byte ptr [esi + eax], bl
         : +add ebx, eax
         : +mov dword ptr [ebp - 0x14], ebx
         : +mov al, byte ptr [ebp + 0x10] 	(graphics.c:1320)
         : +mov ecx, dword ptr [gBack_screen (DATA)]
         : +mov ecx, dword ptr [ecx + 8]
         : +mov edx, dword ptr [ebp - 0x14]
         : +mov byte ptr [ecx + edx], al
0x4b774f : pop edi 	(graphics.c:1323)
0x4b7750 : pop esi
0x4b7751 : pop ebx
0x4b7752 : leave 
0x4b7753 : ret 


DrawMapSmallBlip is only 79.12% similar to the original, diff above
```

*AI generated. Time taken: 313s, tokens: 48,165*
