### PR TITLE
DoPSPowerHeadup 100% match

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -411,11 +411,13 @@ void DoPSPowerHeadup(int pY, int pLevel, char* pName, int pBar_colour) {
     DimRectangle(gBack_screen, gCurrent_graf_data->ps_dim_left, pY, gCurrent_graf_data->ps_dim_right, gCurrent_graf_data->ps_dim_height + pY, 1);
     TransDRPixelmapText(gBack_screen, gCurrent_graf_data->ps_name_left, gCurrent_graf_data->ps_name_top_border + pY, gFonts + 6, pName, gBack_screen->width);
 
-    for (i = (6 - gCurrent_graf_data->ps_bars_per_level) * gCurrent_graf_data->ps_bars_per_level + 1; i > (gCurrent_graf_data->ps_bars_per_level * pLevel + 1); i--) {
-        DubreyBar(i, pY + gCurrent_graf_data->ps_bar_top_border, 0);
+    pLevel = gCurrent_graf_data->ps_bars_per_level * pLevel;
+    pY += gCurrent_graf_data->ps_bar_top_border;
+    for (i = (6 - gCurrent_graf_data->ps_bars_per_level) * gCurrent_graf_data->ps_bars_per_level + 1; i > pLevel + 1; i--) {
+        DubreyBar(i, pY, 0);
     }
-    for (i = gCurrent_graf_data->ps_bars_per_level * pLevel + 1; i >= 0; i--) {
-        DubreyBar(i, pY + gCurrent_graf_data->ps_bar_top_border, pBar_colour);
+    for (i = pLevel + 1; i >= 0; i--) {
+        DubreyBar(i, pY, pBar_colour);
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4c530b: DoPSPowerHeadup 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4c536f,59 +0x4727eb,60 @@
0x4c536f : mov eax, dword ptr [eax + 0x40c]
0x4c5375 : add eax, dword ptr [ebp + 8]
0x4c5378 : push eax
0x4c5379 : mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x4c537e : mov eax, dword ptr [eax + 0x408]
0x4c5384 : push eax
0x4c5385 : mov eax, dword ptr [gBack_screen (DATA)]
0x4c538a : push eax
0x4c538b : call TransDRPixelmapText (FUNCTION)
0x4c5390 : add esp, 0x18
0x4c5393 : -mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x4c5398 : -mov eax, dword ptr [eax + 0x410]
0x4c539e : -imul eax, dword ptr [ebp + 0xc]
0x4c53a2 : -mov dword ptr [ebp + 0xc], eax
0x4c53a5 : -mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x4c53aa : -mov eax, dword ptr [eax + 0x418]
0x4c53b0 : -add dword ptr [ebp + 8], eax
0x4c53b3 : mov eax, 6 	(displays.c:414)
0x4c53b8 : mov ecx, dword ptr [gCurrent_graf_data (DATA)]
0x4c53be : sub eax, dword ptr [ecx + 0x410]
0x4c53c4 : mov ecx, dword ptr [gCurrent_graf_data (DATA)]
0x4c53ca : imul eax, dword ptr [ecx + 0x410]
0x4c53d1 : inc eax
0x4c53d2 : mov dword ptr [ebp - 0x14], eax
0x4c53d5 : jmp 0x3
0x4c53da : dec dword ptr [ebp - 0x14]
0x4c53dd : -mov eax, dword ptr [ebp + 0xc]
         : +mov eax, dword ptr [gCurrent_graf_data (DATA)]
         : +mov eax, dword ptr [eax + 0x410]
         : +imul eax, dword ptr [ebp + 0xc]
0x4c53e0 : inc eax
0x4c53e1 : cmp eax, dword ptr [ebp - 0x14]
0x4c53e4 : -jge 0x17
         : +jge 0x22
0x4c53ea : push 0 	(displays.c:415)
0x4c53ec : -mov eax, dword ptr [ebp + 8]
         : +mov eax, dword ptr [gCurrent_graf_data (DATA)]
         : +mov eax, dword ptr [eax + 0x418]
         : +add eax, dword ptr [ebp + 8]
0x4c53ef : push eax
0x4c53f0 : mov eax, dword ptr [ebp - 0x14]
0x4c53f3 : push eax
0x4c53f4 : call DubreyBar (FUNCTION)
0x4c53f9 : add esp, 0xc
0x4c53fc : -jmp -0x27
0x4c5401 : -mov eax, dword ptr [ebp + 0xc]
         : +jmp -0x3e 	(displays.c:416)
         : +mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(displays.c:417)
         : +mov eax, dword ptr [eax + 0x410]
         : +imul eax, dword ptr [ebp + 0xc]
0x4c5404 : inc eax
0x4c5405 : mov dword ptr [ebp - 0x14], eax
0x4c5408 : jmp 0x3
0x4c540d : dec dword ptr [ebp - 0x14]
0x4c5410 : cmp dword ptr [ebp - 0x14], 0
0x4c5414 : -jl 0x19
         : +jl 0x24
0x4c541a : mov eax, dword ptr [ebp + 0x14] 	(displays.c:418)
0x4c541d : push eax
0x4c541e : -mov eax, dword ptr [ebp + 8]
         : +mov eax, dword ptr [gCurrent_graf_data (DATA)]
         : +mov eax, dword ptr [eax + 0x418]
         : +add eax, dword ptr [ebp + 8]
0x4c5421 : push eax
0x4c5422 : mov eax, dword ptr [ebp - 0x14]
0x4c5425 : push eax
0x4c5426 : call DubreyBar (FUNCTION)
0x4c542b : add esp, 0xc
0x4c542e : -jmp -0x26
         : +jmp -0x31 	(displays.c:419)
0x4c5433 : pop edi 	(displays.c:420)
0x4c5434 : pop esi
0x4c5435 : pop ebx
0x4c5436 : leave 
0x4c5437 : ret 


DoPSPowerHeadup is only 83.24% similar to the original, diff above
```

*AI generated. Time taken: 63s, tokens: 9,715*
