### PR TITLE
NetOptRight 100% match

### DIFF
--- a/src/DETHRACE/common/newgame.c
+++ b/src/DETHRACE/common/newgame.c
@@ -1070,14 +1070,14 @@ int NetOptRight(int* pCurrent_choice, int* pCurrent_mode) {
     int new_value;
 
     DRS3StartSound(gEffects_outlet, 3000);
-    if (gRadio_bastards__newgame[*pCurrent_choice - 3].count < 2) {
-        NetCheckboxChanged(*pCurrent_choice - 3);
-    } else {
+    if (gRadio_bastards__newgame[*pCurrent_choice - 3].count > 1) {
         new_value = gRadio_bastards__newgame[*pCurrent_choice - 3].current_value + 1;
         if (new_value == gRadio_bastards__newgame[*pCurrent_choice - 3].count) {
             new_value = 0;
         }
         NetRadioChanged(*pCurrent_choice - 3, new_value);
+    } else {
+        NetCheckboxChanged(*pCurrent_choice - 3);
     }
     return 1;
 }


### PR DESCRIPTION
## Match result

```
0x4b16e7: NetOptRight 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b16ef,22 +0x48fb0e,29 @@
0x4b16ef : push edi
0x4b16f0 : push 0xbb8 	(newgame.c:1072)
0x4b16f5 : mov eax, dword ptr [gEffects_outlet (DATA)]
0x4b16fa : push eax
0x4b16fb : call DRS3StartSound (FUNCTION)
0x4b1700 : add esp, 8
0x4b1703 : mov eax, dword ptr [ebp + 8] 	(newgame.c:1073)
0x4b1706 : mov eax, dword ptr [eax]
0x4b1708 : sub eax, 3
0x4b170b : shl eax, 5
0x4b170e : -cmp dword ptr [eax + gRadio_bastards__newgame[0].count (DATA)], 1
0x4b1715 : -jle 0x50
         : +cmp dword ptr [eax + gRadio_bastards__newgame[0].count (DATA)], 2
         : +jge 0x16
         : +mov eax, dword ptr [ebp + 8] 	(newgame.c:1074)
         : +mov eax, dword ptr [eax]
         : +sub eax, 3
         : +push eax
         : +call NetCheckboxChanged (FUNCTION)
         : +add esp, 4
         : +jmp 0x4b 	(newgame.c:1075)
0x4b171b : mov eax, dword ptr [ebp + 8] 	(newgame.c:1076)
0x4b171e : mov eax, dword ptr [eax]
0x4b1720 : sub eax, 3
0x4b1723 : shl eax, 5
0x4b1726 : mov eax, dword ptr [eax + gRadio_bastards__newgame[0].current_value (OFFSET)]
0x4b172c : inc eax
0x4b172d : mov dword ptr [ebp - 4], eax
0x4b1730 : mov eax, dword ptr [ebp + 8] 	(newgame.c:1077)
0x4b1733 : mov eax, dword ptr [eax]
0x4b1735 : sub eax, 3

---
+++
@@ -0x4b1744,24 +0x48fb79,17 @@
0x4b1744 : jne 0x7
0x4b174a : mov dword ptr [ebp - 4], 0 	(newgame.c:1078)
0x4b1751 : mov eax, dword ptr [ebp - 4] 	(newgame.c:1080)
0x4b1754 : push eax
0x4b1755 : mov eax, dword ptr [ebp + 8]
0x4b1758 : mov eax, dword ptr [eax]
0x4b175a : sub eax, 3
0x4b175d : push eax
0x4b175e : call NetRadioChanged (FUNCTION)
0x4b1763 : add esp, 8
0x4b1766 : -jmp 0x11
0x4b176b : -mov eax, dword ptr [ebp + 8]
0x4b176e : -mov eax, dword ptr [eax]
0x4b1770 : -sub eax, 3
0x4b1773 : -push eax
0x4b1774 : -call NetCheckboxChanged (FUNCTION)
0x4b1779 : -add esp, 4
0x4b177c : mov eax, 1 	(newgame.c:1082)
0x4b1781 : jmp 0x0
0x4b1786 : pop edi 	(newgame.c:1083)
0x4b1787 : pop esi
0x4b1788 : pop ebx
0x4b1789 : leave 
0x4b178a : ret 


NetOptRight is only 83.33% similar to the original, diff above
```

*AI generated. Time taken: 185s, tokens: 15,599*
