### PR TITLE
SelectSkillLevel 100% match

### DIFF
--- a/src/DETHRACE/common/newgame.c
+++ b/src/DETHRACE/common/newgame.c
@@ -393,9 +393,10 @@ int SelectSkillLevel(void) {
     result = DoInterfaceScreen(&interface_spec, 0, gProgram_state.skill_level);
     if (result > 2) {
         return 0;
+    } else {
+        gProgram_state.skill_level = result;
+        return 1;
     }
-    gProgram_state.skill_level = result;
-    return 1;
 }
 
 // IDA: int __cdecl DoOnePlayerStart()


### PR DESCRIPTION
## Match result

```
0x4b0436: SelectSkillLevel 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b043d,18 +0x48e50b,22 @@
0x4b043d : push esi
0x4b043e : push edi
0x4b043f : mov eax, dword ptr [gProgram_state+40 (OFFSET)] 	(newgame.c:393)
0x4b0444 : push eax
0x4b0445 : push 0
0x4b0447 : push interface_spec (DATA)
0x4b044c : call DoInterfaceScreen (FUNCTION)
0x4b0451 : add esp, 0xc
0x4b0454 : mov dword ptr [ebp - 4], eax
0x4b0457 : cmp dword ptr [ebp - 4], 2 	(newgame.c:394)
0x4b045b : -jle 0xc
         : +jle 0x7
0x4b0461 : xor eax, eax 	(newgame.c:395)
0x4b0463 : -jmp 0x17
0x4b0468 : jmp 0x12
0x4b046d : mov eax, dword ptr [ebp - 4] 	(newgame.c:397)
0x4b0470 : mov dword ptr [gProgram_state+40 (OFFSET)], eax
0x4b0475 : mov eax, 1 	(newgame.c:398)
0x4b047a : jmp 0x0
         : +pop edi 	(newgame.c:399)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


SelectSkillLevel is only 83.33% similar to the original, diff above
```

*AI generated. Time taken: 116s, tokens: 18,852*
