### PR TITLE
TransBrPixelmapText 100% match

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -1662,10 +1662,9 @@ void OoerrIveGotTextInMeBoxMissus(int pFont_index, char* pText, br_pixelmap* pPi
 // IDA: void __usercall TransBrPixelmapText(br_pixelmap *pPixelmap@<EAX>, int pX@<EDX>, int pY@<EBX>, br_uint_32 pColour@<ECX>, br_font *pFont, signed char *pText)
 // FUNCTION: CARM95 0x004c7ec5
 void TransBrPixelmapText(br_pixelmap* pPixelmap, int pX, int pY, br_uint_32 pColour, br_font* pFont, char* pText) {
-    int len;
+    int len[2];
 
-    len = TranslationMode() ? 2 : 0;
-    BrPixelmapText(pPixelmap, pX, pY - len, pColour, pFont, (char*)pText);
+    BrPixelmapText(pPixelmap, pX, pY - (TranslationMode() ? 2 : 0), pColour, pFont, (char*)pText);
 }
 
 // IDA: void __usercall TransDRPixelmapText(br_pixelmap *pPixelmap@<EAX>, int pX@<EDX>, int pY@<EBX>, tDR_font *pFont@<ECX>, char *pText, int pRight_edge)

--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -1664,7 +1664,7 @@ void OoerrIveGotTextInMeBoxMissus(int pFont_index, char* pText, br_pixelmap* pPi
 void TransBrPixelmapText(br_pixelmap* pPixelmap, int pX, int pY, br_uint_32 pColour, br_font* pFont, char* pText) {
     int len[2];
 
-    BrPixelmapText(pPixelmap, pX, pY - (TranslationMode() ? 2 : 0), pColour, pFont, (char*)pText);
+    BrPixelmapText(pPixelmap, pX, pY - (TranslationMode() ? 2 : 0), pColour, pFont, pText);
 }
 
 // IDA: void __usercall TransDRPixelmapText(br_pixelmap *pPixelmap@<EAX>, int pX@<EDX>, int pY@<EBX>, tDR_font *pFont@<ECX>, char *pText, int pRight_edge)


### PR DESCRIPTION
## Match result

```
0x4c7ec5: TransBrPixelmapText 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4c7ec5,30 +0x475c2f,31 @@
0x4c7ec5 : push ebp 	(displays.c:1664)
0x4c7ec6 : mov ebp, esp
0x4c7ec8 : -sub esp, 8
         : +sub esp, 4
0x4c7ecb : push ebx
0x4c7ecc : push esi
0x4c7ecd : push edi
         : +call TranslationMode (FUNCTION) 	(displays.c:1667)
         : +test eax, eax
         : +je 0xc
         : +mov dword ptr [ebp - 4], 2
         : +jmp 0x7
         : +mov dword ptr [ebp - 4], 0
0x4c7ece : mov eax, dword ptr [ebp + 0x1c] 	(displays.c:1668)
0x4c7ed1 : push eax
0x4c7ed2 : mov eax, dword ptr [ebp + 0x18]
0x4c7ed5 : push eax
0x4c7ed6 : mov eax, dword ptr [ebp + 0x14]
0x4c7ed9 : push eax
0x4c7eda : -mov ebx, dword ptr [ebp + 0x10]
0x4c7edd : -call TranslationMode (FUNCTION)
0x4c7ee2 : -cmp eax, 1
0x4c7ee5 : -mov eax, 0
0x4c7eea : -adc eax, -1
0x4c7eed : -and eax, 2
0x4c7ef0 : -sub ebx, eax
0x4c7ef2 : -push ebx
         : +mov eax, dword ptr [ebp + 0x10]
         : +sub eax, dword ptr [ebp - 4]
         : +push eax
0x4c7ef3 : mov eax, dword ptr [ebp + 0xc]
0x4c7ef6 : push eax
0x4c7ef7 : mov eax, dword ptr [ebp + 8]
0x4c7efa : push eax
0x4c7efb : call BrPixelmapText (FUNCTION)
0x4c7f00 : add esp, 0x18
0x4c7f03 : pop edi 	(displays.c:1669)
0x4c7f04 : pop esi
0x4c7f05 : pop ebx
0x4c7f06 : leave 


TransBrPixelmapText is only 69.84% similar to the original, diff above
```

*AI generated. Time taken: 330s, tokens: 36,439*
