### PR TITLE
ProcessCursorGiblets 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -2910,52 +2910,50 @@ void ProcessCursorGiblets(int pPeriod) {
     tCursor_giblet* gib;
 
     time_now = PDGetTotalTime();
-    for (i = 0; i < COUNT_OF(gCursor_giblets); i++) {
-        gib = &gCursor_giblets[i];
+    for (gib = gCursor_giblets, i = 0; i < COUNT_OF(gCursor_giblets); i++, gib++) {
         kill_the_giblet = 0;
-        if (gib->current_giblet == -1) {
-            continue;
-        }
-        if (!gib->landed && gib->e_t_a <= time_now) {
-            gib->landed = 1;
-            gib->the_speed = 0.f;
-        }
-        if (gib->landed) {
-            gib->giblet_change_period -= pPeriod / 2;
-            if (gib->giblet_change_period < 50) {
-                gib->giblet_change_period = 50;
+        if (gib->current_giblet != -1) {
+            if (!gib->landed && gib->e_t_a <= time_now) {
+                gib->landed = 1;
+                gib->the_speed = 0.f;
             }
-            if (gib->giblet_change_period <= time_now - gib->last_giblet_change) {
-                if (gCursor_giblet_sequences[gib->sequence_index][0] == gib->current_giblet) {
-                    gib->current_giblet = 1;
-                } else {
-                    gib->current_giblet++;
+            if (gib->landed) {
+                gib->giblet_change_period -= pPeriod / 2;
+                if (gib->giblet_change_period < 50) {
+                    gib->giblet_change_period = 50;
                 }
-                gib->last_giblet_change = time_now;
-            }
-            gib->y_coord += pPeriod * gib->the_speed / 1000.f;
-            if (gib->y_coord <= gGraf_data[gGraf_data_index].height) {
-                if (gib->the_speed < gGraf_specs[gGraf_spec_index].total_height * 160 / 480) {
-                    gib->the_speed += pPeriod * gGraf_specs[gGraf_spec_index].total_height * 60 / 480 / 1000.f;
+                if (gib->giblet_change_period <= time_now - gib->last_giblet_change) {
+                    if (gCursor_giblet_sequences[gib->sequence_index][0] == gib->current_giblet) {
+                        gib->current_giblet = 1;
+                    } else {
+                        gib->current_giblet++;
+                    }
+                    gib->last_giblet_change = time_now;
+                }
+                gib->y_coord += pPeriod * gib->the_speed / 1000.0;
+                if (gib->y_coord > gGraf_data[gGraf_data_index].height) {
+                    kill_the_giblet = 1;
+                } else {
+                    if (gib->the_speed < gGraf_specs[gGraf_spec_index].total_height * 160u / 480u) {
+                        gib->the_speed += (gGraf_specs[gGraf_spec_index].total_height * 60u / 480u) * (float)pPeriod / 1000.f;
+                    }
                 }
             } else {
-                kill_the_giblet = 1;
+                if (gib->y_speed < gGraf_specs[gGraf_spec_index].total_height * 160u / 480u) {
+                    gib->y_speed += (gGraf_specs[gGraf_spec_index].total_height * 60u / 480u) * (float)pPeriod / 1000.f * 2.f;
+                }
+                gib->x_coord += pPeriod * gib->x_speed / 1000.f;
+                gib->y_coord += pPeriod * gib->y_speed / 1000.f;
+                if (gib->x_coord < 0.f || gib->y_coord < 0.f || gib->x_coord >= gGraf_data[gGraf_data_index].width || gib->y_coord >= gGraf_data[gGraf_data_index].height) {
+                    kill_the_giblet = 1;
+                }
             }
-        } else {
-            if (gib->y_speed < gGraf_specs[gGraf_spec_index].total_height * 160 / 480) {
-                gib->y_speed += pPeriod * gGraf_specs[gGraf_spec_index].total_height * 60 / 480 / 1000.f * 2.f;
+            if (kill_the_giblet) {
+                gib->current_giblet = -1;
+                DeallocateTransientBitmap(gib->transient_index);
+            } else {
+                DrawCursorGiblet(gib);
             }
-            gib->x_coord += pPeriod * gib->x_speed / 1000.f;
-            gib->y_coord += pPeriod * gib->y_speed / 1000.f;
-            if (gib->x_coord < 0.f || gib->x_coord >= gGraf_data[gGraf_spec_index].width || gib->y_coord < 0.f || gib->y_coord >= gGraf_data[gGraf_spec_index].height) {
-                kill_the_giblet = 1;
-            }
-        }
-        if (kill_the_giblet) {
-            gib->current_giblet = -1;
-            DeallocateTransientBitmap(gib->transient_index);
-        } else {
-            DrawCursorGiblet(gib);
         }
     }
 }


### PR DESCRIPTION
## Match result

```
0x4b8ebe: ProcessCursorGiblets 100% match.

OK!
```

#### Original match

```
---
+++
@@ -0x4b8ebe,43 +0x483a53,47 @@
0x4b8ebe : push ebp 	(graphics.c:2906)
0x4b8ebf : mov ebp, esp
0x4b8ec1 : -sub esp, 0x50
         : +sub esp, 0x38
0x4b8ec4 : push ebx
0x4b8ec5 : push esi
0x4b8ec6 : push edi
0x4b8ec7 : call PDGetTotalTime (FUNCTION) 	(graphics.c:2912)
0x4b8ecc : mov dword ptr [ebp - 4], eax
0x4b8ecf : -mov dword ptr [ebp - 0x10], gCursor_giblets[0].current_giblet (DATA)
0x4b8ed6 : mov dword ptr [ebp - 0xc], 0 	(graphics.c:2913)
0x4b8edd : -jmp 0x7
         : +jmp 0x3
0x4b8ee2 : inc dword ptr [ebp - 0xc]
0x4b8ee5 : -add dword ptr [ebp - 0x10], 0x30
0x4b8ee9 : cmp dword ptr [ebp - 0xc], 0x2d
0x4b8eed : -jge 0x356
         : +jge 0x33e
         : +mov eax, dword ptr [ebp - 0xc] 	(graphics.c:2914)
         : +shl eax, 4
         : +lea eax, [eax + eax*2]
         : +add eax, gCursor_giblets[0].current_giblet (DATA)
         : +mov dword ptr [ebp - 0x10], eax
0x4b8ef3 : mov dword ptr [ebp - 8], 0 	(graphics.c:2915)
0x4b8efa : mov eax, dword ptr [ebp - 0x10] 	(graphics.c:2916)
0x4b8efd : cmp dword ptr [eax], -1
0x4b8f00 : -je 0x33e
         : +jne 0x5
         : +jmp -0x36 	(graphics.c:2917)
0x4b8f06 : mov eax, dword ptr [ebp - 0x10] 	(graphics.c:2919)
0x4b8f09 : cmp dword ptr [eax + 8], 0
0x4b8f0d : jne 0x23
0x4b8f13 : mov eax, dword ptr [ebp - 0x10]
0x4b8f16 : mov ecx, dword ptr [ebp - 4]
0x4b8f19 : cmp dword ptr [eax + 0x2c], ecx
0x4b8f1c : ja 0x14
0x4b8f22 : mov eax, dword ptr [ebp - 0x10] 	(graphics.c:2920)
0x4b8f25 : mov dword ptr [eax + 8], 1
0x4b8f2c : mov eax, dword ptr [ebp - 0x10] 	(graphics.c:2921)
0x4b8f2f : mov dword ptr [eax + 0x20], 0
0x4b8f36 : mov eax, dword ptr [ebp - 0x10] 	(graphics.c:2923)
0x4b8f39 : cmp dword ptr [eax + 8], 0
0x4b8f3d : -je 0x166
         : +je 0x14f
0x4b8f43 : xor ecx, ecx 	(graphics.c:2924)
0x4b8f45 : mov eax, dword ptr [ebp + 8]
0x4b8f48 : cdq 
0x4b8f49 : sub eax, edx
0x4b8f4b : sar eax, 1
0x4b8f4d : sub ecx, eax
0x4b8f4f : neg ecx
0x4b8f51 : mov eax, dword ptr [ebp - 0x10]
0x4b8f54 : sub dword ptr [eax + 0x28], ecx
0x4b8f57 : mov eax, dword ptr [ebp - 0x10] 	(graphics.c:2925)

---
+++
@@ -0x4b8fab,180 +0x483b4b,183 @@
0x4b8fab : mov eax, dword ptr [ebp - 0x10] 	(graphics.c:2932)
0x4b8fae : inc dword ptr [eax]
0x4b8fb0 : mov eax, dword ptr [ebp - 4] 	(graphics.c:2934)
0x4b8fb3 : mov ecx, dword ptr [ebp - 0x10]
0x4b8fb6 : mov dword ptr [ecx + 0x24], eax
0x4b8fb9 : mov eax, dword ptr [ebp - 0x10] 	(graphics.c:2936)
0x4b8fbc : mov ecx, dword ptr [ebp + 8]
0x4b8fbf : mov dword ptr [ebp - 0x14], ecx
0x4b8fc2 : fild dword ptr [ebp - 0x14]
0x4b8fc5 : fmul dword ptr [eax + 0x20]
0x4b8fc8 : -fdiv qword ptr [1000.0 (FLOAT)]
         : +fdiv dword ptr [1000.0 (FLOAT)]
0x4b8fce : mov eax, dword ptr [ebp - 0x10]
0x4b8fd1 : fadd dword ptr [eax + 0x1c]
0x4b8fd4 : mov eax, dword ptr [ebp - 0x10]
0x4b8fd7 : fstp dword ptr [eax + 0x1c]
0x4b8fda : mov eax, dword ptr [gGraf_data_index (DATA)] 	(graphics.c:2937)
0x4b8fdf : mov ecx, eax
0x4b8fe1 : shl eax, 7
0x4b8fe4 : sub eax, ecx
0x4b8fe6 : lea eax, [eax + eax*8]
0x4b8fe9 : mov eax, dword ptr [eax + ecx + gGraf_data[0].height (OFFSET)]
0x4b8ff0 : mov dword ptr [ebp - 0x18], eax
0x4b8ff3 : fild dword ptr [ebp - 0x18]
0x4b8ff6 : mov eax, dword ptr [ebp - 0x10]
0x4b8ff9 : fcomp dword ptr [eax + 0x1c]
0x4b8ffc : fnstsw ax
0x4b8ffe : test ah, 1
0x4b9001 : -je 0xc
0x4b9007 : -mov dword ptr [ebp - 8], 1
0x4b900e : -jmp 0x91
         : +jne 0x7f
0x4b9013 : mov eax, dword ptr [gGraf_spec_index (DATA)] 	(graphics.c:2938)
0x4b9018 : mov ecx, eax
0x4b901a : lea eax, [eax + eax*2]
0x4b901d : lea eax, [ecx + eax*4]
0x4b9020 : mov eax, dword ptr [eax*4 + gGraf_specs[0].total_height (OFFSET)]
0x4b9027 : lea eax, [eax + eax*4]
0x4b902a : shl eax, 5
0x4b902d : mov ecx, 0x1e0
0x4b9032 : -sub edx, edx
0x4b9034 : -div ecx
0x4b9036 : -mov dword ptr [ebp - 0x20], eax
0x4b9039 : -mov dword ptr [ebp - 0x1c], 0
0x4b9040 : -fild qword ptr [ebp - 0x20]
         : +cdq 
         : +idiv ecx
         : +mov dword ptr [ebp - 0x1c], eax
         : +fild dword ptr [ebp - 0x1c]
0x4b9043 : mov eax, dword ptr [ebp - 0x10]
0x4b9046 : fcomp dword ptr [eax + 0x20]
0x4b9049 : fnstsw ax
0x4b904b : test ah, 0x41
0x4b904e : -jne 0x50
         : +jne 0x41
0x4b9054 : mov eax, dword ptr [gGraf_spec_index (DATA)] 	(graphics.c:2939)
0x4b9059 : mov ecx, eax
0x4b905b : lea eax, [eax + eax*2]
0x4b905e : lea eax, [ecx + eax*4]
0x4b9061 : mov eax, dword ptr [eax*4 + gGraf_specs[0].total_height (OFFSET)]
         : +imul eax, dword ptr [ebp + 8]
0x4b9068 : shl eax, 2
0x4b906b : lea eax, [eax + eax*2]
0x4b906e : lea eax, [eax + eax*4]
0x4b9071 : mov ecx, 0x1e0
0x4b9076 : -sub edx, edx
0x4b9078 : -div ecx
0x4b907a : -mov dword ptr [ebp - 0x28], eax
0x4b907d : -mov dword ptr [ebp - 0x24], 0
0x4b9084 : -fild qword ptr [ebp - 0x28]
0x4b9087 : -mov eax, dword ptr [ebp + 8]
0x4b908a : -mov dword ptr [ebp - 0x2c], eax
0x4b908d : -fild dword ptr [ebp - 0x2c]
0x4b9090 : -fmulp st(1)
         : +cdq 
         : +idiv ecx
         : +mov dword ptr [ebp - 0x20], eax
         : +fild dword ptr [ebp - 0x20]
0x4b9092 : fdiv dword ptr [1000.0 (FLOAT)]
0x4b9098 : mov eax, dword ptr [ebp - 0x10]
0x4b909b : fadd dword ptr [eax + 0x20]
0x4b909e : mov eax, dword ptr [ebp - 0x10]
0x4b90a1 : fstp dword ptr [eax + 0x20]
0x4b90a4 : -jmp 0x168
         : +jmp 0x7 	(graphics.c:2941)
         : +mov dword ptr [ebp - 8], 1 	(graphics.c:2942)
         : +jmp 0x151 	(graphics.c:2944)
0x4b90a9 : mov eax, dword ptr [gGraf_spec_index (DATA)] 	(graphics.c:2945)
0x4b90ae : mov ecx, eax
0x4b90b0 : lea eax, [eax + eax*2]
0x4b90b3 : lea eax, [ecx + eax*4]
0x4b90b6 : mov eax, dword ptr [eax*4 + gGraf_specs[0].total_height (OFFSET)]
0x4b90bd : lea eax, [eax + eax*4]
0x4b90c0 : shl eax, 5
0x4b90c3 : mov ecx, 0x1e0
0x4b90c8 : -sub edx, edx
0x4b90ca : -div ecx
0x4b90cc : -mov dword ptr [ebp - 0x34], eax
0x4b90cf : -mov dword ptr [ebp - 0x30], 0
0x4b90d6 : -fild qword ptr [ebp - 0x34]
         : +cdq 
         : +idiv ecx
         : +mov dword ptr [ebp - 0x24], eax
         : +fild dword ptr [ebp - 0x24]
0x4b90d9 : mov eax, dword ptr [ebp - 0x10]
0x4b90dc : fcomp dword ptr [eax + 0x14]
0x4b90df : fnstsw ax
0x4b90e1 : test ah, 0x41
0x4b90e4 : -jne 0x56
         : +jne 0x47
0x4b90ea : mov eax, dword ptr [gGraf_spec_index (DATA)] 	(graphics.c:2946)
0x4b90ef : mov ecx, eax
0x4b90f1 : lea eax, [eax + eax*2]
0x4b90f4 : lea eax, [ecx + eax*4]
0x4b90f7 : mov eax, dword ptr [eax*4 + gGraf_specs[0].total_height (OFFSET)]
         : +imul eax, dword ptr [ebp + 8]
0x4b90fe : shl eax, 2
0x4b9101 : lea eax, [eax + eax*2]
0x4b9104 : lea eax, [eax + eax*4]
0x4b9107 : mov ecx, 0x1e0
0x4b910c : -sub edx, edx
0x4b910e : -div ecx
0x4b9110 : -mov dword ptr [ebp - 0x3c], eax
0x4b9113 : -mov dword ptr [ebp - 0x38], 0
0x4b911a : -fild qword ptr [ebp - 0x3c]
0x4b911d : -mov eax, dword ptr [ebp + 8]
0x4b9120 : -mov dword ptr [ebp - 0x40], eax
0x4b9123 : -fild dword ptr [ebp - 0x40]
0x4b9126 : -fmulp st(1)
         : +cdq 
         : +idiv ecx
         : +mov dword ptr [ebp - 0x28], eax
         : +fild dword ptr [ebp - 0x28]
0x4b9128 : fdiv dword ptr [1000.0 (FLOAT)]
0x4b912e : fmul dword ptr [2.0 (FLOAT)]
0x4b9134 : mov eax, dword ptr [ebp - 0x10]
0x4b9137 : fadd dword ptr [eax + 0x14]
0x4b913a : mov eax, dword ptr [ebp - 0x10]
0x4b913d : fstp dword ptr [eax + 0x14]
0x4b9140 : mov eax, dword ptr [ebp - 0x10] 	(graphics.c:2948)
0x4b9143 : mov ecx, dword ptr [ebp + 8]
0x4b9146 : -mov dword ptr [ebp - 0x44], ecx
0x4b9149 : -fild dword ptr [ebp - 0x44]
         : +mov dword ptr [ebp - 0x2c], ecx
         : +fild dword ptr [ebp - 0x2c]
0x4b914c : fmul dword ptr [eax + 0x10]
0x4b914f : fdiv dword ptr [1000.0 (FLOAT)]
0x4b9155 : mov eax, dword ptr [ebp - 0x10]
0x4b9158 : fadd dword ptr [eax + 0x18]
0x4b915b : mov eax, dword ptr [ebp - 0x10]
0x4b915e : fstp dword ptr [eax + 0x18]
0x4b9161 : mov eax, dword ptr [ebp - 0x10] 	(graphics.c:2949)
0x4b9164 : mov ecx, dword ptr [ebp + 8]
0x4b9167 : -mov dword ptr [ebp - 0x48], ecx
0x4b916a : -fild dword ptr [ebp - 0x48]
         : +mov dword ptr [ebp - 0x30], ecx
         : +fild dword ptr [ebp - 0x30]
0x4b916d : fmul dword ptr [eax + 0x14]
0x4b9170 : fdiv dword ptr [1000.0 (FLOAT)]
0x4b9176 : mov eax, dword ptr [ebp - 0x10]
0x4b9179 : fadd dword ptr [eax + 0x1c]
0x4b917c : mov eax, dword ptr [ebp - 0x10]
0x4b917f : fstp dword ptr [eax + 0x1c]
0x4b9182 : mov eax, dword ptr [ebp - 0x10] 	(graphics.c:2950)
0x4b9185 : fld dword ptr [eax + 0x18]
0x4b9188 : fcomp dword ptr [0.0 (FLOAT)]
0x4b918e : fnstsw ax
0x4b9190 : test ah, 1
0x4b9193 : jne 0x71
         : +mov eax, dword ptr [gGraf_spec_index (DATA)]
         : +mov ecx, eax
         : +shl eax, 7
         : +sub eax, ecx
         : +lea eax, [eax + eax*8]
         : +mov eax, dword ptr [eax + ecx + gGraf_data[0].width (DATA)]
         : +mov dword ptr [ebp - 0x34], eax
         : +fild dword ptr [ebp - 0x34]
         : +mov eax, dword ptr [ebp - 0x10]
         : +fcomp dword ptr [eax + 0x18]
         : +fnstsw ax
         : +test ah, 0x41
         : +jne 0x44
0x4b9199 : mov eax, dword ptr [ebp - 0x10]
0x4b919c : fld dword ptr [eax + 0x1c]
0x4b919f : fcomp dword ptr [0.0 (FLOAT)]
0x4b91a5 : fnstsw ax
0x4b91a7 : test ah, 1
0x4b91aa : -jne 0x5a
0x4b91b0 : -mov eax, dword ptr [gGraf_data_index (DATA)]
0x4b91b5 : -mov ecx, eax
0x4b91b7 : -shl eax, 7
0x4b91ba : -sub eax, ecx
0x4b91bc : -lea eax, [eax + eax*8]
0x4b91bf : -mov eax, dword ptr [eax + ecx + gGraf_data[0].width (DATA)]
0x4b91c6 : -mov dword ptr [ebp - 0x4c], eax
0x4b91c9 : -fild dword ptr [ebp - 0x4c]
0x4b91cc : -mov eax, dword ptr [ebp - 0x10]
0x4b91cf : -fcomp dword ptr [eax + 0x18]
0x4b91d2 : -fnstsw ax
0x4b91d4 : -test ah, 0x41
0x4b91d7 : jne 0x2d
0x4b91dd : -mov eax, dword ptr [gGraf_data_index (DATA)]
         : +mov eax, dword ptr [gGraf_spec_index (DATA)]
0x4b91e2 : mov ecx, eax
0x4b91e4 : shl eax, 7
0x4b91e7 : sub eax, ecx
0x4b91e9 : lea eax, [eax + eax*8]
0x4b91ec : mov eax, dword ptr [eax + ecx + gGraf_data[0].height (OFFSET)]
0x4b91f3 : -mov dword ptr [ebp - 0x50], eax
0x4b91f6 : -fild dword ptr [ebp - 0x50]
         : +mov dword ptr [ebp - 0x38], eax
         : +fild dword ptr [ebp - 0x38]
0x4b91f9 : mov eax, dword ptr [ebp - 0x10]
0x4b91fc : fcomp dword ptr [eax + 0x1c]
0x4b91ff : fnstsw ax
0x4b9201 : test ah, 0x41
0x4b9204 : je 0x7
0x4b920a : mov dword ptr [ebp - 8], 1 	(graphics.c:2951)
0x4b9211 : cmp dword ptr [ebp - 8], 0 	(graphics.c:2954)
0x4b9215 : je 0x1d
0x4b921b : mov eax, dword ptr [ebp - 0x10] 	(graphics.c:2955)
0x4b921e : mov dword ptr [eax], 0xffffffff
0x4b9224 : mov eax, dword ptr [ebp - 0x10] 	(graphics.c:2956)
0x4b9227 : mov eax, dword ptr [eax + 0xc]
0x4b922a : push eax
         : +call DeallocateTransientBitmap (FUNCTION)
         : +add esp, 4
         : +jmp 0xc 	(graphics.c:2957)
         : +mov eax, dword ptr [ebp - 0x10] 	(graphics.c:2958)
         : +push eax
         : +call DrawCursorGiblet (FUNCTION)
         : +add esp, 4
         : +jmp -0x34b 	(graphics.c:2960)
         : +pop edi 	(graphics.c:2961)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


ProcessCursorGiblets is only 73.43% similar to the original, diff above
```

*AI generated. Time taken: 223s, tokens: 44,985*
