### PR TITLE
IsHeadupTextClever 100% match

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -772,10 +772,9 @@ void DRPixelmapCentredText(br_pixelmap* pPixelmap, int pX, int pY, tDR_font* pFo
 int IsHeadupTextClever(signed char* pText) {
 
     while (*pText) {
-        if (*pText < 0) {
+        if (*pText++ < 0) {
             return 1;
         }
-        pText++;
     }
     return 0;
 }


### PR DESCRIPTION
## Match result

```
0x4c5bd4: IsHeadupTextClever 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4c5bd4,21 +0x473448,24 @@
0x4c5bd4 : push ebp 	(displays.c:772)
0x4c5bd5 : mov ebp, esp
0x4c5bd7 : -sub esp, 4
0x4c5bda : push ebx
0x4c5bdb : push esi
0x4c5bdc : push edi
0x4c5bdd : mov eax, dword ptr [ebp + 8] 	(displays.c:774)
0x4c5be0 : movsx eax, byte ptr [eax]
0x4c5be3 : test eax, eax
0x4c5be5 : -je 0x26
         : +je 0x20
0x4c5beb : mov eax, dword ptr [ebp + 8] 	(displays.c:775)
0x4c5bee : -mov dword ptr [ebp - 4], eax
0x4c5bf1 : -inc dword ptr [ebp + 8]
0x4c5bf4 : -mov eax, dword ptr [ebp - 4]
0x4c5bf7 : movsx eax, byte ptr [eax]
0x4c5bfa : test eax, eax
0x4c5bfc : jge 0xa
0x4c5c02 : mov eax, 1 	(displays.c:776)
0x4c5c07 : -jmp 0xc
0x4c5c0c : -jmp -0x34
         : +jmp 0xf
         : +inc dword ptr [ebp + 8] 	(displays.c:778)
         : +jmp -0x2e 	(displays.c:779)
0x4c5c11 : xor eax, eax 	(displays.c:780)
         : +jmp 0x0
         : +pop edi 	(displays.c:781)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


IsHeadupTextClever is only 62.22% similar to the original, diff above
```

*AI generated. Time taken: 66s, tokens: 8,680*
