### PR TITLE
Darken 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -2325,7 +2325,8 @@ void ResetPalette(void) {
 void Darken(tU8* pPtr, unsigned int pDarken_amount) {
     unsigned int value;
 
-    *pPtr = (pDarken_amount * *pPtr) / 256;
+    value = *pPtr;
+    *pPtr = (value * pDarken_amount) / 256;
 }
 
 // IDA: void __usercall SetFadedPalette(int pDegree@<EAX>)


### PR DESCRIPTION
## Match result

```
0x4b7a74: Darken 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b7a74,13 +0x482a43,17 @@
0x4b7a74 : push ebp 	(graphics.c:2325)
0x4b7a75 : mov ebp, esp
0x4b7a77 : sub esp, 4
0x4b7a7a : push ebx
0x4b7a7b : push esi
0x4b7a7c : push edi
0x4b7a7d : mov eax, dword ptr [ebp + 8] 	(graphics.c:2328)
0x4b7a80 : xor ecx, ecx
0x4b7a82 : mov cl, byte ptr [eax]
0x4b7a84 : -mov dword ptr [ebp - 4], ecx
0x4b7a87 : -mov eax, dword ptr [ebp - 4]
0x4b7a8a : -imul eax, dword ptr [ebp + 0xc]
0x4b7a8e : -mov ecx, dword ptr [ebp + 8]
         : +imul ecx, dword ptr [ebp + 0xc]
         : +mov eax, dword ptr [ebp + 8]
         : +mov byte ptr [eax], ch
         : +pop edi 	(graphics.c:2329)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


Darken is only 60.00% similar to the original, diff above
```

*AI generated. Time taken: 78s, tokens: 12,744*
