### PR TITLE
DRMatrix34TApplyP 100% match

### DIFF
--- a/src/DETHRACE/common/utility.c
+++ b/src/DETHRACE/common/utility.c
@@ -1052,12 +1052,9 @@ void DRMatrix34TApplyP(br_vector3* pA, br_vector3* pB, br_matrix34* pC) {
     t2 = BR_SUB(pB->v[1], pC->m[3][1]);
     t3 = BR_SUB(pB->v[2], pC->m[3][2]);
 
-    // this avoids the +fstp in the line above, but including the "add" breaks it again. Some combination of braces etc...
-    // pA->v[0] = BR_MUL(pC->m[0][2], t3);
-
-    pA->v[0] = pC->m[0][2] * t3 + pC->m[0][1] * t2 + pC->m[0][0] * t1;
-    pA->v[1] = pC->m[1][0] * t1 + pC->m[1][2] * t3 + pC->m[1][1] * t2;
-    pA->v[2] = pC->m[2][0] * t1 + pC->m[2][1] * t2 + pC->m[2][2] * t3;
+    pA->v[0] = BR_MAC3(t1, pC->m[0][0], t2, pC->m[0][1], t3, pC->m[0][2]);
+    pA->v[1] = BR_MAC3(t1, pC->m[1][0], t3, pC->m[1][2], t2, pC->m[1][1]);
+    pA->v[2] = BR_MAC3(t1, pC->m[2][0], t2, pC->m[2][1], t3, pC->m[2][2]);
 }
 
 // IDA: tU16 __usercall PaletteEntry16Bit@<AX>(br_pixelmap *pPal@<EAX>, int pEntry@<EDX>)


### PR DESCRIPTION
## Match result

```
0x4c302d: DRMatrix34TApplyP 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4c3041,43 +0x4ba98d,44 @@
0x4c3041 : fstp dword ptr [ebp - 4]
0x4c3044 : mov eax, dword ptr [ebp + 0xc] 	(utility.c:1052)
0x4c3047 : fld dword ptr [eax + 4]
0x4c304a : mov eax, dword ptr [ebp + 0x10]
0x4c304d : fsub dword ptr [eax + 0x28]
0x4c3050 : fstp dword ptr [ebp - 8]
0x4c3053 : mov eax, dword ptr [ebp + 0xc] 	(utility.c:1053)
0x4c3056 : fld dword ptr [eax + 8]
0x4c3059 : mov eax, dword ptr [ebp + 0x10]
0x4c305c : fsub dword ptr [eax + 0x2c]
0x4c305f : -fst dword ptr [ebp - 0xc]
0x4c3062 : -mov eax, dword ptr [ebp + 0x10]
0x4c3065 : -fmul dword ptr [eax + 8]
         : +fstp dword ptr [ebp - 0xc]
0x4c3068 : mov eax, dword ptr [ebp + 0x10] 	(utility.c:1058)
0x4c306b : fld dword ptr [eax + 4]
0x4c306e : fmul dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp + 0x10]
         : +fld dword ptr [eax + 8]
         : +fmul dword ptr [ebp - 0xc]
0x4c3071 : faddp st(1)
0x4c3073 : mov eax, dword ptr [ebp + 0x10]
0x4c3076 : fld dword ptr [eax]
0x4c3078 : fmul dword ptr [ebp - 4]
0x4c307b : faddp st(1)
0x4c307d : mov eax, dword ptr [ebp + 8]
0x4c3080 : fstp dword ptr [eax]
0x4c3082 : mov eax, dword ptr [ebp + 0x10] 	(utility.c:1059)
0x4c3085 : -fld dword ptr [eax + 0xc]
0x4c3088 : -fmul dword ptr [ebp - 4]
         : +fld dword ptr [eax + 0x10]
         : +fmul dword ptr [ebp - 8]
0x4c308b : mov eax, dword ptr [ebp + 0x10]
0x4c308e : fld dword ptr [eax + 0x14]
0x4c3091 : fmul dword ptr [ebp - 0xc]
0x4c3094 : faddp st(1)
0x4c3096 : mov eax, dword ptr [ebp + 0x10]
0x4c3099 : -fld dword ptr [eax + 0x10]
0x4c309c : -fmul dword ptr [ebp - 8]
         : +fld dword ptr [eax + 0xc]
         : +fmul dword ptr [ebp - 4]
0x4c309f : faddp st(1)
0x4c30a1 : mov eax, dword ptr [ebp + 8]
0x4c30a4 : fstp dword ptr [eax + 4]
0x4c30a7 : mov eax, dword ptr [ebp + 0x10] 	(utility.c:1060)
0x4c30aa : fld dword ptr [eax + 0x18]
0x4c30ad : fmul dword ptr [ebp - 4]
0x4c30b0 : mov eax, dword ptr [ebp + 0x10]
0x4c30b3 : fld dword ptr [eax + 0x1c]
0x4c30b6 : fmul dword ptr [ebp - 8]
0x4c30b9 : faddp st(1)


DRMatrix34TApplyP is only 88.37% similar to the original, diff above
```

*AI generated. Time taken: 172s, tokens: 37,515*
