### PR TITLE
TellyOutImage 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -3399,22 +3399,14 @@ void TellyOutImage(br_pixelmap* pImage, int pLeft, int pTop) {
     int drop_distance;
 
     start_time = PDGetTotalTime();
-    while (1) {
-        the_time = PDGetTotalTime();
-        if (start_time + 100 <= the_time) {
-            break;
-        }
-        DrawTellyImage(pImage, pLeft, pTop, 100 * (start_time + 100 - the_time) / 100);
+    while (start_time + 100 > (the_time = PDGetTotalTime())) {
+        DrawTellyImage(pImage, pLeft, pTop, (100 - the_time + start_time) * 100 / 100);
     }
     DrawTellyImage(pImage, pLeft, pTop, 1000);
 
     start_time = PDGetTotalTime();
-    while (1) {
-        the_time = PDGetTotalTime();
-        if (start_time + 100 <= the_time) {
-            break;
-        }
-        DrawTellyLine(pImage, pLeft, pTop, 100 * (start_time + 100 - the_time) / 100);
+    while (start_time + 100 > (the_time = PDGetTotalTime())) {
+        DrawTellyLine(pImage, pLeft, pTop, (100 - the_time + start_time) * 100 / 100);
     }
     DrawTellyLine(pImage, pLeft, pTop, 0);
 }


### PR DESCRIPTION
## Match result

```
0x4ba04e: TellyOutImage 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4ba054,76 +0x4850f7,78 @@
0x4ba054 : push ebx
0x4ba055 : push esi
0x4ba056 : push edi
0x4ba057 : call PDGetTotalTime (FUNCTION) 	(graphics.c:3401)
0x4ba05c : mov dword ptr [ebp - 0xc], eax
0x4ba05f : call PDGetTotalTime (FUNCTION) 	(graphics.c:3403)
0x4ba064 : mov dword ptr [ebp - 4], eax
0x4ba067 : mov eax, dword ptr [ebp - 0xc] 	(graphics.c:3404)
0x4ba06a : add eax, 0x64
0x4ba06d : cmp eax, dword ptr [ebp - 4]
0x4ba070 : -jle 0x36
0x4ba076 : -mov eax, 0x64
         : +jg 0x5
         : +jmp 0x34 	(graphics.c:3405)
         : +mov eax, dword ptr [ebp - 0xc] 	(graphics.c:3407)
         : +add eax, 0x64
0x4ba07b : sub eax, dword ptr [ebp - 4]
0x4ba07e : -add eax, dword ptr [ebp - 0xc]
0x4ba081 : shl eax, 2
0x4ba084 : lea eax, [eax + eax*4]
0x4ba087 : lea eax, [eax + eax*4]
0x4ba08a : mov ecx, 0x64
0x4ba08f : cdq 
0x4ba090 : idiv ecx
0x4ba092 : push eax
0x4ba093 : mov eax, dword ptr [ebp + 0x10]
0x4ba096 : push eax
0x4ba097 : mov eax, dword ptr [ebp + 0xc]
0x4ba09a : push eax
0x4ba09b : mov eax, dword ptr [ebp + 8]
0x4ba09e : push eax
0x4ba09f : call DrawTellyImage (FUNCTION)
0x4ba0a4 : add esp, 0x10
0x4ba0a7 : -jmp -0x4d
         : +jmp -0x50 	(graphics.c:3408)
0x4ba0ac : push 0x3e8 	(graphics.c:3409)
0x4ba0b1 : mov eax, dword ptr [ebp + 0x10]
0x4ba0b4 : push eax
0x4ba0b5 : mov eax, dword ptr [ebp + 0xc]
0x4ba0b8 : push eax
0x4ba0b9 : mov eax, dword ptr [ebp + 8]
0x4ba0bc : push eax
0x4ba0bd : call DrawTellyImage (FUNCTION)
0x4ba0c2 : add esp, 0x10
0x4ba0c5 : call PDGetTotalTime (FUNCTION) 	(graphics.c:3411)
0x4ba0ca : mov dword ptr [ebp - 0xc], eax
0x4ba0cd : call PDGetTotalTime (FUNCTION) 	(graphics.c:3413)
0x4ba0d2 : mov dword ptr [ebp - 4], eax
0x4ba0d5 : mov eax, dword ptr [ebp - 0xc] 	(graphics.c:3414)
0x4ba0d8 : add eax, 0x64
0x4ba0db : cmp eax, dword ptr [ebp - 4]
0x4ba0de : -jle 0x36
0x4ba0e4 : -mov eax, 0x64
         : +jg 0x5
         : +jmp 0x34 	(graphics.c:3415)
         : +mov eax, dword ptr [ebp - 0xc] 	(graphics.c:3417)
         : +add eax, 0x64
0x4ba0e9 : sub eax, dword ptr [ebp - 4]
0x4ba0ec : -add eax, dword ptr [ebp - 0xc]
0x4ba0ef : shl eax, 2
0x4ba0f2 : lea eax, [eax + eax*4]
0x4ba0f5 : lea eax, [eax + eax*4]
0x4ba0f8 : mov ecx, 0x64
0x4ba0fd : cdq 
0x4ba0fe : idiv ecx
0x4ba100 : push eax
0x4ba101 : mov eax, dword ptr [ebp + 0x10]
0x4ba104 : push eax
0x4ba105 : mov eax, dword ptr [ebp + 0xc]
0x4ba108 : push eax
0x4ba109 : mov eax, dword ptr [ebp + 8]
0x4ba10c : push eax
0x4ba10d : call DrawTellyLine (FUNCTION)
0x4ba112 : add esp, 0x10
0x4ba115 : -jmp -0x4d
         : +jmp -0x50 	(graphics.c:3418)
0x4ba11a : push 0 	(graphics.c:3419)
0x4ba11c : mov eax, dword ptr [ebp + 0x10]
0x4ba11f : push eax
0x4ba120 : mov eax, dword ptr [ebp + 0xc]
0x4ba123 : push eax
0x4ba124 : mov eax, dword ptr [ebp + 8]
0x4ba127 : push eax
0x4ba128 : call DrawTellyLine (FUNCTION)
0x4ba12d : add esp, 0x10
0x4ba130 : pop edi 	(graphics.c:3420)


TellyOutImage is only 89.29% similar to the original, diff above
```

*AI generated. Time taken: 402s, tokens: 46,576*
