### PR TITLE
TransDRPixelmapCleverText 100% effective match

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -1686,11 +1686,15 @@ void TransDRPixelmapText(br_pixelmap* pPixelmap, int pX, int pY, tDR_font* pFont
 // FUNCTION: CARM95 0x004c7fd5
 void TransDRPixelmapCleverText(br_pixelmap* pPixelmap, int pX, int pY, tDR_font* pFont, char* pText, int pRight_edge) {
 
-    if (gAusterity_mode && FlicsPlayedFromDisk() && gCached_font != pFont) {
-        if (gCached_font && gCached_font - gFonts > 13) {
-            DisposeFont(gCached_font - gFonts);
+    if (gAusterity_mode) {
+        if (FlicsPlayedFromDisk()) {
+            if (pFont != gCached_font) {
+                if (gCached_font && gFonts - gCached_font <= -13) {
+                    DisposeFont(gCached_font - gFonts);
+                }
+                gCached_font = pFont;
+            }
         }
-        gCached_font = pFont;
     }
     LoadFont(pFont - gFonts);
     DRPixelmapCleverText2(pPixelmap, pX, pY - (TranslationMode() == 0 ? 0 : 2), pFont, pText, pRight_edge);


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4c7fd5,22 +0x475d4d,22 @@
0x4c7fd5 : push ebp 	(displays.c:1687)
0x4c7fd6 : mov ebp, esp
0x4c7fd8 : push ebx
0x4c7fd9 : push esi
0x4c7fda : push edi
0x4c7fdb : cmp dword ptr [gAusterity_mode (DATA)], 0 	(displays.c:1689)
0x4c7fe2 : -je 0x68
         : +je 0x67
0x4c7fe8 : call FlicsPlayedFromDisk (FUNCTION) 	(displays.c:1690)
0x4c7fed : test eax, eax
0x4c7fef : -je 0x5b
0x4c7ff5 : -mov eax, dword ptr [ebp + 0x14]
0x4c7ff8 : -cmp dword ptr [gCached_font (DATA)], eax
         : +je 0x5a
         : +mov eax, dword ptr [gCached_font (DATA)] 	(displays.c:1691)
         : +cmp dword ptr [ebp + 0x14], eax
0x4c7ffe : je 0x4c
0x4c8004 : cmp dword ptr [gCached_font (DATA)], 0 	(displays.c:1692)
0x4c800b : je 0x37
0x4c8011 : mov eax, gFonts[0].images (DATA)
0x4c8016 : sub eax, dword ptr [gCached_font (DATA)]
0x4c801c : mov ecx, 0x39c
0x4c8021 : cdq 
0x4c8022 : idiv ecx
0x4c8024 : cmp eax, -0xd
0x4c8027 : jg 0x1b

---
+++
@@ -0x4c808e,10 +0x475e05,11 @@
0x4c808e : mov eax, dword ptr [ebp + 0xc]
0x4c8091 : push eax
0x4c8092 : mov eax, dword ptr [ebp + 8]
0x4c8095 : push eax
0x4c8096 : call DRPixelmapCleverText2 (FUNCTION)
0x4c809b : add esp, 0x18
0x4c809e : pop edi 	(displays.c:1701)
0x4c809f : pop esi
0x4c80a0 : pop ebx
0x4c80a1 : leave 
         : +ret 


0x4c7fd5: TransDRPixelmapCleverText 100% effective match (differs, but only in ways that don't affect behavior).

OK!
```

#### Original match

```
---
+++
@@ -0x4c7fd5,32 +0x475d4d,32 @@
0x4c7fd5 : push ebp 	(displays.c:1687)
0x4c7fd6 : mov ebp, esp
0x4c7fd8 : push ebx
0x4c7fd9 : push esi
0x4c7fda : push edi
0x4c7fdb : cmp dword ptr [gAusterity_mode (DATA)], 0 	(displays.c:1689)
0x4c7fe2 : -je 0x68
         : +je 0x66
0x4c7fe8 : call FlicsPlayedFromDisk (FUNCTION)
0x4c7fed : test eax, eax
0x4c7fef : -je 0x5b
0x4c7ff5 : -mov eax, dword ptr [ebp + 0x14]
0x4c7ff8 : -cmp dword ptr [gCached_font (DATA)], eax
0x4c7ffe : -je 0x4c
         : +je 0x59
         : +mov eax, dword ptr [gCached_font (DATA)]
         : +cmp dword ptr [ebp + 0x14], eax
         : +je 0x4b
0x4c8004 : cmp dword ptr [gCached_font (DATA)], 0 	(displays.c:1690)
0x4c800b : -je 0x37
0x4c8011 : -mov eax, gFonts[0].images (DATA)
0x4c8016 : -sub eax, dword ptr [gCached_font (DATA)]
         : +je 0x36
         : +mov eax, dword ptr [gCached_font (DATA)]
         : +sub eax, gFonts[0].images (DATA)
0x4c801c : mov ecx, 0x39c
0x4c8021 : cdq 
0x4c8022 : idiv ecx
0x4c8024 : -cmp eax, -0xd
0x4c8027 : -jg 0x1b
         : +cmp eax, 0xd
         : +jle 0x1b
0x4c802d : mov eax, dword ptr [gCached_font (DATA)] 	(displays.c:1691)
0x4c8032 : sub eax, gFonts[0].images (DATA)
0x4c8037 : mov ecx, 0x39c
0x4c803c : cdq 
0x4c803d : idiv ecx
0x4c803f : push eax
0x4c8040 : call DisposeFont (FUNCTION)
0x4c8045 : add esp, 4
0x4c8048 : mov eax, dword ptr [ebp + 0x14] 	(displays.c:1693)
0x4c804b : mov dword ptr [gCached_font (DATA)], eax

---
+++
@@ -0x4c808d,10 +0x475e03,12 @@
0x4c808d : push ebx
0x4c808e : mov eax, dword ptr [ebp + 0xc]
0x4c8091 : push eax
0x4c8092 : mov eax, dword ptr [ebp + 8]
0x4c8095 : push eax
0x4c8096 : call DRPixelmapCleverText2 (FUNCTION)
0x4c809b : add esp, 0x18
0x4c809e : pop edi 	(displays.c:1697)
0x4c809f : pop esi
0x4c80a0 : pop ebx
         : +leave 
         : +ret 


TransDRPixelmapCleverText is only 82.81% similar to the original, diff above
```

*AI generated. Time taken: 144s, tokens: 14,060*
