### PR TITLE
CheckHorns 100% match

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -1351,10 +1351,10 @@ void CheckHorns(void) {
 
     if (gNet_mode == eNet_mode_none) {
         CheckHornLocal(&gProgram_state.current_car);
-        return;
-    }
-    for (i = 0; i < gNumber_of_net_players; i++) {
-        CheckHorn3D(gNet_players[i].car);
+    } else {
+        for (i = 0; i < gNumber_of_net_players; i++) {
+            CheckHorn3D(gNet_players[i].car);
+        }
     }
 }
 

--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -1349,12 +1349,12 @@ void CheckHorn3D(tCar_spec* pCar) {
 void CheckHorns(void) {
     int i;
 
-    if (gNet_mode != eNet_mode_none) {
-        for (i = 0; i < gNumber_of_net_players; i++) {
-            CheckHorn3D(gNet_players[i].car);
-        }
-    } else {
+    if (gNet_mode == eNet_mode_none) {
         CheckHornLocal(&gProgram_state.current_car);
+        return;
+    }
+    for (i = 0; i < gNumber_of_net_players; i++) {
+        CheckHorn3D(gNet_players[i].car);
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4a343d: CheckHorns 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4a343d,32 +0x466886,32 @@
0x4a343d : push ebp 	(controls.c:1349)
0x4a343e : mov ebp, esp
0x4a3440 : sub esp, 4
0x4a3443 : push ebx
0x4a3444 : push esi
0x4a3445 : push edi
0x4a3446 : cmp dword ptr [gNet_mode (DATA)], 0 	(controls.c:1352)
0x4a344d : -jne 0x18
0x4a3453 : -mov eax, gProgram_state (DATA)
0x4a3458 : -add eax, 0xb0
0x4a345d : -push eax
0x4a345e : -call CheckHornLocal (FUNCTION)
0x4a3463 : -add esp, 4
0x4a3466 : -jmp 0x38
         : +je 0x3d
0x4a346b : mov dword ptr [ebp - 4], 0 	(controls.c:1353)
0x4a3472 : jmp 0x3
0x4a3477 : inc dword ptr [ebp - 4]
0x4a347a : mov eax, dword ptr [gNumber_of_net_players (DATA)]
0x4a347f : cmp dword ptr [ebp - 4], eax
0x4a3482 : jge 0x1b
0x4a3488 : mov eax, dword ptr [ebp - 4] 	(controls.c:1354)
0x4a348b : shl eax, 6
0x4a348e : mov eax, dword ptr [eax + eax*2 + gNet_players[0].car (OFFSET)]
0x4a3495 : push eax
0x4a3496 : call CheckHorn3D (FUNCTION)
0x4a349b : add esp, 4
0x4a349e : jmp -0x2c 	(controls.c:1355)
         : +jmp 0x13 	(controls.c:1356)
         : +mov eax, gProgram_state (DATA) 	(controls.c:1357)
         : +add eax, 0xb0
         : +push eax
         : +call CheckHornLocal (FUNCTION)
         : +add esp, 4
0x4a34a3 : pop edi 	(controls.c:1359)
0x4a34a4 : pop esi
0x4a34a5 : pop ebx
0x4a34a6 : leave 
0x4a34a7 : ret 


CheckHorns is only 78.12% similar to the original, diff above
```

*AI generated. Time taken: 98s, tokens: 10,814*
