### PR TITLE
DRTextCleverWidth 100% match

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -743,16 +743,13 @@ int DRTextCleverWidth(tDR_font* pFont, signed char* pText) {
     unsigned char* c;
 
     result = 0;
-    len = strlen((char*)pText) + 1;
+    len = strlen((char*)pText);
 
     for (i = 0, c = (unsigned char*)pText; i < len; i++, c++) {
-        if (*c < 224) {
-            if (i < (len - 1)) {
-                result += pFont->spacing;
-            }
-            result += pFont->width_table[*c - pFont->offset];
+        if (*c >= 224) {
+            pFont = &gFonts[256] - *c;
         } else {
-            pFont = &gFonts[256 - *c];
+            result += pFont->width_table[*c - pFont->offset] + (i < (len - 1) ? pFont->spacing : 0);
         }
     }
     return result;


### PR DESCRIPTION
## Match result

```
0x4c5591: DRTextCleverWidth 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4c5591,60 +0x47333a,64 @@
0x4c5591 : push ebp 	(displays.c:739)
0x4c5592 : mov ebp, esp
0x4c5594 : -sub esp, 0x14
         : +sub esp, 0x10
0x4c5597 : push ebx
0x4c5598 : push esi
0x4c5599 : push edi
0x4c559a : mov dword ptr [ebp - 4], 0 	(displays.c:745)
0x4c55a1 : mov edi, dword ptr [ebp + 0xc] 	(displays.c:746)
0x4c55a4 : mov ecx, 0xffffffff
0x4c55a9 : sub eax, eax
0x4c55ab : repne scasb al, byte ptr es:[edi]
0x4c55ad : not ecx
0x4c55af : -lea eax, [ecx - 1]
0x4c55b2 : -mov dword ptr [ebp - 0x10], eax
         : +mov dword ptr [ebp - 0x10], ecx
0x4c55b5 : mov dword ptr [ebp - 0xc], 0 	(displays.c:748)
0x4c55bc : mov eax, dword ptr [ebp + 0xc]
0x4c55bf : mov dword ptr [ebp - 8], eax
0x4c55c2 : jmp 0x6
0x4c55c7 : inc dword ptr [ebp - 0xc]
0x4c55ca : inc dword ptr [ebp - 8]
0x4c55cd : mov eax, dword ptr [ebp - 0xc]
0x4c55d0 : cmp dword ptr [ebp - 0x10], eax
0x4c55d3 : -jle 0x7f
         : +jle 0x70
0x4c55d9 : mov eax, dword ptr [ebp - 8] 	(displays.c:749)
0x4c55dc : xor ecx, ecx
0x4c55de : mov cl, byte ptr [eax]
0x4c55e0 : cmp ecx, 0xe0
0x4c55e6 : -jl 0x2b
0x4c55ec : -mov eax, gFonts[0].images (DATA)
0x4c55f1 : -add eax, 0x39c00
0x4c55f6 : -mov ecx, dword ptr [ebp - 8]
0x4c55f9 : -xor edx, edx
0x4c55fb : -mov dl, byte ptr [ecx]
0x4c55fd : -mov ecx, edx
0x4c55ff : -lea edx, [edx + edx*8]
0x4c5602 : -lea edx, [ecx + edx*4]
0x4c5605 : -lea edx, [edx + edx*4]
0x4c5608 : -lea edx, [edx + edx*4]
0x4c560b : -sub edx, ecx
0x4c560d : -sub eax, edx
0x4c560f : -mov dword ptr [ebp + 8], eax
0x4c5612 : -jmp 0x3c
         : +jge 0x32
0x4c5617 : mov eax, dword ptr [ebp - 0x10] 	(displays.c:750)
0x4c561a : dec eax
0x4c561b : cmp eax, dword ptr [ebp - 0xc]
0x4c561e : -jg 0xc
0x4c5624 : -mov dword ptr [ebp - 0x14], 0
0x4c562b : -jmp 0x9
         : +jle 0x9
0x4c5630 : mov eax, dword ptr [ebp + 8] 	(displays.c:751)
0x4c5633 : mov eax, dword ptr [eax + 0x10]
0x4c5636 : -mov dword ptr [ebp - 0x14], eax
         : +add dword ptr [ebp - 4], eax
0x4c5639 : mov eax, dword ptr [ebp - 8] 	(displays.c:753)
0x4c563c : xor ecx, ecx
0x4c563e : mov cl, byte ptr [eax]
0x4c5640 : mov eax, dword ptr [ebp + 8]
0x4c5643 : sub ecx, dword ptr [eax + 0x14]
0x4c5646 : mov eax, dword ptr [ebp + 8]
0x4c5649 : mov eax, dword ptr [eax + ecx*4 + 0x1c]
0x4c564d : -add eax, dword ptr [ebp - 0x14]
0x4c5650 : add dword ptr [ebp - 4], eax
         : +jmp 0x26 	(displays.c:754)
         : +mov eax, 0x100 	(displays.c:755)
         : +mov ecx, dword ptr [ebp - 8]
         : +xor edx, edx
         : +mov dl, byte ptr [ecx]
         : +sub eax, edx
         : +mov ecx, eax
         : +lea eax, [eax + eax*8]
         : +lea eax, [ecx + eax*4]
         : +lea eax, [eax + eax*4]
         : +lea eax, [eax + eax*4]
         : +sub eax, ecx
         : +add eax, gFonts[0].images (DATA)
         : +mov dword ptr [ebp + 8], eax
         : +jmp -0x82 	(displays.c:757)
         : +mov eax, dword ptr [ebp - 4] 	(displays.c:758)
         : +jmp 0x0
         : +pop edi 	(displays.c:759)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DRTextCleverWidth is only 58.06% similar to the original, diff above
```

*AI generated. Time taken: 109s, tokens: 20,612*
