### PR TITLE
ChangeHeadupText 100% match

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -1032,11 +1032,12 @@ void MoveHeadupTo(int pHeadup_index, int pNew_x, int pNew_y) {
 void ChangeHeadupText(int pHeadup_index, char* pNew_text) {
     tHeadup* the_headup;
 
-    if (pHeadup_index >= 0) {
-        the_headup = &gHeadups[pHeadup_index];
-        strcpy(the_headup->data.text_info.text, pNew_text);
-        MungeHeadupWidth(the_headup);
+    if (pHeadup_index < 0) {
+        return;
     }
+    the_headup = &gHeadups[pHeadup_index];
+    strcpy(the_headup->data.text_info.text, pNew_text);
+    MungeHeadupWidth(the_headup);
 }
 
 // IDA: void __usercall ChangeHeadupImage(int pHeadup_index@<EAX>, int pNew_image@<EDX>)


### PR DESCRIPTION
## Match result

```
0x4c6169: ChangeHeadupText 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4c6169,19 +0x473ee5,18 @@
0x4c6169 : push ebp 	(displays.c:1032)
0x4c616a : mov ebp, esp
0x4c616c : sub esp, 4
0x4c616f : push ebx
0x4c6170 : push esi
0x4c6171 : push edi
0x4c6172 : cmp dword ptr [ebp + 8], 0 	(displays.c:1035)
0x4c6176 : -jge 0x5
0x4c617c : -jmp 0x4c
         : +jl 0x4c
0x4c6181 : mov eax, dword ptr [ebp + 8] 	(displays.c:1036)
0x4c6184 : mov ecx, eax
0x4c6186 : lea eax, [eax + eax*8]
0x4c6189 : lea eax, [ecx + eax*4]
0x4c618c : lea eax, [eax + eax*8]
0x4c618f : sub eax, ecx
0x4c6191 : add eax, gHeadups[0].type (DATA)
0x4c6196 : mov dword ptr [ebp - 4], eax
0x4c6199 : mov edi, dword ptr [ebp + 0xc] 	(displays.c:1037)
0x4c619c : mov ecx, 0xffffffff

---
+++
@@ -0x4c61b3,10 +0x473f2a,15 @@
0x4c61b3 : mov esi, edx
0x4c61b5 : shr ecx, 2
0x4c61b8 : rep movsd dword ptr es:[edi], dword ptr [esi]
0x4c61ba : mov ecx, eax
0x4c61bc : and ecx, 3
0x4c61bf : rep movsb byte ptr es:[edi], byte ptr [esi]
0x4c61c1 : mov eax, dword ptr [ebp - 4] 	(displays.c:1038)
0x4c61c4 : push eax
0x4c61c5 : call MungeHeadupWidth (FUNCTION)
0x4c61ca : add esp, 4
         : +pop edi 	(displays.c:1040)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


ChangeHeadupText is only 89.74% similar to the original, diff above
```

*AI generated. Time taken: 55s, tokens: 6,196*
