### PR TITLE
AllocateCamera 100% match

### DIFF
--- a/src/DETHRACE/common/init.c
+++ b/src/DETHRACE/common/init.c
@@ -124,10 +124,10 @@ void AllocateCamera(void) {
 
     gRearview_camera->t.t.mat.m[2][2] = -1.0f;
     camera_ptr = (br_camera*)gRearview_camera->type_data;
-    camera_ptr->hither_z = gCamera_hither;
     camera_ptr->type = BR_CAMERA_PERSPECTIVE_FOV;
-    camera_ptr->yon_z = gCamera_yon;
     camera_ptr->field_of_view = BrDegreeToAngle(gCamera_angle);
+    camera_ptr->hither_z = gCamera_hither;
+    camera_ptr->yon_z = gCamera_yon;
     camera_ptr->aspect = (double)gWidth / (double)gHeight;
     gRearview_camera = BrActorAdd(gSelf, gRearview_camera);
     if (gRearview_camera == NULL) {


### PR DESCRIPTION
## Match result

```
0x4bbf22: AllocateCamera 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4bc061,32 +0x485962,32 @@
0x4bc061 : jne 0xa
0x4bc067 : push 5 	(init.c:122)
0x4bc069 : call FatalError (FUNCTION)
0x4bc06e : add esp, 4
0x4bc071 : mov eax, dword ptr [gRearview_camera (DATA)] 	(init.c:125)
0x4bc076 : mov dword ptr [eax + 0x4c], 0xbf800000
0x4bc07d : mov eax, dword ptr [gRearview_camera (DATA)] 	(init.c:126)
0x4bc082 : mov eax, dword ptr [eax + 0x5c]
0x4bc085 : mov dword ptr [ebp - 8], eax
0x4bc088 : mov eax, dword ptr [ebp - 8] 	(init.c:127)
         : +mov ecx, dword ptr [gCamera_hither (DATA)]
         : +mov dword ptr [eax + 8], ecx
         : +mov eax, dword ptr [ebp - 8] 	(init.c:128)
0x4bc08b : mov byte ptr [eax + 4], 1
         : +mov eax, dword ptr [ebp - 8] 	(init.c:129)
         : +mov ecx, dword ptr [gCamera_yon (DATA)]
         : +mov dword ptr [eax + 0xc], ecx
0x4bc08f : fld dword ptr [gCamera_angle (DATA)] 	(init.c:130)
0x4bc095 : fmul qword ptr [182.04444444444445 (FLOAT)]
0x4bc09b : call __ftol (FUNCTION)
0x4bc0a0 : mov ecx, dword ptr [ebp - 8]
0x4bc0a3 : mov word ptr [ecx + 6], ax
0x4bc0a7 : -mov eax, dword ptr [ebp - 8]
0x4bc0aa : -mov ecx, dword ptr [gCamera_hither (DATA)]
0x4bc0b0 : -mov dword ptr [eax + 8], ecx
0x4bc0b3 : -mov eax, dword ptr [ebp - 8]
0x4bc0b6 : -mov ecx, dword ptr [gCamera_yon (DATA)]
0x4bc0bc : -mov dword ptr [eax + 0xc], ecx
0x4bc0bf : mov eax, dword ptr [gWidth (DATA)] 	(init.c:131)
0x4bc0c4 : mov dword ptr [ebp - 0x14], eax
0x4bc0c7 : fild dword ptr [ebp - 0x14]
0x4bc0ca : mov eax, dword ptr [gHeight (DATA)]
0x4bc0cf : mov dword ptr [ebp - 0x18], eax
0x4bc0d2 : fild dword ptr [ebp - 0x18]
0x4bc0d5 : fdivp st(1)
0x4bc0d7 : mov eax, dword ptr [ebp - 8]
0x4bc0da : fstp dword ptr [eax + 0x10]
0x4bc0dd : mov eax, dword ptr [gRearview_camera (DATA)] 	(init.c:132)


AllocateCamera is only 95.56% similar to the original, diff above
```

*AI generated. Time taken: 955s, tokens: 7,113*
