### PR TITLE
NewScreenWobble 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -1029,8 +1029,7 @@ void NewScreenWobble(double pAmplitude_x, double pAmplitude_y, double pPeriod) {
         if (gWobble_array[i].time_started == 0) {
             oldest_index = i;
             break;
-        }
-        if (gWobble_array[i].time_started < oldest_time) {
+        } else if (gWobble_array[i].time_started < oldest_time) {
             oldest_time = gWobble_array[i].time_started;
             oldest_index = i;
         }


### PR DESCRIPTION
## Match result

```
0x4b3e75: NewScreenWobble 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b3e78,47 +0x47f0cd,51 @@
0x4b3e78 : sub esp, 0xc
0x4b3e7b : push ebx
0x4b3e7c : push esi
0x4b3e7d : push edi
0x4b3e7e : mov dword ptr [ebp - 0xc], 0xffffffff 	(graphics.c:1026)
0x4b3e85 : mov dword ptr [ebp - 4], 0x7fffffff 	(graphics.c:1027)
0x4b3e8c : mov dword ptr [ebp - 8], 0 	(graphics.c:1028)
0x4b3e93 : jmp 0x3
0x4b3e98 : inc dword ptr [ebp - 8]
0x4b3e9b : cmp dword ptr [ebp - 8], 5
0x4b3e9f : -jge 0x52
         : +jge 0x4d
0x4b3ea5 : mov eax, dword ptr [ebp - 8] 	(graphics.c:1029)
0x4b3ea8 : shl eax, 4
0x4b3eab : cmp dword ptr [eax + gWobble_array[0].time_started (OFFSET)], 0
0x4b3eb2 : -jne 0x10
         : +jne 0xb
0x4b3eb8 : mov eax, dword ptr [ebp - 8] 	(graphics.c:1030)
0x4b3ebb : mov dword ptr [ebp - 0xc], eax
0x4b3ebe : -jmp 0x34
0x4b3ec3 : -jmp 0x2a
         : +jmp 0x2f 	(graphics.c:1031)
0x4b3ec8 : mov eax, dword ptr [ebp - 8] 	(graphics.c:1033)
0x4b3ecb : shl eax, 4
0x4b3ece : mov ecx, dword ptr [ebp - 4]
0x4b3ed1 : cmp dword ptr [eax + gWobble_array[0].time_started (OFFSET)], ecx
0x4b3ed7 : jge 0x15
0x4b3edd : mov eax, dword ptr [ebp - 8] 	(graphics.c:1034)
0x4b3ee0 : shl eax, 4
0x4b3ee3 : mov eax, dword ptr [eax + gWobble_array[0].time_started (OFFSET)]
0x4b3ee9 : mov dword ptr [ebp - 4], eax
0x4b3eec : mov eax, dword ptr [ebp - 8] 	(graphics.c:1035)
0x4b3eef : mov dword ptr [ebp - 0xc], eax
0x4b3ef2 : -jmp -0x5f
         : +jmp -0x5a 	(graphics.c:1037)
0x4b3ef7 : call GetTotalTime (FUNCTION) 	(graphics.c:1038)
0x4b3efc : mov ecx, dword ptr [ebp - 0xc]
0x4b3eff : shl ecx, 4
0x4b3f02 : mov dword ptr [ecx + gWobble_array[0].time_started (OFFSET)], eax
0x4b3f08 : fld qword ptr [ebp + 8] 	(graphics.c:1039)
0x4b3f0b : mov eax, dword ptr [ebp - 0xc]
0x4b3f0e : shl eax, 4
0x4b3f11 : fstp dword ptr [eax + gWobble_array[0].amplitude_x (DATA)]
0x4b3f17 : fld qword ptr [ebp + 0x10] 	(graphics.c:1040)
0x4b3f1a : mov eax, dword ptr [ebp - 0xc]
0x4b3f1d : shl eax, 4
0x4b3f20 : fstp dword ptr [eax + gWobble_array[0].amplitude_y (OFFSET)]
0x4b3f26 : fld qword ptr [ebp + 0x18] 	(graphics.c:1041)
0x4b3f29 : mov eax, dword ptr [ebp - 0xc]
0x4b3f2c : shl eax, 4
0x4b3f2f : fstp dword ptr [eax + gWobble_array[0].period (OFFSET)]
         : +pop edi 	(graphics.c:1042)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


NewScreenWobble is only 86.27% similar to the original, diff above
```

*AI generated. Time taken: 151s, tokens: 19,224*
