### PR TITLE
DRPixelmapRectangleOnscreenCopy 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -2617,22 +2617,23 @@ void DRPixelmapRectangleOnscreenCopy(br_pixelmap* pDest, br_int_16 pDest_x, br_i
     }
 #endif
 
+    source_ptr = (tU8*)pSource->pixels + (pSource->row_bytes * pSource_y + pSource_x);
+    dest_ptr = (tU8*)pDest->pixels + (pDest->row_bytes * pDest_y + pDest_x);
     source_row_wrap = pSource->row_bytes - pWidth;
     dest_row_wrap = pDest->row_bytes - pWidth;
-    dest_ptr = (tU8*)pDest->pixels + (pDest->row_bytes * pDest_y + pDest_x);
-    source_ptr = (tU8*)pSource->pixels + (pSource->row_bytes * pSource_y + pSource_x);
 
     for (y_count = 0; y_count < pHeight; y_count++) {
         for (x_count = 0; x_count < pWidth; x_count++) {
-            the_byte = *source_ptr;
+            the_byte = *source_ptr++;
             if (the_byte) {
                 *dest_ptr = the_byte;
+                dest_ptr++;
+            } else {
+                dest_ptr++;
             }
-            source_ptr++;
-            dest_ptr++;
         }
-        source_ptr += source_row_wrap;
         dest_ptr += dest_row_wrap;
+        source_ptr += source_row_wrap;
     }
 }
 

