### PR TITLE
SetFadedPalette 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -2335,7 +2335,16 @@ void SetFadedPalette(int pDegree) {
     br_pixelmap* the_palette;
     char* the_pixels;
 
-    memcpy(gScratch_pixels, gCurrent_palette->pixels, 0x400u);
+    if ((char*)gScratch_pixels < (char*)gCurrent_palette->pixels + 0x400u
+        && (char*)gCurrent_palette->pixels < (char*)gScratch_pixels + 0x400u) {
+#ifdef DETHRACE_FIX_BUGS
+        memmove(gScratch_pixels, gCurrent_palette->pixels, 0x400u);
+#else
+        memcpy(gScratch_pixels, gCurrent_palette->pixels, 0x400u);
+#endif
+    } else {
+        memcpy(gScratch_pixels, gCurrent_palette->pixels, 0x400u);
+    }
     for (j = 0; j < 256; j++) {
         Darken((tU8*)&gScratch_pixels[4 * j], pDegree);
         Darken((tU8*)(&gScratch_pixels[4 * j]) + 1, pDegree);

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -2338,9 +2338,9 @@ void SetFadedPalette(int pDegree) {
     memcpy(gScratch_pixels, gCurrent_palette->pixels, 0x400u);
     for (j = 0; j < 256; j++) {
         Darken((tU8*)&gScratch_pixels[4 * j], pDegree);
-        Darken((tU8*)&gScratch_pixels[4 * j + 1], pDegree);
-        Darken((tU8*)&gScratch_pixels[4 * j + 2], pDegree);
-        Darken((tU8*)&gScratch_pixels[4 * j + 3], pDegree);
+        Darken((tU8*)(&gScratch_pixels[4 * j]) + 1, pDegree);
+        Darken((tU8*)(&gScratch_pixels[4 * j]) + 2, pDegree);
+        Darken((tU8*)(&gScratch_pixels[4 * j]) + 3, pDegree);
     }
     DRSetPalette2(gScratch_palette, 0);
 }

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -2358,21 +2358,13 @@ void SetFadedPalette(int pDegree) {
     br_pixelmap* the_palette;
     char* the_pixels;
 
-    if ((char*)gScratch_pixels < (char*)gCurrent_palette->pixels + 0x400u
-        && (char*)gCurrent_palette->pixels < (char*)gScratch_pixels + 0x400u) {
-#ifdef DETHRACE_FIX_BUGS
-        memmove(gScratch_pixels, gCurrent_palette->pixels, 0x400u);
-#else
-        memcpy(gScratch_pixels, gCurrent_palette->pixels, 0x400u);
-#endif
-    } else {
-        memcpy(gScratch_pixels, gCurrent_palette->pixels, 0x400u);
-    }
+    memcpy(gScratch_pixels, gCurrent_palette->pixels, 0x400u);
+
     for (j = 0; j < 256; j++) {
         Darken((tU8*)&gScratch_pixels[4 * j], pDegree);
-        Darken((tU8*)(&gScratch_pixels[4 * j]) + 1, pDegree);
-        Darken((tU8*)(&gScratch_pixels[4 * j]) + 2, pDegree);
-        Darken((tU8*)(&gScratch_pixels[4 * j]) + 3, pDegree);
+        Darken((tU8*)&gScratch_pixels[4 * j] + 1, pDegree);
+        Darken((tU8*)&gScratch_pixels[4 * j] + 2, pDegree);
+        Darken((tU8*)&gScratch_pixels[4 * j] + 3, pDegree);
     }
     DRSetPalette2(gScratch_palette, 0);
 }


### PR DESCRIPTION
## Match result

```
0x4b79b5: SetFadedPalette 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b79f3,40 +0x482a9f,40 @@
0x4b79f3 : mov eax, dword ptr [ebp - 0xc]
0x4b79f6 : shl eax, 2
0x4b79f9 : add eax, dword ptr [gScratch_pixels (DATA)]
0x4b79ff : push eax
0x4b7a00 : call Darken (FUNCTION)
0x4b7a05 : add esp, 8
0x4b7a08 : mov eax, dword ptr [ebp + 8] 	(graphics.c:2341)
0x4b7a0b : push eax
0x4b7a0c : mov eax, dword ptr [ebp - 0xc]
0x4b7a0f : shl eax, 2
         : +inc eax
0x4b7a12 : add eax, dword ptr [gScratch_pixels (DATA)]
0x4b7a18 : -inc eax
0x4b7a19 : push eax
0x4b7a1a : call Darken (FUNCTION)
0x4b7a1f : add esp, 8
0x4b7a22 : mov eax, dword ptr [ebp + 8] 	(graphics.c:2342)
0x4b7a25 : push eax
0x4b7a26 : mov eax, dword ptr [ebp - 0xc]
0x4b7a29 : shl eax, 2
         : +add eax, 2
0x4b7a2c : add eax, dword ptr [gScratch_pixels (DATA)]
0x4b7a32 : -add eax, 2
0x4b7a35 : push eax
0x4b7a36 : call Darken (FUNCTION)
0x4b7a3b : add esp, 8
0x4b7a3e : mov eax, dword ptr [ebp + 8] 	(graphics.c:2343)
0x4b7a41 : push eax
0x4b7a42 : mov eax, dword ptr [ebp - 0xc]
0x4b7a45 : shl eax, 2
         : +add eax, 3
0x4b7a48 : add eax, dword ptr [gScratch_pixels (DATA)]
0x4b7a4e : -add eax, 3
0x4b7a51 : push eax
0x4b7a52 : call Darken (FUNCTION)
0x4b7a57 : add esp, 8
0x4b7a5a : jmp -0x80 	(graphics.c:2344)
0x4b7a5f : push 0 	(graphics.c:2345)
0x4b7a61 : mov eax, dword ptr [gScratch_palette (DATA)]
0x4b7a66 : push eax
0x4b7a67 : call DRSetPalette2 (FUNCTION)
0x4b7a6c : add esp, 8
0x4b7a6f : pop edi 	(graphics.c:2346)


SetFadedPalette is only 95.16% similar to the original, diff above
```

*AI generated. Time taken: 70s, tokens: 7,786*
