### PR TITLE
DrawTellyLine 100% effective match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -3356,9 +3356,9 @@ void DrawTellyLine(br_pixelmap* pImage, int pLeft, int pTop, int pPercentage) {
     int the_height;
 
     the_width = pImage->width;
-    the_height = pImage->height / 2 + pTop;
-    BrPixelmapLine(gBack_screen, pLeft, the_height, pLeft + the_width, the_height, 0);
-    BrPixelmapLine(gBack_screen, the_width / 2 + pLeft - pPercentage * the_width / 200, the_height, the_width / 2 + pLeft + pPercentage * the_width / 200, the_height, 1);
+    the_height = pImage->height;
+    BrPixelmapLine(gBack_screen, pLeft, the_height / 2 + pTop, pLeft + the_width, the_height / 2 + pTop, 0);
+    BrPixelmapLine(gBack_screen, the_width / 2 + pLeft - pPercentage * the_width / 200, the_height / 2 + pTop, the_width / 2 + pLeft + pPercentage * the_width / 200, the_height / 2 + pTop, 1);
     PDScreenBufferSwap(0);
 }
 


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4b9ee7,22 +0x484dbf,22 @@
0x4b9ee7 : mov cx, word ptr [eax + 0x36]
0x4b9eeb : mov dword ptr [ebp - 8], ecx
0x4b9eee : push 0 	(graphics.c:3360)
0x4b9ef0 : mov eax, dword ptr [ebp - 8]
0x4b9ef3 : cdq 
0x4b9ef4 : sub eax, edx
0x4b9ef6 : sar eax, 1
0x4b9ef8 : mov ecx, dword ptr [ebp + 0x10]
0x4b9efb : add ecx, eax
0x4b9efd : push ecx
0x4b9efe : -mov eax, dword ptr [ebp + 0xc]
0x4b9f01 : -add eax, dword ptr [ebp - 4]
         : +mov eax, dword ptr [ebp - 4]
         : +add eax, dword ptr [ebp + 0xc]
0x4b9f04 : push eax
0x4b9f05 : mov eax, dword ptr [ebp - 8]
0x4b9f08 : cdq 
0x4b9f09 : sub eax, edx
0x4b9f0b : sar eax, 1
0x4b9f0d : mov ecx, dword ptr [ebp + 0x10]
0x4b9f10 : add ecx, eax
0x4b9f12 : push ecx
0x4b9f13 : mov eax, dword ptr [ebp + 0xc]
0x4b9f16 : push eax


0x4b9ecd: DrawTellyLine 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x4b9ed3,72 +0x484dab,70 @@
0x4b9ed3 : push ebx
0x4b9ed4 : push esi
0x4b9ed5 : push edi
0x4b9ed6 : mov eax, dword ptr [ebp + 8] 	(graphics.c:3358)
0x4b9ed9 : xor ecx, ecx
0x4b9edb : mov cx, word ptr [eax + 0x34]
0x4b9edf : mov dword ptr [ebp - 4], ecx
0x4b9ee2 : mov eax, dword ptr [ebp + 8] 	(graphics.c:3359)
0x4b9ee5 : xor ecx, ecx
0x4b9ee7 : mov cx, word ptr [eax + 0x36]
         : +sar ecx, 1
         : +add ecx, dword ptr [ebp + 0x10]
0x4b9eeb : mov dword ptr [ebp - 8], ecx
0x4b9eee : push 0 	(graphics.c:3360)
0x4b9ef0 : mov eax, dword ptr [ebp - 8]
0x4b9ef3 : -cdq 
0x4b9ef4 : -sub eax, edx
0x4b9ef6 : -sar eax, 1
0x4b9ef8 : -mov ecx, dword ptr [ebp + 0x10]
0x4b9efb : -add ecx, eax
0x4b9efd : -push ecx
0x4b9efe : -mov eax, dword ptr [ebp + 0xc]
0x4b9f01 : -add eax, dword ptr [ebp - 4]
         : +push eax
         : +mov eax, dword ptr [ebp - 4]
         : +add eax, dword ptr [ebp + 0xc]
0x4b9f04 : push eax
0x4b9f05 : mov eax, dword ptr [ebp - 8]
0x4b9f08 : -cdq 
0x4b9f09 : -sub eax, edx
0x4b9f0b : -sar eax, 1
0x4b9f0d : -mov ecx, dword ptr [ebp + 0x10]
0x4b9f10 : -add ecx, eax
0x4b9f12 : -push ecx
         : +push eax
0x4b9f13 : mov eax, dword ptr [ebp + 0xc]
0x4b9f16 : push eax
0x4b9f17 : mov eax, dword ptr [gBack_screen (DATA)]
0x4b9f1c : push eax
0x4b9f1d : call BrPixelmapLine (FUNCTION)
0x4b9f22 : add esp, 0x18
0x4b9f25 : push 1 	(graphics.c:3361)
0x4b9f27 : mov eax, dword ptr [ebp - 8]
0x4b9f2a : -cdq 
0x4b9f2b : -sub eax, edx
0x4b9f2d : -sar eax, 1
0x4b9f2f : -mov ecx, dword ptr [ebp + 0x10]
0x4b9f32 : -add ecx, eax
0x4b9f34 : -push ecx
         : +push eax
0x4b9f35 : mov eax, dword ptr [ebp - 4]
0x4b9f38 : imul eax, dword ptr [ebp + 0x14]
0x4b9f3c : mov ecx, 0xc8
0x4b9f41 : cdq 
0x4b9f42 : idiv ecx
0x4b9f44 : mov ecx, eax
0x4b9f46 : mov eax, dword ptr [ebp - 4]
0x4b9f49 : cdq 
0x4b9f4a : sub eax, edx
0x4b9f4c : sar eax, 1
0x4b9f4e : add ecx, eax
0x4b9f50 : add ecx, dword ptr [ebp + 0xc]
0x4b9f53 : push ecx
0x4b9f54 : mov eax, dword ptr [ebp - 8]
0x4b9f57 : -cdq 
0x4b9f58 : -sub eax, edx
0x4b9f5a : -sar eax, 1
0x4b9f5c : -mov ecx, dword ptr [ebp + 0x10]
0x4b9f5f : -add ecx, eax
0x4b9f61 : -push ecx
         : +push eax
0x4b9f62 : mov eax, dword ptr [ebp - 4]
0x4b9f65 : cdq 
0x4b9f66 : sub eax, edx
0x4b9f68 : sar eax, 1
0x4b9f6a : mov ecx, dword ptr [ebp + 0xc]
0x4b9f6d : add ecx, eax
0x4b9f6f : mov eax, dword ptr [ebp - 4]
0x4b9f72 : imul eax, dword ptr [ebp + 0x14]
0x4b9f76 : mov ebx, 0xc8
         : +cdq 
         : +idiv ebx
         : +sub ecx, eax
         : +push ecx
         : +mov eax, dword ptr [gBack_screen (DATA)]
         : +push eax
         : +call BrPixelmapLine (FUNCTION)
         : +add esp, 0x18
         : +push 0 	(graphics.c:3362)
         : +call PDScreenBufferSwap (FUNCTION)
         : +add esp, 4
         : +pop edi 	(graphics.c:3363)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DrawTellyLine is only 66.22% similar to the original, diff above
```

*AI generated. Time taken: 77s, tokens: 31,285*
