### PR TITLE
FadePaletteDown 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -2352,18 +2352,14 @@ void FadePaletteDown(void) {
     int start_time;
     int the_time;
 
-    if (!gFaded_palette) {
+    if (gFaded_palette) {
+    } else {
         gFaded_palette = 1;
         MungeEngineNoise();
         gFaded_palette = 0;
         start_time = PDGetTotalTime();
-        while (1) {
-            the_time = PDGetTotalTime() - start_time;
-            if (the_time >= 500) {
-                break;
-            }
-            i = 256 - ((the_time * 256) / 500);
-            SetFadedPalette(i);
+        while ((the_time = PDGetTotalTime() - start_time) < 500) {
+            SetFadedPalette(256 - ((the_time * 256) / 500));
         }
         SetFadedPalette(0);
         gFaded_palette = 1;

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -2376,17 +2376,18 @@ void FadePaletteDown(void) {
     int the_time;
 
     if (gFaded_palette) {
-    } else {
-        gFaded_palette = 1;
-        MungeEngineNoise();
-        gFaded_palette = 0;
-        start_time = PDGetTotalTime();
-        while ((the_time = PDGetTotalTime() - start_time) < 500) {
-            SetFadedPalette(256 - ((the_time * 256) / 500));
-        }
-        SetFadedPalette(0);
-        gFaded_palette = 1;
+        return;
     }
+
+    gFaded_palette = 1;
+    MungeEngineNoise();
+    gFaded_palette = 0;
+    start_time = PDGetTotalTime();
+    while ((the_time = PDGetTotalTime() - start_time) < 500) {
+        SetFadedPalette(256 - ((the_time * 256) / 500));
+    }
+    SetFadedPalette(0);
+    gFaded_palette = 1;
 }
 
 // IDA: void __cdecl FadePaletteUp()


### PR DESCRIPTION
## Match result

```
0x4b7a98: FadePaletteDown 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b7a98,39 +0x482b20,41 @@
0x4b7a98 : push ebp 	(graphics.c:2350)
0x4b7a99 : mov ebp, esp
0x4b7a9b : sub esp, 0xc
0x4b7a9e : push ebx
0x4b7a9f : push esi
0x4b7aa0 : push edi
0x4b7aa1 : cmp dword ptr [gFaded_palette (DATA)], 0 	(graphics.c:2355)
0x4b7aa8 : -je 0x5
0x4b7aae : -jmp 0x70
         : +jne 0x7b
0x4b7ab3 : mov dword ptr [gFaded_palette (DATA)], 1 	(graphics.c:2356)
0x4b7abd : call MungeEngineNoise (FUNCTION) 	(graphics.c:2357)
0x4b7ac2 : mov dword ptr [gFaded_palette (DATA)], 0 	(graphics.c:2358)
0x4b7acc : call PDGetTotalTime (FUNCTION) 	(graphics.c:2359)
0x4b7ad1 : mov dword ptr [ebp - 0xc], eax
0x4b7ad4 : call PDGetTotalTime (FUNCTION) 	(graphics.c:2361)
0x4b7ad9 : sub eax, dword ptr [ebp - 0xc]
0x4b7adc : mov dword ptr [ebp - 4], eax
0x4b7adf : cmp dword ptr [ebp - 4], 0x1f4 	(graphics.c:2362)
0x4b7ae6 : -jge 0x23
         : +jl 0x5
         : +jmp 0x29 	(graphics.c:2363)
0x4b7aec : mov ecx, 0x100 	(graphics.c:2365)
0x4b7af1 : mov eax, dword ptr [ebp - 4]
0x4b7af4 : shl eax, 8
0x4b7af7 : mov ebx, 0x1f4
0x4b7afc : cdq 
0x4b7afd : idiv ebx
0x4b7aff : sub ecx, eax
0x4b7b01 : -push ecx
         : +mov dword ptr [ebp - 8], ecx
         : +mov eax, dword ptr [ebp - 8] 	(graphics.c:2366)
         : +push eax
0x4b7b02 : call SetFadedPalette (FUNCTION)
0x4b7b07 : add esp, 4
0x4b7b0a : -jmp -0x3b
         : +jmp -0x46 	(graphics.c:2367)
0x4b7b0f : push 0 	(graphics.c:2368)
0x4b7b11 : call SetFadedPalette (FUNCTION)
0x4b7b16 : add esp, 4
0x4b7b19 : mov dword ptr [gFaded_palette (DATA)], 1 	(graphics.c:2369)
0x4b7b23 : pop edi 	(graphics.c:2371)
0x4b7b24 : pop esi
0x4b7b25 : pop ebx
0x4b7b26 : leave 
0x4b7b27 : ret 


FadePaletteDown is only 85.00% similar to the original, diff above
```

*AI generated. Time taken: 171s, tokens: 14,739*
