### PR TITLE
SwitchToRealResolution 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -3527,14 +3527,15 @@ void ShadowMode(void) {
 // FUNCTION: CARM95 0x004ba581
 int SwitchToRealResolution(void) {
 
-    if (gGraf_data_index == gReal_graf_data_index) {
+    if (gGraf_data_index != gReal_graf_data_index) {
+        gGraf_data_index = gReal_graf_data_index;
+        gGraf_spec_index = gReal_graf_data_index;
+        gCurrent_graf_data = &gGraf_data[gGraf_data_index];
+        PDSwitchToRealResolution();
+        return 1;
+    } else {
         return 0;
     }
-    gGraf_data_index = gReal_graf_data_index;
-    gGraf_spec_index = gReal_graf_data_index;
-    gCurrent_graf_data = &gGraf_data[gReal_graf_data_index];
-    PDSwitchToRealResolution();
-    return 1;
 }
 
 // IDA: int __cdecl SwitchToLoresMode()


### PR DESCRIPTION
## Match result

```
0x4ba581: SwitchToRealResolution 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4ba581,26 +0x485596,30 @@
0x4ba581 : push ebp 	(graphics.c:3528)
0x4ba582 : mov ebp, esp
0x4ba584 : push ebx
0x4ba585 : push esi
0x4ba586 : push edi
0x4ba587 : mov eax, dword ptr [gGraf_data_index (DATA)] 	(graphics.c:3530)
0x4ba58c : cmp dword ptr [gReal_graf_data_index (DATA)], eax
0x4ba592 : -je 0x43
         : +jne 0x7
         : +xor eax, eax 	(graphics.c:3531)
         : +jmp 0x3e
0x4ba598 : mov eax, dword ptr [gReal_graf_data_index (DATA)] 	(graphics.c:3533)
0x4ba59d : mov dword ptr [gGraf_data_index (DATA)], eax
0x4ba5a2 : mov eax, dword ptr [gReal_graf_data_index (DATA)] 	(graphics.c:3534)
0x4ba5a7 : mov dword ptr [gGraf_spec_index (DATA)], eax
0x4ba5ac : -mov eax, dword ptr [gGraf_data_index (DATA)]
         : +mov eax, dword ptr [gReal_graf_data_index (DATA)] 	(graphics.c:3535)
0x4ba5b1 : mov ecx, eax
0x4ba5b3 : shl eax, 7
0x4ba5b6 : sub eax, ecx
0x4ba5b8 : lea eax, [eax + eax*8]
0x4ba5bb : add eax, ecx
0x4ba5bd : add eax, gGraf_data[0].width (DATA)
0x4ba5c2 : mov dword ptr [gCurrent_graf_data (DATA)], eax
0x4ba5c7 : call PDSwitchToRealResolution (FUNCTION) 	(graphics.c:3536)
0x4ba5cc : mov eax, 1 	(graphics.c:3537)
0x4ba5d1 : -jmp 0xc
0x4ba5d6 : -jmp 0x7
0x4ba5db : -xor eax, eax
0x4ba5dd : jmp 0x0
         : +pop edi 	(graphics.c:3538)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


SwitchToRealResolution is only 75.00% similar to the original, diff above
```

*AI generated. Time taken: 178s, tokens: 20,417*
