### PR TITLE
SetBRenderScreenAndBuffers 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -767,6 +767,8 @@ void CopyStripImage(br_pixelmap* pDest, br_int_16 pDest_x, br_int_16 pOffset_x, 
 // FUNCTION: CARM95 0x004b35fb
 void SetBRenderScreenAndBuffers(int pX_offset, int pY_offset, int pWidth, int pHeight) {
 
+    if (gBrZb_initialized) {
+    }
     PDAllocateScreenAndBack();
     if (!pWidth) {
         pWidth = gBack_screen->width;
@@ -775,10 +777,10 @@ void SetBRenderScreenAndBuffers(int pX_offset, int pY_offset, int pWidth, int pH
         pHeight = gBack_screen->height;
     }
     gRender_screen = DRPixelmapAllocateSub(gBack_screen, pX_offset, pY_offset, pWidth, pHeight);
+    gX_offset = pX_offset;
+    gY_offset = pY_offset;
     gWidth = pWidth;
     gHeight = pHeight;
-    gY_offset = pY_offset;
-    gX_offset = pX_offset;
     if (gGraf_specs[gGraf_spec_index].doubled) {
         gScreen->base_x = (gGraf_specs[gGraf_spec_index].phys_width - 2 * gGraf_specs[gGraf_spec_index].total_width) / 2;
         gScreen->base_y = (gGraf_specs[gGraf_spec_index].phys_height - 2 * gGraf_specs[gGraf_spec_index].total_height) / 2;


### PR DESCRIPTION
## Match result

```
0x4b35fb: SetBRenderScreenAndBuffers 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b35fb,17 +0x47e85a,15 @@
0x4b35fb : push ebp 	(graphics.c:768)
0x4b35fc : mov ebp, esp
0x4b35fe : push ebx
0x4b35ff : push esi
0x4b3600 : push edi
0x4b3601 : -cmp dword ptr [gBrZb_initialized (DATA)], 0
0x4b3608 : -je 0x0
0x4b360e : call PDAllocateScreenAndBack (FUNCTION) 	(graphics.c:770)
0x4b3613 : cmp dword ptr [ebp + 0x10], 0 	(graphics.c:771)
0x4b3617 : jne 0xe
0x4b361d : mov eax, dword ptr [gBack_screen (DATA)] 	(graphics.c:772)
0x4b3622 : xor ecx, ecx
0x4b3624 : mov cx, word ptr [eax + 0x34]
0x4b3628 : mov dword ptr [ebp + 0x10], ecx
0x4b362b : cmp dword ptr [ebp + 0x14], 0 	(graphics.c:774)
0x4b362f : jne 0xe
0x4b3635 : mov eax, dword ptr [gBack_screen (DATA)] 	(graphics.c:775)

---
+++
@@ -0x4b364a,28 +0x47e89c,28 @@
0x4b364a : push eax
0x4b364b : mov eax, dword ptr [ebp + 0xc]
0x4b364e : push eax
0x4b364f : mov eax, dword ptr [ebp + 8]
0x4b3652 : push eax
0x4b3653 : mov eax, dword ptr [gBack_screen (DATA)]
0x4b3658 : push eax
0x4b3659 : call DRPixelmapAllocateSub (FUNCTION)
0x4b365e : add esp, 0x14
0x4b3661 : mov dword ptr [gRender_screen (DATA)], eax
0x4b3666 : -mov eax, dword ptr [ebp + 8]
0x4b3669 : -mov dword ptr [gX_offset (DATA)], eax
0x4b366e : -mov eax, dword ptr [ebp + 0xc]
0x4b3671 : -mov dword ptr [gY_offset (DATA)], eax
0x4b3676 : mov eax, dword ptr [ebp + 0x10] 	(graphics.c:778)
0x4b3679 : mov dword ptr [gWidth (DATA)], eax
0x4b367e : mov eax, dword ptr [ebp + 0x14] 	(graphics.c:779)
0x4b3681 : mov dword ptr [gHeight (DATA)], eax
         : +mov eax, dword ptr [ebp + 0xc] 	(graphics.c:780)
         : +mov dword ptr [gY_offset (DATA)], eax
         : +mov eax, dword ptr [ebp + 8] 	(graphics.c:781)
         : +mov dword ptr [gX_offset (DATA)], eax
0x4b3686 : mov eax, dword ptr [gGraf_spec_index (DATA)] 	(graphics.c:782)
0x4b368b : mov ecx, eax
0x4b368d : lea eax, [eax + eax*2]
0x4b3690 : lea eax, [ecx + eax*4]
0x4b3693 : cmp dword ptr [eax*4 + gGraf_specs[0].doubled (OFFSET)], 0
0x4b369b : je 0x7d
0x4b36a1 : mov eax, dword ptr [gGraf_spec_index (DATA)] 	(graphics.c:783)
0x4b36a6 : mov ecx, eax
0x4b36a8 : lea eax, [eax + eax*2]
0x4b36ab : lea eax, [ecx + eax*4]

---
+++
@@ -0x4b37df,10 +0x47ea31,16 @@
0x4b37df : call FatalError (FUNCTION)
0x4b37e4 : add esp, 4
0x4b37e7 : mov eax, dword ptr [gDepth_buffer (DATA)] 	(graphics.c:800)
0x4b37ec : mov al, byte ptr [eax + 0x2c]
0x4b37ef : push eax
0x4b37f0 : mov eax, dword ptr [gRender_screen (DATA)]
0x4b37f5 : mov al, byte ptr [eax + 0x2c]
0x4b37f8 : push eax
0x4b37f9 : call BrZbBegin (FUNCTION)
0x4b37fe : add esp, 8
         : +mov dword ptr [gBrZb_initialized (DATA)], 1 	(graphics.c:801)
         : +pop edi 	(graphics.c:802)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


SetBRenderScreenAndBuffers is only 94.37% similar to the original, diff above
```

*AI generated. Time taken: 222s, tokens: 25,674*
