### PR TITLE
GetNetOptions 100% match

### DIFF
--- a/src/DETHRACE/common/newgame.c
+++ b/src/DETHRACE/common/newgame.c
@@ -889,7 +889,7 @@ void GetNetOptions(tNet_game_options* pGame_options) {
     pGame_options->powerup_respawn = gRadio_bastards__newgame[4].current_value;
     pGame_options->open_game = !gRadio_bastards__newgame[5].current_value;
     pGame_options->grid_start = !gRadio_bastards__newgame[6].current_value;
-    pGame_options->race_sequence_type = gRadio_bastards__newgame[7].current_value ? eNet_sequence_sequential : eNet_sequence_random;
+    pGame_options->race_sequence_type = gRadio_bastards__newgame[7].current_value == 0;
     pGame_options->random_car_choice = gRadio_bastards__newgame[8].current_value;
     pGame_options->car_choice = gRadio_bastards__newgame[9].current_value;
     pGame_options->starting_money_index = gRadio_bastards__newgame[10].current_value;

--- a/src/DETHRACE/common/newgame.c
+++ b/src/DETHRACE/common/newgame.c
@@ -882,7 +882,7 @@ void GetNetOptions(tNet_game_options* pGame_options) {
     pGame_options->powerup_respawn = gRadio_bastards__newgame[4].current_value;
     pGame_options->open_game = !gRadio_bastards__newgame[5].current_value;
     pGame_options->grid_start = !gRadio_bastards__newgame[6].current_value;
-    pGame_options->race_sequence_type = gRadio_bastards__newgame[7].current_value == 0;
+    pGame_options->race_sequence_type = gRadio_bastards__newgame[7].current_value == 0 ? eNet_sequence_random : eNet_sequence_sequential;
     pGame_options->random_car_choice = gRadio_bastards__newgame[8].current_value;
     pGame_options->car_choice = gRadio_bastards__newgame[9].current_value;
     pGame_options->starting_money_index = gRadio_bastards__newgame[10].current_value;


### PR DESCRIPTION
## Match result

```
0x4b2d9b: GetNetOptions 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b2df3,26 +0x48f5bb,26 @@
0x4b2df3 : mov eax, dword ptr [ebp + 8]
0x4b2df6 : mov dword ptr [eax + 0x14], 0
0x4b2dfd : cmp dword ptr [gRadio_bastards__newgame[6].current_value (OFFSET)], 0 	(newgame.c:891)
0x4b2e04 : jne 0xf
0x4b2e0a : mov eax, dword ptr [ebp + 8]
0x4b2e0d : mov dword ptr [eax + 0x1c], 1
0x4b2e14 : jmp 0xa
0x4b2e19 : mov eax, dword ptr [ebp + 8]
0x4b2e1c : mov dword ptr [eax + 0x1c], 0
0x4b2e23 : cmp dword ptr [gRadio_bastards__newgame[7].current_value (OFFSET)], 0 	(newgame.c:892)
0x4b2e2a : -jne 0xf
         : +je 0xf
         : +mov eax, dword ptr [ebp + 8]
         : +mov dword ptr [eax + 0x28], 0
         : +jmp 0xa
0x4b2e30 : mov eax, dword ptr [ebp + 8]
0x4b2e33 : mov dword ptr [eax + 0x28], 1
0x4b2e3a : -jmp 0xa
0x4b2e3f : -mov eax, dword ptr [ebp + 8]
0x4b2e42 : -mov dword ptr [eax + 0x28], 0
0x4b2e49 : mov eax, dword ptr [gRadio_bastards__newgame[8].current_value (OFFSET)] 	(newgame.c:893)
0x4b2e4e : mov ecx, dword ptr [ebp + 8]
0x4b2e51 : mov dword ptr [ecx + 0x24], eax
0x4b2e54 : mov eax, dword ptr [gRadio_bastards__newgame[9].current_value (OFFSET)] 	(newgame.c:894)
0x4b2e59 : mov ecx, dword ptr [ebp + 8]
0x4b2e5c : mov dword ptr [ecx + 0x2c], eax
0x4b2e5f : mov eax, dword ptr [gRadio_bastards__newgame[10].current_value (OFFSET)] 	(newgame.c:895)
0x4b2e64 : mov ecx, dword ptr [ebp + 8]
0x4b2e67 : mov dword ptr [ecx + 0x18], eax
0x4b2e6a : pop edi 	(newgame.c:896)


GetNetOptions is only 92.73% similar to the original, diff above
```

*AI generated. Time taken: 75s, tokens: 8,986*
