### PR TITLE
DoPratcamHit equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -677,27 +677,26 @@ void DoPratcamHit(br_vector3* pHit_vector) {
     int strength_modifier;
     br_scalar strength;
 
+    strength_modifier = 0;
     strength = BrVector3LengthSquared(pHit_vector);
     if (strength > 0.2f) {
         strength_modifier = 8;
     } else if (strength > 0.015f) {
         strength_modifier = 4;
-    } else if (strength >= 0.001f) {
-        strength_modifier = 0;
-    } else {
+    } else if (strength < 0.001f) {
         return;
     }
-    if (fabs(pHit_vector->v[2]) >= fabs(pHit_vector->v[0])) {
-        if (pHit_vector->v[2] >= 0.f) {
-            PratcamEvent(kPratcam_small_hit_front + strength_modifier);
+    if (fabs(pHit_vector->v[2]) < fabs(pHit_vector->v[0])) {
+        if (pHit_vector->v[0] < 0.f) {
+            PratcamEvent(kPratcam_small_hit_right + strength_modifier);
         } else {
-            PratcamEvent(kPratcam_small_hit_behind + strength_modifier);
+            PratcamEvent(kPratcam_small_hit_left + strength_modifier);
         }
     } else {
-        if (pHit_vector->v[0] >= 0.f) {
-            PratcamEvent(kPratcam_small_hit_left + strength_modifier);
+        if (pHit_vector->v[2] < 0.f) {
+            PratcamEvent(kPratcam_small_hit_behind + strength_modifier);
         } else {
-            PratcamEvent(kPratcam_small_hit_right + strength_modifier);
+            PratcamEvent(kPratcam_small_hit_front + strength_modifier);
         }
     }
 }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4be97b,25 +0x46c529,25 @@
0x4be97b : push ebp 	(crush.c:676)
0x4be97c : mov ebp, esp
0x4be97e : sub esp, 8
0x4be981 : push ebx
0x4be982 : push esi
0x4be983 : push edi
0x4be984 : mov dword ptr [ebp - 4], 0 	(crush.c:680)
0x4be98b : mov eax, dword ptr [ebp + 8] 	(crush.c:681)
         : +fld dword ptr [eax + 8]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 8]
         : +mov eax, dword ptr [ebp + 8]
0x4be98e : fld dword ptr [eax + 4]
0x4be991 : mov eax, dword ptr [ebp + 8]
0x4be994 : fmul dword ptr [eax + 4]
0x4be997 : -mov eax, dword ptr [ebp + 8]
0x4be99a : -fld dword ptr [eax + 8]
0x4be99d : -mov eax, dword ptr [ebp + 8]
0x4be9a0 : -fmul dword ptr [eax + 8]
0x4be9a3 : faddp st(1)
0x4be9a5 : mov eax, dword ptr [ebp + 8]
0x4be9a8 : fld dword ptr [eax]
0x4be9aa : mov eax, dword ptr [ebp + 8]
0x4be9ad : fmul dword ptr [eax]
0x4be9af : faddp st(1)
0x4be9b1 : fcom dword ptr [0.20000000298023224 (FLOAT)] 	(crush.c:682)
0x4be9b7 : fstp dword ptr [ebp - 8]
0x4be9ba : fnstsw ax
0x4be9bc : test ah, 0x41


DoPratcamHit is only 95.60% similar to the original, diff above
```

#### Effective match analysis

The diff only reorders the computation of two squared terms before summing: it computes `(arg[2]*arg[2])` first and `(arg[1]*arg[1])` second, instead of the opposite order, then performs the same `faddp` and continues identically with `arg[0]*arg[0]`, compare, and status-word test. No control-flow change is shown, and the arithmetic expression evaluated is the same (`x*x + y*y + z*z`). Under your stated assumptions (ignoring NaNs and tiny FP effects), this is functionally equivalent.

#### Original match

```
---
+++
@@ -0x4be97b,91 +0x46c529,92 @@
0x4be97b : push ebp 	(crush.c:676)
0x4be97c : mov ebp, esp
0x4be97e : sub esp, 8
0x4be981 : push ebx
0x4be982 : push esi
0x4be983 : push edi
0x4be984 : -mov dword ptr [ebp - 4], 0
         : +mov eax, dword ptr [ebp + 8] 	(crush.c:680)
         : +fld dword ptr [eax + 8]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 8]
0x4be98b : mov eax, dword ptr [ebp + 8]
0x4be98e : fld dword ptr [eax + 4]
0x4be991 : mov eax, dword ptr [ebp + 8]
0x4be994 : fmul dword ptr [eax + 4]
0x4be997 : -mov eax, dword ptr [ebp + 8]
0x4be99a : -fld dword ptr [eax + 8]
0x4be99d : -mov eax, dword ptr [ebp + 8]
0x4be9a0 : -fmul dword ptr [eax + 8]
0x4be9a3 : faddp st(1)
0x4be9a5 : mov eax, dword ptr [ebp + 8]
0x4be9a8 : fld dword ptr [eax]
0x4be9aa : mov eax, dword ptr [ebp + 8]
0x4be9ad : fmul dword ptr [eax]
0x4be9af : faddp st(1)
0x4be9b1 : fcom dword ptr [0.20000000298023224 (FLOAT)] 	(crush.c:681)
0x4be9b7 : fstp dword ptr [ebp - 8]
0x4be9ba : fnstsw ax
0x4be9bc : test ah, 0x41
0x4be9bf : jne 0xc
0x4be9c5 : mov dword ptr [ebp - 4], 8 	(crush.c:682)
0x4be9cc : -jmp 0x39
         : +jmp 0x45 	(crush.c:683)
0x4be9d1 : fld dword ptr [ebp - 8]
0x4be9d4 : fcomp dword ptr [0.014999999664723873 (FLOAT)]
0x4be9da : fnstsw ax
0x4be9dc : test ah, 0x41
0x4be9df : jne 0xc
0x4be9e5 : mov dword ptr [ebp - 4], 4 	(crush.c:684)
0x4be9ec : -jmp 0x19
         : +jmp 0x25 	(crush.c:685)
0x4be9f1 : fld dword ptr [ebp - 8]
0x4be9f4 : fcomp dword ptr [0.0010000000474974513 (FLOAT)]
0x4be9fa : fnstsw ax
0x4be9fc : test ah, 1
0x4be9ff : -je 0x5
         : +jne 0xc
         : +mov dword ptr [ebp - 4], 0 	(crush.c:686)
         : +jmp 0x5 	(crush.c:687)
0x4bea05 : jmp 0x94 	(crush.c:688)
0x4bea0a : mov eax, dword ptr [ebp + 8] 	(crush.c:690)
0x4bea0d : fld dword ptr [eax + 8]
0x4bea10 : fabs 
0x4bea12 : mov eax, dword ptr [ebp + 8]
0x4bea15 : fld dword ptr [eax]
0x4bea17 : fabs 
0x4bea19 : fcompp 
0x4bea1b : fnstsw ax
0x4bea1d : test ah, 0x41
0x4bea20 : -jne 0x3e
         : +je 0x3f
         : +mov eax, dword ptr [ebp + 8] 	(crush.c:691)
         : +fld dword ptr [eax + 8]
         : +fcomp dword ptr [0.0 (FLOAT)]
         : +fnstsw ax
         : +test ah, 1
         : +jne 0x14
         : +mov eax, dword ptr [ebp - 4] 	(crush.c:692)
         : +add eax, 0xe
         : +push eax
         : +call PratcamEvent (FUNCTION)
         : +add esp, 4
         : +jmp 0xf 	(crush.c:693)
         : +mov eax, dword ptr [ebp - 4] 	(crush.c:694)
         : +add eax, 0xd
         : +push eax
         : +call PratcamEvent (FUNCTION)
         : +add esp, 4
         : +jmp 0x39 	(crush.c:696)
0x4bea26 : mov eax, dword ptr [ebp + 8] 	(crush.c:697)
0x4bea29 : fld dword ptr [eax]
0x4bea2b : fcomp dword ptr [0.0 (FLOAT)]
0x4bea31 : fnstsw ax
0x4bea33 : test ah, 1
0x4bea36 : -je 0x14
         : +jne 0x14
0x4bea3c : mov eax, dword ptr [ebp - 4] 	(crush.c:698)
0x4bea3f : -add eax, 0x10
         : +add eax, 0xf
0x4bea42 : push eax
0x4bea43 : call PratcamEvent (FUNCTION)
0x4bea48 : add esp, 4
0x4bea4b : jmp 0xf 	(crush.c:699)
0x4bea50 : mov eax, dword ptr [ebp - 4] 	(crush.c:700)
0x4bea53 : -add eax, 0xf
0x4bea56 : -push eax
0x4bea57 : -call PratcamEvent (FUNCTION)
0x4bea5c : -add esp, 4
0x4bea5f : -jmp 0x3a
0x4bea64 : -mov eax, dword ptr [ebp + 8]
0x4bea67 : -fld dword ptr [eax + 8]
0x4bea6a : -fcomp dword ptr [0.0 (FLOAT)]
0x4bea70 : -fnstsw ax
0x4bea72 : -test ah, 1
0x4bea75 : -je 0x14
0x4bea7b : -mov eax, dword ptr [ebp - 4]
0x4bea7e : -add eax, 0xd
0x4bea81 : -push eax
0x4bea82 : -call PratcamEvent (FUNCTION)
0x4bea87 : -add esp, 4
0x4bea8a : -jmp 0xf
0x4bea8f : -mov eax, dword ptr [ebp - 4]
0x4bea92 : -add eax, 0xe
         : +add eax, 0x10
0x4bea95 : push eax
0x4bea96 : call PratcamEvent (FUNCTION)
0x4bea9b : add esp, 4
0x4bea9e : pop edi 	(crush.c:703)
0x4bea9f : pop esi
0x4beaa0 : pop ebx
0x4beaa1 : leave 
0x4beaa2 : ret 


DoPratcamHit is only 66.67% similar to the original, diff above
```

*AI generated. Time taken: 171s, tokens: 27,551*
