### PR TITLE
JoinOrHostGame 100% match

### DIFF
--- a/src/DETHRACE/common/newgame.c
+++ b/src/DETHRACE/common/newgame.c
@@ -873,9 +873,8 @@ tJoin_or_host_result JoinOrHostGame(tNet_game_details** pGame_to_join) {
     case 2:
         *pGame_to_join = gGames_to_join[gLast_graph_sel__newgame].game;
         return eJoin_or_host_join;
-    default:
-        return eJoin_or_host_cancel;
     }
+    return eJoin_or_host_cancel;
 }
 
 // IDA: void __usercall GetNetOptions(tNet_game_options *pGame_options@<EAX>)


### PR DESCRIPTION
## Match result

```
0x4b1113: JoinOrHostGame 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b11cf,36 +0x48f4df,36 @@
0x4b11cf : lea edi, [gProgram_state+6988 (OFFSET)]
0x4b11d5 : mov esi, edx
0x4b11d7 : shr ecx, 2
0x4b11da : rep movsd dword ptr es:[edi], dword ptr [esi]
0x4b11dc : mov ecx, eax
0x4b11de : and ecx, 3
0x4b11e1 : rep movsb byte ptr es:[edi], byte ptr [esi]
0x4b11e3 : call SaveOptions (FUNCTION) 	(newgame.c:867)
0x4b11e8 : mov eax, dword ptr [ebp - 4] 	(newgame.c:868)
0x4b11eb : mov dword ptr [ebp - 8], eax
0x4b11ee : -jmp 0x31
         : +jmp 0x38
0x4b11f3 : mov eax, 2 	(newgame.c:870)
0x4b11f8 : jmp 0x51
0x4b11fd : xor eax, eax 	(newgame.c:872)
0x4b11ff : jmp 0x4a
0x4b1204 : mov eax, dword ptr [gLast_graph_sel__newgame (DATA)] 	(newgame.c:874)
0x4b1209 : mov eax, dword ptr [eax*8 + gGames_to_join[0].game (DATA)]
0x4b1210 : mov ecx, dword ptr [ebp + 8]
0x4b1213 : mov dword ptr [ecx], eax
0x4b1215 : mov eax, 1 	(newgame.c:875)
0x4b121a : jmp 0x2f
         : +xor eax, eax 	(newgame.c:877)
         : +jmp 0x28
0x4b121f : jmp 0x23 	(newgame.c:878)
0x4b1224 : cmp dword ptr [ebp - 8], 0
0x4b1228 : -je -0x3b
         : +je -0x42
0x4b122e : cmp dword ptr [ebp - 8], 1
0x4b1232 : -je -0x3b
         : +je -0x42
0x4b1238 : cmp dword ptr [ebp - 8], 2
0x4b123c : -je -0x3e
0x4b1242 : -jmp 0x0
0x4b1247 : -xor eax, eax
0x4b1249 : -jmp 0x0
         : +je -0x45
         : +jmp -0x2f
0x4b124e : pop edi 	(newgame.c:879)
0x4b124f : pop esi
0x4b1250 : pop ebx
0x4b1251 : leave 
0x4b1252 : ret 


JoinOrHostGame is only 92.39% similar to the original, diff above
```

*AI generated. Time taken: 998s, tokens: 60,515*
