### PR TITLE
ShowCutScene 100% match

### DIFF
--- a/src/DETHRACE/common/cutscene.c
+++ b/src/DETHRACE/common/cutscene.c
@@ -28,7 +28,7 @@ void ShowCutScene(int pIndex, int pWait_end, int pSound_ID, br_scalar pDelay) {
     gProgram_state.cut_scene = 1;
     if (pSound_ID >= 0) {
         DRS3LoadSound(pSound_ID);
-        SetFlicSound(pSound_ID, PDGetTotalTime() + 1000.f * pDelay);
+        SetFlicSound(pSound_ID, PDGetTotalTime() + (int)(1000.f * pDelay));
     }
     SetNonFatalAllocationErrors();
     RunFlic(pIndex);


### PR DESCRIPTION
## Match result

```
0x4a58c0: ShowCutScene 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4a58c0,29 +0x46eae0,31 @@
0x4a58c0 : push ebp 	(cutscene.c:26)
0x4a58c1 : mov ebp, esp
         : +sub esp, 4
0x4a58c3 : push ebx
0x4a58c4 : push esi
0x4a58c5 : push edi
0x4a58c6 : mov dword ptr [gProgram_state+52 (OFFSET)], 1 	(cutscene.c:28)
0x4a58d0 : cmp dword ptr [ebp + 0x10], 0 	(cutscene.c:29)
0x4a58d4 : -jl 0x30
         : +jl 0x34
0x4a58da : mov eax, dword ptr [ebp + 0x10] 	(cutscene.c:30)
0x4a58dd : push eax
0x4a58de : call DRS3LoadSound (FUNCTION)
0x4a58e3 : add esp, 4
0x4a58e6 : call PDGetTotalTime (FUNCTION) 	(cutscene.c:31)
0x4a58eb : -mov ebx, eax
         : +mov dword ptr [ebp - 4], eax
         : +fild dword ptr [ebp - 4]
0x4a58ed : fld dword ptr [ebp + 0x14]
0x4a58f0 : fmul dword ptr [1000.0 (FLOAT)]
         : +faddp st(1)
0x4a58f6 : call __ftol (FUNCTION)
0x4a58fb : -add ebx, eax
0x4a58fd : -push ebx
         : +push eax
0x4a58fe : mov eax, dword ptr [ebp + 0x10]
0x4a5901 : push eax
0x4a5902 : call SetFlicSound (FUNCTION)
0x4a5907 : add esp, 8
0x4a590a : call SetNonFatalAllocationErrors (FUNCTION) 	(cutscene.c:33)
0x4a590f : mov eax, dword ptr [ebp + 8] 	(cutscene.c:34)
0x4a5912 : push eax
0x4a5913 : call RunFlic (FUNCTION)
0x4a5918 : add esp, 4
0x4a591b : call ResetNonFatalAllocationErrors (FUNCTION) 	(cutscene.c:35)


ShowCutScene is only 90.57% similar to the original, diff above
```

*AI generated. Time taken: 68s, tokens: 17,191*
