### PR TITLE
CheckLastCar 100% match

### DIFF
--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -521,9 +521,14 @@ void TotallyRepairCar(void) {
 // FUNCTION: CARM95 0x004be5b5
 void CheckLastCar(void) {
 
-    if (gNet_mode == eNet_mode_none && GetCarCount(eVehicle_opponent) != 0 && NumberOfOpponentsLeft() == 0) {
-        NewTextHeadupSlot(eHeadupSlot_misc, 0, 5000, -kFont_MEDIUMHD, GetMiscString(kMiscString_EveryOpponentWasted));
-        RaceCompleted(eRace_over_opponents);
+    if (gNet_mode != eNet_mode_none) {
+    } else {
+        if (GetCarCount(eVehicle_opponent) != 0) {
+            if (NumberOfOpponentsLeft() == 0) {
+                NewTextHeadupSlot(eHeadupSlot_misc, 0, 5000, -kFont_MEDIUMHD, GetMiscString(kMiscString_EveryOpponentWasted));
+                RaceCompleted(eRace_over_opponents);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4be5b5: CheckLastCar 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4be5b5,18 +0x46bcad,17 @@
0x4be5b5 : push ebp 	(crush.c:522)
0x4be5b6 : mov ebp, esp
0x4be5b8 : push ebx
0x4be5b9 : push esi
0x4be5ba : push edi
0x4be5bb : cmp dword ptr [gNet_mode (DATA)], 0 	(crush.c:524)
0x4be5c2 : -je 0x5
0x4be5c8 : -jmp 0x47
         : +jne 0x47
0x4be5cd : push 2
0x4be5cf : call GetCarCount (FUNCTION)
0x4be5d4 : add esp, 4
0x4be5d7 : test eax, eax
0x4be5d9 : je 0x35
0x4be5df : call NumberOfOpponentsLeft (FUNCTION)
0x4be5e4 : test eax, eax
0x4be5e6 : jne 0x28
0x4be5ec : push 0xa 	(crush.c:525)
0x4be5ee : call GetMiscString (FUNCTION)

---
+++
@@ -0x4be5f6,10 +0x46bce9,15 @@
0x4be5f6 : push eax
0x4be5f7 : push -4
0x4be5f9 : push 0x1388
0x4be5fe : push 0
0x4be600 : push 4
0x4be602 : call NewTextHeadupSlot (FUNCTION)
0x4be607 : add esp, 0x14
0x4be60a : push 2 	(crush.c:526)
0x4be60c : call RaceCompleted (FUNCTION)
0x4be611 : add esp, 4
         : +pop edi 	(crush.c:528)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


CheckLastCar is only 87.10% similar to the original, diff above
```

*AI generated. Time taken: 165s, tokens: 27,653*
