### PR TITLE
AllocateTransientBitmap 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -2813,7 +2813,7 @@ int AllocateTransientBitmap(int pWidth, int pHeight, int pUser_data) {
         }
     }
     FatalError(kFatalError_FindSpareTransientBitmap);
-    return 0;
+    return -1;
 }
 
 // IDA: void __usercall DeallocateTransientBitmap(int pIndex@<EAX>)


### PR DESCRIPTION
## Match result

```
0x4b86c0: AllocateTransientBitmap 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b8712,19 +0x483722,22 @@
0x4b8712 : lea ecx, [ecx + ecx*2]
0x4b8715 : mov dword ptr [ecx*8 + gTransient_bitmaps[0].pixmap (DATA)], eax
0x4b871c : mov eax, dword ptr [ebp - 4] 	(graphics.c:2810)
0x4b871f : lea eax, [eax + eax*2]
0x4b8722 : mov dword ptr [eax*8 + gTransient_bitmaps[0].in_use (OFFSET)], 0
0x4b872d : mov eax, dword ptr [ebp + 0x10] 	(graphics.c:2811)
0x4b8730 : mov ecx, dword ptr [ebp - 4]
0x4b8733 : lea ecx, [ecx + ecx*2]
0x4b8736 : mov dword ptr [ecx*8 + gTransient_bitmaps[0].user_data (OFFSET)], eax
0x4b873d : mov eax, dword ptr [ebp - 4] 	(graphics.c:2812)
0x4b8740 : -jmp 0x19
         : +jmp 0x16
0x4b8745 : jmp -0x75 	(graphics.c:2814)
0x4b874a : push 0x12 	(graphics.c:2815)
0x4b874c : call FatalError (FUNCTION)
0x4b8751 : add esp, 4
0x4b8754 : -mov eax, 0xffffffff
         : +xor eax, eax 	(graphics.c:2816)
0x4b8759 : jmp 0x0
0x4b875e : pop edi 	(graphics.c:2817)
0x4b875f : pop esi
         : +pop ebx
         : +leave 
         : +ret 


AllocateTransientBitmap is only 92.47% similar to the original, diff above
```

*AI generated. Time taken: 65s, tokens: 7,403*
