### PR TITLE
ChangeHeadupColour 100% match

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -1060,7 +1060,8 @@ void ChangeHeadupImage(int pHeadup_index, int pNew_image) {
 // FUNCTION: CARM95 0x004c629e
 void ChangeHeadupColour(int pHeadup_index, int pNew_colour) {
 
-    if (pHeadup_index >= 0) {
+    if (pHeadup_index < 0) {
+    } else {
         gHeadups[pHeadup_index].data.text_info.colour = gColours[pNew_colour];
     }
 }


### PR DESCRIPTION
## Match result

```
0x4c629e: ChangeHeadupColour 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4c629e,17 +0x474010,21 @@
0x4c629e : push ebp 	(displays.c:1066)
0x4c629f : mov ebp, esp
0x4c62a1 : push ebx
0x4c62a2 : push esi
0x4c62a3 : push edi
0x4c62a4 : cmp dword ptr [ebp + 8], 0 	(displays.c:1068)
0x4c62a8 : -jge 0x5
0x4c62ae : -jmp 0x20
         : +jl 0x20
0x4c62b3 : mov eax, dword ptr [ebp + 0xc] 	(displays.c:1069)
0x4c62b6 : mov eax, dword ptr [eax*4 + gColours[0] (DATA)]
0x4c62bd : mov ecx, dword ptr [ebp + 8]
0x4c62c0 : mov edx, ecx
0x4c62c2 : lea ecx, [ecx + ecx*8]
0x4c62c5 : lea ecx, [edx + ecx*4]
0x4c62c8 : lea ecx, [ecx + ecx*8]
0x4c62cb : sub ecx, edx
0x4c62cd : mov dword ptr [ecx + gHeadups[0].data+252 (OFFSET)], eax
         : +pop edi 	(displays.c:1071)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


ChangeHeadupColour is only 78.95% similar to the original, diff above
```

*AI generated. Time taken: 62s, tokens: 5,321*
