### PR TITLE
DRPixelmapRectangleMaskedCopy equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -2531,7 +2531,7 @@ void DRPixelmapRectangleMaskedCopy(br_pixelmap* pDest, br_int_16 pDest_x, br_int
         return;
     }
     if (pDest_y + pHeight > pDest->height) {
-        pHeight = pDest->height - pDest_y;
+        pHeight -= pDest_y + pHeight - pDest->height;
     }
     if (pDest_x < 0) {
         pWidth += pDest_x;
@@ -2548,9 +2548,10 @@ void DRPixelmapRectangleMaskedCopy(br_pixelmap* pDest, br_int_16 pDest_x, br_int
         return;
     }
     if (pDest_x + pWidth > pDest->width) {
-        source_row_wrap += pDest_x + pWidth - pDest->width;
-        dest_row_wrap += pDest_x + pWidth - pDest->width;
-        pWidth = pDest->width - pDest_x;
+        x_delta = pDest_x + pWidth - pDest->width;
+        pWidth -= x_delta;
+        source_row_wrap += x_delta;
+        dest_row_wrap += x_delta;
     }
 
     if (gCurrent_conversion_table != NULL) {
@@ -2558,27 +2559,31 @@ void DRPixelmapRectangleMaskedCopy(br_pixelmap* pDest, br_int_16 pDest_x, br_int
         for (y_count = 0; y_count < pHeight; y_count++) {
             for (x_count = 0; x_count < pWidth; x_count++) {
                 the_byte = *source_ptr;
+                source_ptr++;
                 if (the_byte != 0) {
                     *dest_ptr = conv_table[the_byte];
+                    dest_ptr++;
+                } else {
+                    dest_ptr++;
                 }
-                source_ptr++;
-                dest_ptr++;
             }
-            source_ptr += source_row_wrap;
             dest_ptr += dest_row_wrap;
+            source_ptr += source_row_wrap;
         }
     } else {
         for (y_count = 0; y_count < pHeight; y_count++) {
             for (x_count = 0; x_count < pWidth; x_count++) {
                 the_byte = *source_ptr;
+                source_ptr++;
                 if (the_byte != 0) {
                     *dest_ptr = the_byte;
+                    dest_ptr++;
+                } else {
+                    dest_ptr++;
                 }
-                source_ptr++;
-                dest_ptr++;
             }
-            source_ptr += source_row_wrap;
             dest_ptr += dest_row_wrap;
+            source_ptr += source_row_wrap;
         }
     }
 }

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -2575,11 +2575,9 @@ void DRPixelmapRectangleMaskedCopy(br_pixelmap* pDest, br_int_16 pDest_x, br_int
         conv_table = gCurrent_conversion_table->pixels;
         for (y_count = 0; y_count < pHeight; y_count++) {
             for (x_count = 0; x_count < pWidth; x_count++) {
-                the_byte = *source_ptr;
-                source_ptr++;
+                the_byte = *source_ptr++;
                 if (the_byte != 0) {
-                    *dest_ptr = conv_table[the_byte];
-                    dest_ptr++;
+                    *dest_ptr++ = conv_table[the_byte];
                 } else {
                     dest_ptr++;
                 }
@@ -2590,11 +2588,9 @@ void DRPixelmapRectangleMaskedCopy(br_pixelmap* pDest, br_int_16 pDest_x, br_int
     } else {
         for (y_count = 0; y_count < pHeight; y_count++) {
             for (x_count = 0; x_count < pWidth; x_count++) {
-                the_byte = *source_ptr;
-                source_ptr++;
+                the_byte = *source_ptr++;
                 if (the_byte != 0) {
-                    *dest_ptr = the_byte;
-                    dest_ptr++;
+                    *dest_ptr++ = the_byte;
                 } else {
                     dest_ptr++;
                 }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4b7e1f,22 +0x483164,22 @@
0x4b7e1f : sub eax, ecx
0x4b7e21 : mov dword ptr [ebp - 0x20], eax
0x4b7e24 : mov eax, dword ptr [ebp + 8] 	(graphics.c:2536)
0x4b7e27 : movsx eax, word ptr [eax + 0x28]
0x4b7e2b : movsx ecx, word ptr [ebp + 0x20]
0x4b7e2f : sub eax, ecx
0x4b7e31 : mov dword ptr [ebp - 4], eax
0x4b7e34 : movsx eax, word ptr [ebp + 0x10] 	(graphics.c:2538)
0x4b7e38 : test eax, eax
0x4b7e3a : jge 0x53
0x4b7e40 : -movsx eax, word ptr [ebp + 0x24]
0x4b7e44 : -movsx ecx, word ptr [ebp + 0x10]
         : +movsx eax, word ptr [ebp + 0x10] 	(graphics.c:2539)
         : +movsx ecx, word ptr [ebp + 0x24]
0x4b7e48 : add eax, ecx
0x4b7e4a : mov word ptr [ebp + 0x24], ax
0x4b7e4e : movsx eax, word ptr [ebp + 0x24] 	(graphics.c:2540)
0x4b7e52 : test eax, eax
0x4b7e54 : jg 0x5
0x4b7e5a : jmp 0x268 	(graphics.c:2541)
0x4b7e5f : xor eax, eax 	(graphics.c:2543)
0x4b7e61 : mov ecx, dword ptr [ebp + 0x14]
0x4b7e64 : movsx ecx, word ptr [ecx + 0x28]
0x4b7e68 : movsx edx, word ptr [ebp + 0x10]

---
+++
@@ -0x4b7e88,43 +0x4831cd,43 @@
0x4b7e88 : neg eax
0x4b7e8a : sub dword ptr [ebp - 8], eax
0x4b7e8d : mov word ptr [ebp + 0x10], 0 	(graphics.c:2545)
0x4b7e93 : mov eax, dword ptr [ebp + 8] 	(graphics.c:2547)
0x4b7e96 : xor ecx, ecx
0x4b7e98 : mov cx, word ptr [eax + 0x36]
0x4b7e9c : movsx eax, word ptr [ebp + 0x10]
0x4b7ea0 : cmp ecx, eax
0x4b7ea2 : jg 0x5
0x4b7ea8 : jmp 0x21a 	(graphics.c:2548)
0x4b7ead : -movsx eax, word ptr [ebp + 0x24]
0x4b7eb1 : -movsx ecx, word ptr [ebp + 0x10]
         : +movsx eax, word ptr [ebp + 0x10] 	(graphics.c:2550)
         : +movsx ecx, word ptr [ebp + 0x24]
0x4b7eb5 : add eax, ecx
0x4b7eb7 : mov ecx, dword ptr [ebp + 8]
0x4b7eba : xor edx, edx
0x4b7ebc : mov dx, word ptr [ecx + 0x36]
0x4b7ec0 : cmp eax, edx
0x4b7ec2 : jle 0x1f
0x4b7ec8 : movsx eax, word ptr [ebp + 0x24] 	(graphics.c:2551)
0x4b7ecc : -movsx ecx, word ptr [ebp + 0x24]
0x4b7ed0 : -movsx edx, word ptr [ebp + 0x10]
         : +movsx ecx, word ptr [ebp + 0x10]
         : +movsx edx, word ptr [ebp + 0x24]
0x4b7ed4 : add ecx, edx
0x4b7ed6 : mov edx, dword ptr [ebp + 8]
0x4b7ed9 : xor ebx, ebx
0x4b7edb : mov bx, word ptr [edx + 0x36]
0x4b7edf : sub ecx, ebx
0x4b7ee1 : sub eax, ecx
0x4b7ee3 : mov word ptr [ebp + 0x24], ax
0x4b7ee7 : movsx eax, word ptr [ebp + 0xc] 	(graphics.c:2553)
0x4b7eeb : test eax, eax
0x4b7eed : jge 0x59
0x4b7ef3 : -movsx eax, word ptr [ebp + 0x20]
0x4b7ef7 : -movsx ecx, word ptr [ebp + 0xc]
         : +movsx eax, word ptr [ebp + 0xc] 	(graphics.c:2554)
         : +movsx ecx, word ptr [ebp + 0x20]
0x4b7efb : add eax, ecx
0x4b7efd : mov word ptr [ebp + 0x20], ax
0x4b7f01 : movsx eax, word ptr [ebp + 0x20] 	(graphics.c:2555)
0x4b7f05 : test eax, eax
0x4b7f07 : jg 0x5
0x4b7f0d : jmp 0x1b5 	(graphics.c:2556)
0x4b7f12 : xor eax, eax 	(graphics.c:2558)
0x4b7f14 : movsx ecx, word ptr [ebp + 0xc]
0x4b7f18 : sub eax, ecx
0x4b7f1a : neg eax

---
+++
@@ -0x4b7f41,30 +0x483286,30 @@
0x4b7f41 : neg eax
0x4b7f43 : sub dword ptr [ebp - 4], eax
0x4b7f46 : mov word ptr [ebp + 0xc], 0 	(graphics.c:2562)
0x4b7f4c : mov eax, dword ptr [ebp + 8] 	(graphics.c:2564)
0x4b7f4f : xor ecx, ecx
0x4b7f51 : mov cx, word ptr [eax + 0x34]
0x4b7f55 : movsx eax, word ptr [ebp + 0xc]
0x4b7f59 : cmp ecx, eax
0x4b7f5b : jg 0x5
0x4b7f61 : jmp 0x161 	(graphics.c:2565)
0x4b7f66 : -movsx eax, word ptr [ebp + 0x20]
0x4b7f6a : -movsx ecx, word ptr [ebp + 0xc]
         : +movsx eax, word ptr [ebp + 0xc] 	(graphics.c:2567)
         : +movsx ecx, word ptr [ebp + 0x20]
0x4b7f6e : add eax, ecx
0x4b7f70 : mov ecx, dword ptr [ebp + 8]
0x4b7f73 : xor edx, edx
0x4b7f75 : mov dx, word ptr [ecx + 0x34]
0x4b7f79 : cmp eax, edx
0x4b7f7b : jle 0x2f
0x4b7f81 : -movsx eax, word ptr [ebp + 0x20]
0x4b7f85 : -movsx ecx, word ptr [ebp + 0xc]
         : +movsx eax, word ptr [ebp + 0xc] 	(graphics.c:2568)
         : +movsx ecx, word ptr [ebp + 0x20]
0x4b7f89 : add eax, ecx
0x4b7f8b : mov ecx, dword ptr [ebp + 8]
0x4b7f8e : xor edx, edx
0x4b7f90 : mov dx, word ptr [ecx + 0x34]
0x4b7f94 : sub eax, edx
0x4b7f96 : mov dword ptr [ebp - 0x24], eax
0x4b7f99 : movsx eax, word ptr [ebp + 0x20] 	(graphics.c:2569)
0x4b7f9d : sub eax, dword ptr [ebp - 0x24]
0x4b7fa0 : mov word ptr [ebp + 0x20], ax
0x4b7fa4 : mov eax, dword ptr [ebp - 0x24] 	(graphics.c:2570)


DRPixelmapRectangleMaskedCopy is only 94.71% similar to the original, diff above
```

#### Effective match analysis

All shown changes are operand-load reorderings before `add` (e.g., loading `[ebp+0x24]` and `[ebp+0x10]` in opposite registers, then doing `add eax, ecx`). Since integer addition is commutative and no intervening flag-dependent instructions use those loads, the computed sums and subsequent stores/branches are unchanged. The branch structure and targets in the shown regions are the same (no control-flow reshuffling indicated), so functionally this diff is equivalent.

#### Original match

```
---
+++
@@ -0x4b7e34,21 +0x482eb7,21 @@
0x4b7e34 : movsx eax, word ptr [ebp + 0x10] 	(graphics.c:2521)
0x4b7e38 : test eax, eax
0x4b7e3a : jge 0x53
0x4b7e40 : movsx eax, word ptr [ebp + 0x24] 	(graphics.c:2522)
0x4b7e44 : movsx ecx, word ptr [ebp + 0x10]
0x4b7e48 : add eax, ecx
0x4b7e4a : mov word ptr [ebp + 0x24], ax
0x4b7e4e : movsx eax, word ptr [ebp + 0x24] 	(graphics.c:2523)
0x4b7e52 : test eax, eax
0x4b7e54 : jg 0x5
0x4b7e5a : -jmp 0x268
         : +jmp 0x260 	(graphics.c:2524)
0x4b7e5f : xor eax, eax 	(graphics.c:2526)
0x4b7e61 : mov ecx, dword ptr [ebp + 0x14]
0x4b7e64 : movsx ecx, word ptr [ecx + 0x28]
0x4b7e68 : movsx edx, word ptr [ebp + 0x10]
0x4b7e6c : imul ecx, edx
0x4b7e6f : sub eax, ecx
0x4b7e71 : neg eax
0x4b7e73 : sub dword ptr [ebp - 0xc], eax
0x4b7e76 : xor eax, eax 	(graphics.c:2527)
0x4b7e78 : mov ecx, dword ptr [ebp + 8]

---
+++
@@ -0x4b7e86,50 +0x482f09,46 @@
0x4b7e86 : sub eax, ecx
0x4b7e88 : neg eax
0x4b7e8a : sub dword ptr [ebp - 8], eax
0x4b7e8d : mov word ptr [ebp + 0x10], 0 	(graphics.c:2528)
0x4b7e93 : mov eax, dword ptr [ebp + 8] 	(graphics.c:2530)
0x4b7e96 : xor ecx, ecx
0x4b7e98 : mov cx, word ptr [eax + 0x36]
0x4b7e9c : movsx eax, word ptr [ebp + 0x10]
0x4b7ea0 : cmp ecx, eax
0x4b7ea2 : jg 0x5
0x4b7ea8 : -jmp 0x21a
         : +jmp 0x212 	(graphics.c:2531)
0x4b7ead : movsx eax, word ptr [ebp + 0x24] 	(graphics.c:2533)
0x4b7eb1 : movsx ecx, word ptr [ebp + 0x10]
0x4b7eb5 : add eax, ecx
0x4b7eb7 : mov ecx, dword ptr [ebp + 8]
0x4b7eba : xor edx, edx
0x4b7ebc : mov dx, word ptr [ecx + 0x36]
0x4b7ec0 : cmp eax, edx
0x4b7ec2 : -jle 0x1f
0x4b7ec8 : -movsx eax, word ptr [ebp + 0x24]
0x4b7ecc : -movsx ecx, word ptr [ebp + 0x24]
0x4b7ed0 : -movsx edx, word ptr [ebp + 0x10]
0x4b7ed4 : -add ecx, edx
0x4b7ed6 : -mov edx, dword ptr [ebp + 8]
0x4b7ed9 : -xor ebx, ebx
0x4b7edb : -mov bx, word ptr [edx + 0x36]
0x4b7edf : -sub ecx, ebx
0x4b7ee1 : -sub eax, ecx
0x4b7ee3 : -mov word ptr [ebp + 0x24], ax
         : +jle 0x13
         : +mov eax, dword ptr [ebp + 8] 	(graphics.c:2534)
         : +xor ecx, ecx
         : +mov cx, word ptr [eax + 0x36]
         : +movsx eax, word ptr [ebp + 0x10]
         : +sub ecx, eax
         : +mov word ptr [ebp + 0x24], cx
0x4b7ee7 : movsx eax, word ptr [ebp + 0xc] 	(graphics.c:2536)
0x4b7eeb : test eax, eax
0x4b7eed : jge 0x59
0x4b7ef3 : movsx eax, word ptr [ebp + 0x20] 	(graphics.c:2537)
0x4b7ef7 : movsx ecx, word ptr [ebp + 0xc]
0x4b7efb : add eax, ecx
0x4b7efd : mov word ptr [ebp + 0x20], ax
0x4b7f01 : movsx eax, word ptr [ebp + 0x20] 	(graphics.c:2538)
0x4b7f05 : test eax, eax
0x4b7f07 : jg 0x5
0x4b7f0d : -jmp 0x1b5
         : +jmp 0x1b9 	(graphics.c:2539)
0x4b7f12 : xor eax, eax 	(graphics.c:2541)
0x4b7f14 : movsx ecx, word ptr [ebp + 0xc]
0x4b7f18 : sub eax, ecx
0x4b7f1a : neg eax
0x4b7f1c : sub dword ptr [ebp - 0xc], eax
0x4b7f1f : xor eax, eax 	(graphics.c:2542)
0x4b7f21 : movsx ecx, word ptr [ebp + 0xc]
0x4b7f25 : sub eax, ecx
0x4b7f27 : neg eax
0x4b7f29 : sub dword ptr [ebp - 8], eax

---
+++
@@ -0x4b7f3f,106 +0x482fb6,115 @@
0x4b7f3f : sub eax, ecx
0x4b7f41 : neg eax
0x4b7f43 : sub dword ptr [ebp - 4], eax
0x4b7f46 : mov word ptr [ebp + 0xc], 0 	(graphics.c:2545)
0x4b7f4c : mov eax, dword ptr [ebp + 8] 	(graphics.c:2547)
0x4b7f4f : xor ecx, ecx
0x4b7f51 : mov cx, word ptr [eax + 0x34]
0x4b7f55 : movsx eax, word ptr [ebp + 0xc]
0x4b7f59 : cmp ecx, eax
0x4b7f5b : jg 0x5
0x4b7f61 : -jmp 0x161
         : +jmp 0x165 	(graphics.c:2548)
0x4b7f66 : movsx eax, word ptr [ebp + 0x20] 	(graphics.c:2550)
0x4b7f6a : movsx ecx, word ptr [ebp + 0xc]
0x4b7f6e : add eax, ecx
0x4b7f70 : mov ecx, dword ptr [ebp + 8]
0x4b7f73 : xor edx, edx
0x4b7f75 : mov dx, word ptr [ecx + 0x34]
0x4b7f79 : cmp eax, edx
0x4b7f7b : -jle 0x2f
         : +jle 0x43
0x4b7f81 : movsx eax, word ptr [ebp + 0x20] 	(graphics.c:2551)
0x4b7f85 : movsx ecx, word ptr [ebp + 0xc]
0x4b7f89 : add eax, ecx
0x4b7f8b : mov ecx, dword ptr [ebp + 8]
0x4b7f8e : xor edx, edx
0x4b7f90 : mov dx, word ptr [ecx + 0x34]
0x4b7f94 : sub eax, edx
0x4b7f96 : -mov dword ptr [ebp - 0x24], eax
         : +add dword ptr [ebp - 0x20], eax
0x4b7f99 : movsx eax, word ptr [ebp + 0x20] 	(graphics.c:2552)
0x4b7f9d : -sub eax, dword ptr [ebp - 0x24]
0x4b7fa0 : -mov word ptr [ebp + 0x20], ax
0x4b7fa4 : -mov eax, dword ptr [ebp - 0x24]
0x4b7fa7 : -add dword ptr [ebp - 0x20], eax
0x4b7faa : -mov eax, dword ptr [ebp - 0x24]
         : +movsx ecx, word ptr [ebp + 0xc]
         : +add eax, ecx
         : +mov ecx, dword ptr [ebp + 8]
         : +xor edx, edx
         : +mov dx, word ptr [ecx + 0x34]
         : +sub eax, edx
0x4b7fad : add dword ptr [ebp - 4], eax
         : +mov eax, dword ptr [ebp + 8] 	(graphics.c:2553)
         : +xor ecx, ecx
         : +mov cx, word ptr [eax + 0x34]
         : +movsx eax, word ptr [ebp + 0xc]
         : +sub ecx, eax
         : +mov word ptr [ebp + 0x20], cx
0x4b7fb0 : cmp dword ptr [gCurrent_conversion_table (DATA)], 0 	(graphics.c:2556)
0x4b7fb7 : -je 0x91
         : +je 0x89
0x4b7fbd : mov eax, dword ptr [gCurrent_conversion_table (DATA)] 	(graphics.c:2557)
0x4b7fc2 : mov eax, dword ptr [eax + 8]
0x4b7fc5 : mov dword ptr [ebp - 0x10], eax
0x4b7fc8 : -mov dword ptr [ebp - 0x1c], 0
0x4b7fcf : -jmp 0x3
0x4b7fd4 : -inc dword ptr [ebp - 0x1c]
0x4b7fd7 : -movsx eax, word ptr [ebp + 0x24]
0x4b7fdb : -cmp eax, dword ptr [ebp - 0x1c]
0x4b7fde : -jle 0x65
0x4b7fe4 : -mov dword ptr [ebp - 0x14], 0
0x4b7feb : -jmp 0x3
0x4b7ff0 : -inc dword ptr [ebp - 0x14]
0x4b7ff3 : -movsx eax, word ptr [ebp + 0x20]
0x4b7ff7 : -cmp eax, dword ptr [ebp - 0x14]
0x4b7ffa : -jle 0x38
0x4b8000 : -mov eax, dword ptr [ebp - 0xc]
0x4b8003 : -mov al, byte ptr [eax]
0x4b8005 : -mov byte ptr [ebp - 0x18], al
0x4b8008 : -inc dword ptr [ebp - 0xc]
0x4b800b : -xor eax, eax
0x4b800d : -mov al, byte ptr [ebp - 0x18]
0x4b8010 : -test eax, eax
0x4b8012 : -je 0x18
0x4b8018 : -xor eax, eax
0x4b801a : -mov al, byte ptr [ebp - 0x18]
0x4b801d : -mov ecx, dword ptr [ebp - 0x10]
0x4b8020 : -mov al, byte ptr [eax + ecx]
0x4b8023 : -mov ecx, dword ptr [ebp - 8]
0x4b8026 : -mov byte ptr [ecx], al
0x4b8028 : -inc dword ptr [ebp - 8]
0x4b802b : -jmp 0x3
0x4b8030 : -inc dword ptr [ebp - 8]
0x4b8033 : -jmp -0x48
0x4b8038 : -mov eax, dword ptr [ebp - 4]
0x4b803b : -add dword ptr [ebp - 8], eax
0x4b803e : -mov eax, dword ptr [ebp - 0x20]
0x4b8041 : -add dword ptr [ebp - 0xc], eax
0x4b8044 : -jmp -0x75
0x4b8049 : -jmp 0x79
0x4b804e : mov dword ptr [ebp - 0x1c], 0 	(graphics.c:2558)
0x4b8055 : jmp 0x3
0x4b805a : inc dword ptr [ebp - 0x1c]
0x4b805d : movsx eax, word ptr [ebp + 0x24]
0x4b8061 : cmp eax, dword ptr [ebp - 0x1c]
0x4b8064 : jle 0x5d
0x4b806a : mov dword ptr [ebp - 0x14], 0 	(graphics.c:2559)
0x4b8071 : jmp 0x3
0x4b8076 : inc dword ptr [ebp - 0x14]
0x4b8079 : movsx eax, word ptr [ebp + 0x20]
0x4b807d : cmp eax, dword ptr [ebp - 0x14]
0x4b8080 : jle 0x30
0x4b8086 : mov eax, dword ptr [ebp - 0xc] 	(graphics.c:2560)
0x4b8089 : mov al, byte ptr [eax]
0x4b808b : mov byte ptr [ebp - 0x18], al
0x4b808e : -inc dword ptr [ebp - 0xc]
0x4b8091 : xor eax, eax 	(graphics.c:2561)
0x4b8093 : mov al, byte ptr [ebp - 0x18]
0x4b8096 : test eax, eax
0x4b8098 : je 0x10
         : +xor eax, eax 	(graphics.c:2562)
         : +mov al, byte ptr [ebp - 0x18]
         : +mov ecx, dword ptr [ebp - 0x10]
         : +mov al, byte ptr [eax + ecx]
         : +mov ecx, dword ptr [ebp - 8]
         : +mov byte ptr [ecx], al
         : +inc dword ptr [ebp - 0xc] 	(graphics.c:2564)
         : +inc dword ptr [ebp - 8] 	(graphics.c:2565)
         : +jmp -0x40 	(graphics.c:2566)
         : +mov eax, dword ptr [ebp - 0x20] 	(graphics.c:2567)
         : +add dword ptr [ebp - 0xc], eax
         : +mov eax, dword ptr [ebp - 4] 	(graphics.c:2568)
         : +add dword ptr [ebp - 8], eax
         : +jmp -0x6d 	(graphics.c:2569)
         : +jmp 0x71 	(graphics.c:2570)
         : +mov dword ptr [ebp - 0x1c], 0 	(graphics.c:2571)
         : +jmp 0x3
         : +inc dword ptr [ebp - 0x1c]
         : +movsx eax, word ptr [ebp + 0x24]
         : +cmp eax, dword ptr [ebp - 0x1c]
         : +jle 0x55
         : +mov dword ptr [ebp - 0x14], 0 	(graphics.c:2572)
         : +jmp 0x3
         : +inc dword ptr [ebp - 0x14]
         : +movsx eax, word ptr [ebp + 0x20]
         : +cmp eax, dword ptr [ebp - 0x14]
         : +jle 0x28
         : +mov eax, dword ptr [ebp - 0xc] 	(graphics.c:2573)
         : +mov al, byte ptr [eax]
         : +mov byte ptr [ebp - 0x18], al
         : +xor eax, eax 	(graphics.c:2574)
         : +mov al, byte ptr [ebp - 0x18]
         : +test eax, eax
         : +je 0x8
0x4b809e : mov al, byte ptr [ebp - 0x18] 	(graphics.c:2575)
0x4b80a1 : mov ecx, dword ptr [ebp - 8]
0x4b80a4 : mov byte ptr [ecx], al
         : +inc dword ptr [ebp - 0xc] 	(graphics.c:2577)
0x4b80a6 : inc dword ptr [ebp - 8] 	(graphics.c:2578)
0x4b80a9 : -jmp 0x3
0x4b80ae : -inc dword ptr [ebp - 8]
0x4b80b1 : -jmp -0x40
         : +jmp -0x38 	(graphics.c:2579)
         : +mov eax, dword ptr [ebp - 0x20] 	(graphics.c:2580)
         : +add dword ptr [ebp - 0xc], eax
0x4b80b6 : mov eax, dword ptr [ebp - 4] 	(graphics.c:2581)
0x4b80b9 : add dword ptr [ebp - 8], eax
0x4b80bc : -mov eax, dword ptr [ebp - 0x20]
0x4b80bf : -add dword ptr [ebp - 0xc], eax
         : +jmp -0x65 	(graphics.c:2582)
         : +pop edi 	(graphics.c:2584)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRPixelmapRectangleMaskedCopy is only 69.80% similar to the original, diff above
```

*AI generated. Time taken: 171s, tokens: 26,689*
