### PR TITLE
DropOutImageThruBottom 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -3284,13 +3284,9 @@ void DropOutImageThruBottom(br_pixelmap* pImage, int pLeft, int pTop, int pTop_c
     tS32 the_time;
     int drop_distance;
 
-    start_time = PDGetTotalTime();
     drop_distance = pBottom_clip - pTop;
-    while (1) {
-        the_time = PDGetTotalTime();
-        if (the_time >= start_time + 100) {
-            break;
-        }
+    start_time = PDGetTotalTime();
+    while ((the_time = PDGetTotalTime()) < start_time + 100) {
         DrawDropImage(pImage,
             pLeft,
             pTop,


### PR DESCRIPTION
## Match result

```
0x4b9c5d: DropOutImageThruBottom 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b9c5d,47 +0x484bea,48 @@
0x4b9c5d : push ebp 	(graphics.c:3282)
0x4b9c5e : mov ebp, esp
0x4b9c60 : sub esp, 0xc
0x4b9c63 : push ebx
0x4b9c64 : push esi
0x4b9c65 : push edi
         : +call PDGetTotalTime (FUNCTION) 	(graphics.c:3287)
         : +mov dword ptr [ebp - 0xc], eax
0x4b9c66 : mov eax, dword ptr [ebp + 0x18] 	(graphics.c:3288)
0x4b9c69 : sub eax, dword ptr [ebp + 0x10]
0x4b9c6c : mov dword ptr [ebp - 8], eax
0x4b9c6f : -call PDGetTotalTime (FUNCTION)
0x4b9c74 : -mov dword ptr [ebp - 0xc], eax
0x4b9c77 : call PDGetTotalTime (FUNCTION) 	(graphics.c:3290)
0x4b9c7c : mov dword ptr [ebp - 4], eax
0x4b9c7f : mov eax, dword ptr [ebp - 0xc] 	(graphics.c:3291)
0x4b9c82 : add eax, 0x64
0x4b9c85 : cmp eax, dword ptr [ebp - 4]
0x4b9c88 : -jle 0x34
         : +jg 0x5
         : +jmp 0x34 	(graphics.c:3292)
0x4b9c8e : mov eax, dword ptr [ebp - 4] 	(graphics.c:3299)
0x4b9c91 : sub eax, dword ptr [ebp - 0xc]
0x4b9c94 : imul eax, dword ptr [ebp - 8]
0x4b9c98 : mov ecx, 0x64
0x4b9c9d : cdq 
0x4b9c9e : idiv ecx
0x4b9ca0 : push eax
0x4b9ca1 : mov eax, dword ptr [ebp + 0x18]
0x4b9ca4 : push eax
0x4b9ca5 : mov eax, dword ptr [ebp + 0x14]
0x4b9ca8 : push eax
0x4b9ca9 : mov eax, dword ptr [ebp + 0x10]
0x4b9cac : push eax
0x4b9cad : mov eax, dword ptr [ebp + 0xc]
0x4b9cb0 : push eax
0x4b9cb1 : mov eax, dword ptr [ebp + 8]
0x4b9cb4 : push eax
0x4b9cb5 : call DrawDropImage (FUNCTION)
0x4b9cba : add esp, 0x18
0x4b9cbd : -jmp -0x4b
         : +jmp -0x50 	(graphics.c:3300)
0x4b9cc2 : push 0x3e8 	(graphics.c:3301)
0x4b9cc7 : mov eax, dword ptr [ebp + 0x18]
0x4b9cca : push eax
0x4b9ccb : mov eax, dword ptr [ebp + 0x14]
0x4b9cce : push eax
0x4b9ccf : mov eax, dword ptr [ebp + 0x10]
0x4b9cd2 : push eax
0x4b9cd3 : mov eax, dword ptr [ebp + 0xc]
0x4b9cd6 : push eax
0x4b9cd7 : mov eax, dword ptr [ebp + 8]


DropOutImageThruBottom is only 91.89% similar to the original, diff above
```

*AI generated. Time taken: 870s, tokens: 153,975*
