### PR TITLE
EncodeFileWrapper 100% match

### DIFF
--- a/src/DETHRACE/common/utility.c
+++ b/src/DETHRACE/common/utility.c
@@ -1642,23 +1642,21 @@ void EncodeFileWrapper(char* pThe_path) {
     if (STR_ENDS_WITH(pThe_path, len, ".TXT")) {
         return;
     }
-    if (STR_ENDS_WITH(pThe_path, len, "DKEYMAP0.TXT")
-        && STR_ENDS_WITH(pThe_path, len, "DKEYMAP1.TXT")
-        && STR_ENDS_WITH(pThe_path, len, "DKEYMAP2.TXT")
-        && STR_ENDS_WITH(pThe_path, len, "DKEYMAP3.TXT")
-        && STR_ENDS_WITH(pThe_path, len, "KEYMAP_0.TXT")
-        && STR_ENDS_WITH(pThe_path, len, "KEYMAP_1.TXT")
-        && STR_ENDS_WITH(pThe_path, len, "KEYMAP_2.TXT")
-        && STR_ENDS_WITH(pThe_path, len, "KEYMAP_3.TXT")
-        && STR_ENDS_WITH(pThe_path, len, "OPTIONS.TXT")
-        && STR_ENDS_WITH(pThe_path, len, "KEYNAMES.TXT")
-        && STR_ENDS_WITH(pThe_path, len, "KEYMAP.TXT")) {
-
-        if (!STR_ENDS_WITH(pThe_path, len, "PATHS.TXT")) {
-            return;
-        }
-        EncodeFile(pThe_path);
+    if (!STR_ENDS_WITH(pThe_path, len, "DKEYMAP0.TXT")
+        || !STR_ENDS_WITH(pThe_path, len, "DKEYMAP1.TXT")
+        || !STR_ENDS_WITH(pThe_path, len, "DKEYMAP2.TXT")
+        || !STR_ENDS_WITH(pThe_path, len, "DKEYMAP3.TXT")
+        || !STR_ENDS_WITH(pThe_path, len, "KEYMAP_0.TXT")
+        || !STR_ENDS_WITH(pThe_path, len, "KEYMAP_1.TXT")
+        || !STR_ENDS_WITH(pThe_path, len, "KEYMAP_2.TXT")
+        || !STR_ENDS_WITH(pThe_path, len, "KEYMAP_3.TXT")
+        || !STR_ENDS_WITH(pThe_path, len, "OPTIONS.TXT")
+        || !STR_ENDS_WITH(pThe_path, len, "KEYNAMES.TXT")
+        || !STR_ENDS_WITH(pThe_path, len, "KEYMAP.TXT")
+        || !STR_ENDS_WITH(pThe_path, len, "PATHS.TXT")) {
+        return;
     }
+    EncodeFile(pThe_path);
 }
 
 // IDA: void __usercall EncodeAllFilesInDirectory(char *pThe_path@<EAX>)


### PR DESCRIPTION
## Match result

```
0x4c3b44: EncodeFileWrapper 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4c3b76,101 +0x4bbf3d,101 @@
0x4c3b76 : repe cmpsb byte ptr [esi], byte ptr es:[edi]
0x4c3b78 : je 0x5
0x4c3b7e : jmp 0x16d 	(utility.c:1643)
0x4c3b83 : mov eax, dword ptr [ebp - 4] 	(utility.c:1655)
0x4c3b86 : sub eax, 0xc
0x4c3b89 : add eax, dword ptr [ebp + 8]
0x4c3b8c : mov edi, "DKEYMAP0.TXT" (STRING)
0x4c3b91 : mov ecx, 0xd
0x4c3b96 : mov esi, eax
0x4c3b98 : repe cmpsb byte ptr [esi], byte ptr es:[edi]
0x4c3b9a : -je 0x13f
         : +je 0x150
0x4c3ba0 : mov eax, dword ptr [ebp - 4]
0x4c3ba3 : sub eax, 0xc
0x4c3ba6 : add eax, dword ptr [ebp + 8]
0x4c3ba9 : mov edi, "DKEYMAP1.TXT" (STRING)
0x4c3bae : mov ecx, 0xd
0x4c3bb3 : mov esi, eax
0x4c3bb5 : repe cmpsb byte ptr [esi], byte ptr es:[edi]
0x4c3bb7 : -je 0x122
         : +je 0x133
0x4c3bbd : mov eax, dword ptr [ebp - 4]
0x4c3bc0 : sub eax, 0xc
0x4c3bc3 : add eax, dword ptr [ebp + 8]
0x4c3bc6 : mov edi, "DKEYMAP2.TXT" (STRING)
0x4c3bcb : mov ecx, 0xd
0x4c3bd0 : mov esi, eax
0x4c3bd2 : repe cmpsb byte ptr [esi], byte ptr es:[edi]
0x4c3bd4 : -je 0x105
         : +je 0x116
0x4c3bda : mov eax, dword ptr [ebp - 4]
0x4c3bdd : sub eax, 0xc
0x4c3be0 : add eax, dword ptr [ebp + 8]
0x4c3be3 : mov edi, "DKEYMAP3.TXT" (STRING)
0x4c3be8 : mov ecx, 0xd
0x4c3bed : mov esi, eax
0x4c3bef : repe cmpsb byte ptr [esi], byte ptr es:[edi]
0x4c3bf1 : -je 0xe8
         : +je 0xf9
0x4c3bf7 : mov eax, dword ptr [ebp - 4]
0x4c3bfa : sub eax, 0xc
0x4c3bfd : add eax, dword ptr [ebp + 8]
0x4c3c00 : mov edi, "KEYMAP_0.TXT" (STRING)
0x4c3c05 : mov ecx, 0xd
0x4c3c0a : mov esi, eax
0x4c3c0c : repe cmpsb byte ptr [esi], byte ptr es:[edi]
0x4c3c0e : -je 0xcb
         : +je 0xdc
0x4c3c14 : mov eax, dword ptr [ebp - 4]
0x4c3c17 : sub eax, 0xc
0x4c3c1a : add eax, dword ptr [ebp + 8]
0x4c3c1d : mov edi, "KEYMAP_1.TXT" (STRING)
0x4c3c22 : mov ecx, 0xd
0x4c3c27 : mov esi, eax
0x4c3c29 : repe cmpsb byte ptr [esi], byte ptr es:[edi]
0x4c3c2b : -je 0xae
         : +je 0xbf
0x4c3c31 : mov eax, dword ptr [ebp - 4]
0x4c3c34 : sub eax, 0xc
0x4c3c37 : add eax, dword ptr [ebp + 8]
0x4c3c3a : mov edi, "KEYMAP_2.TXT" (STRING)
0x4c3c3f : mov ecx, 0xd
0x4c3c44 : mov esi, eax
0x4c3c46 : repe cmpsb byte ptr [esi], byte ptr es:[edi]
0x4c3c48 : -je 0x91
         : +je 0xa2
0x4c3c4e : mov eax, dword ptr [ebp - 4]
0x4c3c51 : sub eax, 0xc
0x4c3c54 : add eax, dword ptr [ebp + 8]
0x4c3c57 : mov edi, "KEYMAP_3.TXT" (STRING)
0x4c3c5c : mov ecx, 0xd
0x4c3c61 : mov esi, eax
0x4c3c63 : repe cmpsb byte ptr [esi], byte ptr es:[edi]
0x4c3c65 : -je 0x74
         : +je 0x85
0x4c3c6b : mov eax, dword ptr [ebp - 4]
0x4c3c6e : sub eax, 0xb
0x4c3c71 : add eax, dword ptr [ebp + 8]
0x4c3c74 : mov edi, "OPTIONS.TXT" (STRING)
0x4c3c79 : mov ecx, 0xc
0x4c3c7e : mov esi, eax
0x4c3c80 : repe cmpsb byte ptr [esi], byte ptr es:[edi]
0x4c3c82 : -je 0x57
         : +je 0x68
0x4c3c88 : mov eax, dword ptr [ebp - 4]
0x4c3c8b : sub eax, 0xc
0x4c3c8e : add eax, dword ptr [ebp + 8]
0x4c3c91 : mov edi, "KEYNAMES.TXT" (STRING)
0x4c3c96 : mov ecx, 0xd
0x4c3c9b : mov esi, eax
0x4c3c9d : repe cmpsb byte ptr [esi], byte ptr es:[edi]
0x4c3c9f : -je 0x3a
         : +je 0x4b
0x4c3ca5 : mov eax, dword ptr [ebp - 4]
0x4c3ca8 : sub eax, 0xa
0x4c3cab : add eax, dword ptr [ebp + 8]
0x4c3cae : mov edi, "KEYMAP.TXT" (STRING)
0x4c3cb3 : mov ecx, 0xb
0x4c3cb8 : mov esi, eax
0x4c3cba : repe cmpsb byte ptr [esi], byte ptr es:[edi]
0x4c3cbc : -je 0x1d
         : +je 0x2e
0x4c3cc2 : mov eax, dword ptr [ebp - 4] 	(utility.c:1657)
0x4c3cc5 : sub eax, 9
0x4c3cc8 : add eax, dword ptr [ebp + 8]
0x4c3ccb : mov edi, "PATHS.TXT" (STRING)
0x4c3cd0 : mov ecx, 0xa
0x4c3cd5 : mov esi, eax
0x4c3cd7 : repe cmpsb byte ptr [esi], byte ptr es:[edi]
0x4c3cd9 : jne 0x5
0x4c3cdf : jmp 0xc 	(utility.c:1658)
0x4c3ce4 : mov eax, dword ptr [ebp + 8] 	(utility.c:1660)


EncodeFileWrapper is only 91.41% similar to the original, diff above
```

*AI generated. Time taken: 247s, tokens: 33,108*
