### PR TITLE
CheckForBeingOutOfThisWorld 100% match

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -1276,28 +1276,32 @@ void CheckForBeingOutOfThisWorld(void) {
     static tU32 sLast_check;
     int time_step;
 
-    the_time = PDGetTotalTime();
+    time_step = PDGetTotalTime() - the_time;
+    the_time += time_step;
 
-    if (gRecover_timer == 0 || ((gProgram_state.current_car.frame_collision_flag || gProgram_state.current_car.number_of_wheels_on_ground) && !IsCarInTheSea())) {
-        gRecover_timer = 0;
-        if ((the_time - sLast_check) > 200) {
-            sLast_check = the_time;
-            if (HasCarFallenOffWorld(&gProgram_state.current_car)) {
-                gRecover_timer = 3000;
+    if (gRecover_timer != 0) {
+        if ((gProgram_state.current_car.frame_collision_flag || gProgram_state.current_car.number_of_wheels_on_ground) && !IsCarInTheSea()) {
+            gRecover_timer = 0;
+        } else {
+            gRecover_timer -= gFrame_period;
+            if (gRecover_timer <= 0 || IsCarInTheSea() == 2) {
+                gRecover_timer = 0;
+                RecoverCar();
+                gHad_auto_recover = 1;
             }
+            return;
         }
-        if (IsCarInTheSea()) {
-            if (!gRecover_timer) {
-                gRecover_timer = 3000;
-            }
-        }
-        return;
     }
-    gRecover_timer -= gFrame_period;
-    if (gRecover_timer <= 0 || IsCarInTheSea() == 2) {
-        gRecover_timer = 0;
-        RecoverCar();
-        gHad_auto_recover = 1;
+    if ((the_time - sLast_check) > 200) {
+        sLast_check = the_time;
+        if (HasCarFallenOffWorld(&gProgram_state.current_car)) {
+            gRecover_timer = 3000;
+        }
+    }
+    if (IsCarInTheSea()) {
+        if (!gRecover_timer) {
+            gRecover_timer = 3000;
+        }
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4a3328: CheckForBeingOutOfThisWorld 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4a3328,51 +0x46659c,54 @@
0x4a3328 : push ebp 	(controls.c:1272)
0x4a3329 : mov ebp, esp
0x4a332b : sub esp, 4
0x4a332e : push ebx
0x4a332f : push esi
0x4a3330 : push edi
0x4a3331 : call PDGetTotalTime (FUNCTION) 	(controls.c:1279)
0x4a3336 : -sub eax, dword ptr [the_time (DATA)]
0x4a333c : -mov dword ptr [ebp - 4], eax
0x4a333f : -mov eax, dword ptr [ebp - 4]
0x4a3342 : -add dword ptr [the_time (DATA)], eax
         : +mov dword ptr [the_time (DATA)], eax
0x4a3348 : cmp dword ptr [gRecover_timer (DATA)], 0 	(controls.c:1281)
0x4a334f : -je 0x7a
         : +je 0x27
0x4a3355 : cmp dword ptr [gProgram_state+740 (OFFSET)], 0
0x4a335c : jne 0xd
0x4a3362 : cmp dword ptr [gProgram_state+5692 (OFFSET)], 0
0x4a3369 : -je 0x1c
         : +je 0x85
0x4a336f : call IsCarInTheSea (FUNCTION)
0x4a3374 : test eax, eax
0x4a3376 : -jne 0xf
         : +jne 0x78
0x4a337c : mov dword ptr [gRecover_timer (DATA)], 0 	(controls.c:1282)
0x4a3386 : -jmp 0x44
0x4a338b : -mov eax, dword ptr [gFrame_period (DATA)]
0x4a3390 : -sub dword ptr [gRecover_timer (DATA)], eax
0x4a3396 : -cmp dword ptr [gRecover_timer (DATA)], 0
0x4a339d : -jle 0xe
0x4a33a3 : -call IsCarInTheSea (FUNCTION)
0x4a33a8 : -cmp eax, 2
0x4a33ab : -jne 0x19
0x4a33b1 : -mov dword ptr [gRecover_timer (DATA)], 0
0x4a33bb : -call RecoverCar (FUNCTION)
0x4a33c0 : -mov dword ptr [gHad_auto_recover (DATA)], 1
0x4a33ca : -jmp 0x69
0x4a33cf : mov eax, dword ptr [the_time (DATA)] 	(controls.c:1283)
0x4a33d4 : sub eax, dword ptr [sLast_check (DATA)]
0x4a33da : cmp eax, 0xc8
0x4a33df : jbe 0x2f
0x4a33e5 : mov eax, dword ptr [the_time (DATA)] 	(controls.c:1284)
0x4a33ea : mov dword ptr [sLast_check (DATA)], eax
0x4a33ef : mov eax, gProgram_state (DATA) 	(controls.c:1285)
0x4a33f4 : add eax, 0xb0
0x4a33f9 : push eax
0x4a33fa : call HasCarFallenOffWorld (FUNCTION)
0x4a33ff : add esp, 4
0x4a3402 : test eax, eax
0x4a3404 : je 0xa
0x4a340a : mov dword ptr [gRecover_timer (DATA)], 0xbb8 	(controls.c:1286)
0x4a3414 : call IsCarInTheSea (FUNCTION) 	(controls.c:1289)
0x4a3419 : test eax, eax
0x4a341b : je 0x17
0x4a3421 : cmp dword ptr [gRecover_timer (DATA)], 0 	(controls.c:1290)
         : +jne 0xa
         : +mov dword ptr [gRecover_timer (DATA)], 0xbb8 	(controls.c:1291)
         : +jmp 0x3f 	(controls.c:1294)
         : +mov eax, dword ptr [gFrame_period (DATA)] 	(controls.c:1296)
         : +sub dword ptr [gRecover_timer (DATA)], eax
         : +cmp dword ptr [gRecover_timer (DATA)], 0 	(controls.c:1297)
         : +jle 0xe
         : +call IsCarInTheSea (FUNCTION)
         : +cmp eax, 2
         : +jne 0x19
         : +mov dword ptr [gRecover_timer (DATA)], 0 	(controls.c:1298)
         : +call RecoverCar (FUNCTION) 	(controls.c:1299)
         : +mov dword ptr [gHad_auto_recover (DATA)], 1 	(controls.c:1300)
         : +pop edi 	(controls.c:1302)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


CheckForBeingOutOfThisWorld is only 60.95% similar to the original, diff above
```

*AI generated. Time taken: 219s, tokens: 37,279*
