### PR TITLE
InitialiseDeathRace 100% match

### DIFF
--- a/src/DETHRACE/common/init.c
+++ b/src/DETHRACE/common/init.c
@@ -657,6 +657,8 @@ void InitialiseApplication(int pArgc, char** pArgv) {
 // IDA: void __usercall InitialiseDeathRace(int pArgc@<EAX>, char **pArgv@<EDX>)
 // FUNCTION: CARM95 0x004bba24
 void InitialiseDeathRace(int pArgc, char** pArgv) {
+    tPath_name the_path;
+
     PDInitialiseSystem();
     InitialiseApplication(pArgc, pArgv);
     gInitialisation_finished = 1;


### PR DESCRIPTION
## Match result

```
0x4bba24: InitialiseDeathRace 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4bba24,13 +0x4864fd,18 @@
0x4bba24 : push ebp 	(init.c:659)
0x4bba25 : mov ebp, esp
0x4bba27 : -sub esp, 0x100
0x4bba2d : push ebx
0x4bba2e : push esi
0x4bba2f : push edi
0x4bba30 : call PDInitialiseSystem (FUNCTION) 	(init.c:660)
0x4bba35 : mov eax, dword ptr [ebp + 0xc] 	(init.c:661)
0x4bba38 : push eax
0x4bba39 : mov eax, dword ptr [ebp + 8]
0x4bba3c : push eax
0x4bba3d : call InitialiseApplication (FUNCTION)
0x4bba42 : add esp, 8
         : +mov dword ptr [gInitialisation_finished (DATA)], 1 	(init.c:662)
         : +pop edi 	(init.c:663)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


InitialiseDeathRace is only 77.42% similar to the original, diff above
```

*AI generated. Time taken: 138s, tokens: 31,989*
