### PR TITLE
DamageUnit2 100% match

### DIFF
--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -582,7 +582,11 @@ void DamageUnit2(tCar_spec* pCar, int pUnit_type, int pDamage_amount) {
         last_level = the_damage->damage_level;
         the_damage->damage_level += pDamage_amount;
         if (the_damage->damage_level >= 99) {
-            the_damage->damage_level = (pDamage_amount < 10) ? last_level : 99;
+            if (pDamage_amount < 10) {
+                the_damage->damage_level = last_level;
+            } else {
+                the_damage->damage_level = 99;
+            }
         }
         if (pCar->driver == eDriver_oppo || gNet_mode != eNet_mode_none) {
             SetKnackeredFlag(pCar);


### PR DESCRIPTION
## Match result

```
0x4be737: DamageUnit2 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4be78e,27 +0x46bee1,27 @@
0x4be78e : mov eax, dword ptr [ebp - 8] 	(crush.c:582)
0x4be791 : mov eax, dword ptr [eax + 8]
0x4be794 : mov dword ptr [ebp - 4], eax
0x4be797 : mov eax, dword ptr [ebp + 0x10] 	(crush.c:583)
0x4be79a : mov ecx, dword ptr [ebp - 8]
0x4be79d : add dword ptr [ecx + 8], eax
0x4be7a0 : mov eax, dword ptr [ebp - 8] 	(crush.c:584)
0x4be7a3 : cmp dword ptr [eax + 8], 0x63
0x4be7a7 : jl 0x22
0x4be7ad : cmp dword ptr [ebp + 0x10], 0xa 	(crush.c:585)
0x4be7b1 : -jge 0xe
         : +jl 0xf
         : +mov eax, dword ptr [ebp - 8]
         : +mov dword ptr [eax + 8], 0x63
         : +jmp 0x9
0x4be7b7 : mov eax, dword ptr [ebp - 4]
0x4be7ba : mov ecx, dword ptr [ebp - 8]
0x4be7bd : mov dword ptr [ecx + 8], eax
0x4be7c0 : -jmp 0xa
0x4be7c5 : -mov eax, dword ptr [ebp - 8]
0x4be7c8 : -mov dword ptr [eax + 8], 0x63
0x4be7cf : mov eax, dword ptr [ebp + 8] 	(crush.c:587)
0x4be7d2 : cmp dword ptr [eax + 8], 2
0x4be7d6 : je 0xd
0x4be7dc : cmp dword ptr [gNet_mode (DATA)], 0
0x4be7e3 : je 0x11
0x4be7e9 : mov eax, dword ptr [ebp + 8] 	(crush.c:588)
0x4be7ec : push eax
0x4be7ed : call SetKnackeredFlag (FUNCTION)
0x4be7f2 : add esp, 4
0x4be7f5 : jmp 0x6c 	(crush.c:589)


DamageUnit2 is only 94.94% similar to the original, diff above
```

*AI generated. Time taken: 91s, tokens: 23,694*
