### PR TITLE
TDamageDriver 100% match

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -873,10 +873,10 @@ void TDamageEngine(void) {
 // FUNCTION: CARM95 0x004a127f
 void TDamageDriver(void) {
 
-    if (gProgram_state.current_car.damage_units[eDamage_driver].damage_level >= 80) {
-        DamageUnit(&gProgram_state.current_car, eDamage_driver, 2);
-    } else {
+    if (gProgram_state.current_car.damage_units[eDamage_driver].damage_level < 80) {
         DamageUnit(&gProgram_state.current_car, eDamage_driver, 80 - gProgram_state.current_car.damage_units[2].damage_level);
+    } else {
+        DamageUnit(&gProgram_state.current_car, eDamage_driver, 2);
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4a127f: TDamageDriver 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4a127f,28 +0x4659e1,28 @@
0x4a127f : push ebp 	(controls.c:875)
0x4a1280 : mov ebp, esp
0x4a1282 : push ebx
0x4a1283 : push esi
0x4a1284 : push edi
0x4a1285 : cmp dword ptr [gProgram_state+2136 (OFFSET)], 0x50 	(controls.c:877)
0x4a128c : -jge 0x26
0x4a1292 : -mov eax, 0x50
0x4a1297 : -sub eax, dword ptr [gProgram_state+2136 (OFFSET)]
0x4a129d : -push eax
         : +jl 0x1c
         : +push 2 	(controls.c:878)
0x4a129e : push 2
0x4a12a0 : mov eax, gProgram_state (DATA)
0x4a12a5 : add eax, 0xb0
0x4a12aa : push eax
0x4a12ab : call DamageUnit (FUNCTION)
0x4a12b0 : add esp, 0xc
0x4a12b3 : -jmp 0x17
0x4a12b8 : -push 2
         : +jmp 0x21 	(controls.c:879)
         : +mov eax, 0x50 	(controls.c:880)
         : +sub eax, dword ptr [gProgram_state+2136 (OFFSET)]
         : +push eax
0x4a12ba : push 2
0x4a12bc : mov eax, gProgram_state (DATA)
0x4a12c1 : add eax, 0xb0
0x4a12c6 : push eax
0x4a12c7 : call DamageUnit (FUNCTION)
0x4a12cc : add esp, 0xc
0x4a12cf : pop edi 	(controls.c:882)
0x4a12d0 : pop esi
0x4a12d1 : pop ebx
0x4a12d2 : leave 


TDamageDriver is only 79.31% similar to the original, diff above
```

*AI generated. Time taken: 86s, tokens: 10,988*
