### PR TITLE
GenerateDarkenedShadeTable 100% match

### DIFF
--- a/src/DETHRACE/common/utility.c
+++ b/src/DETHRACE/common/utility.c
@@ -1008,7 +1008,7 @@ br_pixelmap* GenerateDarkenedShadeTable(int pHeight, br_pixelmap* pPalette, int 
                     }
                 } else {
                     if (ratio1 >= 0.75) {
-                        ratio2 = 1.0 - (1.0 - ratio1) * (1.0 - pThree_quarter) * 4.0;
+                        ratio2 = 1.0 - (1.0 - ratio1) * (1.0f - pThree_quarter) * 4.0;
                     } else {
                         ratio2 = (ratio1 - .5) * (pThree_quarter - pHalf) * 4. + pHalf;
                     }


### PR DESCRIPTION
## Match result

```
0x4c2b84: GenerateDarkenedShadeTable 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4c2d58,21 +0x4ba7c7,21 @@
0x4c2d58 : fmul qword ptr [4.0 (FLOAT)]
0x4c2d5e : fstp qword ptr [ebp - 0x24]
0x4c2d61 : jmp 0x59 	(utility.c:1009)
0x4c2d66 : fld qword ptr [ebp - 0x10] 	(utility.c:1010)
0x4c2d69 : fcomp qword ptr [0.75 (FLOAT)]
0x4c2d6f : fnstsw ax
0x4c2d71 : test ah, 1
0x4c2d74 : jne 0x28
0x4c2d7a : fld qword ptr [1.0 (FLOAT)] 	(utility.c:1011)
0x4c2d80 : fsub qword ptr [ebp - 0x10]
0x4c2d83 : -fld dword ptr [1.0 (FLOAT)]
         : +fld qword ptr [1.0 (FLOAT)]
0x4c2d89 : fsub dword ptr [ebp + 0x24]
0x4c2d8c : fmulp st(1)
0x4c2d8e : fmul qword ptr [4.0 (FLOAT)]
0x4c2d94 : fsubr qword ptr [1.0 (FLOAT)]
0x4c2d9a : fstp qword ptr [ebp - 0x24]
0x4c2d9d : jmp 0x1d 	(utility.c:1012)
0x4c2da2 : fld dword ptr [ebp + 0x24] 	(utility.c:1013)
0x4c2da5 : fsub dword ptr [ebp + 0x20]
0x4c2da8 : fld qword ptr [ebp - 0x10]
0x4c2dab : fsub qword ptr [0.5 (FLOAT)]


GenerateDarkenedShadeTable is only 99.56% similar to the original, diff above
```

*AI generated. Time taken: 61s, tokens: 7,695*
