### PR TITLE
DropOutImageThruTop 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -3332,13 +3332,9 @@ void DropOutImageThruTop(br_pixelmap* pImage, int pLeft, int pTop, int pTop_clip
     tS32 the_time;
     int drop_distance;
 
-    start_time = PDGetTotalTime();
     drop_distance = pImage->height - pTop_clip + pTop;
-    while (1) {
-        the_time = PDGetTotalTime();
-        if (the_time >= start_time + 100) {
-            break;
-        }
+    start_time = PDGetTotalTime();
+    while ((the_time = PDGetTotalTime()) < start_time + 100) {
         DrawDropImage(pImage,
             pLeft,
             pTop,


### PR DESCRIPTION
## Match result

```
0x4b9d75: DropOutImageThruTop 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b9d75,50 +0x484d0c,51 @@
0x4b9d75 : push ebp 	(graphics.c:3330)
0x4b9d76 : mov ebp, esp
0x4b9d78 : sub esp, 0xc
0x4b9d7b : push ebx
0x4b9d7c : push esi
0x4b9d7d : push edi
         : +call PDGetTotalTime (FUNCTION) 	(graphics.c:3335)
         : +mov dword ptr [ebp - 0xc], eax
0x4b9d7e : mov eax, dword ptr [ebp + 8] 	(graphics.c:3336)
0x4b9d81 : xor ecx, ecx
0x4b9d83 : mov cx, word ptr [eax + 0x36]
0x4b9d87 : sub ecx, dword ptr [ebp + 0x14]
0x4b9d8a : add ecx, dword ptr [ebp + 0x10]
0x4b9d8d : mov dword ptr [ebp - 8], ecx
0x4b9d90 : call PDGetTotalTime (FUNCTION) 	(graphics.c:3338)
0x4b9d95 : -mov dword ptr [ebp - 0xc], eax
0x4b9d98 : -call PDGetTotalTime (FUNCTION)
0x4b9d9d : mov dword ptr [ebp - 4], eax
0x4b9da0 : mov eax, dword ptr [ebp - 0xc] 	(graphics.c:3339)
0x4b9da3 : add eax, 0x64
0x4b9da6 : cmp eax, dword ptr [ebp - 4]
0x4b9da9 : -jle 0x34
         : +jg 0x5
         : +jmp 0x34 	(graphics.c:3340)
0x4b9daf : mov eax, dword ptr [ebp - 0xc] 	(graphics.c:3347)
0x4b9db2 : sub eax, dword ptr [ebp - 4]
0x4b9db5 : imul eax, dword ptr [ebp - 8]
0x4b9db9 : mov ecx, 0x64
0x4b9dbe : cdq 
0x4b9dbf : idiv ecx
0x4b9dc1 : push eax
0x4b9dc2 : mov eax, dword ptr [ebp + 0x18]
0x4b9dc5 : push eax
0x4b9dc6 : mov eax, dword ptr [ebp + 0x14]
0x4b9dc9 : push eax
0x4b9dca : mov eax, dword ptr [ebp + 0x10]
0x4b9dcd : push eax
0x4b9dce : mov eax, dword ptr [ebp + 0xc]
0x4b9dd1 : push eax
0x4b9dd2 : mov eax, dword ptr [ebp + 8]
0x4b9dd5 : push eax
0x4b9dd6 : call DrawDropImage (FUNCTION)
0x4b9ddb : add esp, 0x18
0x4b9dde : -jmp -0x4b
         : +jmp -0x50 	(graphics.c:3348)
0x4b9de3 : push 0x3e8 	(graphics.c:3349)
0x4b9de8 : mov eax, dword ptr [ebp + 0x18]
0x4b9deb : push eax
0x4b9dec : mov eax, dword ptr [ebp + 0x14]
0x4b9def : push eax
0x4b9df0 : mov eax, dword ptr [ebp + 0x10]
0x4b9df3 : push eax
0x4b9df4 : mov eax, dword ptr [ebp + 0xc]
0x4b9df7 : push eax
0x4b9df8 : mov eax, dword ptr [ebp + 8]


DropOutImageThruTop is only 92.31% similar to the original, diff above
```

*AI generated. Time taken: 680s, tokens: 95,701*
