### PR TITLE
NetOptLeft 100% match

### DIFF
--- a/src/DETHRACE/common/newgame.c
+++ b/src/DETHRACE/common/newgame.c
@@ -1052,14 +1052,14 @@ int NetOptLeft(int* pCurrent_choice, int* pCurrent_mode) {
     int new_value;
 
     DRS3StartSound(gEffects_outlet, 3000);
-    if (gRadio_bastards__newgame[*pCurrent_choice - 3].count < 2) {
-        NetCheckboxChanged(*pCurrent_choice - 3);
-    } else {
+    if (gRadio_bastards__newgame[*pCurrent_choice - 3].count > 1) {
         new_value = gRadio_bastards__newgame[*pCurrent_choice - 3].current_value - 1;
         if (new_value < 0) {
             new_value = gRadio_bastards__newgame[*pCurrent_choice - 3].count - 1;
         }
         NetRadioChanged(*pCurrent_choice - 3, new_value);
+    } else {
+        NetCheckboxChanged(*pCurrent_choice - 3);
     }
     return 1;
 }


### PR DESCRIPTION
## Match result

```
0x4b14b3: NetOptLeft 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b14bb,22 +0x48fa6c,29 @@
0x4b14bb : push edi
0x4b14bc : push 0xbb8 	(newgame.c:1054)
0x4b14c1 : mov eax, dword ptr [gEffects_outlet (DATA)]
0x4b14c6 : push eax
0x4b14c7 : call DRS3StartSound (FUNCTION)
0x4b14cc : add esp, 8
0x4b14cf : mov eax, dword ptr [ebp + 8] 	(newgame.c:1055)
0x4b14d2 : mov eax, dword ptr [eax]
0x4b14d4 : sub eax, 3
0x4b14d7 : shl eax, 5
0x4b14da : -cmp dword ptr [eax + gRadio_bastards__newgame[0].count (DATA)], 1
0x4b14e1 : -jle 0x4e
         : +cmp dword ptr [eax + gRadio_bastards__newgame[0].count (DATA)], 2
         : +jge 0x16
         : +mov eax, dword ptr [ebp + 8] 	(newgame.c:1056)
         : +mov eax, dword ptr [eax]
         : +sub eax, 3
         : +push eax
         : +call NetCheckboxChanged (FUNCTION)
         : +add esp, 4
         : +jmp 0x49 	(newgame.c:1057)
0x4b14e7 : mov eax, dword ptr [ebp + 8] 	(newgame.c:1058)
0x4b14ea : mov eax, dword ptr [eax]
0x4b14ec : sub eax, 3
0x4b14ef : shl eax, 5
0x4b14f2 : mov eax, dword ptr [eax + gRadio_bastards__newgame[0].current_value (OFFSET)]
0x4b14f8 : dec eax
0x4b14f9 : mov dword ptr [ebp - 4], eax
0x4b14fc : cmp dword ptr [ebp - 4], 0 	(newgame.c:1059)
0x4b1500 : jge 0x15
0x4b1506 : mov eax, dword ptr [ebp + 8] 	(newgame.c:1060)

---
+++
@@ -0x4b1517,24 +0x48fade,17 @@
0x4b1517 : dec eax
0x4b1518 : mov dword ptr [ebp - 4], eax
0x4b151b : mov eax, dword ptr [ebp - 4] 	(newgame.c:1062)
0x4b151e : push eax
0x4b151f : mov eax, dword ptr [ebp + 8]
0x4b1522 : mov eax, dword ptr [eax]
0x4b1524 : sub eax, 3
0x4b1527 : push eax
0x4b1528 : call NetRadioChanged (FUNCTION)
0x4b152d : add esp, 8
0x4b1530 : -jmp 0x11
0x4b1535 : -mov eax, dword ptr [ebp + 8]
0x4b1538 : -mov eax, dword ptr [eax]
0x4b153a : -sub eax, 3
0x4b153d : -push eax
0x4b153e : -call NetCheckboxChanged (FUNCTION)
0x4b1543 : -add esp, 4
0x4b1546 : mov eax, 1 	(newgame.c:1064)
0x4b154b : jmp 0x0
0x4b1550 : pop edi 	(newgame.c:1065)
0x4b1551 : pop esi
0x4b1552 : pop ebx
0x4b1553 : leave 
0x4b1554 : ret 


NetOptLeft is only 83.64% similar to the original, diff above
```

*AI generated. Time taken: 69s, tokens: 11,138*
