### PR TITLE
PollCameraControls 100% match

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -2085,7 +2085,8 @@ void PollCameraControls(tU32 pTime_difference) {
         }
         last_swirl_mode = swirl_mode;
     }
-    if (!gMap_mode && !gProgram_state.cockpit_on && (!gAction_replay_mode || gAction_replay_camera_mode <= eAction_replay_standard)) {
+    if (gMap_mode) {
+    } else if (!gProgram_state.cockpit_on && (!gAction_replay_mode || gAction_replay_camera_mode <= eAction_replay_standard)) {
         if (KeyIsDown(31) || (up_and_down_mode && !going_up)) {
             gCamera_zoom = pTime_difference * TIME_CONV_THING / (double)(2 * swirl_mode + 1) + gCamera_zoom;
             if (gCamera_zoom > 2.0f) {
@@ -2099,6 +2100,7 @@ void PollCameraControls(tU32 pTime_difference) {
             gCamera_zoom = gCamera_zoom - pTime_difference * TIME_CONV_THING / (double)(2 * swirl_mode + 1);
             if (gCamera_zoom < 0.1f) {
                 gCamera_zoom = 0.1f;
+                going_up = 0;
                 if (up_and_down_mode) {
                     if (gCamera_zoom < 1.0f) {
                         gCamera_zoom = 1.0f;
@@ -2106,7 +2108,7 @@ void PollCameraControls(tU32 pTime_difference) {
                 }
             }
         }
-        if (swirl_mode && gProgram_state.current_car.speedo_speed < 0.001449275362318841) {
+        if (swirl_mode && gProgram_state.current_car.speedo_speed < 0.0014492753623188406) {
             left = 1;
             right = 0;
         } else {

--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -2108,7 +2108,7 @@ void PollCameraControls(tU32 pTime_difference) {
                 }
             }
         }
-        if (swirl_mode && gProgram_state.current_car.speedo_speed < 0.0014492753623188406) {
+        if (swirl_mode && gProgram_state.current_car.speedo_speed < (1 / WORLD_SCALE_D / 100.0)) {
             left = 1;
             right = 0;
         } else {


### PR DESCRIPTION
## Match result

```
0x4a4214: PollCameraControls 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4a42e6,28 +0x468aa4,27 @@
0x4a42e6 : push 0 	(controls.c:2082)
0x4a42e8 : call SaveCameraPosition (FUNCTION)
0x4a42ed : add esp, 4
0x4a42f0 : jmp 0xa 	(controls.c:2083)
0x4a42f5 : push 0 	(controls.c:2084)
0x4a42f7 : call RestoreCameraPosition (FUNCTION)
0x4a42fc : add esp, 4
0x4a42ff : mov eax, dword ptr [ebp - 0x14] 	(controls.c:2086)
0x4a4302 : mov dword ptr [last_swirl_mode (DATA)], eax
0x4a4307 : cmp dword ptr [gMap_mode (DATA)], 0 	(controls.c:2088)
0x4a430e : -je 0x5
0x4a4314 : -jmp 0x2ca
         : +jne 0x2c3
0x4a4319 : cmp dword ptr [gProgram_state+80 (OFFSET)], 0
0x4a4320 : -jne 0x2bd
         : +jne 0x2b6
0x4a4326 : cmp dword ptr [gAction_replay_mode (DATA)], 0
0x4a432d : je 0xd
0x4a4333 : cmp dword ptr [gAction_replay_camera_mode (DATA)], 0
0x4a433a : -jg 0x2a3
         : +jg 0x29c
0x4a4340 : push 0x1f 	(controls.c:2089)
0x4a4342 : call KeyIsDown (FUNCTION)
0x4a4347 : add esp, 4
0x4a434a : test eax, eax
0x4a434c : jne 0x14
0x4a4352 : cmp dword ptr [ebp - 4], 0
0x4a4356 : je 0x80
0x4a435c : cmp dword ptr [ebp - 0x10], 0
0x4a4360 : jne 0x76
0x4a4366 : mov eax, dword ptr [ebp + 8] 	(controls.c:2090)

---
+++
@@ -0x4a43c7,54 +0x468b80,53 @@
0x4a43c7 : fnstsw ax
0x4a43c9 : test ah, 0x41
0x4a43cc : jne 0xa
0x4a43d2 : mov dword ptr [gCamera_zoom (DATA)], 0x3f800000 	(controls.c:2095)
0x4a43dc : push 0x1e 	(controls.c:2098)
0x4a43de : call KeyIsDown (FUNCTION)
0x4a43e3 : add esp, 4
0x4a43e6 : test eax, eax
0x4a43e8 : jne 0x14
0x4a43ee : cmp dword ptr [ebp - 4], 0
0x4a43f2 : -je 0x87
         : +je 0x80
0x4a43f8 : cmp dword ptr [ebp - 0x10], 0
0x4a43fc : -je 0x7d
         : +je 0x76
0x4a4402 : mov eax, dword ptr [ebp + 8] 	(controls.c:2099)
0x4a4405 : mov dword ptr [ebp - 0x34], eax
0x4a4408 : mov dword ptr [ebp - 0x30], 0
0x4a440f : fild qword ptr [ebp - 0x34]
0x4a4412 : fmul dword ptr [0.0005000000237487257 (FLOAT)]
0x4a4418 : mov eax, dword ptr [ebp - 0x14]
0x4a441b : add eax, eax
0x4a441d : inc eax
0x4a441e : mov dword ptr [ebp - 0x38], eax
0x4a4421 : fild dword ptr [ebp - 0x38]
0x4a4424 : fdivp st(1)
0x4a4426 : fsubr dword ptr [gCamera_zoom (DATA)]
0x4a442c : fcom dword ptr [0.10000000149011612 (FLOAT)] 	(controls.c:2100)
0x4a4432 : fstp dword ptr [gCamera_zoom (DATA)]
0x4a4438 : fnstsw ax
0x4a443a : test ah, 1
0x4a443d : -je 0x3c
         : +je 0x35
0x4a4443 : mov dword ptr [gCamera_zoom (DATA)], 0x3dcccccd 	(controls.c:2101)
0x4a444d : -mov dword ptr [ebp - 0x10], 0
0x4a4454 : cmp dword ptr [ebp - 4], 0 	(controls.c:2102)
0x4a4458 : je 0x21
0x4a445e : fld dword ptr [gCamera_zoom (DATA)] 	(controls.c:2103)
0x4a4464 : fcomp dword ptr [1.0 (FLOAT)]
0x4a446a : fnstsw ax
0x4a446c : test ah, 1
0x4a446f : je 0xa
0x4a4475 : mov dword ptr [gCamera_zoom (DATA)], 0x3f800000 	(controls.c:2104)
0x4a447f : cmp dword ptr [ebp - 0x14], 0 	(controls.c:2109)
0x4a4483 : je 0x2a
0x4a4489 : fld dword ptr [gProgram_state+1988 (OFFSET)]
0x4a448f : -fcomp qword ptr [0.0014492753623188406 (FLOAT)]
         : +fcomp qword ptr [0.001449275362318841 (FLOAT)]
0x4a4495 : fnstsw ax
0x4a4497 : test ah, 1
0x4a449a : je 0x13
0x4a44a0 : mov dword ptr [ebp - 0x18], 1 	(controls.c:2110)
0x4a44a7 : mov dword ptr [ebp - 0xc], 0 	(controls.c:2111)
0x4a44ae : jmp 0x1a 	(controls.c:2112)
0x4a44b3 : push 0x20 	(controls.c:2113)
0x4a44b5 : call KeyIsDown (FUNCTION)
0x4a44ba : add esp, 4
0x4a44bd : mov dword ptr [ebp - 0x18], eax

---
+++
@@ -0x4a459f,10 +0x468d51,16 @@
0x4a459f : and eax, 0xffff
0x4a45a4 : sub ebx, eax
0x4a45a6 : mov word ptr [gCamera_yaw (DATA)], bx
0x4a45ad : cmp dword ptr [ebp - 8], 0 	(controls.c:2127)
0x4a45b1 : je 0x13
0x4a45b7 : mov word ptr [gCamera_yaw (DATA)], 0 	(controls.c:2128)
0x4a45c0 : mov dword ptr [gCamera_reset (DATA)], 1 	(controls.c:2129)
0x4a45ca : jmp 0x14 	(controls.c:2131)
0x4a45cf : cmp dword ptr [ebp - 8], 0
0x4a45d3 : jne 0xa
         : +mov dword ptr [gCamera_reset (DATA)], 0 	(controls.c:2132)
         : +pop edi 	(controls.c:2135)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


PollCameraControls is only 94.61% similar to the original, diff above
```

*AI generated. Time taken: 474s, tokens: 61,486*
