### PR TITLE
NewImageHeadupSlot 100% match

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -915,10 +915,10 @@ int NewImageHeadupSlot(int pSlot_index, int pFlash_rate, int pLifetime, int pIma
         the_headup->type = eHeadup_image;
         the_headup->slot_index = pSlot_index;
         the_headup->justification = headup_slot->justification;
-        if (pSlot_index < 0) {
-            the_headup->cockpit_anchored = 0;
-        } else {
+        if (pSlot_index >= 0) {
             the_headup->cockpit_anchored = headup_slot->cockpit_anchored;
+        } else {
+            the_headup->cockpit_anchored = 0;
         }
         the_headup->dimmed_background = headup_slot->dimmed_background;
         the_headup->dim_left = headup_slot->dim_left;
@@ -927,14 +927,17 @@ int NewImageHeadupSlot(int pSlot_index, int pFlash_rate, int pLifetime, int pIma
         the_headup->dim_bottom = headup_slot->dim_bottom;
         the_headup->original_x = headup_slot->x;
 
-        if (headup_slot->justification) {
-            if (headup_slot->justification == eJust_right) {
-                the_headup->x = the_headup->original_x - gHeadup_images[pImage_index]->width;
-            } else if (headup_slot->justification == eJust_centre) {
-                the_headup->x = the_headup->original_x - gHeadup_images[pImage_index]->width / 2;
-            }
-        } else {
+        switch (headup_slot->justification) {
+        case 0:
             the_headup->x = the_headup->original_x;
+            break;
+        case eJust_centre:
+            the_headup->x = the_headup->original_x - gHeadup_images[pImage_index]->width / 2;
+            break;
+        case eJust_right:
+            the_headup->x = the_headup->original_x - gHeadup_images[pImage_index]->width;
+        default:
+            break;
         }
         the_headup->y = headup_slot->y;
         if (pFlash_rate) {


### PR DESCRIPTION
## Match result

```
0x4c5c4b: NewImageHeadupSlot 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4c5c4b,23 +0x47399b,23 @@
0x4c5c4b : push ebp 	(displays.c:913)
0x4c5c4c : mov ebp, esp
0x4c5c4e : -sub esp, 0x10
         : +sub esp, 0xc
0x4c5c51 : push ebx
0x4c5c52 : push esi
0x4c5c53 : push edi
0x4c5c54 : mov eax, dword ptr [ebp + 8] 	(displays.c:918)
0x4c5c57 : push eax
0x4c5c58 : call FindAHeadupHoleWoofBarkSoundsABitRude (FUNCTION)
0x4c5c5d : add esp, 4
0x4c5c60 : mov dword ptr [ebp - 0xc], eax
0x4c5c63 : cmp dword ptr [ebp - 0xc], 0 	(displays.c:919)
0x4c5c67 : -jl 0x1d6
         : +jl 0x1c2
0x4c5c6d : mov eax, dword ptr [gProgram_state+80 (OFFSET)] 	(displays.c:920)
0x4c5c72 : lea eax, [eax + eax*4]
0x4c5c75 : lea eax, [eax + eax*4]
0x4c5c78 : shl eax, 5
0x4c5c7b : mov ecx, dword ptr [ebp + 8]
0x4c5c7e : lea ecx, [ecx + ecx*4]
0x4c5c81 : lea eax, [eax + ecx*8]
0x4c5c84 : add eax, gProgram_state (DATA)
0x4c5c89 : add eax, 0xa48
0x4c5c8e : mov dword ptr [ebp - 4], eax

---
+++
@@ -0x4c5ca9,28 +0x4739f9,28 @@
0x4c5ca9 : mov eax, dword ptr [ebp - 8] 	(displays.c:922)
0x4c5cac : mov dword ptr [eax], 3
0x4c5cb2 : mov eax, dword ptr [ebp + 8] 	(displays.c:923)
0x4c5cb5 : mov ecx, dword ptr [ebp - 8]
0x4c5cb8 : mov dword ptr [ecx + 0x18], eax
0x4c5cbb : mov eax, dword ptr [ebp - 4] 	(displays.c:924)
0x4c5cbe : mov eax, dword ptr [eax + 0x24]
0x4c5cc1 : mov ecx, dword ptr [ebp - 8]
0x4c5cc4 : mov dword ptr [ecx + 0x3c], eax
0x4c5cc7 : cmp dword ptr [ebp + 8], 0 	(displays.c:925)
0x4c5ccb : -jl 0x11
         : +jge 0xf
         : +mov eax, dword ptr [ebp - 8] 	(displays.c:926)
         : +mov dword ptr [eax + 0x34], 0
         : +jmp 0xc 	(displays.c:927)
0x4c5cd1 : mov eax, dword ptr [ebp - 4] 	(displays.c:928)
0x4c5cd4 : mov eax, dword ptr [eax + 0xc]
0x4c5cd7 : mov ecx, dword ptr [ebp - 8]
0x4c5cda : mov dword ptr [ecx + 0x34], eax
0x4c5cdd : -jmp 0xa
0x4c5ce2 : -mov eax, dword ptr [ebp - 8]
0x4c5ce5 : -mov dword ptr [eax + 0x34], 0
0x4c5cec : mov eax, dword ptr [ebp - 4] 	(displays.c:930)
0x4c5cef : mov eax, dword ptr [eax + 0x10]
0x4c5cf2 : mov ecx, dword ptr [ebp - 8]
0x4c5cf5 : mov dword ptr [ecx + 0x1c], eax
0x4c5cf8 : mov eax, dword ptr [ebp - 4] 	(displays.c:931)
0x4c5cfb : mov eax, dword ptr [eax + 0x14]
0x4c5cfe : mov ecx, dword ptr [ebp - 8]
0x4c5d01 : mov dword ptr [ecx + 0x20], eax
0x4c5d04 : mov eax, dword ptr [ebp - 4] 	(displays.c:932)
0x4c5d07 : mov eax, dword ptr [eax + 0x18]

---
+++
@@ -0x4c5d19,57 +0x473a69,53 @@
0x4c5d19 : mov dword ptr [ecx + 0x28], eax
0x4c5d1c : mov eax, dword ptr [ebp - 4] 	(displays.c:934)
0x4c5d1f : mov eax, dword ptr [eax + 0x20]
0x4c5d22 : mov ecx, dword ptr [ebp - 8]
0x4c5d25 : mov dword ptr [ecx + 0x2c], eax
0x4c5d28 : mov eax, dword ptr [ebp - 4] 	(displays.c:935)
0x4c5d2b : mov eax, dword ptr [eax]
0x4c5d2d : mov ecx, dword ptr [ebp - 8]
0x4c5d30 : mov dword ptr [ecx + 0xc], eax
0x4c5d33 : mov eax, dword ptr [ebp - 4] 	(displays.c:937)
0x4c5d36 : -mov eax, dword ptr [eax + 0x24]
0x4c5d39 : -mov dword ptr [ebp - 0x10], eax
0x4c5d3c : -jmp 0x5e
         : +cmp dword ptr [eax + 0x24], 0
         : +je 0x62
         : +mov eax, dword ptr [ebp - 4] 	(displays.c:938)
         : +cmp dword ptr [eax + 0x24], 1
         : +jne 0x23
0x4c5d41 : mov eax, dword ptr [ebp - 8] 	(displays.c:939)
0x4c5d44 : mov eax, dword ptr [eax + 0xc]
         : +mov ecx, dword ptr [ebp + 0x14]
         : +mov ecx, dword ptr [ecx*4 + gHeadup_images[0] (DATA)]
         : +xor edx, edx
         : +mov dx, word ptr [ecx + 0x34]
         : +sub eax, edx
0x4c5d47 : mov ecx, dword ptr [ebp - 8]
0x4c5d4a : mov dword ptr [ecx + 4], eax
0x4c5d4d : -jmp 0x70
         : +jmp 0x2d 	(displays.c:940)
         : +mov eax, dword ptr [ebp - 4]
         : +cmp dword ptr [eax + 0x24], 2
         : +jne 0x20
0x4c5d52 : mov eax, dword ptr [ebp - 8] 	(displays.c:941)
0x4c5d55 : mov eax, dword ptr [eax + 0xc]
0x4c5d58 : mov ecx, dword ptr [ebp + 0x14]
0x4c5d5b : mov ecx, dword ptr [ecx*4 + gHeadup_images[0] (DATA)]
0x4c5d62 : xor edx, edx
0x4c5d64 : mov dx, word ptr [ecx + 0x34]
0x4c5d68 : sar edx, 1
0x4c5d6a : sub eax, edx
0x4c5d6c : mov ecx, dword ptr [ebp - 8]
0x4c5d6f : mov dword ptr [ecx + 4], eax
0x4c5d72 : -jmp 0x4b
         : +jmp 0xc 	(displays.c:943)
0x4c5d77 : mov eax, dword ptr [ebp - 8] 	(displays.c:944)
0x4c5d7a : mov eax, dword ptr [eax + 0xc]
0x4c5d7d : -mov ecx, dword ptr [ebp + 0x14]
0x4c5d80 : -mov ecx, dword ptr [ecx*4 + gHeadup_images[0] (DATA)]
0x4c5d87 : -xor edx, edx
0x4c5d89 : -mov dx, word ptr [ecx + 0x34]
0x4c5d8d : -sub eax, edx
0x4c5d8f : mov ecx, dword ptr [ebp - 8]
0x4c5d92 : mov dword ptr [ecx + 4], eax
0x4c5d95 : -jmp 0x28
0x4c5d9a : -jmp 0x23
0x4c5d9f : -cmp dword ptr [ebp - 0x10], 0
0x4c5da3 : -je -0x68
0x4c5da9 : -cmp dword ptr [ebp - 0x10], 1
0x4c5dad : -je -0x3c
0x4c5db3 : -cmp dword ptr [ebp - 0x10], 2
0x4c5db7 : -je -0x6b
0x4c5dbd : -jmp 0x0
0x4c5dc2 : mov eax, dword ptr [ebp - 4] 	(displays.c:946)
0x4c5dc5 : mov eax, dword ptr [eax + 4]
0x4c5dc8 : mov ecx, dword ptr [ebp - 8]
0x4c5dcb : mov dword ptr [ecx + 8], eax
0x4c5dce : cmp dword ptr [ebp + 0xc], 0 	(displays.c:947)
0x4c5dd2 : je 0x14
0x4c5dd8 : mov eax, 0x3e8 	(displays.c:948)
0x4c5ddd : cdq 
0x4c5dde : idiv dword ptr [ebp + 0xc]
0x4c5de1 : mov ecx, dword ptr [ebp - 8]

---
+++
@@ -0x4c5e0e,10 +0x473b4a,20 @@
0x4c5e0e : je 0x15
0x4c5e14 : call GetTotalTime (FUNCTION) 	(displays.c:955)
0x4c5e19 : mov ecx, dword ptr [ebp + 0x10]
0x4c5e1c : add ecx, eax
0x4c5e1e : mov eax, dword ptr [ebp - 8]
0x4c5e21 : mov dword ptr [eax + 0x40], ecx
0x4c5e24 : jmp 0xa 	(displays.c:956)
0x4c5e29 : mov eax, dword ptr [ebp - 8] 	(displays.c:957)
0x4c5e2c : mov dword ptr [eax + 0x40], 0
0x4c5e33 : mov eax, dword ptr [ebp + 0x14] 	(displays.c:959)
         : +mov eax, dword ptr [eax*4 + gHeadup_images[0] (DATA)]
         : +mov ecx, dword ptr [ebp - 8]
         : +mov dword ptr [ecx + 0x48], eax
         : +mov eax, dword ptr [ebp - 0xc] 	(displays.c:961)
         : +jmp 0x0
         : +pop edi 	(displays.c:962)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


NewImageHeadupSlot is only 80.42% similar to the original, diff above
```

*AI generated. Time taken: 262s, tokens: 30,868*
