### PR TITLE
DropInImageFromTop 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -3260,13 +3260,9 @@ void DropInImageFromTop(br_pixelmap* pImage, int pLeft, int pTop, int pTop_clip,
     tS32 the_time;
     int drop_distance;
 
-    start_time = PDGetTotalTime();
     drop_distance = pImage->height - pTop_clip + pTop;
-    while (1) {
-        the_time = PDGetTotalTime();
-        if (the_time >= start_time + 100) {
-            break;
-        }
+    start_time = PDGetTotalTime();
+    while (start_time + 100 > (the_time = PDGetTotalTime())) {
         DrawDropImage(pImage,
             pLeft,
             pTop,


### PR DESCRIPTION
## Match result

```
0x4b9adf: DropInImageFromTop 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b9adf,51 +0x484b51,52 @@
0x4b9adf : push ebp 	(graphics.c:3258)
0x4b9ae0 : mov ebp, esp
0x4b9ae2 : sub esp, 0xc
0x4b9ae5 : push ebx
0x4b9ae6 : push esi
0x4b9ae7 : push edi
         : +call PDGetTotalTime (FUNCTION) 	(graphics.c:3263)
         : +mov dword ptr [ebp - 0xc], eax
0x4b9ae8 : mov eax, dword ptr [ebp + 8] 	(graphics.c:3264)
0x4b9aeb : xor ecx, ecx
0x4b9aed : mov cx, word ptr [eax + 0x36]
0x4b9af1 : sub ecx, dword ptr [ebp + 0x14]
0x4b9af4 : add ecx, dword ptr [ebp + 0x10]
0x4b9af7 : mov dword ptr [ebp - 8], ecx
0x4b9afa : call PDGetTotalTime (FUNCTION) 	(graphics.c:3266)
0x4b9aff : -mov dword ptr [ebp - 0xc], eax
0x4b9b02 : -call PDGetTotalTime (FUNCTION)
0x4b9b07 : mov dword ptr [ebp - 4], eax
0x4b9b0a : mov eax, dword ptr [ebp - 0xc] 	(graphics.c:3267)
0x4b9b0d : add eax, 0x64
0x4b9b10 : cmp eax, dword ptr [ebp - 4]
0x4b9b13 : -jle 0x37
         : +jg 0x5
         : +jmp 0x37 	(graphics.c:3268)
0x4b9b19 : mov eax, dword ptr [ebp - 4] 	(graphics.c:3275)
0x4b9b1c : sub eax, dword ptr [ebp - 0xc]
0x4b9b1f : sub eax, 0x64
0x4b9b22 : imul eax, dword ptr [ebp - 8]
0x4b9b26 : mov ecx, 0x64
0x4b9b2b : cdq 
0x4b9b2c : idiv ecx
0x4b9b2e : push eax
0x4b9b2f : mov eax, dword ptr [ebp + 0x18]
0x4b9b32 : push eax
0x4b9b33 : mov eax, dword ptr [ebp + 0x14]
0x4b9b36 : push eax
0x4b9b37 : mov eax, dword ptr [ebp + 0x10]
0x4b9b3a : push eax
0x4b9b3b : mov eax, dword ptr [ebp + 0xc]
0x4b9b3e : push eax
0x4b9b3f : mov eax, dword ptr [ebp + 8]
0x4b9b42 : push eax
0x4b9b43 : call DrawDropImage (FUNCTION)
0x4b9b48 : add esp, 0x18
0x4b9b4b : -jmp -0x4e
         : +jmp -0x53 	(graphics.c:3276)
0x4b9b50 : push 0 	(graphics.c:3277)
0x4b9b52 : mov eax, dword ptr [ebp + 0x18]
0x4b9b55 : push eax
0x4b9b56 : mov eax, dword ptr [ebp + 0x14]
0x4b9b59 : push eax
0x4b9b5a : mov eax, dword ptr [ebp + 0x10]
0x4b9b5d : push eax
0x4b9b5e : mov eax, dword ptr [ebp + 0xc]
0x4b9b61 : push eax
0x4b9b62 : mov eax, dword ptr [ebp + 8]


DropInImageFromTop is only 92.44% similar to the original, diff above
```

*AI generated. Time taken: 570s, tokens: 40,194*
