### PR TITLE
DropInImageFromBottom 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -3308,13 +3308,9 @@ void DropInImageFromBottom(br_pixelmap* pImage, int pLeft, int pTop, int pTop_cl
     tS32 the_time;
     int drop_distance;
 
-    start_time = PDGetTotalTime();
     drop_distance = pBottom_clip - pTop;
-    while (1) {
-        the_time = PDGetTotalTime();
-        if (the_time >= start_time + 100) {
-            break;
-        }
+    start_time = PDGetTotalTime();
+    while ((the_time = PDGetTotalTime()) < start_time + 100) {
         DrawDropImage(pImage,
             pLeft,
             pTop,


### PR DESCRIPTION
## Match result

```
0x4b9ce8: DropInImageFromBottom 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b9ce8,48 +0x484c7a,49 @@
0x4b9ce8 : push ebp 	(graphics.c:3306)
0x4b9ce9 : mov ebp, esp
0x4b9ceb : sub esp, 0xc
0x4b9cee : push ebx
0x4b9cef : push esi
0x4b9cf0 : push edi
         : +call PDGetTotalTime (FUNCTION) 	(graphics.c:3311)
         : +mov dword ptr [ebp - 0xc], eax
0x4b9cf1 : mov eax, dword ptr [ebp + 0x18] 	(graphics.c:3312)
0x4b9cf4 : sub eax, dword ptr [ebp + 0x10]
0x4b9cf7 : mov dword ptr [ebp - 8], eax
0x4b9cfa : -call PDGetTotalTime (FUNCTION)
0x4b9cff : -mov dword ptr [ebp - 0xc], eax
0x4b9d02 : call PDGetTotalTime (FUNCTION) 	(graphics.c:3314)
0x4b9d07 : mov dword ptr [ebp - 4], eax
0x4b9d0a : mov eax, dword ptr [ebp - 0xc] 	(graphics.c:3315)
0x4b9d0d : add eax, 0x64
0x4b9d10 : cmp eax, dword ptr [ebp - 4]
0x4b9d13 : -jle 0x39
         : +jg 0x5
         : +jmp 0x39 	(graphics.c:3316)
0x4b9d19 : mov eax, 0x64 	(graphics.c:3323)
0x4b9d1e : sub eax, dword ptr [ebp - 4]
0x4b9d21 : add eax, dword ptr [ebp - 0xc]
0x4b9d24 : imul eax, dword ptr [ebp - 8]
0x4b9d28 : mov ecx, 0x64
0x4b9d2d : cdq 
0x4b9d2e : idiv ecx
0x4b9d30 : push eax
0x4b9d31 : mov eax, dword ptr [ebp + 0x18]
0x4b9d34 : push eax
0x4b9d35 : mov eax, dword ptr [ebp + 0x14]
0x4b9d38 : push eax
0x4b9d39 : mov eax, dword ptr [ebp + 0x10]
0x4b9d3c : push eax
0x4b9d3d : mov eax, dword ptr [ebp + 0xc]
0x4b9d40 : push eax
0x4b9d41 : mov eax, dword ptr [ebp + 8]
0x4b9d44 : push eax
0x4b9d45 : call DrawDropImage (FUNCTION)
0x4b9d4a : add esp, 0x18
0x4b9d4d : -jmp -0x50
         : +jmp -0x55 	(graphics.c:3324)
0x4b9d52 : push 0 	(graphics.c:3325)
0x4b9d54 : mov eax, dword ptr [ebp + 0x18]
0x4b9d57 : push eax
0x4b9d58 : mov eax, dword ptr [ebp + 0x14]
0x4b9d5b : push eax
0x4b9d5c : mov eax, dword ptr [ebp + 0x10]
0x4b9d5f : push eax
0x4b9d60 : mov eax, dword ptr [ebp + 0xc]
0x4b9d63 : push eax
0x4b9d64 : mov eax, dword ptr [ebp + 8]


DropInImageFromBottom is only 92.04% similar to the original, diff above
```

*AI generated. Time taken: 483s, tokens: 41,401*
