### PR TITLE
SortOutSmoke 100% match

### DIFF
--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -934,20 +934,23 @@ void SortOutSmoke(tCar_spec* pCar) {
     int pass;
     int repeat;
 
+    pass = 0;
+    repeat = 0;
+
     if (!pCar || pCar->driver <= eDriver_non_car) {
         return;
     }
     for (i = 0; i < COUNT_OF(pCar->damage_units); i++) {
-        if (pCar->damage_units[i].damage_level != pCar->damage_units[i].smoke_last_level) {
-            step = gSmoke_damage_step[i];
-            if (step) {
-                if (pCar->damage_units[i].damage_level > pCar->damage_units[i].smoke_last_level) {
-                    old_colour = (99 - pCar->damage_units[i].smoke_last_level) / step;
-                    colour = (99 - pCar->damage_units[i].damage_level) / step;
-                    if (old_colour != colour && colour <= 2) {
-                        ConditionalSmokeColumn(pCar, i, colour);
-                    }
-                }
+        if (pCar->damage_units[i].damage_level == pCar->damage_units[i].smoke_last_level) {
+            continue;
+        }
+
+        step = gSmoke_damage_step[i];
+        if (step != 0 && pCar->damage_units[i].damage_level > pCar->damage_units[i].smoke_last_level) {
+            colour = (99 - pCar->damage_units[i].damage_level) / step;
+            old_colour = (99 - pCar->damage_units[i].smoke_last_level) / step;
+            if (step > 0 && old_colour != colour && colour <= 2) {
+                ConditionalSmokeColumn(pCar, i, colour);
             }
         }
     }


### PR DESCRIPTION
## Match result

```
0x4bf7c2: SortOutSmoke 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4bf7c2,91 +0x46d009,98 @@
0x4bf7c2 : push ebp 	(crush.c:929)
0x4bf7c3 : mov ebp, esp
0x4bf7c5 : sub esp, 0x18
0x4bf7c8 : push ebx
0x4bf7c9 : push esi
0x4bf7ca : push edi
0x4bf7cb : -mov dword ptr [ebp - 0x14], 0
0x4bf7d2 : -mov dword ptr [ebp - 4], 0
0x4bf7d9 : cmp dword ptr [ebp + 8], 0 	(crush.c:937)
0x4bf7dd : je 0xd
0x4bf7e3 : mov eax, dword ptr [ebp + 8]
0x4bf7e6 : cmp dword ptr [eax + 8], 1
0x4bf7ea : jg 0x5
0x4bf7f0 : -jmp 0x129
         : +jmp 0x11a 	(crush.c:938)
0x4bf7f5 : mov dword ptr [ebp - 0x10], 0 	(crush.c:940)
0x4bf7fc : jmp 0x3
0x4bf801 : inc dword ptr [ebp - 0x10]
0x4bf804 : cmp dword ptr [ebp - 0x10], 0xc
0x4bf808 : -jge 0x104
         : +jge 0xf5
0x4bf80e : mov eax, dword ptr [ebp - 0x10] 	(crush.c:941)
0x4bf811 : mov ecx, eax
0x4bf813 : lea eax, [eax + eax*4]
0x4bf816 : lea eax, [eax + eax*8]
0x4bf819 : sub eax, ecx
0x4bf81b : mov ecx, dword ptr [ebp + 8]
0x4bf81e : mov edx, dword ptr [ebp - 0x10]
0x4bf821 : mov ebx, edx
0x4bf823 : lea edx, [edx + edx*4]
0x4bf826 : lea edx, [edx + edx*8]
0x4bf829 : sub edx, ebx
0x4bf82b : mov ebx, dword ptr [ebp + 8]
0x4bf82e : mov edx, dword ptr [edx + ebx + 0x758]
0x4bf835 : cmp dword ptr [eax + ecx + 0x750], edx
0x4bf83c : -jne 0x5
0x4bf842 : -jmp -0x46
         : +je 0xbc
0x4bf847 : mov eax, dword ptr [ebp - 0x10] 	(crush.c:942)
0x4bf84a : xor ecx, ecx
0x4bf84c : mov cl, byte ptr [eax + gSmoke_damage_step[0] (DATA)]
0x4bf852 : mov dword ptr [ebp - 0x18], ecx
0x4bf855 : cmp dword ptr [ebp - 0x18], 0 	(crush.c:943)
0x4bf859 : -je 0xae
         : +je 0xa4
0x4bf85f : mov eax, dword ptr [ebp - 0x10] 	(crush.c:944)
0x4bf862 : mov ecx, eax
0x4bf864 : lea eax, [eax + eax*4]
0x4bf867 : lea eax, [eax + eax*8]
0x4bf86a : sub eax, ecx
0x4bf86c : mov ecx, dword ptr [ebp + 8]
0x4bf86f : mov edx, dword ptr [ebp - 0x10]
0x4bf872 : mov ebx, edx
0x4bf874 : lea edx, [edx + edx*4]
0x4bf877 : lea edx, [edx + edx*8]
0x4bf87a : sub edx, ebx
0x4bf87c : mov ebx, dword ptr [ebp + 8]
0x4bf87f : mov edx, dword ptr [edx + ebx + 0x758]
0x4bf886 : cmp dword ptr [eax + ecx + 0x750], edx
0x4bf88d : -jle 0x7a
         : +jle 0x70
         : +mov eax, 0x63 	(crush.c:945)
         : +mov ecx, dword ptr [ebp - 0x10]
         : +mov edx, ecx
         : +lea ecx, [ecx + ecx*4]
         : +lea ecx, [ecx + ecx*8]
         : +sub ecx, edx
         : +mov edx, dword ptr [ebp + 8]
         : +sub eax, dword ptr [ecx + edx + 0x758]
         : +cdq 
         : +idiv dword ptr [ebp - 0x18]
         : +mov dword ptr [ebp - 8], eax
0x4bf893 : mov eax, 0x63 	(crush.c:946)
0x4bf898 : mov ecx, dword ptr [ebp - 0x10]
0x4bf89b : mov edx, ecx
0x4bf89d : lea ecx, [ecx + ecx*4]
0x4bf8a0 : lea ecx, [ecx + ecx*8]
0x4bf8a3 : sub ecx, edx
0x4bf8a5 : mov edx, dword ptr [ebp + 8]
0x4bf8a8 : sub eax, dword ptr [ecx + edx + 0x750]
0x4bf8af : cdq 
0x4bf8b0 : idiv dword ptr [ebp - 0x18]
0x4bf8b3 : mov dword ptr [ebp - 0xc], eax
0x4bf8b6 : -mov eax, 0x63
0x4bf8bb : -mov ecx, dword ptr [ebp - 0x10]
0x4bf8be : -mov edx, ecx
0x4bf8c0 : -lea ecx, [ecx + ecx*4]
0x4bf8c3 : -lea ecx, [ecx + ecx*8]
0x4bf8c6 : -sub ecx, edx
0x4bf8c8 : -mov edx, dword ptr [ebp + 8]
0x4bf8cb : -sub eax, dword ptr [ecx + edx + 0x758]
0x4bf8d2 : -cdq 
0x4bf8d3 : -idiv dword ptr [ebp - 0x18]
0x4bf8d6 : -mov dword ptr [ebp - 8], eax
0x4bf8d9 : -cmp dword ptr [ebp - 0x18], 0
0x4bf8dd : -jle 0x2a
0x4bf8e3 : mov eax, dword ptr [ebp - 0xc] 	(crush.c:947)
0x4bf8e6 : cmp dword ptr [ebp - 8], eax
0x4bf8e9 : je 0x1e
0x4bf8ef : cmp dword ptr [ebp - 0xc], 2
0x4bf8f3 : jg 0x14
0x4bf8f9 : mov eax, dword ptr [ebp - 0xc] 	(crush.c:948)
0x4bf8fc : push eax
0x4bf8fd : mov eax, dword ptr [ebp - 0x10]
0x4bf900 : push eax
0x4bf901 : mov eax, dword ptr [ebp + 8]
0x4bf904 : push eax
         : +call ConditionalSmokeColumn (FUNCTION)
         : +add esp, 0xc
         : +jmp -0x102 	(crush.c:953)
         : +mov eax, dword ptr [ebp + 8] 	(crush.c:954)
         : +push eax
         : +call SetSmokeLastDamageLevel (FUNCTION)
         : +add esp, 4
         : +pop edi 	(crush.c:955)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


SortOutSmoke is only 74.07% similar to the original, diff above
```

*AI generated. Time taken: 118s, tokens: 14,721*
