### PR TITLE
DRPixelmapText 100% match

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -187,14 +187,13 @@ void DRPixelmapText(br_pixelmap* pPixelmap, int pX, int pY, tDR_font* pFont, cha
     int ch_width;
     unsigned char* ch;
 
+    x = pX;
     len = strlen(pText);
-    ch = (unsigned char*)pText;
-    if (pX >= 0 && pPixelmap->width >= pRight_edge && pY >= 0 && (pY + pFont->height) <= pPixelmap->height) {
-        x = pX;
-        for (i = 0; i < len; i++) {
-            chr = ch[i] - pFont->offset;
+    if (pX < 0 || pPixelmap->width < pRight_edge || pY < 0 || (pY + pFont->height) > pPixelmap->height) {
+        for (i = 0, ch = (unsigned char*)pText; i < len; i++, ch++) {
+            chr = *ch - pFont->offset;
             ch_width = pFont->width_table[chr];
-            DRPixelmapRectangleOnscreenCopy(
+            DRPixelmapRectangleMaskedCopy(
                 gBack_screen,
                 x,
                 pY,
@@ -207,11 +206,10 @@ void DRPixelmapText(br_pixelmap* pPixelmap, int pX, int pY, tDR_font* pFont, cha
             x += ch_width + pFont->spacing;
         }
     } else {
-        x = pX;
-        for (i = 0; i < len; i++) {
-            chr = ch[i] - pFont->offset;
+        for (i = 0, ch = (unsigned char*)pText; i < len; i++, ch++) {
+            chr = *ch - pFont->offset;
             ch_width = pFont->width_table[chr];
-            DRPixelmapRectangleMaskedCopy(
+            DRPixelmapRectangleOnscreenCopy(
                 gBack_screen,
                 x,
                 pY,


### PR DESCRIPTION
## Match result

```
0x4c4256: DRPixelmapText 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4c4256,57 +0x4720e6,103 @@
0x4c4256 : push ebp 	(displays.c:182)
0x4c4257 : mov ebp, esp
0x4c4259 : sub esp, 0x18
0x4c425c : push ebx
0x4c425d : push esi
0x4c425e : push edi
0x4c425f : -mov eax, dword ptr [ebp + 0xc]
0x4c4262 : -mov dword ptr [ebp - 4], eax
0x4c4265 : mov edi, dword ptr [ebp + 0x18] 	(displays.c:190)
0x4c4268 : mov ecx, 0xffffffff
0x4c426d : sub eax, eax
0x4c426f : repne scasb al, byte ptr es:[edi]
0x4c4271 : not ecx
0x4c4273 : lea eax, [ecx - 1]
0x4c4276 : mov dword ptr [ebp - 0x18], eax
         : +mov eax, dword ptr [ebp + 0x18] 	(displays.c:191)
         : +mov dword ptr [ebp - 0x10], eax
0x4c4279 : cmp dword ptr [ebp + 0xc], 0 	(displays.c:192)
0x4c427d : -jl 0x36
         : +jl 0xc2
0x4c4283 : mov eax, dword ptr [ebp + 8]
0x4c4286 : xor ecx, ecx
0x4c4288 : mov cx, word ptr [eax + 0x34]
0x4c428c : cmp ecx, dword ptr [ebp + 0x1c]
0x4c428f : -jl 0x24
         : +jl 0xb0
0x4c4295 : cmp dword ptr [ebp + 0x10], 0
0x4c4299 : -jl 0x1a
         : +jl 0xa6
0x4c429f : mov eax, dword ptr [ebp + 0x14]
0x4c42a2 : mov eax, dword ptr [eax + 8]
0x4c42a5 : add eax, dword ptr [ebp + 0x10]
0x4c42a8 : mov ecx, dword ptr [ebp + 8]
0x4c42ab : xor edx, edx
0x4c42ad : mov dx, word ptr [ecx + 0x36]
0x4c42b1 : cmp eax, edx
0x4c42b3 : -jle 0x8b
         : +jg 0x8c
         : +mov eax, dword ptr [ebp + 0xc] 	(displays.c:193)
         : +mov dword ptr [ebp - 4], eax
0x4c42b9 : mov dword ptr [ebp - 0xc], 0 	(displays.c:194)
0x4c42c0 : -mov eax, dword ptr [ebp + 0x18]
0x4c42c3 : -mov dword ptr [ebp - 0x10], eax
0x4c42c6 : -jmp 0x6
         : +jmp 0x3
0x4c42cb : inc dword ptr [ebp - 0xc]
0x4c42ce : -inc dword ptr [ebp - 0x10]
0x4c42d1 : mov eax, dword ptr [ebp - 0xc]
0x4c42d4 : cmp dword ptr [ebp - 0x18], eax
0x4c42d7 : -jle 0x62
0x4c42dd : -mov eax, dword ptr [ebp - 0x10]
0x4c42e0 : -xor ecx, ecx
0x4c42e2 : -mov cl, byte ptr [eax]
         : +jle 0x66
         : +mov eax, dword ptr [ebp - 0xc] 	(displays.c:195)
         : +mov ecx, dword ptr [ebp - 0x10]
         : +xor edx, edx
         : +mov dl, byte ptr [eax + ecx]
0x4c42e4 : mov eax, dword ptr [ebp + 0x14]
0x4c42e7 : -sub ecx, dword ptr [eax + 0x14]
0x4c42ea : -mov dword ptr [ebp - 8], ecx
         : +sub edx, dword ptr [eax + 0x14]
         : +mov dword ptr [ebp - 8], edx
         : +mov eax, dword ptr [ebp - 8] 	(displays.c:196)
         : +mov ecx, dword ptr [ebp + 0x14]
         : +mov eax, dword ptr [ecx + eax*4 + 0x1c]
         : +mov dword ptr [ebp - 0x14], eax
         : +mov eax, dword ptr [ebp + 0x14] 	(displays.c:205)
         : +mov eax, dword ptr [eax + 8]
         : +push eax
         : +mov eax, dword ptr [ebp - 0x14]
         : +push eax
         : +mov eax, dword ptr [ebp + 0x14]
         : +mov eax, dword ptr [eax + 8]
         : +imul eax, dword ptr [ebp - 8]
         : +push eax
         : +push 0
         : +mov eax, dword ptr [ebp + 0x14]
         : +mov eax, dword ptr [eax]
         : +push eax
         : +mov eax, dword ptr [ebp + 0x10]
         : +push eax
         : +mov eax, dword ptr [ebp - 4]
         : +push eax
         : +mov eax, dword ptr [gBack_screen (DATA)]
         : +push eax
         : +call DRPixelmapRectangleOnscreenCopy (FUNCTION)
         : +add esp, 0x20
         : +mov eax, dword ptr [ebp + 0x14] 	(displays.c:207)
         : +mov eax, dword ptr [eax + 0x10]
         : +add eax, dword ptr [ebp - 0x14]
         : +add dword ptr [ebp - 4], eax
         : +jmp -0x75 	(displays.c:208)
         : +jmp 0x87 	(displays.c:209)
         : +mov eax, dword ptr [ebp + 0xc] 	(displays.c:210)
         : +mov dword ptr [ebp - 4], eax
         : +mov dword ptr [ebp - 0xc], 0 	(displays.c:211)
         : +jmp 0x3
         : +inc dword ptr [ebp - 0xc]
         : +mov eax, dword ptr [ebp - 0xc]
         : +cmp dword ptr [ebp - 0x18], eax
         : +jle 0x66
         : +mov eax, dword ptr [ebp - 0xc] 	(displays.c:212)
         : +mov ecx, dword ptr [ebp - 0x10]
         : +xor edx, edx
         : +mov dl, byte ptr [eax + ecx]
         : +mov eax, dword ptr [ebp + 0x14]
         : +sub edx, dword ptr [eax + 0x14]
         : +mov dword ptr [ebp - 8], edx
0x4c42ed : mov eax, dword ptr [ebp - 8] 	(displays.c:213)
0x4c42f0 : mov ecx, dword ptr [ebp + 0x14]
0x4c42f3 : mov eax, dword ptr [ecx + eax*4 + 0x1c]
0x4c42f7 : mov dword ptr [ebp - 0x14], eax
0x4c42fa : mov eax, dword ptr [ebp + 0x14] 	(displays.c:222)
0x4c42fd : mov eax, dword ptr [eax + 8]
0x4c4300 : push eax
0x4c4301 : mov eax, dword ptr [ebp - 0x14]
0x4c4304 : push eax
0x4c4305 : mov eax, dword ptr [ebp + 0x14]

---
+++
@@ -0x4c431c,62 +0x472239,16 @@
0x4c431c : mov eax, dword ptr [ebp - 4]
0x4c431f : push eax
0x4c4320 : mov eax, dword ptr [gBack_screen (DATA)]
0x4c4325 : push eax
0x4c4326 : call DRPixelmapRectangleMaskedCopy (FUNCTION)
0x4c432b : add esp, 0x20
0x4c432e : mov eax, dword ptr [ebp + 0x14] 	(displays.c:224)
0x4c4331 : mov eax, dword ptr [eax + 0x10]
0x4c4334 : add eax, dword ptr [ebp - 0x14]
0x4c4337 : add dword ptr [ebp - 4], eax
0x4c433a : -jmp -0x74
0x4c433f : -jmp 0x86
0x4c4344 : -mov dword ptr [ebp - 0xc], 0
0x4c434b : -mov eax, dword ptr [ebp + 0x18]
0x4c434e : -mov dword ptr [ebp - 0x10], eax
0x4c4351 : -jmp 0x6
0x4c4356 : -inc dword ptr [ebp - 0xc]
0x4c4359 : -inc dword ptr [ebp - 0x10]
0x4c435c : -mov eax, dword ptr [ebp - 0xc]
0x4c435f : -cmp dword ptr [ebp - 0x18], eax
0x4c4362 : -jle 0x62
0x4c4368 : -mov eax, dword ptr [ebp - 0x10]
0x4c436b : -xor ecx, ecx
0x4c436d : -mov cl, byte ptr [eax]
0x4c436f : -mov eax, dword ptr [ebp + 0x14]
0x4c4372 : -sub ecx, dword ptr [eax + 0x14]
0x4c4375 : -mov dword ptr [ebp - 8], ecx
0x4c4378 : -mov eax, dword ptr [ebp - 8]
0x4c437b : -mov ecx, dword ptr [ebp + 0x14]
0x4c437e : -mov eax, dword ptr [ecx + eax*4 + 0x1c]
0x4c4382 : -mov dword ptr [ebp - 0x14], eax
0x4c4385 : -mov eax, dword ptr [ebp + 0x14]
0x4c4388 : -mov eax, dword ptr [eax + 8]
0x4c438b : -push eax
0x4c438c : -mov eax, dword ptr [ebp - 0x14]
0x4c438f : -push eax
0x4c4390 : -mov eax, dword ptr [ebp + 0x14]
0x4c4393 : -mov eax, dword ptr [eax + 8]
0x4c4396 : -imul eax, dword ptr [ebp - 8]
0x4c439a : -push eax
0x4c439b : -push 0
0x4c439d : -mov eax, dword ptr [ebp + 0x14]
0x4c43a0 : -mov eax, dword ptr [eax]
0x4c43a2 : -push eax
0x4c43a3 : -mov eax, dword ptr [ebp + 0x10]
0x4c43a6 : -push eax
0x4c43a7 : -mov eax, dword ptr [ebp - 4]
0x4c43aa : -push eax
0x4c43ab : -mov eax, dword ptr [gBack_screen (DATA)]
0x4c43b0 : -push eax
0x4c43b1 : -call DRPixelmapRectangleOnscreenCopy (FUNCTION)
0x4c43b6 : -add esp, 0x20
0x4c43b9 : -mov eax, dword ptr [ebp + 0x14]
0x4c43bc : -mov eax, dword ptr [eax + 0x10]
0x4c43bf : -add eax, dword ptr [ebp - 0x14]
0x4c43c2 : -add dword ptr [ebp - 4], eax
0x4c43c5 : -jmp -0x74
         : +jmp -0x75 	(displays.c:225)
0x4c43ca : pop edi 	(displays.c:227)
0x4c43cb : pop esi
0x4c43cc : pop ebx
0x4c43cd : leave 
0x4c43ce : ret 


DRPixelmapText is only 50.78% similar to the original, diff above
```

*AI generated. Time taken: 110s, tokens: 18,733*
