### PR TITLE
AllocateRearviewPixelmap 100% match

### DIFF
--- a/src/DETHRACE/common/init.c
+++ b/src/DETHRACE/common/init.c
@@ -218,7 +218,7 @@ void AllocateRearviewPixelmap(void) {
                 * gGraf_specs[gGraf_spec_index].depth_bytes,
             kMem_rear_screen_pixels);
         if (gScreen->row_bytes < 0) {
-            BrFatal("..\\..\\source\\common\\init.c", 260, "Bruce bug at line %d, file ..\\..\\source\\common\\init.c", 4);
+            BrFatal("C:\\Msdev\\Projects\\DethRace\\Init.c", 260, "Bruce bug at line %d, file C:\\Msdev\\Projects\\DethRace\\Init.c", 260);
         }
         gRearview_screen = DRPixelmapAllocate(
             gScreen->type,


### PR DESCRIPTION
## Match result

```
0x4bb741: AllocateRearviewPixelmap 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4bb768,46 +0x485c61,46 @@
0x4bb768 : mov eax, dword ptr [gRearview_screen (DATA)] 	(init.c:210)
0x4bb76d : push eax
0x4bb76e : call BrPixelmapFree (FUNCTION)
0x4bb773 : add esp, 4
0x4bb776 : mov eax, dword ptr [gRearview_depth_buffer (DATA)] 	(init.c:211)
0x4bb77b : push eax
0x4bb77c : call BrPixelmapFree (FUNCTION)
0x4bb781 : add esp, 4
0x4bb784 : mov dword ptr [gRearview_screen (DATA)], 0 	(init.c:212)
0x4bb78e : cmp dword ptr [gProgram_state+72 (OFFSET)], 0 	(init.c:214)
0x4bb795 : -je 0xe7
         : +je 0xe4
0x4bb79b : push 0x9a 	(init.c:219)
0x4bb7a0 : mov eax, dword ptr [gProgram_state+1320 (OFFSET)]
0x4bb7a5 : sub eax, dword ptr [gProgram_state+1312 (OFFSET)]
0x4bb7ab : add eax, 4
0x4bb7ae : mov ecx, dword ptr [gProgram_state+1324 (OFFSET)]
0x4bb7b4 : sub ecx, dword ptr [gProgram_state+1316 (OFFSET)]
0x4bb7ba : inc ecx
0x4bb7bb : imul eax, ecx
0x4bb7be : mov ecx, dword ptr [gGraf_spec_index (DATA)]
0x4bb7c4 : mov edx, ecx
0x4bb7c6 : lea ecx, [ecx + ecx*2]
0x4bb7c9 : lea ecx, [edx + ecx*4]
0x4bb7cc : imul eax, dword ptr [ecx*4 + gGraf_specs[0].depth_bytes (OFFSET)]
0x4bb7d4 : push eax
0x4bb7d5 : call BrMemAllocate (FUNCTION)
0x4bb7da : add esp, 8
0x4bb7dd : mov dword ptr [ebp - 4], eax
0x4bb7e0 : mov eax, dword ptr [gScreen (DATA)] 	(init.c:220)
0x4bb7e5 : movsx eax, word ptr [eax + 0x28]
0x4bb7e9 : test eax, eax
0x4bb7eb : -jge 0x1c
         : +jge 0x19
         : +push 4 	(init.c:221)
         : +push "Bruce bug at line %d, file ..\\..\\source\\common\\init.c" (STRING)
0x4bb7f1 : push 0x104
0x4bb7f6 : -push "Bruce bug at line %d, file C:\\Msdev\\Projects\\DethRace\\Init.c" (STRING)
0x4bb7fb : -push 0x104
0x4bb800 : -push "C:\\Msdev\\Projects\\DethRace\\Init.c" (STRING)
         : +push "..\\..\\source\\common\\init.c" (STRING)
0x4bb805 : call BrFatal (FUNCTION)
0x4bb80a : add esp, 0x10
0x4bb80d : push 0 	(init.c:228)
0x4bb80f : mov eax, dword ptr [ebp - 4]
0x4bb812 : push eax
0x4bb813 : mov eax, dword ptr [gProgram_state+1324 (OFFSET)]
0x4bb818 : sub eax, dword ptr [gProgram_state+1316 (OFFSET)]
0x4bb81e : push eax
0x4bb81f : mov eax, dword ptr [gProgram_state+1320 (OFFSET)]
0x4bb824 : sub eax, dword ptr [gProgram_state+1312 (OFFSET)]

---
+++
@@ -0x4bb864,10 +0x485d5a,13 @@
0x4bb864 : mov eax, dword ptr [gRearview_screen (DATA)]
0x4bb869 : mov word ptr [eax + 0x3a], cx
0x4bb86d : push 1 	(init.c:232)
0x4bb86f : mov eax, dword ptr [gRearview_screen (DATA)]
0x4bb874 : push eax
0x4bb875 : call BrPixelmapMatch (FUNCTION)
0x4bb87a : add esp, 8
0x4bb87d : mov dword ptr [gRearview_depth_buffer (DATA)], eax
0x4bb882 : pop edi 	(init.c:235)
0x4bb883 : pop esi
         : +pop ebx
         : +leave 
         : +ret 


AllocateRearviewPixelmap is only 92.57% similar to the original, diff above
```

*AI generated. Time taken: 89s, tokens: 10,983*
