### PR TITLE
RepairCar 100% match

### DIFF
--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -448,12 +448,12 @@ float RepairCar2(tCar_spec* pCar, tU32 pFrame_period, br_scalar* pTotal_deflecti
 // IDA: float __usercall RepairCar@<ST0>(tU16 pCar_ID@<EAX>, tU32 pFrame_period@<EDX>, br_scalar *pTotal_deflection@<EBX>)
 // FUNCTION: CARM95 0x004be159
 float RepairCar(tU16 pCar_ID, tU32 pFrame_period, br_scalar* pTotal_deflection) {
-
-    if (VEHICLE_TYPE_FROM_ID(pCar_ID) == eVehicle_self) {
-        return RepairCar2(&gProgram_state.current_car, pFrame_period, pTotal_deflection);
-    }
-
-    return RepairCar2(GetCarSpec(VEHICLE_TYPE_FROM_ID(pCar_ID), VEHICLE_INDEX_FROM_ID(pCar_ID)), pFrame_period, pTotal_deflection);
+    return RepairCar2(
+        VEHICLE_TYPE_FROM_ID(pCar_ID) == eVehicle_self
+            ? &gProgram_state.current_car
+            : GetCarSpec(VEHICLE_TYPE_FROM_ID(pCar_ID), VEHICLE_INDEX_FROM_ID(pCar_ID)),
+        pFrame_period,
+        pTotal_deflection);
 }
 
 // IDA: void __usercall TotallyRepairACar(tCar_spec *pCar@<EAX>)


### PR DESCRIPTION
## Match result

```
0x4be159: RepairCar 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4be159,40 +0x46b8ae,43 @@
0x4be159 : push ebp 	(crush.c:450)
0x4be15a : mov ebp, esp
0x4be15c : -sub esp, 4
0x4be15f : push ebx
0x4be160 : push esi
0x4be161 : push edi
0x4be162 : mov eax, dword ptr [ebp + 8] 	(crush.c:452)
0x4be165 : and eax, 0xff00
0x4be16a : xor ecx, ecx
0x4be16c : and ecx, 0xffffff00
0x4be172 : cmp eax, ecx
0x4be174 : -jne 0x12
         : +jne 0x20
         : +mov eax, dword ptr [ebp + 0x10] 	(crush.c:453)
         : +push eax
         : +mov eax, dword ptr [ebp + 0xc]
         : +push eax
0x4be17a : mov eax, gProgram_state (DATA)
0x4be17f : add eax, 0xb0
0x4be184 : -mov dword ptr [ebp - 4], eax
0x4be187 : -jmp 0x20
         : +push eax
         : +call RepairCar2 (FUNCTION)
         : +add esp, 0xc
         : +jmp 0x33
         : +mov eax, dword ptr [ebp + 0x10] 	(crush.c:456)
         : +push eax
         : +mov eax, dword ptr [ebp + 0xc]
         : +push eax
0x4be18c : mov eax, dword ptr [ebp + 8]
0x4be18f : and eax, 0xff
0x4be194 : push eax
0x4be195 : mov eax, dword ptr [ebp + 8]
0x4be198 : and eax, 0xffff
0x4be19d : shr eax, 8
0x4be1a0 : push eax
0x4be1a1 : call GetCarSpec (FUNCTION)
0x4be1a6 : add esp, 8
0x4be1a9 : -mov dword ptr [ebp - 4], eax
0x4be1ac : -mov eax, dword ptr [ebp + 0x10]
0x4be1af : -push eax
0x4be1b0 : -mov eax, dword ptr [ebp + 0xc]
0x4be1b3 : -push eax
0x4be1b4 : -mov eax, dword ptr [ebp - 4]
0x4be1b7 : push eax
0x4be1b8 : call RepairCar2 (FUNCTION)
0x4be1bd : add esp, 0xc
0x4be1c0 : jmp 0x0
0x4be1c5 : pop edi 	(crush.c:457)
0x4be1c6 : pop esi
0x4be1c7 : pop ebx
0x4be1c8 : leave 
0x4be1c9 : ret 


RepairCar is only 72.29% similar to the original, diff above
```

*AI generated. Time taken: 101s, tokens: 10,962*
