### PR TITLE
TotallyRepairACar 100% match

### DIFF
--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -467,6 +467,7 @@ void TotallyRepairACar(tCar_spec* pCar) {
     tChanged_vertex pipe_array[600];
     br_bounds storage_bounds;
 
+    pipe_vertex_count = 0;
     StopCarSmokingInstantly(pCar);
     if (IsActionReplayAvailable()) {
         PipeInstantUnSmudge(pCar);
@@ -479,32 +480,31 @@ void TotallyRepairACar(tCar_spec* pCar) {
     }
     memcpy(&storage_bounds, &pCar->bounds[1], sizeof(br_bounds));
     memcpy(&pCar->bounds[1], &pCar->max_bounds[1], sizeof(br_bounds));
-    if (TestForCarInSensiblePlace(pCar)) {
-        for (j = 0; j < pCar->car_actor_count; j++) {
-            the_car_actor = &pCar->car_model_actors[j];
-            if (the_car_actor->undamaged_vertices != NULL) {
-                pipe_vertex_count = 0;
-                for (k = 0; k < the_car_actor->actor->model->nvertices; k++) {
-                    if (pipe_vertex_count < COUNT_OF(pipe_array)) {
-                        BrVector3Sub(&pipe_array[pipe_vertex_count].delta_coordinates,
-                            &the_car_actor->undamaged_vertices[k].p, &the_car_actor->actor->model->vertices[k].p);
-                        if (!Vector3IsZero(&pipe_array[pipe_vertex_count].delta_coordinates)) {
-                            pipe_array[pipe_vertex_count].vertex_index = k;
-                            pipe_vertex_count++;
-                        }
+    if (!TestForCarInSensiblePlace(pCar)) {
+        memcpy(&pCar->bounds[1], &storage_bounds, sizeof(br_bounds));
+        return;
+    }
+    for (j = 0, the_car_actor = pCar->car_model_actors; j < pCar->car_actor_count; j++, the_car_actor++) {
+        if (the_car_actor->undamaged_vertices != NULL) {
+            pipe_vertex_count = 0;
+            for (k = 0; k < the_car_actor->actor->model->nvertices; k++) {
+                if (pipe_vertex_count < COUNT_OF(pipe_array)) {
+                    BrVector3Sub(&pipe_array[pipe_vertex_count].delta_coordinates,
+                        &the_car_actor->undamaged_vertices[k].p, &the_car_actor->actor->model->vertices[k].p);
+                    if (!Vector3IsZero(&pipe_array[pipe_vertex_count].delta_coordinates)) {
+                        pipe_array[pipe_vertex_count].vertex_index = k;
+                        pipe_vertex_count++;
                     }
                 }
-                memcpy(the_car_actor->actor->model->vertices,
-                    the_car_actor->undamaged_vertices,
-                    the_car_actor->actor->model->nvertices * sizeof(br_vertex));
-                BrModelUpdate(the_car_actor->actor->model, BR_MODU_VERTEX_COLOURS | BR_MODU_VERTEX_POSITIONS);
-                if (pipe_vertex_count != 0 && IsActionReplayAvailable()) {
-                    PipeSingleModelGeometry(pCar->car_ID, j, pipe_vertex_count, pipe_array);
-                }
+            }
+            memcpy(the_car_actor->actor->model->vertices,
+                the_car_actor->undamaged_vertices,
+                the_car_actor->actor->model->nvertices * sizeof(br_vertex));
+            BrModelUpdate(the_car_actor->actor->model, BR_MODU_VERTEX_COLOURS | BR_MODU_VERTEX_POSITIONS);
+            if (pipe_vertex_count != 0 && IsActionReplayAvailable()) {
+                PipeSingleModelGeometry(pCar->car_ID, j, pipe_vertex_count, pipe_array);
             }
         }
-    } else {
-        memcpy(&pCar->bounds[1], &storage_bounds, sizeof(br_bounds));
     }
 }
 

--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -478,10 +478,34 @@ void TotallyRepairACar(tCar_spec* pCar) {
         pCar->damage_units[i].last_level = 0;
         pCar->damage_units[i].smoke_last_level = 0;
     }
+    #ifdef DETHRACE_FIX_BUGS
+    if ((char*)&storage_bounds < (char*)&pCar->bounds[1] + sizeof(br_bounds)
+        && (char*)&pCar->bounds[1] < (char*)&storage_bounds + sizeof(br_bounds)) {
+        memmove(&storage_bounds, &pCar->bounds[1], sizeof(br_bounds));
+    } else {
+        memcpy(&storage_bounds, &pCar->bounds[1], sizeof(br_bounds));
+    }
+    if ((char*)&pCar->bounds[1] < (char*)&pCar->max_bounds[1] + sizeof(br_bounds)
+        && (char*)&pCar->max_bounds[1] < (char*)&pCar->bounds[1] + sizeof(br_bounds)) {
+        memmove(&pCar->bounds[1], &pCar->max_bounds[1], sizeof(br_bounds));
+    } else {
+        memcpy(&pCar->bounds[1], &pCar->max_bounds[1], sizeof(br_bounds));
+    }
+    #else
     memcpy(&storage_bounds, &pCar->bounds[1], sizeof(br_bounds));
     memcpy(&pCar->bounds[1], &pCar->max_bounds[1], sizeof(br_bounds));
+    #endif
     if (!TestForCarInSensiblePlace(pCar)) {
+        #ifdef DETHRACE_FIX_BUGS
+        if ((char*)&pCar->bounds[1] < (char*)&storage_bounds + sizeof(br_bounds)
+            && (char*)&storage_bounds < (char*)&pCar->bounds[1] + sizeof(br_bounds)) {
+            memmove(&pCar->bounds[1], &storage_bounds, sizeof(br_bounds));
+        } else {
+            memcpy(&pCar->bounds[1], &storage_bounds, sizeof(br_bounds));
+        }
+        #else
         memcpy(&pCar->bounds[1], &storage_bounds, sizeof(br_bounds));
+        #endif
         return;
     }
     for (j = 0, the_car_actor = pCar->car_model_actors; j < pCar->car_actor_count; j++, the_car_actor++) {
@@ -497,9 +521,24 @@ void TotallyRepairACar(tCar_spec* pCar) {
                     }
                 }
             }
+            #ifdef DETHRACE_FIX_BUGS
+            if ((char*)the_car_actor->actor->model->vertices
+                < (char*)the_car_actor->undamaged_vertices + the_car_actor->actor->model->nvertices * sizeof(br_vertex)
+                && (char*)the_car_actor->undamaged_vertices
+                    < (char*)the_car_actor->actor->model->vertices + the_car_actor->actor->model->nvertices * sizeof(br_vertex)) {
+                memmove(the_car_actor->actor->model->vertices,
+                    the_car_actor->undamaged_vertices,
+                    the_car_actor->actor->model->nvertices * sizeof(br_vertex));
+            } else {
+                memcpy(the_car_actor->actor->model->vertices,
+                    the_car_actor->undamaged_vertices,
+                    the_car_actor->actor->model->nvertices * sizeof(br_vertex));
+            }
+            #else
             memcpy(the_car_actor->actor->model->vertices,
                 the_car_actor->undamaged_vertices,
                 the_car_actor->actor->model->nvertices * sizeof(br_vertex));
+            #endif
             BrModelUpdate(the_car_actor->actor->model, BR_MODU_VERTEX_COLOURS | BR_MODU_VERTEX_POSITIONS);
             if (pipe_vertex_count != 0 && IsActionReplayAvailable()) {
                 PipeSingleModelGeometry(pCar->car_ID, j, pipe_vertex_count, pipe_array);

--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -465,7 +465,6 @@ void TotallyRepairACar(tCar_spec* pCar) {
     br_bounds storage_bounds;
 
     pipe_vertex_count = 0;
-    
     StopCarSmokingInstantly(pCar);
     if (IsActionReplayAvailable()) {
         PipeInstantUnSmudge(pCar);

--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -465,6 +465,7 @@ void TotallyRepairACar(tCar_spec* pCar) {
     br_bounds storage_bounds;
 
     pipe_vertex_count = 0;
+    
     StopCarSmokingInstantly(pCar);
     if (IsActionReplayAvailable()) {
         PipeInstantUnSmudge(pCar);

--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -478,34 +478,11 @@ void TotallyRepairACar(tCar_spec* pCar) {
         pCar->damage_units[i].last_level = 0;
         pCar->damage_units[i].smoke_last_level = 0;
     }
-    #ifdef DETHRACE_FIX_BUGS
-    if ((char*)&storage_bounds < (char*)&pCar->bounds[1] + sizeof(br_bounds)
-        && (char*)&pCar->bounds[1] < (char*)&storage_bounds + sizeof(br_bounds)) {
-        memmove(&storage_bounds, &pCar->bounds[1], sizeof(br_bounds));
-    } else {
-        memcpy(&storage_bounds, &pCar->bounds[1], sizeof(br_bounds));
-    }
-    if ((char*)&pCar->bounds[1] < (char*)&pCar->max_bounds[1] + sizeof(br_bounds)
-        && (char*)&pCar->max_bounds[1] < (char*)&pCar->bounds[1] + sizeof(br_bounds)) {
-        memmove(&pCar->bounds[1], &pCar->max_bounds[1], sizeof(br_bounds));
-    } else {
-        memcpy(&pCar->bounds[1], &pCar->max_bounds[1], sizeof(br_bounds));
-    }
-    #else
     memcpy(&storage_bounds, &pCar->bounds[1], sizeof(br_bounds));
     memcpy(&pCar->bounds[1], &pCar->max_bounds[1], sizeof(br_bounds));
-    #endif
+
     if (!TestForCarInSensiblePlace(pCar)) {
-        #ifdef DETHRACE_FIX_BUGS
-        if ((char*)&pCar->bounds[1] < (char*)&storage_bounds + sizeof(br_bounds)
-            && (char*)&storage_bounds < (char*)&pCar->bounds[1] + sizeof(br_bounds)) {
-            memmove(&pCar->bounds[1], &storage_bounds, sizeof(br_bounds));
-        } else {
-            memcpy(&pCar->bounds[1], &storage_bounds, sizeof(br_bounds));
-        }
-        #else
         memcpy(&pCar->bounds[1], &storage_bounds, sizeof(br_bounds));
-        #endif
         return;
     }
     for (j = 0, the_car_actor = pCar->car_model_actors; j < pCar->car_actor_count; j++, the_car_actor++) {
@@ -521,24 +498,10 @@ void TotallyRepairACar(tCar_spec* pCar) {
                     }
                 }
             }
-            #ifdef DETHRACE_FIX_BUGS
-            if ((char*)the_car_actor->actor->model->vertices
-                < (char*)the_car_actor->undamaged_vertices + the_car_actor->actor->model->nvertices * sizeof(br_vertex)
-                && (char*)the_car_actor->undamaged_vertices
-                    < (char*)the_car_actor->actor->model->vertices + the_car_actor->actor->model->nvertices * sizeof(br_vertex)) {
-                memmove(the_car_actor->actor->model->vertices,
-                    the_car_actor->undamaged_vertices,
-                    the_car_actor->actor->model->nvertices * sizeof(br_vertex));
-            } else {
-                memcpy(the_car_actor->actor->model->vertices,
-                    the_car_actor->undamaged_vertices,
-                    the_car_actor->actor->model->nvertices * sizeof(br_vertex));
-            }
-            #else
             memcpy(the_car_actor->actor->model->vertices,
                 the_car_actor->undamaged_vertices,
                 the_car_actor->actor->model->nvertices * sizeof(br_vertex));
-            #endif
+
             BrModelUpdate(the_car_actor->actor->model, BR_MODU_VERTEX_COLOURS | BR_MODU_VERTEX_POSITIONS);
             if (pipe_vertex_count != 0 && IsActionReplayAvailable()) {
                 PipeSingleModelGeometry(pCar->car_ID, j, pipe_vertex_count, pipe_array);


### PR DESCRIPTION
## Match result

```
0x4be1ca: TotallyRepairACar 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4be1ca,18 +0x46b924,17 @@
0x4be1ca : push ebp 	(crush.c:461)
0x4be1cb : mov ebp, esp
0x4be1cd : mov eax, 0x25ac
0x4be1d2 : call $$$00001(1) (FUNCTION)
0x4be1d7 : push ebx
0x4be1d8 : push esi
0x4be1d9 : push edi
0x4be1da : -mov dword ptr [ebp - 0x25a8], 0
0x4be1e4 : mov eax, dword ptr [ebp + 8] 	(crush.c:470)
0x4be1e7 : push eax
0x4be1e8 : call StopCarSmokingInstantly (FUNCTION)
0x4be1ed : add esp, 4
0x4be1f0 : call IsActionReplayAvailable (FUNCTION) 	(crush.c:471)
0x4be1f5 : test eax, eax
0x4be1f7 : je 0xc
0x4be1fd : mov eax, dword ptr [ebp + 8] 	(crush.c:472)
0x4be200 : push eax
0x4be201 : call PipeInstantUnSmudge (FUNCTION)

---
+++
@@ -0x4be29b,89 +0x46b9eb,85 @@
0x4be29b : mov edi, dword ptr [ebp + 8]
0x4be29e : add edi, 0xfc
0x4be2a4 : add esi, 0x144
0x4be2aa : mov ecx, 6
0x4be2af : rep movsd dword ptr es:[edi], dword ptr [esi]
0x4be2b1 : mov eax, dword ptr [ebp + 8] 	(crush.c:482)
0x4be2b4 : push eax
0x4be2b5 : call TestForCarInSensiblePlace (FUNCTION)
0x4be2ba : add esp, 4
0x4be2bd : test eax, eax
0x4be2bf : -jne 0x18
0x4be2c5 : -lea esi, [ebp - 0x18]
0x4be2c8 : -mov edi, dword ptr [ebp + 8]
0x4be2cb : -add edi, 0xfc
0x4be2d1 : -mov ecx, 6
0x4be2d6 : -rep movsd dword ptr es:[edi], dword ptr [esi]
0x4be2d8 : -jmp 0x248
         : +je 0x255
0x4be2dd : mov dword ptr [ebp - 0x25a4], 0 	(crush.c:483)
0x4be2e7 : -mov eax, dword ptr [ebp + 8]
0x4be2ea : -add eax, 0x12b8
0x4be2ef : -mov dword ptr [ebp - 0x1c], eax
0x4be2f2 : -jmp 0xa
         : +jmp 0x6
0x4be2f7 : inc dword ptr [ebp - 0x25a4]
0x4be2fd : -add dword ptr [ebp - 0x1c], 0x30
0x4be301 : mov eax, dword ptr [ebp + 8]
0x4be304 : mov ecx, dword ptr [ebp - 0x25a4]
0x4be30a : cmp dword ptr [eax + 0x664], ecx
0x4be310 : -jle 0x20f
         : +jle 0x226
         : +mov eax, dword ptr [ebp - 0x25a4] 	(crush.c:484)
         : +shl eax, 4
         : +lea eax, [eax + eax*2]
         : +add eax, dword ptr [ebp + 8]
         : +add eax, 0x12b8
         : +mov dword ptr [ebp - 0x1c], eax
0x4be316 : mov eax, dword ptr [ebp - 0x1c] 	(crush.c:485)
0x4be319 : cmp dword ptr [eax + 0x2c], 0
0x4be31d : je 0x1fd
0x4be323 : mov dword ptr [ebp - 0x25a8], 0 	(crush.c:486)
0x4be32d : mov dword ptr [ebp - 0x25ac], 0 	(crush.c:487)
0x4be337 : jmp 0x6
0x4be33c : inc dword ptr [ebp - 0x25ac]
0x4be342 : mov eax, dword ptr [ebp - 0x1c]
0x4be345 : mov eax, dword ptr [eax]
0x4be347 : mov eax, dword ptr [eax + 0x18]
0x4be34a : xor ecx, ecx
0x4be34c : mov cx, word ptr [eax + 0x10]
0x4be350 : cmp ecx, dword ptr [ebp - 0x25ac]
0x4be356 : jle 0x144
0x4be35c : cmp dword ptr [ebp - 0x25a8], 0x258 	(crush.c:488)
0x4be366 : jge 0x12f
0x4be36c : -mov eax, dword ptr [ebp - 0x1c]
0x4be36f : -mov eax, dword ptr [eax + 0x2c]
0x4be372 : -mov ecx, dword ptr [ebp - 0x25ac]
0x4be378 : -lea ecx, [ecx + ecx*4]
0x4be37b : -fld dword ptr [eax + ecx*8]
         : +mov eax, dword ptr [ebp - 0x25ac] 	(crush.c:490)
         : +lea eax, [eax + eax*4]
         : +mov ecx, dword ptr [ebp - 0x1c]
         : +mov ecx, dword ptr [ecx + 0x2c]
         : +fld dword ptr [ecx + eax*8]
0x4be37e : mov eax, dword ptr [ebp - 0x1c]
0x4be381 : mov eax, dword ptr [eax]
0x4be383 : mov eax, dword ptr [eax + 0x18]
0x4be386 : mov eax, dword ptr [eax + 8]
0x4be389 : mov ecx, dword ptr [ebp - 0x25ac]
0x4be38f : lea ecx, [ecx + ecx*4]
0x4be392 : fsub dword ptr [eax + ecx*8]
0x4be395 : mov eax, dword ptr [ebp - 0x25a8]
0x4be39b : shl eax, 4
0x4be39e : fstp dword ptr [ebp + eax - 0x259c]
0x4be3a5 : -mov eax, dword ptr [ebp - 0x1c]
0x4be3a8 : -mov eax, dword ptr [eax + 0x2c]
0x4be3ab : -mov ecx, dword ptr [ebp - 0x25ac]
0x4be3b1 : -lea ecx, [ecx + ecx*4]
0x4be3b4 : -fld dword ptr [eax + ecx*8 + 4]
         : +mov eax, dword ptr [ebp - 0x25ac]
         : +lea eax, [eax + eax*4]
         : +mov ecx, dword ptr [ebp - 0x1c]
         : +mov ecx, dword ptr [ecx + 0x2c]
         : +fld dword ptr [ecx + eax*8 + 4]
0x4be3b8 : mov eax, dword ptr [ebp - 0x1c]
0x4be3bb : mov eax, dword ptr [eax]
0x4be3bd : mov eax, dword ptr [eax + 0x18]
0x4be3c0 : mov eax, dword ptr [eax + 8]
0x4be3c3 : mov ecx, dword ptr [ebp - 0x25ac]
0x4be3c9 : lea ecx, [ecx + ecx*4]
0x4be3cc : fsub dword ptr [eax + ecx*8 + 4]
0x4be3d0 : mov eax, dword ptr [ebp - 0x25a8]
0x4be3d6 : shl eax, 4
0x4be3d9 : fstp dword ptr [ebp + eax - 0x2598]
0x4be3e0 : -mov eax, dword ptr [ebp - 0x1c]
0x4be3e3 : -mov eax, dword ptr [eax + 0x2c]
0x4be3e6 : -mov ecx, dword ptr [ebp - 0x25ac]
0x4be3ec : -lea ecx, [ecx + ecx*4]
0x4be3ef : -fld dword ptr [eax + ecx*8 + 8]
         : +mov eax, dword ptr [ebp - 0x25ac]
         : +lea eax, [eax + eax*4]
         : +mov ecx, dword ptr [ebp - 0x1c]
         : +mov ecx, dword ptr [ecx + 0x2c]
         : +fld dword ptr [ecx + eax*8 + 8]
0x4be3f3 : mov eax, dword ptr [ebp - 0x1c]
0x4be3f6 : mov eax, dword ptr [eax]
0x4be3f8 : mov eax, dword ptr [eax + 0x18]
0x4be3fb : mov eax, dword ptr [eax + 8]
0x4be3fe : mov ecx, dword ptr [ebp - 0x25ac]
0x4be404 : lea ecx, [ecx + ecx*4]
0x4be407 : fsub dword ptr [eax + ecx*8 + 8]
0x4be40b : mov eax, dword ptr [ebp - 0x25a8]
0x4be411 : shl eax, 4
0x4be414 : fstp dword ptr [ebp + eax - 0x2594]

---
+++
@@ -0x4be4fe,14 +0x46bc3e,22 @@
0x4be4fe : push eax
0x4be4ff : mov eax, dword ptr [ebp - 0x25a8]
0x4be505 : push eax
0x4be506 : mov eax, dword ptr [ebp - 0x25a4]
0x4be50c : push eax
0x4be50d : mov eax, dword ptr [ebp + 8]
0x4be510 : mov ax, word ptr [eax + 0x250]
0x4be517 : push eax
0x4be518 : call PipeSingleModelGeometry (FUNCTION)
0x4be51d : add esp, 0x10
0x4be520 : -jmp -0x22e
         : +jmp -0x241 	(crush.c:505)
         : +jmp 0x13 	(crush.c:506)
         : +lea esi, [ebp - 0x18] 	(crush.c:507)
         : +mov edi, dword ptr [ebp + 8]
         : +add edi, 0xfc
         : +mov ecx, 6
         : +rep movsd dword ptr es:[edi], dword ptr [esi]
0x4be525 : pop edi 	(crush.c:509)
0x4be526 : pop esi
0x4be527 : pop ebx
         : +leave 
         : +ret 


TotallyRepairACar is only 85.18% similar to the original, diff above
```

*AI generated. Time taken: 406s, tokens: 56,665*
