### PR TITLE
DRTextWidth 100% match

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -723,13 +723,11 @@ int DRTextWidth(tDR_font* pFont, char* pText) {
     int result;
     char* c;
 
-    c = pText;
     result = 0;
     len = strlen(pText);
 
-    for (i = 0; i < len; i++) {
+    for (i = 0, c = pText; i < len; i++, c++) {
         result += pFont->width_table[*c - pFont->offset];
-        c++;
     }
     return result + pFont->spacing * (len - 1);
 }


### PR DESCRIPTION
## Match result

```
0x4c5514: DRTextWidth 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4c5514,40 +0x4732bd,40 @@
0x4c5514 : push ebp 	(displays.c:720)
0x4c5515 : mov ebp, esp
0x4c5517 : sub esp, 0x10
0x4c551a : push ebx
0x4c551b : push esi
0x4c551c : push edi
         : +mov eax, dword ptr [ebp + 0xc] 	(displays.c:726)
         : +mov dword ptr [ebp - 8], eax
0x4c551d : mov dword ptr [ebp - 4], 0 	(displays.c:727)
0x4c5524 : mov edi, dword ptr [ebp + 0xc] 	(displays.c:728)
0x4c5527 : mov ecx, 0xffffffff
0x4c552c : sub eax, eax
0x4c552e : repne scasb al, byte ptr es:[edi]
0x4c5530 : not ecx
0x4c5532 : lea eax, [ecx - 1]
0x4c5535 : mov dword ptr [ebp - 0x10], eax
0x4c5538 : mov dword ptr [ebp - 0xc], 0 	(displays.c:730)
0x4c553f : -mov eax, dword ptr [ebp + 0xc]
0x4c5542 : -mov dword ptr [ebp - 8], eax
0x4c5545 : -jmp 0x6
         : +jmp 0x3
0x4c554a : inc dword ptr [ebp - 0xc]
0x4c554d : -inc dword ptr [ebp - 8]
0x4c5550 : mov eax, dword ptr [ebp - 0xc]
0x4c5553 : cmp dword ptr [ebp - 0x10], eax
0x4c5556 : -jle 0x1b
         : +jle 0x1e
0x4c555c : mov eax, dword ptr [ebp - 8] 	(displays.c:731)
0x4c555f : movsx eax, byte ptr [eax]
0x4c5562 : mov ecx, dword ptr [ebp + 8]
0x4c5565 : sub eax, dword ptr [ecx + 0x14]
0x4c5568 : mov ecx, dword ptr [ebp + 8]
0x4c556b : mov eax, dword ptr [ecx + eax*4 + 0x1c]
0x4c556f : add dword ptr [ebp - 4], eax
         : +inc dword ptr [ebp - 8] 	(displays.c:732)
0x4c5572 : jmp -0x2d 	(displays.c:733)
0x4c5577 : mov eax, dword ptr [ebp + 8] 	(displays.c:734)
0x4c557a : mov eax, dword ptr [eax + 0x10]
0x4c557d : mov ecx, dword ptr [ebp - 0x10]
0x4c5580 : dec ecx
0x4c5581 : imul eax, ecx
0x4c5584 : add eax, dword ptr [ebp - 4]
0x4c5587 : jmp 0x0
0x4c558c : pop edi 	(displays.c:735)
0x4c558d : pop esi


DRTextWidth is only 88.37% similar to the original, diff above
```

*AI generated. Time taken: 57s, tokens: 20,917*
