### PR TITLE
NewTextHeadupSlot2 100% match

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -851,23 +851,20 @@ int NewTextHeadupSlot2(int pSlot_index, int pFlash_rate, int pLifetime, int pFon
             }
             headup_slot = &gProgram_state.current_car.headup_slots[gProgram_state.cockpit_on][pSlot_index];
             the_headup = &gHeadups[index];
-            the_headup->data.coloured_text_info.coloured_font = &gFonts[-pFont_index];
+            the_headup->data.coloured_text_info.coloured_font = gFonts - pFont_index;
             if (pSlot_index == 4) {
                 the_headup->type = eHeadup_box_text;
             } else {
                 the_headup->type = eHeadup_coloured_text;
             }
-            if (!pText) {
-                LOG_PANIC("panic");
-            }
             strcpy(the_headup->data.text_info.text, pText);
 
             the_headup->slot_index = pSlot_index;
             the_headup->justification = headup_slot->justification;
-            if (pSlot_index < 0) {
-                the_headup->cockpit_anchored = 0;
-            } else {
+            if (pSlot_index >= 0) {
                 the_headup->cockpit_anchored = headup_slot->cockpit_anchored;
+            } else {
+                the_headup->cockpit_anchored = 0;
             }
             the_headup->dimmed_background = headup_slot->dimmed_background;
             the_headup->dim_left = headup_slot->dim_left;


### PR DESCRIPTION
## Match result

```
0x4c56b1: NewTextHeadupSlot2 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4c576b,28 +0x473748,28 @@
0x4c576b : lea ebx, [esi + ebx*2]
0x4c576e : lea edi, [ebx*4 + gQueued_headups[0].text (OFFSET)]
0x4c5775 : mov esi, edx
0x4c5777 : shr ecx, 2
0x4c577a : rep movsd dword ptr es:[edi], dword ptr [esi]
0x4c577c : mov ecx, eax
0x4c577e : and ecx, 3
0x4c5781 : rep movsb byte ptr es:[edi], byte ptr [esi]
0x4c5783 : inc dword ptr [gQueued_headup_count (DATA)] 	(displays.c:851)
0x4c5789 : mov dword ptr [ebp - 0x10], 0xffffffff 	(displays.c:852)
0x4c5790 : -jmp 0x1df
         : +jmp 0x1ee 	(displays.c:853)
0x4c5795 : mov eax, dword ptr [ebp + 8] 	(displays.c:854)
0x4c5798 : push eax
0x4c5799 : call FindAHeadupHoleWoofBarkSoundsABitRude (FUNCTION)
0x4c579e : add esp, 4
0x4c57a1 : mov dword ptr [ebp - 0x10], eax
0x4c57a4 : cmp dword ptr [ebp - 0x10], 0 	(displays.c:855)
0x4c57a8 : -jl 0x1c6
         : +jl 0x1d5
0x4c57ae : cmp dword ptr [ebp + 8], 4 	(displays.c:856)
0x4c57b2 : jne 0x8
0x4c57b8 : mov eax, dword ptr [ebp - 8] 	(displays.c:857)
0x4c57bb : mov dword ptr [gLast_centre_headup (DATA)], eax
0x4c57c0 : mov eax, dword ptr [gProgram_state+80 (OFFSET)] 	(displays.c:859)
0x4c57c5 : lea eax, [eax + eax*4]
0x4c57c8 : lea eax, [eax + eax*4]
0x4c57cb : shl eax, 5
0x4c57ce : mov ecx, dword ptr [ebp + 8]
0x4c57d1 : lea ecx, [ecx + ecx*4]

---
+++
@@ -0x4c57dc,38 +0x4737b9,41 @@
0x4c57dc : add eax, 0xa48
0x4c57e1 : mov dword ptr [ebp - 4], eax
0x4c57e4 : mov eax, dword ptr [ebp - 0x10] 	(displays.c:860)
0x4c57e7 : mov ecx, eax
0x4c57e9 : lea eax, [eax + eax*8]
0x4c57ec : lea eax, [ecx + eax*4]
0x4c57ef : lea eax, [eax + eax*8]
0x4c57f2 : sub eax, ecx
0x4c57f4 : add eax, gHeadups[0].type (DATA)
0x4c57f9 : mov dword ptr [ebp - 0xc], eax
0x4c57fc : -mov eax, gFonts[0].images (DATA)
0x4c5801 : -mov ecx, dword ptr [ebp + 0x14]
0x4c5804 : -mov edx, ecx
0x4c5806 : -lea ecx, [ecx + ecx*8]
0x4c5809 : -lea ecx, [edx + ecx*4]
0x4c580c : -lea ecx, [ecx + ecx*4]
0x4c580f : -lea ecx, [ecx + ecx*4]
0x4c5812 : -sub ecx, edx
         : +mov eax, dword ptr [ebp + 0x14] 	(displays.c:861)
         : +mov ecx, eax
         : +lea eax, [eax + eax*8]
         : +lea eax, [ecx + eax*4]
         : +lea eax, [eax + eax*4]
         : +lea eax, [eax + eax*4]
0x4c5814 : sub eax, ecx
         : +neg eax
         : +add eax, gFonts[0].images (DATA)
0x4c5816 : mov ecx, dword ptr [ebp - 0xc]
0x4c5819 : mov dword ptr [ecx + 0x144], eax
0x4c581f : cmp dword ptr [ebp + 8], 4 	(displays.c:862)
0x4c5823 : jne 0xe
0x4c5829 : mov eax, dword ptr [ebp - 0xc] 	(displays.c:863)
0x4c582c : mov dword ptr [eax], 5
0x4c5832 : jmp 0x9 	(displays.c:864)
0x4c5837 : mov eax, dword ptr [ebp - 0xc] 	(displays.c:865)
0x4c583a : mov dword ptr [eax], 2
         : +cmp dword ptr [ebp + 0x18], 0 	(displays.c:867)
         : +jne 0x5
         : +call abort (FUNCTION) 	(displays.c:868)
0x4c5840 : mov edi, dword ptr [ebp + 0x18] 	(displays.c:870)
0x4c5843 : mov ecx, 0xffffffff
0x4c5848 : sub eax, eax
0x4c584a : repne scasb al, byte ptr es:[edi]
0x4c584c : not ecx
0x4c584e : sub edi, ecx
0x4c5850 : mov eax, ecx
0x4c5852 : mov edx, edi
0x4c5854 : mov edi, dword ptr [ebp - 0xc]
0x4c5857 : add edi, 0x48

---
+++
@@ -0x4c5863,28 +0x47384f,28 @@
0x4c5863 : and ecx, 3
0x4c5866 : rep movsb byte ptr es:[edi], byte ptr [esi]
0x4c5868 : mov eax, dword ptr [ebp + 8] 	(displays.c:872)
0x4c586b : mov ecx, dword ptr [ebp - 0xc]
0x4c586e : mov dword ptr [ecx + 0x18], eax
0x4c5871 : mov eax, dword ptr [ebp - 4] 	(displays.c:873)
0x4c5874 : mov eax, dword ptr [eax + 0x24]
0x4c5877 : mov ecx, dword ptr [ebp - 0xc]
0x4c587a : mov dword ptr [ecx + 0x3c], eax
0x4c587d : cmp dword ptr [ebp + 8], 0 	(displays.c:874)
0x4c5881 : -jl 0x11
         : +jge 0xf
         : +mov eax, dword ptr [ebp - 0xc] 	(displays.c:875)
         : +mov dword ptr [eax + 0x34], 0
         : +jmp 0xc 	(displays.c:876)
0x4c5887 : mov eax, dword ptr [ebp - 4] 	(displays.c:877)
0x4c588a : mov eax, dword ptr [eax + 0xc]
0x4c588d : mov ecx, dword ptr [ebp - 0xc]
0x4c5890 : mov dword ptr [ecx + 0x34], eax
0x4c5893 : -jmp 0xa
0x4c5898 : -mov eax, dword ptr [ebp - 0xc]
0x4c589b : -mov dword ptr [eax + 0x34], 0
0x4c58a2 : mov eax, dword ptr [ebp - 4] 	(displays.c:879)
0x4c58a5 : mov eax, dword ptr [eax + 0x10]
0x4c58a8 : mov ecx, dword ptr [ebp - 0xc]
0x4c58ab : mov dword ptr [ecx + 0x1c], eax
0x4c58ae : mov eax, dword ptr [ebp - 4] 	(displays.c:880)
0x4c58b1 : mov eax, dword ptr [eax + 0x14]
0x4c58b4 : mov ecx, dword ptr [ebp - 0xc]
0x4c58b7 : mov dword ptr [ecx + 0x20], eax
0x4c58ba : mov eax, dword ptr [ebp - 4] 	(displays.c:881)
0x4c58bd : mov eax, dword ptr [eax + 0x18]


NewTextHeadupSlot2 is only 92.67% similar to the original, diff above
```

*AI generated. Time taken: 99s, tokens: 17,276*
