### PR TITLE
ChangeHeadupImage 100% match

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -1044,18 +1044,19 @@ void ChangeHeadupText(int pHeadup_index, char* pNew_text) {
 void ChangeHeadupImage(int pHeadup_index, int pNew_image) {
     tHeadup* the_headup;
 
-    if (pHeadup_index >= 0) {
+    if (pHeadup_index < 0) {
+    } else {
         the_headup = &gHeadups[pHeadup_index];
         the_headup->data.image_info.image = gHeadup_images[pNew_image];
         switch (the_headup->justification) {
         case eJust_left:
             the_headup->x = the_headup->original_x;
             break;
-        case eJust_right:
-            the_headup->x = the_headup->original_x - the_headup->data.image_info.image->width;
-            break;
         case eJust_centre:
             the_headup->x = the_headup->original_x - the_headup->data.image_info.image->width / 2;
+            break;
+        case eJust_right:
+            the_headup->x = the_headup->original_x - the_headup->data.image_info.image->width;
             break;
         }
     }


### PR DESCRIPTION
## Match result

```
0x4c61d2: ChangeHeadupImage 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4c61d2,19 +0x473f49,18 @@
0x4c61d2 : push ebp 	(displays.c:1044)
0x4c61d3 : mov ebp, esp
0x4c61d5 : sub esp, 8
0x4c61d8 : push ebx
0x4c61d9 : push esi
0x4c61da : push edi
0x4c61db : cmp dword ptr [ebp + 8], 0 	(displays.c:1047)
0x4c61df : -jge 0x5
0x4c61e5 : -jmp 0xaf
         : +jl 0xaf
0x4c61ea : mov eax, dword ptr [ebp + 8] 	(displays.c:1048)
0x4c61ed : mov ecx, eax
0x4c61ef : lea eax, [eax + eax*8]
0x4c61f2 : lea eax, [ecx + eax*4]
0x4c61f5 : lea eax, [eax + eax*8]
0x4c61f8 : sub eax, ecx
0x4c61fa : add eax, gHeadups[0].type (DATA)
0x4c61ff : mov dword ptr [ebp - 4], eax
0x4c6202 : mov eax, dword ptr [ebp + 0xc] 	(displays.c:1049)
0x4c6205 : mov eax, dword ptr [eax*4 + gHeadup_images[0] (DATA)]

---
+++
@@ -0x4c6223,33 +0x473f95,38 @@
0x4c6223 : mov eax, dword ptr [eax + 0xc]
0x4c6226 : mov ecx, dword ptr [ebp - 4]
0x4c6229 : mov dword ptr [ecx + 4], eax
0x4c622c : jmp 0x68 	(displays.c:1053)
0x4c6231 : mov eax, dword ptr [ebp - 4] 	(displays.c:1055)
0x4c6234 : mov eax, dword ptr [eax + 0xc]
0x4c6237 : mov ecx, dword ptr [ebp - 4]
0x4c623a : mov ecx, dword ptr [ecx + 0x48]
0x4c623d : xor edx, edx
0x4c623f : mov dx, word ptr [ecx + 0x34]
0x4c6243 : -sar edx, 1
0x4c6245 : sub eax, edx
0x4c6247 : mov ecx, dword ptr [ebp - 4]
0x4c624a : mov dword ptr [ecx + 4], eax
0x4c624d : -jmp 0x47
         : +jmp 0x49 	(displays.c:1056)
0x4c6252 : mov eax, dword ptr [ebp - 4] 	(displays.c:1058)
0x4c6255 : mov eax, dword ptr [eax + 0xc]
0x4c6258 : mov ecx, dword ptr [ebp - 4]
0x4c625b : mov ecx, dword ptr [ecx + 0x48]
0x4c625e : xor edx, edx
0x4c6260 : mov dx, word ptr [ecx + 0x34]
         : +sar edx, 1
0x4c6264 : sub eax, edx
0x4c6266 : mov ecx, dword ptr [ebp - 4]
0x4c6269 : mov dword ptr [ecx + 4], eax
0x4c626c : jmp 0x28 	(displays.c:1059)
0x4c6271 : jmp 0x23 	(displays.c:1060)
0x4c6276 : cmp dword ptr [ebp - 8], 0
0x4c627a : je -0x60
0x4c6280 : cmp dword ptr [ebp - 8], 1
0x4c6284 : -je -0x38
         : +je -0x59
0x4c628a : cmp dword ptr [ebp - 8], 2
0x4c628e : -je -0x63
         : +je -0x44
0x4c6294 : jmp 0x0
         : +pop edi 	(displays.c:1062)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


ChangeHeadupImage is only 86.89% similar to the original, diff above
```

*AI generated. Time taken: 166s, tokens: 15,790*
