### PR TITLE
SplashScreenWith 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -2421,36 +2421,39 @@ void SplashScreenWith(char* pPixmap_name) {
     br_pixelmap* the_map;
 
     the_map = BrMapFind(pPixmap_name);
-    if (gCurrent_splash == NULL || the_map != gCurrent_splash) {
-        FadePaletteDown();
-        EnsureRenderPalette();
+    if (gCurrent_splash != NULL && the_map == gCurrent_splash) {
+        return;
+    }
 
+    FadePaletteDown();
+    EnsureRenderPalette();
+
+    if (gCurrent_splash != NULL) {
+        KillSplashScreen();
+    }
+    gCurrent_splash = the_map;
+    if (gCurrent_splash == NULL) {
+        gCurrent_splash = LoadPixelmap(pPixmap_name);
         if (gCurrent_splash != NULL) {
-            KillSplashScreen();
+            BrMapAdd(gCurrent_splash);
         }
-        gCurrent_splash = the_map;
-        if (the_map == NULL) {
-            the_map = LoadPixelmap(pPixmap_name);
-            gCurrent_splash = the_map;
-            if (the_map != NULL) {
-                BrMapAdd(the_map);
-            }
-        }
-        if (gCurrent_splash != NULL) {
-            BrPixelmapRectangleCopy(
-                gBack_screen,
-                0,
-                0,
-                gCurrent_splash,
-                0,
-                0,
-                gCurrent_splash->width,
-                gCurrent_splash->height);
-            PDScreenBufferSwap(0);
-            if (gFaded_palette) {
-                FadePaletteUp();
-            }
-        }
+    }
+    if (gCurrent_splash != NULL) {
+        BrPixelmapRectangleCopy(
+            gBack_screen,
+            0,
+            0,
+            gCurrent_splash,
+            0,
+            0,
+            gCurrent_splash->width,
+            gCurrent_splash->height);
+    } else {
+        return;
+    }
+    PDScreenBufferSwap(0);
+    if (gFaded_palette) {
+        FadePaletteUp();
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4b7c0b: SplashScreenWith 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b7c0e,60 +0x482ca2,67 @@
0x4b7c0e : sub esp, 4
0x4b7c11 : push ebx
0x4b7c12 : push esi
0x4b7c13 : push edi
0x4b7c14 : mov eax, dword ptr [ebp + 8] 	(graphics.c:2423)
0x4b7c17 : push eax
0x4b7c18 : call BrMapFind (FUNCTION)
0x4b7c1d : add esp, 4
0x4b7c20 : mov dword ptr [ebp - 4], eax
0x4b7c23 : cmp dword ptr [gCurrent_splash (DATA)], 0 	(graphics.c:2424)
0x4b7c2a : -je 0x13
         : +je 0xe
0x4b7c30 : mov eax, dword ptr [gCurrent_splash (DATA)]
0x4b7c35 : cmp dword ptr [ebp - 4], eax
0x4b7c38 : -jne 0x5
0x4b7c3e : -jmp 0xc4
         : +je 0xb8
0x4b7c43 : call FadePaletteDown (FUNCTION) 	(graphics.c:2425)
0x4b7c48 : call EnsureRenderPalette (FUNCTION) 	(graphics.c:2426)
0x4b7c4d : cmp dword ptr [gCurrent_splash (DATA)], 0 	(graphics.c:2428)
0x4b7c54 : je 0x5
0x4b7c5a : call KillSplashScreen (FUNCTION) 	(graphics.c:2429)
0x4b7c5f : mov eax, dword ptr [ebp - 4] 	(graphics.c:2431)
0x4b7c62 : mov dword ptr [gCurrent_splash (DATA)], eax
0x4b7c67 : -cmp dword ptr [gCurrent_splash (DATA)], 0
0x4b7c6e : -jne 0x2c
         : +cmp dword ptr [ebp - 4], 0 	(graphics.c:2432)
         : +jne 0x2d
0x4b7c74 : mov eax, dword ptr [ebp + 8] 	(graphics.c:2433)
0x4b7c77 : push eax
0x4b7c78 : call LoadPixelmap (FUNCTION)
0x4b7c7d : add esp, 4
         : +mov dword ptr [ebp - 4], eax
         : +mov eax, dword ptr [ebp - 4] 	(graphics.c:2434)
0x4b7c80 : mov dword ptr [gCurrent_splash (DATA)], eax
0x4b7c85 : -cmp dword ptr [gCurrent_splash (DATA)], 0
0x4b7c8c : -je 0xe
0x4b7c92 : -mov eax, dword ptr [gCurrent_splash (DATA)]
         : +cmp dword ptr [ebp - 4], 0 	(graphics.c:2435)
         : +je 0xc
         : +mov eax, dword ptr [ebp - 4] 	(graphics.c:2436)
0x4b7c97 : push eax
0x4b7c98 : call BrMapAdd (FUNCTION)
0x4b7c9d : add esp, 4
0x4b7ca0 : cmp dword ptr [gCurrent_splash (DATA)], 0 	(graphics.c:2439)
0x4b7ca7 : -je 0x39
         : +je 0x50
0x4b7cad : mov eax, dword ptr [gCurrent_splash (DATA)] 	(graphics.c:2448)
0x4b7cb2 : xor ecx, ecx
0x4b7cb4 : mov cx, word ptr [eax + 0x36]
0x4b7cb8 : push ecx
0x4b7cb9 : mov eax, dword ptr [gCurrent_splash (DATA)]
0x4b7cbe : xor ecx, ecx
0x4b7cc0 : mov cx, word ptr [eax + 0x34]
0x4b7cc4 : push ecx
0x4b7cc5 : push 0
0x4b7cc7 : push 0
0x4b7cc9 : mov eax, dword ptr [gCurrent_splash (DATA)]
0x4b7cce : push eax
0x4b7ccf : push 0
0x4b7cd1 : push 0
0x4b7cd3 : mov eax, dword ptr [gBack_screen (DATA)]
0x4b7cd8 : push eax
0x4b7cd9 : call BrPixelmapRectangleCopy (FUNCTION)
0x4b7cde : add esp, 0x20
0x4b7ce1 : -jmp 0x5
0x4b7ce6 : -jmp 0x1c
0x4b7ceb : push 0 	(graphics.c:2449)
0x4b7ced : call PDScreenBufferSwap (FUNCTION)
0x4b7cf2 : add esp, 4
         : +cmp dword ptr [gFaded_palette (DATA)], 0 	(graphics.c:2450)
         : +je 0x5
         : +call FadePaletteUp (FUNCTION) 	(graphics.c:2451)
         : +pop edi 	(graphics.c:2455)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


SplashScreenWith is only 77.86% similar to the original, diff above
```

*AI generated. Time taken: 412s, tokens: 54,746*
