### PR TITLE
OoerrIveGotTextInMeBoxMissus 100% match

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -1601,17 +1601,18 @@ void OoerrIveGotTextInMeBoxMissus(int pFont_index, char* pText, br_pixelmap* pPi
     int font_needed_loading;
     char line[256];
 
-    font = &gFonts[pFont_index];
     current_width = 0;
+    current_y = pTop;
+    font = &gFonts[pFont_index];
     font_needed_loading = font->images == NULL;
     if (font_needed_loading) {
         LoadFont(pFont_index);
     }
     centre = (pRight + pLeft) / 2;
-    current_y = pTop;
-    width = pRight - pLeft;
-    line_char_index = 0;
+    line[0] = 0;
     input_str_index = 0;
+    line_char_index = 0;
+    width = pRight - pLeft;
     start_line = 0;
 
     while (pText[input_str_index]) {
@@ -1619,7 +1620,7 @@ void OoerrIveGotTextInMeBoxMissus(int pFont_index, char* pText, br_pixelmap* pPi
         line[line_char_index + 1] = 0;
         current_width += font->spacing + font->width_table[pText[input_str_index] - font->offset];
         if (current_width > width) {
-            for (i = input_str_index; i >= start_line; i--) {
+            for (i = input_str_index; i > start_line; i--) {
                 if (pText[i] == ' ') {
                     break;
                 }
@@ -1627,8 +1628,9 @@ void OoerrIveGotTextInMeBoxMissus(int pFont_index, char* pText, br_pixelmap* pPi
             if (i == start_line) {
                 i = input_str_index;
             }
-            line_char_index += i - input_str_index;
+            line_char_index = i - start_line;
             input_str_index = i;
+            line[line_char_index + 1] = 0;
             if (pText[input_str_index] == ' ') {
                 input_str_index++;
             }
@@ -1638,10 +1640,10 @@ void OoerrIveGotTextInMeBoxMissus(int pFont_index, char* pText, br_pixelmap* pPi
             } else {
                 TransDRPixelmapText(gBack_screen, pLeft, current_y, font, line, pRight);
             }
-            current_width = 0;
             current_y += 3 * (font->height - (TranslationMode() ? 2 : 0)) / 2;
-            line_char_index = 0;
             start_line = input_str_index;
+            line_char_index = 0;
+            current_width = 0;
         } else {
             line_char_index++;
             input_str_index++;
@@ -1649,7 +1651,7 @@ void OoerrIveGotTextInMeBoxMissus(int pFont_index, char* pText, br_pixelmap* pPi
     }
     if (line_char_index != 0) {
         if (pCentred) {
-            TransDRPixelmapText(gBack_screen, centre - (DRTextWidth(font, line) / 2), current_y, font, line, (DRTextWidth(font, line) / 2) + centre);
+            DRPixelmapCentredText(gBack_screen, centre, current_y, font, line);
         } else {
             TransDRPixelmapText(gBack_screen, pLeft, current_y, font, line, pRight);
         }


### PR DESCRIPTION
## Match result

```
0x4c7b7f: OoerrIveGotTextInMeBoxMissus 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4c7b7f,104 +0x4758c0,101 @@
0x4c7b7f : push ebp 	(displays.c:1591)
0x4c7b80 : mov ebp, esp
0x4c7b82 : sub esp, 0x128
0x4c7b88 : push ebx
0x4c7b89 : push esi
0x4c7b8a : push edi
0x4c7b8b : -mov dword ptr [ebp - 0x11c], 0
0x4c7b95 : -mov eax, dword ptr [ebp + 0x18]
0x4c7b98 : -mov dword ptr [ebp - 0x10c], eax
0x4c7b9e : mov eax, dword ptr [ebp + 8] 	(displays.c:1604)
0x4c7ba1 : mov ecx, eax
0x4c7ba3 : lea eax, [eax + eax*8]
0x4c7ba6 : lea eax, [ecx + eax*4]
0x4c7ba9 : lea eax, [eax + eax*4]
0x4c7bac : lea eax, [eax + eax*4]
0x4c7baf : sub eax, ecx
0x4c7bb1 : add eax, gFonts[0].images (DATA)
0x4c7bb6 : mov dword ptr [ebp - 0x124], eax
         : +mov dword ptr [ebp - 0x11c], 0 	(displays.c:1605)
0x4c7bbc : mov eax, dword ptr [ebp - 0x124] 	(displays.c:1606)
0x4c7bc2 : cmp dword ptr [eax], 0
0x4c7bc5 : jne 0xf
0x4c7bcb : mov dword ptr [ebp - 0x108], 1
0x4c7bd5 : jmp 0xa
0x4c7bda : mov dword ptr [ebp - 0x108], 0
0x4c7be4 : cmp dword ptr [ebp - 0x108], 0 	(displays.c:1607)
0x4c7beb : je 0xc
0x4c7bf1 : mov eax, dword ptr [ebp + 8] 	(displays.c:1608)
0x4c7bf4 : push eax
0x4c7bf5 : call LoadFont (FUNCTION)
0x4c7bfa : add esp, 4
0x4c7bfd : mov eax, dword ptr [ebp + 0x1c] 	(displays.c:1610)
0x4c7c00 : add eax, dword ptr [ebp + 0x14]
0x4c7c03 : cdq 
0x4c7c04 : sub eax, edx
0x4c7c06 : sar eax, 1
0x4c7c08 : mov dword ptr [ebp - 4], eax
0x4c7c0b : -mov byte ptr [ebp - 0x104], 0
0x4c7c12 : -mov dword ptr [ebp - 0x120], 0
0x4c7c1c : -mov dword ptr [ebp - 0x110], 0
         : +mov eax, dword ptr [ebp + 0x18] 	(displays.c:1611)
         : +mov dword ptr [ebp - 0x10c], eax
0x4c7c26 : mov eax, dword ptr [ebp + 0x1c] 	(displays.c:1612)
0x4c7c29 : sub eax, dword ptr [ebp + 0x14]
0x4c7c2c : mov dword ptr [ebp - 0x114], eax
         : +mov dword ptr [ebp - 0x110], 0 	(displays.c:1613)
         : +mov dword ptr [ebp - 0x120], 0 	(displays.c:1614)
0x4c7c32 : mov dword ptr [ebp - 0x118], 0 	(displays.c:1615)
0x4c7c3c : mov eax, dword ptr [ebp - 0x120] 	(displays.c:1617)
0x4c7c42 : mov ecx, dword ptr [ebp + 0xc]
0x4c7c45 : movsx eax, byte ptr [eax + ecx]
0x4c7c49 : test eax, eax
0x4c7c4b : -je 0x1e8
         : +je 0x1da
0x4c7c51 : mov eax, dword ptr [ebp - 0x120] 	(displays.c:1618)
0x4c7c57 : mov ecx, dword ptr [ebp + 0xc]
0x4c7c5a : mov al, byte ptr [eax + ecx]
0x4c7c5d : mov ecx, dword ptr [ebp - 0x110]
0x4c7c63 : mov byte ptr [ebp + ecx - 0x104], al
0x4c7c6a : mov eax, dword ptr [ebp - 0x110] 	(displays.c:1619)
0x4c7c70 : mov byte ptr [ebp + eax - 0x103], 0
0x4c7c78 : mov eax, dword ptr [ebp + 0xc] 	(displays.c:1620)
0x4c7c7b : mov ecx, dword ptr [ebp - 0x120]
0x4c7c81 : movsx eax, byte ptr [eax + ecx]
0x4c7c85 : mov ecx, dword ptr [ebp - 0x124]
0x4c7c8b : sub eax, dword ptr [ecx + 0x14]
0x4c7c8e : mov ecx, dword ptr [ebp - 0x124]
0x4c7c94 : mov eax, dword ptr [ecx + eax*4 + 0x1c]
0x4c7c98 : mov ecx, dword ptr [ebp - 0x124]
0x4c7c9e : add eax, dword ptr [ecx + 0x10]
0x4c7ca1 : add dword ptr [ebp - 0x11c], eax
0x4c7ca7 : mov eax, dword ptr [ebp - 0x114] 	(displays.c:1621)
0x4c7cad : cmp dword ptr [ebp - 0x11c], eax
0x4c7cb3 : -jle 0x16f
         : +jle 0x161
0x4c7cb9 : mov eax, dword ptr [ebp - 0x120] 	(displays.c:1622)
0x4c7cbf : mov dword ptr [ebp - 0x128], eax
0x4c7cc5 : jmp 0x6
0x4c7cca : dec dword ptr [ebp - 0x128]
0x4c7cd0 : mov eax, dword ptr [ebp - 0x128]
0x4c7cd6 : cmp dword ptr [ebp - 0x118], eax
0x4c7cdc : -jge 0x20
         : +jg 0x20
0x4c7ce2 : mov eax, dword ptr [ebp - 0x128] 	(displays.c:1623)
0x4c7ce8 : mov ecx, dword ptr [ebp + 0xc]
0x4c7ceb : movsx eax, byte ptr [eax + ecx]
0x4c7cef : cmp eax, 0x20
0x4c7cf2 : jne 0x5
0x4c7cf8 : jmp 0x5 	(displays.c:1624)
0x4c7cfd : jmp -0x38 	(displays.c:1626)
0x4c7d02 : mov eax, dword ptr [ebp - 0x128] 	(displays.c:1627)
0x4c7d08 : cmp dword ptr [ebp - 0x118], eax
0x4c7d0e : jne 0xc
0x4c7d14 : mov eax, dword ptr [ebp - 0x120] 	(displays.c:1628)
0x4c7d1a : mov dword ptr [ebp - 0x128], eax
0x4c7d20 : mov eax, dword ptr [ebp - 0x128] 	(displays.c:1630)
0x4c7d26 : -sub eax, dword ptr [ebp - 0x118]
0x4c7d2c : -mov dword ptr [ebp - 0x110], eax
         : +sub eax, dword ptr [ebp - 0x120]
         : +add dword ptr [ebp - 0x110], eax
0x4c7d32 : mov eax, dword ptr [ebp - 0x128] 	(displays.c:1631)
0x4c7d38 : mov dword ptr [ebp - 0x120], eax
0x4c7d3e : -mov eax, dword ptr [ebp - 0x110]
0x4c7d44 : -mov byte ptr [ebp + eax - 0x103], 0
0x4c7d4c : mov eax, dword ptr [ebp - 0x120] 	(displays.c:1632)
0x4c7d52 : mov ecx, dword ptr [ebp + 0xc]
0x4c7d55 : movsx eax, byte ptr [eax + ecx]
0x4c7d59 : cmp eax, 0x20
0x4c7d5c : jne 0x6
0x4c7d62 : inc dword ptr [ebp - 0x120] 	(displays.c:1633)
0x4c7d68 : mov eax, dword ptr [ebp - 0x110] 	(displays.c:1635)
0x4c7d6e : mov byte ptr [ebp + eax - 0x104], 0
0x4c7d76 : cmp dword ptr [ebp + 0x24], 0 	(displays.c:1636)
0x4c7d7a : je 0x2c

---
+++
@@ -0x4c7db7,57 +0x475ae3,79 @@
0x4c7db7 : mov eax, dword ptr [ebp - 0x124]
0x4c7dbd : push eax
0x4c7dbe : mov eax, dword ptr [ebp - 0x10c]
0x4c7dc4 : push eax
0x4c7dc5 : mov eax, dword ptr [ebp + 0x14]
0x4c7dc8 : push eax
0x4c7dc9 : mov eax, dword ptr [gBack_screen (DATA)]
0x4c7dce : push eax
0x4c7dcf : call TransDRPixelmapText (FUNCTION)
0x4c7dd4 : add esp, 0x18
         : +mov dword ptr [ebp - 0x11c], 0 	(displays.c:1641)
0x4c7dd7 : mov eax, dword ptr [ebp - 0x124] 	(displays.c:1642)
0x4c7ddd : mov ebx, dword ptr [eax + 8]
0x4c7de0 : call TranslationMode (FUNCTION)
0x4c7de5 : cmp eax, 1
0x4c7de8 : mov eax, 0
0x4c7ded : adc eax, -1
0x4c7df0 : and eax, 2
0x4c7df3 : sub ebx, eax
0x4c7df5 : lea eax, [ebx + ebx*2]
0x4c7df8 : cdq 
0x4c7df9 : sub eax, edx
0x4c7dfb : sar eax, 1
0x4c7dfd : add dword ptr [ebp - 0x10c], eax
         : +mov dword ptr [ebp - 0x110], 0 	(displays.c:1643)
0x4c7e03 : mov eax, dword ptr [ebp - 0x120] 	(displays.c:1644)
0x4c7e09 : mov dword ptr [ebp - 0x118], eax
0x4c7e0f : -mov dword ptr [ebp - 0x110], 0
0x4c7e19 : -mov dword ptr [ebp - 0x11c], 0
0x4c7e23 : jmp 0xc 	(displays.c:1645)
0x4c7e28 : inc dword ptr [ebp - 0x110] 	(displays.c:1646)
0x4c7e2e : inc dword ptr [ebp - 0x120] 	(displays.c:1647)
0x4c7e34 : -jmp -0x1fd
         : +jmp -0x1ef 	(displays.c:1649)
0x4c7e39 : cmp dword ptr [ebp - 0x110], 0 	(displays.c:1650)
0x4c7e40 : -je 0x61
         : +je 0x9f
0x4c7e46 : cmp dword ptr [ebp + 0x24], 0 	(displays.c:1651)
0x4c7e4a : -je 0x2c
         : +je 0x6a
         : +lea eax, [ebp - 0x104] 	(displays.c:1652)
         : +push eax
         : +mov eax, dword ptr [ebp - 0x124]
         : +push eax
         : +call DRTextWidth (FUNCTION)
         : +add esp, 8
         : +cdq 
         : +sub eax, edx
         : +sar eax, 1
         : +mov ecx, dword ptr [ebp - 4]
         : +add ecx, eax
         : +push ecx
0x4c7e50 : lea eax, [ebp - 0x104]
0x4c7e56 : push eax
0x4c7e57 : mov eax, dword ptr [ebp - 0x124]
0x4c7e5d : push eax
0x4c7e5e : mov eax, dword ptr [ebp - 0x10c]
0x4c7e64 : push eax
0x4c7e65 : -mov eax, dword ptr [ebp - 4]
         : +mov ebx, dword ptr [ebp - 4]
         : +lea eax, [ebp - 0x104]
0x4c7e68 : push eax
         : +mov eax, dword ptr [ebp - 0x124]
         : +push eax
         : +call DRTextWidth (FUNCTION)
         : +add esp, 8
         : +cdq 
         : +sub eax, edx
         : +sar eax, 1
         : +sub ebx, eax
         : +push ebx
0x4c7e69 : mov eax, dword ptr [gBack_screen (DATA)]
0x4c7e6e : push eax
0x4c7e6f : -call DRPixelmapCentredText (FUNCTION)
0x4c7e74 : -add esp, 0x14
         : +call TransDRPixelmapText (FUNCTION)
         : +add esp, 0x18
0x4c7e77 : jmp 0x2b 	(displays.c:1653)
0x4c7e7c : mov eax, dword ptr [ebp + 0x1c] 	(displays.c:1654)
0x4c7e7f : push eax
0x4c7e80 : lea eax, [ebp - 0x104]
0x4c7e86 : push eax
0x4c7e87 : mov eax, dword ptr [ebp - 0x124]
0x4c7e8d : push eax
0x4c7e8e : mov eax, dword ptr [ebp - 0x10c]
0x4c7e94 : push eax
0x4c7e95 : mov eax, dword ptr [ebp + 0x14]


OoerrIveGotTextInMeBoxMissus is only 85.01% similar to the original, diff above
```

*AI generated. Time taken: 157s, tokens: 27,088*
