### PR TITLE
FadePaletteUp 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -2377,16 +2377,12 @@ void FadePaletteUp(void) {
     int start_time;
     int the_time;
 
-    if (gFaded_palette) {
+    if (!gFaded_palette) {
+    } else {
         gFaded_palette = 0;
         start_time = PDGetTotalTime();
-        while (1) {
-            the_time = PDGetTotalTime() - start_time;
-            if (the_time >= 500) {
-                break;
-            }
-            i = (the_time * 256) / 500;
-            SetFadedPalette(i);
+        while ((the_time = PDGetTotalTime() - start_time) < 500) {
+            SetFadedPalette((the_time * 256) / 500);
         }
         DRSetPalette(gCurrent_palette);
     }

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -2398,14 +2398,15 @@ void FadePaletteUp(void) {
     int the_time;
 
     if (!gFaded_palette) {
-    } else {
-        gFaded_palette = 0;
-        start_time = PDGetTotalTime();
-        while ((the_time = PDGetTotalTime() - start_time) < 500) {
-            SetFadedPalette((the_time * 256) / 500);
-        }
-        DRSetPalette(gCurrent_palette);
+        return;
     }
+
+    gFaded_palette = 0;
+    start_time = PDGetTotalTime();
+    while ((the_time = PDGetTotalTime() - start_time) < 500) {
+        SetFadedPalette((the_time * 256) / 500);
+    }
+    DRSetPalette(gCurrent_palette);
 }
 
 // IDA: void __cdecl KillSplashScreen()


### PR DESCRIPTION
## Match result

```
0x4b7b28: FadePaletteUp 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b7b28,35 +0x482bb6,37 @@
0x4b7b28 : push ebp 	(graphics.c:2375)
0x4b7b29 : mov ebp, esp
0x4b7b2b : sub esp, 0xc
0x4b7b2e : push ebx
0x4b7b2f : push esi
0x4b7b30 : push edi
0x4b7b31 : cmp dword ptr [gFaded_palette (DATA)], 0 	(graphics.c:2380)
0x4b7b38 : -jne 0x5
0x4b7b3e : -jmp 0x54
         : +je 0x5f
0x4b7b43 : mov dword ptr [gFaded_palette (DATA)], 0 	(graphics.c:2381)
0x4b7b4d : call PDGetTotalTime (FUNCTION) 	(graphics.c:2382)
0x4b7b52 : mov dword ptr [ebp - 0xc], eax
0x4b7b55 : call PDGetTotalTime (FUNCTION) 	(graphics.c:2384)
0x4b7b5a : sub eax, dword ptr [ebp - 0xc]
0x4b7b5d : mov dword ptr [ebp - 4], eax
0x4b7b60 : cmp dword ptr [ebp - 4], 0x1f4 	(graphics.c:2385)
0x4b7b67 : -jge 0x1c
         : +jl 0x5
         : +jmp 0x22 	(graphics.c:2386)
0x4b7b6d : mov eax, dword ptr [ebp - 4] 	(graphics.c:2388)
0x4b7b70 : shl eax, 8
0x4b7b73 : mov ecx, 0x1f4
0x4b7b78 : cdq 
0x4b7b79 : idiv ecx
         : +mov dword ptr [ebp - 8], eax
         : +mov eax, dword ptr [ebp - 8] 	(graphics.c:2389)
0x4b7b7b : push eax
0x4b7b7c : call SetFadedPalette (FUNCTION)
0x4b7b81 : add esp, 4
0x4b7b84 : -jmp -0x34
         : +jmp -0x3f 	(graphics.c:2390)
0x4b7b89 : mov eax, dword ptr [gCurrent_palette (DATA)] 	(graphics.c:2391)
0x4b7b8e : push eax
0x4b7b8f : call DRSetPalette (FUNCTION)
0x4b7b94 : add esp, 4
0x4b7b97 : pop edi 	(graphics.c:2393)
0x4b7b98 : pop esi
0x4b7b99 : pop ebx
0x4b7b9a : leave 
0x4b7b9b : ret 


FadePaletteUp is only 86.11% similar to the original, diff above
```

*AI generated. Time taken: 265s, tokens: 32,700*
