### PR TITLE
DrawTellyImage 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -3359,12 +3359,14 @@ void DrawTellyLine(br_pixelmap* pImage, int pLeft, int pTop, int pPercentage) {
 void DrawTellyImage(br_pixelmap* pImage, int pLeft, int pTop, int pPercentage) {
     int the_height;
 
-    BrPixelmapRectangleFill(gBack_screen, pLeft, pTop, pImage->width, pImage->height, 0);
-    if (pPercentage != 1000) {
+    the_height = pImage->height;
+    BrPixelmapRectangleFill(gBack_screen, pLeft, pTop, pImage->width, the_height, 0);
+    if (pPercentage == 1000) {
+    } else {
         DRPixelmapRectangleVScaledCopy(
             gBack_screen,
             pLeft,
-            pTop + pImage->height * (100 - pPercentage) / 200,
+            pTop + the_height * (100 - pPercentage) / 200,
             pImage,
             0,
             0,


### PR DESCRIPTION
## Match result

```
0x4b9f9e: DrawTellyImage 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b9f9e,66 +0x484f7e,68 @@
0x4b9f9e : push ebp 	(graphics.c:3359)
0x4b9f9f : mov ebp, esp
0x4b9fa1 : sub esp, 4
0x4b9fa4 : push ebx
0x4b9fa5 : push esi
0x4b9fa6 : push edi
         : +push 0 	(graphics.c:3362)
0x4b9fa7 : mov eax, dword ptr [ebp + 8]
0x4b9faa : xor ecx, ecx
0x4b9fac : mov cx, word ptr [eax + 0x36]
0x4b9fb0 : -mov dword ptr [ebp - 4], ecx
0x4b9fb3 : -push 0
0x4b9fb5 : -mov eax, dword ptr [ebp - 4]
0x4b9fb8 : -push eax
         : +push ecx
0x4b9fb9 : mov eax, dword ptr [ebp + 8]
0x4b9fbc : xor ecx, ecx
0x4b9fbe : mov cx, word ptr [eax + 0x34]
0x4b9fc2 : push ecx
0x4b9fc3 : mov eax, dword ptr [ebp + 0x10]
0x4b9fc6 : push eax
0x4b9fc7 : mov eax, dword ptr [ebp + 0xc]
0x4b9fca : push eax
0x4b9fcb : mov eax, dword ptr [gBack_screen (DATA)]
0x4b9fd0 : push eax
0x4b9fd1 : call BrPixelmapRectangleFill (FUNCTION)
0x4b9fd6 : add esp, 0x18
0x4b9fd9 : cmp dword ptr [ebp + 0x14], 0x3e8 	(graphics.c:3363)
0x4b9fe0 : -jne 0x5
0x4b9fe6 : -jmp 0x5e
         : +je 0x68
0x4b9feb : mov eax, dword ptr [ebp + 8] 	(graphics.c:3372)
0x4b9fee : xor ecx, ecx
0x4b9ff0 : mov cx, word ptr [eax + 0x36]
0x4b9ff4 : imul ecx, dword ptr [ebp + 0x14]
0x4b9ff8 : mov ebx, 0x64
0x4b9ffd : mov eax, ecx
0x4b9fff : cdq 
0x4ba000 : idiv ebx
0x4ba002 : push eax
0x4ba003 : mov eax, dword ptr [ebp + 8]
0x4ba006 : mov ax, word ptr [eax + 0x34]
0x4ba00a : push eax
0x4ba00b : push 0
0x4ba00d : push 0
0x4ba00f : mov eax, dword ptr [ebp + 8]
0x4ba012 : push eax
         : +mov eax, dword ptr [ebp + 8]
         : +xor ecx, ecx
         : +mov cx, word ptr [eax + 0x36]
0x4ba013 : mov eax, 0x64
0x4ba018 : sub eax, dword ptr [ebp + 0x14]
0x4ba01b : -imul eax, dword ptr [ebp - 4]
0x4ba01f : -mov ecx, 0xc8
         : +imul ecx, eax
         : +mov ebx, 0xc8
         : +mov eax, ecx
0x4ba024 : cdq 
0x4ba025 : -idiv ecx
         : +idiv ebx
0x4ba027 : mov ecx, dword ptr [ebp + 0x10]
0x4ba02a : add ecx, eax
0x4ba02c : push ecx
0x4ba02d : mov eax, dword ptr [ebp + 0xc]
0x4ba030 : push eax
0x4ba031 : mov eax, dword ptr [gBack_screen (DATA)]
0x4ba036 : push eax
0x4ba037 : call DRPixelmapRectangleVScaledCopy (FUNCTION)
0x4ba03c : add esp, 0x20
0x4ba03f : push 0 	(graphics.c:3373)
0x4ba041 : call PDScreenBufferSwap (FUNCTION)
0x4ba046 : add esp, 4
0x4ba049 : pop edi 	(graphics.c:3375)
0x4ba04a : pop esi
0x4ba04b : pop ebx
0x4ba04c : leave 
         : +ret 


DrawTellyImage is only 85.07% similar to the original, diff above
```

*AI generated. Time taken: 145s, tokens: 27,750*
