### PR TITLE
ToggleShadow 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -3439,8 +3439,7 @@ tShadow_level GetShadowLevel(void) {
 // FUNCTION: CARM95 0x004ba15d
 void ToggleShadow(void) {
 
-    gShadow_level++;
-    if (gShadow_level == eShadow_everyone) {
+    if (gShadow_level++ == eShadow_everyone) {
         gShadow_level = eShadow_none;
     }
     switch (gShadow_level) {
@@ -3456,8 +3455,6 @@ void ToggleShadow(void) {
     case eShadow_everyone:
         NewTextHeadupSlot(eHeadupSlot_misc, 0, 2000, -kFont_MEDIUMHD, GetMiscString(kMiscString_ShadowUnderAllCars));
         break;
-    default:
-        return;
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4ba15d: ToggleShadow 100% match.

OK!
```

#### Original match

```
---
+++
@@ -,74 +,73 @@
0x4ba15d : push ebp 	(graphics.c:3440)
0x4ba15e : mov ebp, esp
0x4ba160 : -sub esp, 8
         : +sub esp, 4
0x4ba163 : push ebx
0x4ba164 : push esi
0x4ba165 : push edi
0x4ba166 : -mov eax, dword ptr [gShadow_level (DATA)]
0x4ba16b : -mov dword ptr [ebp - 4], eax
0x4ba16e : inc dword ptr [gShadow_level (DATA)] 	(graphics.c:3442)
0x4ba174 : -cmp dword ptr [ebp - 4], 3
         : +cmp dword ptr [gShadow_level (DATA)], 3 	(graphics.c:3443)
0x4ba178 : jne 0xa
0x4ba17e : mov dword ptr [gShadow_level (DATA)], 0 	(graphics.c:3444)
0x4ba188 : mov eax, dword ptr [gShadow_level (DATA)] 	(graphics.c:3446)
0x4ba18d : -mov dword ptr [ebp - 8], eax
0x4ba190 : -jmp 0x91
         : +mov dword ptr [ebp - 4], eax
         : +jmp 0x96
0x4ba195 : push 0x68 	(graphics.c:3448)
0x4ba197 : call GetMiscString (FUNCTION)
0x4ba19c : add esp, 4
0x4ba19f : push eax
0x4ba1a0 : push -4
0x4ba1a2 : push 0x7d0
0x4ba1a7 : push 0
0x4ba1a9 : push 4
0x4ba1ab : call NewTextHeadupSlot (FUNCTION)
0x4ba1b0 : add esp, 0x14
0x4ba1b3 : -jmp 0x92
         : +jmp 0x97 	(graphics.c:3449)
0x4ba1b8 : push 0x69 	(graphics.c:3451)
0x4ba1ba : call GetMiscString (FUNCTION)
0x4ba1bf : add esp, 4
0x4ba1c2 : push eax
0x4ba1c3 : push -4
0x4ba1c5 : push 0x7d0
0x4ba1ca : push 0
0x4ba1cc : push 4
0x4ba1ce : call NewTextHeadupSlot (FUNCTION)
0x4ba1d3 : add esp, 0x14
0x4ba1d6 : -jmp 0x6f
         : +jmp 0x74 	(graphics.c:3452)
0x4ba1db : push 0x6a 	(graphics.c:3454)
0x4ba1dd : call GetMiscString (FUNCTION)
0x4ba1e2 : add esp, 4
0x4ba1e5 : push eax
0x4ba1e6 : push -4
0x4ba1e8 : push 0x7d0
0x4ba1ed : push 0
0x4ba1ef : push 4
0x4ba1f1 : call NewTextHeadupSlot (FUNCTION)
0x4ba1f6 : add esp, 0x14
0x4ba1f9 : -jmp 0x4c
         : +jmp 0x51 	(graphics.c:3455)
0x4ba1fe : push 0x6b 	(graphics.c:3457)
0x4ba200 : call GetMiscString (FUNCTION)
0x4ba205 : add esp, 4
0x4ba208 : push eax
0x4ba209 : push -4
0x4ba20b : push 0x7d0
0x4ba210 : push 0
0x4ba212 : push 4
0x4ba214 : call NewTextHeadupSlot (FUNCTION)
0x4ba219 : add esp, 0x14
         : +jmp 0x2e 	(graphics.c:3458)
0x4ba21c : jmp 0x29 	(graphics.c:3460)
0x4ba221 : jmp 0x24 	(graphics.c:3461)
0x4ba226 : -cmp dword ptr [ebp - 8], 3
         : +cmp dword ptr [ebp - 4], 3
0x4ba22a : ja 0x1a
0x4ba230 : -mov eax, dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp - 4]
0x4ba233 : jmp dword ptr [eax*4 + <OFFSET4>]
 : Jump table:
0x4ba23a : -start + 0x38
0x4ba23e : -start + 0x5b
0x4ba242 : -start + 0x7e
0x4ba246 : -start + 0xa1
         : +start + 0x33
         : +start + 0x56
         : +start + 0x79
         : +start + 0x9c
0x4ba24a : pop edi 	(graphics.c:3462)
0x4ba24b : pop esi
0x4ba24c : pop ebx
0x4ba24d : leave 
0x4ba24e : ret 


ToggleShadow is only 80.27% similar to the original, diff above
```

*AI generated. Time taken: 235s, tokens: 25,794*
