### PR TITLE
TellyInImage 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -3389,19 +3389,11 @@ void TellyInImage(br_pixelmap* pImage, int pLeft, int pTop) {
     tS32 the_time;
 
     start_time = PDGetTotalTime();
-    while (1) {
-        the_time = PDGetTotalTime();
-        if (start_time + 100 <= the_time) {
-            break;
-        }
+    while (start_time + 100 > (the_time = PDGetTotalTime())) {
         DrawTellyLine(pImage, pLeft, pTop, 100 * (the_time - start_time) / 100);
     }
     start_time = PDGetTotalTime();
-    while (1) {
-        the_time = PDGetTotalTime();
-        if (start_time + 100 <= the_time) {
-            break;
-        }
+    while (start_time + 100 > (the_time = PDGetTotalTime())) {
         DrawTellyImage(pImage, pLeft, pTop, 100 * (the_time - start_time) / 100);
     }
     DrawTellyImage(pImage, pLeft, pTop, 100);


### PR DESCRIPTION
## Match result

```
0x4b9e09: TellyInImage 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b9e0f,65 +0x484f08,67 @@
0x4b9e0f : push ebx
0x4b9e10 : push esi
0x4b9e11 : push edi
0x4b9e12 : call PDGetTotalTime (FUNCTION) 	(graphics.c:3391)
0x4b9e17 : mov dword ptr [ebp - 8], eax
0x4b9e1a : call PDGetTotalTime (FUNCTION) 	(graphics.c:3393)
0x4b9e1f : mov dword ptr [ebp - 4], eax
0x4b9e22 : mov eax, dword ptr [ebp - 8] 	(graphics.c:3394)
0x4b9e25 : add eax, 0x64
0x4b9e28 : cmp eax, dword ptr [ebp - 4]
0x4b9e2b : -jle 0x31
         : +jg 0x5
         : +jmp 0x31 	(graphics.c:3395)
0x4b9e31 : mov eax, dword ptr [ebp - 4] 	(graphics.c:3397)
0x4b9e34 : sub eax, dword ptr [ebp - 8]
0x4b9e37 : shl eax, 2
0x4b9e3a : lea eax, [eax + eax*4]
0x4b9e3d : lea eax, [eax + eax*4]
0x4b9e40 : mov ecx, 0x64
0x4b9e45 : cdq 
0x4b9e46 : idiv ecx
0x4b9e48 : push eax
0x4b9e49 : mov eax, dword ptr [ebp + 0x10]
0x4b9e4c : push eax
0x4b9e4d : mov eax, dword ptr [ebp + 0xc]
0x4b9e50 : push eax
0x4b9e51 : mov eax, dword ptr [ebp + 8]
0x4b9e54 : push eax
0x4b9e55 : call DrawTellyLine (FUNCTION)
0x4b9e5a : add esp, 0x10
0x4b9e5d : -jmp -0x48
         : +jmp -0x4d 	(graphics.c:3398)
0x4b9e62 : call PDGetTotalTime (FUNCTION) 	(graphics.c:3399)
0x4b9e67 : mov dword ptr [ebp - 8], eax
0x4b9e6a : call PDGetTotalTime (FUNCTION) 	(graphics.c:3401)
0x4b9e6f : mov dword ptr [ebp - 4], eax
0x4b9e72 : mov eax, dword ptr [ebp - 8] 	(graphics.c:3402)
0x4b9e75 : add eax, 0x64
0x4b9e78 : cmp eax, dword ptr [ebp - 4]
0x4b9e7b : -jle 0x31
         : +jg 0x5
         : +jmp 0x31 	(graphics.c:3403)
0x4b9e81 : mov eax, dword ptr [ebp - 4] 	(graphics.c:3405)
0x4b9e84 : sub eax, dword ptr [ebp - 8]
0x4b9e87 : shl eax, 2
0x4b9e8a : lea eax, [eax + eax*4]
0x4b9e8d : lea eax, [eax + eax*4]
0x4b9e90 : mov ecx, 0x64
0x4b9e95 : cdq 
0x4b9e96 : idiv ecx
0x4b9e98 : push eax
0x4b9e99 : mov eax, dword ptr [ebp + 0x10]
0x4b9e9c : push eax
0x4b9e9d : mov eax, dword ptr [ebp + 0xc]
0x4b9ea0 : push eax
0x4b9ea1 : mov eax, dword ptr [ebp + 8]
0x4b9ea4 : push eax
0x4b9ea5 : call DrawTellyImage (FUNCTION)
0x4b9eaa : add esp, 0x10
0x4b9ead : -jmp -0x48
         : +jmp -0x4d 	(graphics.c:3406)
0x4b9eb2 : push 0x64 	(graphics.c:3407)
0x4b9eb4 : mov eax, dword ptr [ebp + 0x10]
0x4b9eb7 : push eax
0x4b9eb8 : mov eax, dword ptr [ebp + 0xc]
0x4b9ebb : push eax
0x4b9ebc : mov eax, dword ptr [ebp + 8]
0x4b9ebf : push eax
0x4b9ec0 : call DrawTellyImage (FUNCTION)
0x4b9ec5 : add esp, 0x10
0x4b9ec8 : pop edi 	(graphics.c:3408)


TellyInImage is only 93.15% similar to the original, diff above
```

*AI generated. Time taken: 249s, tokens: 27,674*
