### PR TITLE
ServiceTheGame 100% match

### DIFF
--- a/src/DETHRACE/common/main.c
+++ b/src/DETHRACE/common/main.c
@@ -95,14 +95,10 @@ void ServiceTheGame(int pRacing) {
         QuitGame();
     }
     if (!pRacing) {
-        CheckSystemKeys(0);
+        CheckSystemKeys(pRacing);
     }
     if (!pRacing && gSound_enabled) {
-        if (gProgram_state.cockpit_on && gProgram_state.cockpit_image_index >= 0) {
-            S3Service(1, 2);
-        } else {
-            S3Service(0, 2);
-        }
+        S3Service(gProgram_state.cockpit_on && gProgram_state.cockpit_image_index >= 0, 2);
     }
     NetService(pRacing);
 }


### PR DESCRIPTION
## Match result

```
0x4a9f29: ServiceTheGame 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4a9f29,43 +0x48b863,49 @@
0x4a9f29 : push ebp 	(main.c:86)
0x4a9f2a : mov ebp, esp
0x4a9f2c : -sub esp, 4
0x4a9f2f : push ebx
0x4a9f30 : push esi
0x4a9f31 : push edi
0x4a9f32 : call CheckMemory (FUNCTION) 	(main.c:88)
0x4a9f37 : cmp dword ptr [ebp + 8], 0 	(main.c:89)
0x4a9f3b : jne 0x5
0x4a9f41 : call CyclePollKeys (FUNCTION) 	(main.c:90)
0x4a9f46 : call PollKeys (FUNCTION) 	(main.c:92)
0x4a9f4b : call rand (FUNCTION) 	(main.c:93)
0x4a9f50 : mov eax, dword ptr [gFrame_period (DATA)] 	(main.c:94)
0x4a9f55 : push eax
0x4a9f56 : call PDServiceSystem (FUNCTION)
0x4a9f5b : add esp, 4
0x4a9f5e : test eax, eax
0x4a9f60 : je 0x5
0x4a9f66 : call QuitGame (FUNCTION) 	(main.c:95)
0x4a9f6b : cmp dword ptr [ebp + 8], 0 	(main.c:97)
0x4a9f6f : -jne 0xc
0x4a9f75 : -mov eax, dword ptr [ebp + 8]
0x4a9f78 : -push eax
         : +jne 0xa
         : +push 0 	(main.c:98)
0x4a9f79 : call CheckSystemKeys (FUNCTION)
0x4a9f7e : add esp, 4
0x4a9f81 : cmp dword ptr [ebp + 8], 0 	(main.c:100)
0x4a9f85 : -jne 0x48
         : +jne 0x44
0x4a9f8b : cmp dword ptr [gSound_enabled (DATA)], 0
0x4a9f92 : -je 0x3b
         : +je 0x37
0x4a9f98 : cmp dword ptr [gProgram_state+80 (OFFSET)], 0 	(main.c:101)
0x4a9f9f : -je 0x19
         : +je 0x1e
0x4a9fa5 : cmp dword ptr [gProgram_state+84 (OFFSET)], 0
0x4a9fac : -jl 0xc
0x4a9fb2 : -mov dword ptr [ebp - 4], 1
0x4a9fb9 : -jmp 0x7
0x4a9fbe : -mov dword ptr [ebp - 4], 0
         : +jl 0x11
0x4a9fc5 : push 2 	(main.c:102)
0x4a9fc7 : -mov eax, dword ptr [ebp - 4]
0x4a9fca : -push eax
         : +push 1
         : +call S3Service (FUNCTION)
         : +add esp, 8
         : +jmp 0xc 	(main.c:103)
         : +push 2 	(main.c:104)
         : +push 0
0x4a9fcb : call S3Service (FUNCTION)
0x4a9fd0 : add esp, 8
0x4a9fd3 : mov eax, dword ptr [ebp + 8] 	(main.c:107)
0x4a9fd6 : push eax
         : +call NetService (FUNCTION)
         : +add esp, 4
         : +pop edi 	(main.c:108)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


ServiceTheGame is only 65.22% similar to the original, diff above
```

*AI generated. Time taken: 90s, tokens: 12,585*