--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -168,7 +168,7 @@ char* gFont_names[21] = {
 
 // GLOBAL: CARM95 0x005201a0
 br_colour gRGB_colours[9] = {
-    BR_COLOUR_RGB(0x00 ,0x00, 0x00),
+    BR_COLOUR_RGB(0x00, 0x00, 0x00),
     BR_COLOUR_RGB(0xff, 0xff, 0xff),
     BR_COLOUR_RGB(0xff, 0x00, 0x00),
     BR_COLOUR_RGB(0x00, 0xff, 0x00),
@@ -2626,8 +2626,7 @@ void DRPixelmapRectangleOnscreenCopy(br_pixelmap* pDest, br_int_16 pDest_x, br_i
         for (x_count = 0; x_count < pWidth; x_count++) {
             the_byte = *source_ptr++;
             if (the_byte) {
-                *dest_ptr = the_byte;
-                dest_ptr++;
+                *dest_ptr++ = the_byte;
             } else {
                 dest_ptr++;
             }


### PR DESCRIPTION
## Match result

```
0x4b8105: DRPixelmapRectangleOnscreenCopy 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4b8105,65 +0x483180,69 @@
0x4b8105 : push ebp 	(graphics.c:2602)
0x4b8106 : mov ebp, esp
0x4b8108 : sub esp, 0x24
0x4b810b : push ebx
0x4b810c : push esi
0x4b810d : push edi
0x4b810e : mov eax, dword ptr [ebp + 0x14] 	(graphics.c:2620)
0x4b8111 : movsx eax, word ptr [eax + 0x28]
0x4b8115 : -movsx ecx, word ptr [ebp + 0x1c]
0x4b8119 : -imul eax, ecx
0x4b811c : -movsx ecx, word ptr [ebp + 0x18]
0x4b8120 : -add eax, ecx
0x4b8122 : -mov ecx, dword ptr [ebp + 0x14]
0x4b8125 : -add eax, dword ptr [ecx + 8]
0x4b8128 : -mov dword ptr [ebp - 0xc], eax
         : +movsx ecx, word ptr [ebp + 0x20]
         : +sub eax, ecx
         : +mov dword ptr [ebp - 0x20], eax
         : +mov eax, dword ptr [ebp + 8] 	(graphics.c:2621)
         : +movsx eax, word ptr [eax + 0x28]
         : +movsx ecx, word ptr [ebp + 0x20]
         : +sub eax, ecx
         : +mov dword ptr [ebp - 4], eax
0x4b812b : mov eax, dword ptr [ebp + 8] 	(graphics.c:2622)
0x4b812e : movsx eax, word ptr [eax + 0x28]
0x4b8132 : movsx ecx, word ptr [ebp + 0x10]
0x4b8136 : imul eax, ecx
0x4b8139 : movsx ecx, word ptr [ebp + 0xc]
0x4b813d : add eax, ecx
0x4b813f : mov ecx, dword ptr [ebp + 8]
0x4b8142 : add eax, dword ptr [ecx + 8]
0x4b8145 : mov dword ptr [ebp - 8], eax
0x4b8148 : mov eax, dword ptr [ebp + 0x14] 	(graphics.c:2623)
0x4b814b : movsx eax, word ptr [eax + 0x28]
0x4b814f : -movsx ecx, word ptr [ebp + 0x20]
0x4b8153 : -sub eax, ecx
0x4b8155 : -mov dword ptr [ebp - 0x20], eax
0x4b8158 : -mov eax, dword ptr [ebp + 8]
0x4b815b : -movsx eax, word ptr [eax + 0x28]
0x4b815f : -movsx ecx, word ptr [ebp + 0x20]
0x4b8163 : -sub eax, ecx
0x4b8165 : -mov dword ptr [ebp - 4], eax
         : +movsx ecx, word ptr [ebp + 0x1c]
         : +imul eax, ecx
         : +movsx ecx, word ptr [ebp + 0x18]
         : +add eax, ecx
         : +mov ecx, dword ptr [ebp + 0x14]
         : +add eax, dword ptr [ecx + 8]
         : +mov dword ptr [ebp - 0xc], eax
0x4b8168 : mov dword ptr [ebp - 0x1c], 0 	(graphics.c:2625)
0x4b816f : jmp 0x3
0x4b8174 : inc dword ptr [ebp - 0x1c]
0x4b8177 : movsx eax, word ptr [ebp + 0x24]
0x4b817b : cmp eax, dword ptr [ebp - 0x1c]
0x4b817e : -jle 0x5d
         : +jle 0x55
0x4b8184 : mov dword ptr [ebp - 0x14], 0 	(graphics.c:2626)
0x4b818b : jmp 0x3
0x4b8190 : inc dword ptr [ebp - 0x14]
0x4b8193 : movsx eax, word ptr [ebp + 0x20]
0x4b8197 : cmp eax, dword ptr [ebp - 0x14]
0x4b819a : -jle 0x30
         : +jle 0x28
0x4b81a0 : mov eax, dword ptr [ebp - 0xc] 	(graphics.c:2627)
0x4b81a3 : mov al, byte ptr [eax]
0x4b81a5 : mov byte ptr [ebp - 0x18], al
0x4b81a8 : -inc dword ptr [ebp - 0xc]
0x4b81ab : xor eax, eax 	(graphics.c:2628)
0x4b81ad : mov al, byte ptr [ebp - 0x18]
0x4b81b0 : test eax, eax
0x4b81b2 : -je 0x10
         : +je 0x8
0x4b81b8 : mov al, byte ptr [ebp - 0x18] 	(graphics.c:2629)
0x4b81bb : mov ecx, dword ptr [ebp - 8]
0x4b81be : mov byte ptr [ecx], al
         : +inc dword ptr [ebp - 0xc] 	(graphics.c:2631)
0x4b81c0 : inc dword ptr [ebp - 8] 	(graphics.c:2632)
0x4b81c3 : -jmp 0x3
0x4b81c8 : -inc dword ptr [ebp - 8]
0x4b81cb : -jmp -0x40
         : +jmp -0x38 	(graphics.c:2633)
         : +mov eax, dword ptr [ebp - 0x20] 	(graphics.c:2634)
         : +add dword ptr [ebp - 0xc], eax
0x4b81d0 : mov eax, dword ptr [ebp - 4] 	(graphics.c:2635)
0x4b81d3 : add dword ptr [ebp - 8], eax
0x4b81d6 : -mov eax, dword ptr [ebp - 0x20]
0x4b81d9 : -add dword ptr [ebp - 0xc], eax
         : +jmp -0x65 	(graphics.c:2636)
         : +pop edi 	(graphics.c:2637)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRPixelmapRectangleOnscreenCopy is only 61.19% similar to the original, diff above
```

*AI generated. Time taken: 221s, tokens: 20,677*
