### PR TITLE
FindAHeadupHoleWoofBarkSoundsABitRude 100% match

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -703,12 +703,12 @@ int FindAHeadupHoleWoofBarkSoundsABitRude(int pSlot_index) {
     int empty_one;
     tHeadup* the_headup;
 
+    the_headup = gHeadups;
     empty_one = -1;
-    for (i = 0, the_headup = gHeadups; i < COUNT_OF(gHeadups); i++, the_headup++) {
+    for (i = 0; i < COUNT_OF(gHeadups); i++, the_headup++) {
         if (pSlot_index >= 0 && the_headup->slot_index == pSlot_index) {
             return i;
-        }
-        if (the_headup->type == eHeadup_unused) {
+        } else if (the_headup->type == eHeadup_unused) {
             empty_one = i;
         }
     }


### PR DESCRIPTION
## Match result

```
0x4c5493: FindAHeadupHoleWoofBarkSoundsABitRude 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4c5493,31 +0x473241,35 @@
0x4c5493 : push ebp 	(displays.c:701)
0x4c5494 : mov ebp, esp
0x4c5496 : sub esp, 0xc
0x4c5499 : push ebx
0x4c549a : push esi
0x4c549b : push edi
0x4c549c : -mov dword ptr [ebp - 4], gHeadups[0].type (DATA)
0x4c54a3 : mov dword ptr [ebp - 0xc], 0xffffffff 	(displays.c:706)
0x4c54aa : mov dword ptr [ebp - 8], 0 	(displays.c:707)
         : +mov dword ptr [ebp - 4], gHeadups[0].type (DATA)
0x4c54b1 : jmp 0xa
0x4c54b6 : inc dword ptr [ebp - 8]
0x4c54b9 : add dword ptr [ebp - 4], 0x14c
0x4c54c0 : cmp dword ptr [ebp - 8], 0xf
0x4c54c4 : -jge 0x3d
         : +jge 0x38
0x4c54ca : cmp dword ptr [ebp + 8], 0 	(displays.c:708)
0x4c54ce : -jl 0x1c
         : +jl 0x17
0x4c54d4 : mov eax, dword ptr [ebp - 4]
0x4c54d7 : mov ecx, dword ptr [ebp + 8]
0x4c54da : cmp dword ptr [eax + 0x18], ecx
0x4c54dd : -jne 0xd
         : +jne 0x8
0x4c54e3 : mov eax, dword ptr [ebp - 8] 	(displays.c:709)
0x4c54e6 : -jmp 0x24
0x4c54eb : -jmp 0x12
         : +jmp 0x1f
0x4c54f0 : mov eax, dword ptr [ebp - 4] 	(displays.c:711)
0x4c54f3 : cmp dword ptr [eax], 0
0x4c54f6 : jne 0x6
0x4c54fc : mov eax, dword ptr [ebp - 8] 	(displays.c:712)
0x4c54ff : mov dword ptr [ebp - 0xc], eax
0x4c5502 : -jmp -0x51
         : +jmp -0x4c 	(displays.c:714)
0x4c5507 : mov eax, dword ptr [ebp - 0xc] 	(displays.c:715)
0x4c550a : jmp 0x0
         : +pop edi 	(displays.c:716)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


FindAHeadupHoleWoofBarkSoundsABitRude is only 72.73% similar to the original, diff above
```

*AI generated. Time taken: 268s, tokens: 31,640*
