### PR TITLE
InitAmbience 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -2490,7 +2490,7 @@ void ChangeAmbience(br_scalar pDelta) {
 void InitAmbience(void) {
 
     gCurrent_ambience = gAmbient_adjustment;
-    ChangeAmbience(gAmbient_adjustment);
+    ChangeAmbience(gCurrent_ambience);
 }
 
 // IDA: void __usercall DRPixelmapRectangleMaskedCopy(br_pixelmap *pDest@<EAX>, br_int_16 pDest_x@<EDX>, br_int_16 pDest_y@<EBX>, br_pixelmap *pSource@<ECX>, br_int_16 pSource_x, br_int_16 pSource_y, br_int_16 pWidth, br_int_16 pHeight)


### PR DESCRIPTION
## Match result

```
0x4b7dae: InitAmbience 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b7dae,16 +0x482e31,16 @@
0x4b7dae : push ebp 	(graphics.c:2490)
0x4b7daf : mov ebp, esp
0x4b7db1 : push ebx
0x4b7db2 : push esi
0x4b7db3 : push edi
0x4b7db4 : mov eax, dword ptr [gAmbient_adjustment (DATA)] 	(graphics.c:2492)
0x4b7db9 : mov dword ptr [gCurrent_ambience (DATA)], eax
0x4b7dbe : -mov eax, dword ptr [gCurrent_ambience (DATA)]
         : +mov eax, dword ptr [gAmbient_adjustment (DATA)] 	(graphics.c:2493)
0x4b7dc3 : push eax
0x4b7dc4 : call ChangeAmbience (FUNCTION)
0x4b7dc9 : add esp, 4
0x4b7dcc : pop edi 	(graphics.c:2494)
0x4b7dcd : pop esi
0x4b7dce : pop ebx
0x4b7dcf : leave 
0x4b7dd0 : ret 


InitAmbience is only 93.75% similar to the original, diff above
```

*AI generated. Time taken: 80s, tokens: 17,210*
