### PR TITLE
GetDirection 100% match

### DIFF
--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -897,20 +897,24 @@ tImpact_location GetDirection(br_vector3* pVelocity) {
     mag_x = fabs(pVelocity->v[0]);
     mag_y = fabs(pVelocity->v[1]);
     mag_z = fabs(pVelocity->v[2]);
-    if (mag_y >= mag_x || mag_z >= mag_x) {
-        if (mag_y <= mag_x || mag_z >= mag_y) {
-            if (pVelocity->v[2] >= 0.0f) {
-                return eImpact_back;
-            } else {
-                return eImpact_front;
-            }
+    if (mag_y < mag_x && mag_z < mag_x) {
+        if (pVelocity->v[0] < 0.0f) {
+            return eImpact_left;
         } else {
-            return pVelocity->v[1] < 0.0;
+            return eImpact_right;
         }
-    } else if (pVelocity->v[0] >= 0.0) {
-        return eImpact_right;
+    } else if (mag_y > mag_x && mag_z < mag_y) {
+        if (pVelocity->v[1] < 0.0f) {
+            return eImpact_bottom;
+        } else {
+            return eImpact_top;
+        }
     } else {
-        return eImpact_left;
+        if (pVelocity->v[2] < 0.0f) {
+            return eImpact_front;
+        } else {
+            return eImpact_back;
+        }
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4c1486: GetDirection 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4c149f,61 +0x46cec5,65 @@
0x4c149f : fabs 
0x4c14a1 : fstp dword ptr [ebp - 8]
0x4c14a4 : mov eax, dword ptr [ebp + 8] 	(crush.c:899)
0x4c14a7 : fld dword ptr [eax + 8]
0x4c14aa : fabs 
0x4c14ac : fstp dword ptr [ebp - 0xc]
0x4c14af : fld dword ptr [ebp - 8] 	(crush.c:900)
0x4c14b2 : fcomp dword ptr [ebp - 4]
0x4c14b5 : fnstsw ax
0x4c14b7 : test ah, 1
0x4c14ba : -je 0x45
         : +je 0x11
0x4c14c0 : fld dword ptr [ebp - 0xc]
0x4c14c3 : fcomp dword ptr [ebp - 4]
0x4c14c6 : fnstsw ax
0x4c14c8 : test ah, 1
0x4c14cb : -je 0x34
0x4c14d1 : -mov eax, dword ptr [ebp + 8]
0x4c14d4 : -fld dword ptr [eax]
0x4c14d6 : -fcomp dword ptr [0.0 (FLOAT)]
0x4c14dc : -fnstsw ax
0x4c14de : -test ah, 1
0x4c14e1 : -je 0xf
0x4c14e7 : -mov eax, 2
0x4c14ec : -jmp 0x98
0x4c14f1 : -jmp 0xa
0x4c14f6 : -mov eax, 3
0x4c14fb : -jmp 0x89
0x4c1500 : -jmp 0x84
         : +jne 0x84
0x4c1505 : fld dword ptr [ebp - 8] 	(crush.c:901)
0x4c1508 : fcomp dword ptr [ebp - 4]
0x4c150b : fnstsw ax
0x4c150d : test ah, 0x41
0x4c1510 : -jne 0x43
         : +jne 0x11
0x4c1516 : fld dword ptr [ebp - 0xc]
0x4c1519 : fcomp dword ptr [ebp - 8]
0x4c151c : fnstsw ax
0x4c151e : test ah, 1
0x4c1521 : -je 0x32
0x4c1527 : -mov eax, dword ptr [ebp + 8]
0x4c152a : -fld dword ptr [eax + 4]
0x4c152d : -fcomp dword ptr [0.0 (FLOAT)]
0x4c1533 : -fnstsw ax
0x4c1535 : -test ah, 1
0x4c1538 : -je 0xf
0x4c153e : -mov eax, 1
0x4c1543 : -jmp 0x41
0x4c1548 : -jmp 0x7
0x4c154d : -xor eax, eax
0x4c154f : -jmp 0x35
0x4c1554 : -jmp 0x30
         : +jne 0x35
0x4c1559 : mov eax, dword ptr [ebp + 8] 	(crush.c:902)
0x4c155c : fld dword ptr [eax + 8]
0x4c155f : fcomp dword ptr [0.0 (FLOAT)]
0x4c1565 : fnstsw ax
0x4c1567 : test ah, 1
0x4c156a : -je 0xf
         : +jne 0xf
         : +mov eax, 5 	(crush.c:903)
         : +jmp 0x70
         : +jmp 0xa 	(crush.c:904)
0x4c1570 : mov eax, 4 	(crush.c:905)
         : +jmp 0x61
         : +jmp 0x28 	(crush.c:907)
         : +mov eax, dword ptr [ebp + 8] 	(crush.c:908)
         : +fld dword ptr [eax + 4]
         : +fcomp qword ptr [0.0 (FLOAT)]
         : +fnstsw ax
         : +test ah, 1
         : +je 0xa
         : +mov eax, 1
         : +jmp 0x2
         : +xor eax, eax
         : +jmp 0x34
         : +jmp 0x2f 	(crush.c:910)
         : +mov eax, dword ptr [ebp + 8]
         : +fld dword ptr [eax]
         : +fcomp qword ptr [0.0 (FLOAT)]
         : +fnstsw ax
         : +test ah, 1
         : +jne 0xf
         : +mov eax, 3 	(crush.c:911)
0x4c1575 : jmp 0xf
0x4c157a : jmp 0xa 	(crush.c:912)
0x4c157f : -mov eax, 5
         : +mov eax, 2 	(crush.c:913)
0x4c1584 : jmp 0x0
         : +pop edi 	(crush.c:915)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


GetDirection is only 57.33% similar to the original, diff above
```

*AI generated. Time taken: 290s, tokens: 30,097*
