### PR TITLE
DrawDropImage 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -3227,30 +3227,31 @@ void DrawDropImage(br_pixelmap* pImage, int pLeft, int pTop, int pTop_clip, int 
         pImage->width,
         pBottom_clip - pTop_clip,
         0);
-    if (pOffset != 1000) {
-        src_y = 0;
-        src_height = pImage->height;
-        y = pOffset + pTop;
-        y_diff = pTop_clip - y;
-        if (y_diff > 0) {
-            src_height -= y_diff;
-            y += y_diff;
-            src_y = y_diff;
-        }
-        y_diff = pBottom_clip - y - pImage->height;
-        if (y_diff < 0) {
-            src_height += y_diff;
-        }
-        BrPixelmapRectangleCopy(gBack_screen,
-            pLeft,
-            y,
-            pImage,
-            0,
-            src_y,
-            pImage->width,
-            src_height);
-        PDScreenBufferSwap(0);
+    if (pOffset == 1000) {
+        return;
     }
+    src_y = 0;
+    src_height = pImage->height;
+    y = pOffset + pTop;
+    y_diff = pTop_clip - y;
+    if (y_diff > 0) {
+        src_y += y_diff;
+        src_height -= y_diff;
+        y += y_diff;
+    }
+    y_diff = pBottom_clip - y - pImage->height;
+    if (y_diff < 0) {
+        src_height += y_diff;
+    }
+    BrPixelmapRectangleCopy(gBack_screen,
+        pLeft,
+        y,
+        pImage,
+        0,
+        src_y,
+        pImage->width,
+        src_height);
+    PDScreenBufferSwap(0);
 }
 
 // IDA: void __usercall DropInImageFromTop(br_pixelmap *pImage@<EAX>, int pLeft@<EDX>, int pTop@<EBX>, int pTop_clip@<ECX>, int pBottom_clip)


### PR DESCRIPTION
## Match result

```
0x4b9b73: DrawDropImage 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b9b8e,43 +0x484a87,42 @@
0x4b9b8e : push ecx
0x4b9b8f : mov eax, dword ptr [ebp + 0x14]
0x4b9b92 : push eax
0x4b9b93 : mov eax, dword ptr [ebp + 0xc]
0x4b9b96 : push eax
0x4b9b97 : mov eax, dword ptr [gBack_screen (DATA)]
0x4b9b9c : push eax
0x4b9b9d : call BrPixelmapRectangleFill (FUNCTION)
0x4b9ba2 : add esp, 0x18
0x4b9ba5 : cmp dword ptr [ebp + 0x1c], 0x3e8 	(graphics.c:3230)
0x4b9bac : -jne 0x5
0x4b9bb2 : -jmp 0xa1
         : +je 0xa1
0x4b9bb7 : mov dword ptr [ebp - 0x10], 0 	(graphics.c:3231)
0x4b9bbe : mov eax, dword ptr [ebp + 8] 	(graphics.c:3232)
0x4b9bc1 : xor ecx, ecx
0x4b9bc3 : mov cx, word ptr [eax + 0x36]
0x4b9bc7 : mov dword ptr [ebp - 4], ecx
0x4b9bca : mov eax, dword ptr [ebp + 0x1c] 	(graphics.c:3233)
0x4b9bcd : add eax, dword ptr [ebp + 0x10]
0x4b9bd0 : mov dword ptr [ebp - 8], eax
0x4b9bd3 : mov eax, dword ptr [ebp + 0x14] 	(graphics.c:3234)
0x4b9bd6 : sub eax, dword ptr [ebp - 8]
0x4b9bd9 : mov dword ptr [ebp - 0xc], eax
0x4b9bdc : cmp dword ptr [ebp - 0xc], 0 	(graphics.c:3235)
0x4b9be0 : jle 0x16
0x4b9be6 : -mov eax, dword ptr [ebp - 0xc]
0x4b9be9 : -add dword ptr [ebp - 0x10], eax
0x4b9bec : xor eax, eax 	(graphics.c:3236)
0x4b9bee : sub eax, dword ptr [ebp - 0xc]
0x4b9bf1 : neg eax
0x4b9bf3 : sub dword ptr [ebp - 4], eax
0x4b9bf6 : mov eax, dword ptr [ebp - 0xc] 	(graphics.c:3237)
0x4b9bf9 : add dword ptr [ebp - 8], eax
         : +mov eax, dword ptr [ebp - 0xc] 	(graphics.c:3238)
         : +mov dword ptr [ebp - 0x10], eax
0x4b9bfc : mov eax, dword ptr [ebp + 0x18] 	(graphics.c:3240)
0x4b9bff : sub eax, dword ptr [ebp - 8]
0x4b9c02 : mov ecx, dword ptr [ebp + 8]
0x4b9c05 : xor edx, edx
0x4b9c07 : mov dx, word ptr [ecx + 0x36]
0x4b9c0b : sub eax, edx
0x4b9c0d : mov dword ptr [ebp - 0xc], eax
0x4b9c10 : cmp dword ptr [ebp - 0xc], 0 	(graphics.c:3241)
0x4b9c14 : jge 0x6
0x4b9c1a : mov eax, dword ptr [ebp - 0xc] 	(graphics.c:3242)

---
+++
@@ -0x4b9c3b,10 +0x484b2f,15 @@
0x4b9c3b : push eax
0x4b9c3c : mov eax, dword ptr [ebp + 0xc]
0x4b9c3f : push eax
0x4b9c40 : mov eax, dword ptr [gBack_screen (DATA)]
0x4b9c45 : push eax
0x4b9c46 : call BrPixelmapRectangleCopy (FUNCTION)
0x4b9c4b : add esp, 0x20
0x4b9c4e : push 0 	(graphics.c:3252)
0x4b9c50 : call PDScreenBufferSwap (FUNCTION)
0x4b9c55 : add esp, 4
         : +pop edi 	(graphics.c:3254)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DrawDropImage is only 92.59% similar to the original, diff above
```

*AI generated. Time taken: 98s, tokens: 19,075*
