### PR TITLE
SetNetAvailability 100% match

### DIFF
--- a/src/DETHRACE/common/newgame.c
+++ b/src/DETHRACE/common/newgame.c
@@ -1712,26 +1712,27 @@ void SetNetAvailability(tNet_game_options* pOptions) {
         case eNet_avail_never:
             gCar_details[i].ownership = eCar_owner_not_allowed;
             break;
-        case eNet_avail_eagle:
-            if (pOptions->car_choice == eNet_car_annie) {
-                gCar_details[i].ownership = eCar_owner_not_allowed;
-            } else {
-                gCar_details[i].ownership = eCar_owner_none;
-            }
-            break;
-        case eNet_avail_hawk:
-            if (pOptions->car_choice == eNet_car_frankie) {
-                gCar_details[i].ownership = eCar_owner_not_allowed;
-            } else {
-                gCar_details[i].ownership = eCar_owner_none;
-            }
-            break;
         case eNet_avail_all:
             if (pOptions->car_choice == eNet_car_all) {
                 gCar_details[i].ownership = eCar_owner_none;
             } else {
                 gCar_details[i].ownership = eCar_owner_not_allowed;
             }
+            break;
+        case eNet_avail_eagle:
+            if (pOptions->car_choice != eNet_car_annie) {
+                gCar_details[i].ownership = eCar_owner_none;
+            } else {
+                gCar_details[i].ownership = eCar_owner_not_allowed;
+            }
+            break;
+        case eNet_avail_hawk:
+            if (pOptions->car_choice != eNet_car_frankie) {
+                gCar_details[i].ownership = eCar_owner_none;
+            } else {
+                gCar_details[i].ownership = eCar_owner_not_allowed;
+            }
+            break;
         }
     }
 }


### PR DESCRIPTION
## Match result

```
0x4b24c2: SetNetAvailability 100% match.

OK!
```

#### Original match

