### PR TITLE
ClearHeadupSlot 100% match

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -138,12 +138,11 @@ void ClearHeadupSlot(int pSlot_index) {
     tHeadup* the_headup;
 
     the_headup = gHeadups;
-    for (i = 0; i < COUNT_OF(gHeadups); i++) {
+    for (i = 0; i < COUNT_OF(gHeadups); i++, the_headup++) {
         if (the_headup->type != eHeadup_unused && the_headup->slot_index == pSlot_index) {
             ClearHeadup(i);
             return;
         }
-        the_headup++;
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4c40e6: ClearHeadupSlot 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4c40e6,31 +0x471f76,31 @@
0x4c40e6 : push ebp 	(displays.c:136)
0x4c40e7 : mov ebp, esp
0x4c40e9 : sub esp, 8
0x4c40ec : push ebx
0x4c40ed : push esi
0x4c40ee : push edi
0x4c40ef : mov dword ptr [ebp - 4], gHeadups[0].type (DATA) 	(displays.c:140)
0x4c40f6 : mov dword ptr [ebp - 8], 0 	(displays.c:141)
0x4c40fd : -jmp 0xa
         : +jmp 0x3
0x4c4102 : inc dword ptr [ebp - 8]
0x4c4105 : -add dword ptr [ebp - 4], 0x14c
0x4c410c : cmp dword ptr [ebp - 8], 0xf
0x4c4110 : -jge 0x31
         : +jge 0x38
0x4c4116 : mov eax, dword ptr [ebp - 4] 	(displays.c:142)
0x4c4119 : cmp dword ptr [eax], 0
0x4c411c : je 0x20
0x4c4122 : mov eax, dword ptr [ebp - 4]
0x4c4125 : mov ecx, dword ptr [ebp + 8]
0x4c4128 : cmp dword ptr [eax + 0x18], ecx
0x4c412b : jne 0x11
0x4c4131 : mov eax, dword ptr [ebp - 8] 	(displays.c:143)
0x4c4134 : push eax
0x4c4135 : call ClearHeadup (FUNCTION)
0x4c413a : add esp, 4
0x4c413d : -jmp 0x5
         : +jmp 0xc 	(displays.c:144)
         : +add dword ptr [ebp - 4], 0x14c 	(displays.c:146)
0x4c4142 : jmp -0x45 	(displays.c:147)
0x4c4147 : pop edi 	(displays.c:148)
0x4c4148 : pop esi
0x4c4149 : pop ebx
0x4c414a : leave 
0x4c414b : ret 


ClearHeadupSlot is only 87.10% similar to the original, diff above
```

*AI generated. Time taken: 86s, tokens: 9,253*