```
---
+++
@@ -,66 +,70 @@
0x4b24c3 : mov ebp, esp
0x4b24c5 : sub esp, 8
0x4b24c8 : push ebx
0x4b24c9 : push esi
0x4b24ca : push edi
0x4b24cb : mov dword ptr [ebp - 4], 0 	(newgame.c:1710)
0x4b24d2 : jmp 0x3
0x4b24d7 : inc dword ptr [ebp - 4]
0x4b24da : mov eax, dword ptr [gNumber_of_racers (DATA)]
0x4b24df : cmp dword ptr [ebp - 4], eax
0x4b24e2 : -jge 0x10d
         : +jge 0x108
0x4b24e8 : mov eax, dword ptr [ebp - 4] 	(newgame.c:1711)
0x4b24eb : lea eax, [eax + eax*8]
0x4b24ee : shl eax, 4
0x4b24f1 : mov ecx, dword ptr [gOpponents (DATA)]
0x4b24f7 : mov eax, dword ptr [eax + ecx + 0x80]
0x4b24fe : mov dword ptr [ebp - 8], eax
0x4b2501 : -jmp 0xc6
         : +jmp 0xc1
0x4b2506 : mov eax, dword ptr [ebp - 4] 	(newgame.c:1713)
0x4b2509 : shl eax, 2
0x4b250c : mov dword ptr [eax + eax*4 + gCar_details[0].ownership (DATA)], 3
0x4b2517 : -jmp 0xd4
         : +jmp 0xcf 	(newgame.c:1714)
         : +mov eax, dword ptr [ebp + 8] 	(newgame.c:1716)
         : +cmp dword ptr [eax + 0x2c], 1
         : +jne 0x16
         : +mov eax, dword ptr [ebp - 4] 	(newgame.c:1717)
         : +shl eax, 2
         : +mov dword ptr [eax + eax*4 + gCar_details[0].ownership (DATA)], 3
         : +jmp 0x11 	(newgame.c:1718)
         : +mov eax, dword ptr [ebp - 4] 	(newgame.c:1719)
         : +shl eax, 2
         : +mov dword ptr [eax + eax*4 + gCar_details[0].ownership (DATA)], 0
         : +jmp 0x96 	(newgame.c:1721)
         : +mov eax, dword ptr [ebp + 8] 	(newgame.c:1723)
         : +cmp dword ptr [eax + 0x2c], 0
         : +jne 0x16
         : +mov eax, dword ptr [ebp - 4] 	(newgame.c:1724)
         : +shl eax, 2
         : +mov dword ptr [eax + eax*4 + gCar_details[0].ownership (DATA)], 3
         : +jmp 0x11 	(newgame.c:1725)
         : +mov eax, dword ptr [ebp - 4] 	(newgame.c:1726)
         : +shl eax, 2
         : +mov dword ptr [eax + eax*4 + gCar_details[0].ownership (DATA)], 0
         : +jmp 0x5d 	(newgame.c:1728)
0x4b251c : mov eax, dword ptr [ebp + 8] 	(newgame.c:1730)
0x4b251f : cmp dword ptr [eax + 0x2c], 3
0x4b2523 : jne 0x16
0x4b2529 : mov eax, dword ptr [ebp - 4] 	(newgame.c:1731)
0x4b252c : shl eax, 2
0x4b252f : mov dword ptr [eax + eax*4 + gCar_details[0].ownership (DATA)], 0
0x4b253a : jmp 0x11 	(newgame.c:1732)
0x4b253f : mov eax, dword ptr [ebp - 4] 	(newgame.c:1733)
0x4b2542 : shl eax, 2
0x4b2545 : mov dword ptr [eax + eax*4 + gCar_details[0].ownership (DATA)], 3
0x4b2550 : -jmp 0x9b
0x4b2555 : -mov eax, dword ptr [ebp + 8]
0x4b2558 : -cmp dword ptr [eax + 0x2c], 1
0x4b255c : -je 0x16
0x4b2562 : -mov eax, dword ptr [ebp - 4]
0x4b2565 : -shl eax, 2
0x4b2568 : -mov dword ptr [eax + eax*4 + gCar_details[0].ownership (DATA)], 0
0x4b2573 : -jmp 0x11
0x4b2578 : -mov eax, dword ptr [ebp - 4]
0x4b257b : -shl eax, 2
0x4b257e : -mov dword ptr [eax + eax*4 + gCar_details[0].ownership (DATA)], 3
0x4b2589 : -jmp 0x62
0x4b258e : -mov eax, dword ptr [ebp + 8]
0x4b2591 : -cmp dword ptr [eax + 0x2c], 0
0x4b2595 : -je 0x16
0x4b259b : -mov eax, dword ptr [ebp - 4]
0x4b259e : -shl eax, 2
0x4b25a1 : -mov dword ptr [eax + eax*4 + gCar_details[0].ownership (DATA)], 0
0x4b25ac : -jmp 0x11
0x4b25b1 : -mov eax, dword ptr [ebp - 4]
0x4b25b4 : -shl eax, 2
0x4b25b7 : -mov dword ptr [eax + eax*4 + gCar_details[0].ownership (DATA)], 3
0x4b25c2 : -jmp 0x29
0x4b25c7 : jmp 0x24 	(newgame.c:1735)
0x4b25cc : cmp dword ptr [ebp - 8], 3
0x4b25d0 : ja 0x1a
0x4b25d6 : mov eax, dword ptr [ebp - 8]
0x4b25d9 : jmp dword ptr [eax*4 + <OFFSET4>]
 : Jump table:
0x4b25e0 : start + 0x44
         : +start + 0x5a
0x4b25e4 : start + 0x93
0x4b25e8 : start + 0xcc
0x4b25ec : -start + 0x5a
0x4b25f0 : -jmp -0x11e
         : +jmp -0x119 	(newgame.c:1736)
         : +pop edi 	(newgame.c:1737)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


SetNetAvailability is only 56.52% similar to the original, diff above
```

*AI generated. Time taken: 182s, tokens: 20,330*
