### PR TITLE
SetRecovery 100% effective match

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -1355,57 +1355,44 @@ void CheckHorns(void) {
 // IDA: void __cdecl SetRecovery()
 // FUNCTION: CARM95 0x004a1d13
 void SetRecovery(void) {
-
-    if (gRace_finished
-        || gProgram_state.current_car.knackered
-        || gWait_for_it
-        || gHad_auto_recover
-        || gPalette_fade_time) {
-        return;
-    }
-
-    if (gNet_mode == eNet_mode_none) {
-        gRecover_car = 1;
-        gRecover_timer = 0;
-        return;
-    }
-    if (gProgram_state.current_car.time_to_recover) {
-        if (GetRaceTime() + 600 >= gProgram_state.current_car.time_to_recover) {
-            NewTextHeadupSlot2(eHeadupSlot_misc, 0, 2000, -kFont_MEDIUMHD, GetMiscString(kMiscString_TOO_LATE_TO_CANCEL), 1);
-            gToo_late = 1;
+    if (!gRace_finished
+        && !gProgram_state.current_car.knackered
+        && !gWait_for_it
+        && !gHad_auto_recover
+        && !gPalette_fade_time) {
+        if (gNet_mode != eNet_mode_none) {
+            if (gProgram_state.current_car.time_to_recover) {
+                if (GetRaceTime() + 600 < gProgram_state.current_car.time_to_recover) {
+                    gProgram_state.current_car.time_to_recover = 0;
+                    NewTextHeadupSlot2(eHeadupSlot_misc, 0, 2000, -kFont_MEDIUMHD, GetMiscString(kMiscString_RECOVERY_CANCELLED), 0);
+                } else {
+                    NewTextHeadupSlot2(eHeadupSlot_misc, 0, 2000, -kFont_MEDIUMHD, GetMiscString(kMiscString_TOO_LATE_TO_CANCEL), 1);
+                    gToo_late = 1;
+                }
+            } else if (CheckRecoverCost()) {
+                if (gCurrent_net_game->type == eNet_game_type_foxy) {
+                    if (gIt_or_fox == gThis_net_player_index) {
+                        gProgram_state.current_car.time_to_recover = GetRaceTime() + 5000;
+                    } else {
+                        gProgram_state.current_car.time_to_recover = GetRaceTime() + 1000;
+                    }
+                } else if (gCurrent_net_game->type == eNet_game_type_tag) {
+                    if (gIt_or_fox != gThis_net_player_index) {
+                        gProgram_state.current_car.time_to_recover = GetRaceTime() + 5000;
+                    } else {
+                        gProgram_state.current_car.time_to_recover = GetRaceTime() + 1000;
+                    }
+                } else {
+                    gProgram_state.current_car.time_to_recover = GetRaceTime() + 3000;
+                }
+                gRecover_timer = 0;
+                gToo_late = 0;
+            }
         } else {
-            gProgram_state.current_car.time_to_recover = 0;
-            NewTextHeadupSlot2(eHeadupSlot_misc, 0, 2000, -kFont_MEDIUMHD, GetMiscString(kMiscString_RECOVERY_CANCELLED), 0);
-        }
-        return;
-    }
-    if (!CheckRecoverCost()) {
-        return;
-    }
-    if (gCurrent_net_game->type == eNet_game_type_foxy) {
-        if (gThis_net_player_index == gIt_or_fox) {
-            gProgram_state.current_car.time_to_recover = GetRaceTime() + 5000;
+            gRecover_car = 1;
             gRecover_timer = 0;
-            gToo_late = 0;
-            return;
-        }
-    } else {
-        if (gCurrent_net_game->type != eNet_game_type_tag) {
-            gProgram_state.current_car.time_to_recover = GetRaceTime() + 3000;
-            gRecover_timer = 0;
-            gToo_late = 0;
-            return;
-        }
-        if (gThis_net_player_index != gIt_or_fox) {
-            gProgram_state.current_car.time_to_recover = GetRaceTime() + 5000;
-            gRecover_timer = 0;
-            gToo_late = 0;
-            return;
         }
     }
-    gProgram_state.current_car.time_to_recover = GetRaceTime() + 1000;
-    gRecover_timer = 0;
-    gToo_late = 0;
 }
 
 // IDA: void __cdecl RecoverCar()


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4a1dd4,36 +0x466ba5,36 @@
0x4a1dd4 : call NewTextHeadupSlot2 (FUNCTION)
0x4a1dd9 : add esp, 0x18
0x4a1ddc : mov dword ptr [gToo_late (DATA)], 1 	(controls.c:1370)
0x4a1de6 : jmp 0xc0 	(controls.c:1372)
0x4a1deb : call CheckRecoverCost (FUNCTION)
0x4a1df0 : test eax, eax
0x4a1df2 : je 0xb3
0x4a1df8 : mov eax, dword ptr [gCurrent_net_game (DATA)] 	(controls.c:1373)
0x4a1dfd : cmp dword ptr [eax + 0x74], 6
0x4a1e01 : jne 0x39
0x4a1e07 : -mov eax, dword ptr [gIt_or_fox (DATA)]
0x4a1e0c : -cmp dword ptr [gThis_net_player_index (DATA)], eax
         : +mov eax, dword ptr [gThis_net_player_index (DATA)] 	(controls.c:1374)
         : +cmp dword ptr [gIt_or_fox (DATA)], eax
0x4a1e12 : jne 0x14
0x4a1e18 : call GetRaceTime (FUNCTION) 	(controls.c:1375)
0x4a1e1d : add eax, 0x1388
0x4a1e22 : mov dword ptr [gProgram_state+6964 (OFFSET)], eax
0x4a1e27 : jmp 0xf 	(controls.c:1376)
0x4a1e2c : call GetRaceTime (FUNCTION) 	(controls.c:1377)
0x4a1e31 : add eax, 0x3e8
0x4a1e36 : mov dword ptr [gProgram_state+6964 (OFFSET)], eax
0x4a1e3b : jmp 0x57 	(controls.c:1379)
0x4a1e40 : mov eax, dword ptr [gCurrent_net_game (DATA)]
0x4a1e45 : cmp dword ptr [eax + 0x74], 5
0x4a1e49 : jne 0x39
0x4a1e4f : -mov eax, dword ptr [gIt_or_fox (DATA)]
0x4a1e54 : -cmp dword ptr [gThis_net_player_index (DATA)], eax
         : +mov eax, dword ptr [gThis_net_player_index (DATA)] 	(controls.c:1380)
         : +cmp dword ptr [gIt_or_fox (DATA)], eax
0x4a1e5a : je 0x14
0x4a1e60 : call GetRaceTime (FUNCTION) 	(controls.c:1381)
0x4a1e65 : add eax, 0x1388
0x4a1e6a : mov dword ptr [gProgram_state+6964 (OFFSET)], eax
0x4a1e6f : jmp 0xf 	(controls.c:1382)
0x4a1e74 : call GetRaceTime (FUNCTION) 	(controls.c:1383)
0x4a1e79 : add eax, 0x3e8
0x4a1e7e : mov dword ptr [gProgram_state+6964 (OFFSET)], eax
0x4a1e83 : jmp 0xf 	(controls.c:1385)
0x4a1e88 : call GetRaceTime (FUNCTION) 	(controls.c:1386)


0x4a1d13: SetRecovery 100% effective match (differs, but only in ways that don't affect behavior).

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4a1d13,93 +0x4668f1,98 @@
0x4a1d13 : push ebp 	(controls.c:1363)
0x4a1d14 : mov ebp, esp
0x4a1d16 : push ebx
0x4a1d17 : push esi
0x4a1d18 : push edi
0x4a1d19 : cmp dword ptr [gRace_finished (DATA)], 0 	(controls.c:1369)
0x4a1d20 : -jne 0x19e
         : +jne 0x34
0x4a1d26 : cmp dword ptr [gProgram_state+1256 (OFFSET)], 0
0x4a1d2d : -jne 0x191
         : +jne 0x27
0x4a1d33 : cmp dword ptr [gWait_for_it (DATA)], 0
0x4a1d3a : -jne 0x184
         : +jne 0x1a
0x4a1d40 : cmp dword ptr [gHad_auto_recover (DATA)], 0
0x4a1d47 : -jne 0x177
         : +jne 0xd
0x4a1d4d : cmp dword ptr [gPalette_fade_time (DATA)], 0
0x4a1d54 : -jne 0x16a
         : +je 0x5
         : +jmp 0x19c 	(controls.c:1370)
0x4a1d5a : cmp dword ptr [gNet_mode (DATA)], 0 	(controls.c:1373)
0x4a1d61 : -je 0x149
         : +jne 0x19
         : +mov dword ptr [gRecover_car (DATA)], 1 	(controls.c:1374)
         : +mov dword ptr [gRecover_timer (DATA)], 0 	(controls.c:1375)
         : +jmp 0x176 	(controls.c:1376)
0x4a1d67 : cmp dword ptr [gProgram_state+6964 (OFFSET)], 0 	(controls.c:1378)
0x4a1d6e : je 0x77
0x4a1d74 : call GetRaceTime (FUNCTION) 	(controls.c:1379)
0x4a1d79 : add eax, 0x258
0x4a1d7e : cmp eax, dword ptr [gProgram_state+6964 (OFFSET)]
0x4a1d84 : -jae 0x2f
         : +jb 0x32
         : +push 1 	(controls.c:1380)
         : +push 0xf2
         : +call GetMiscString (FUNCTION)
         : +add esp, 4
         : +push eax
         : +push -4
         : +push 0x7d0
         : +push 0
         : +push 4
         : +call NewTextHeadupSlot2 (FUNCTION)
         : +add esp, 0x18
         : +mov dword ptr [gToo_late (DATA)], 1 	(controls.c:1381)
         : +jmp 0x2a 	(controls.c:1382)
0x4a1d8a : mov dword ptr [gProgram_state+6964 (OFFSET)], 0 	(controls.c:1383)
0x4a1d94 : push 0 	(controls.c:1384)
0x4a1d96 : push 0x7d
0x4a1d98 : call GetMiscString (FUNCTION)
0x4a1d9d : add esp, 4
0x4a1da0 : push eax
0x4a1da1 : push -4
0x4a1da3 : push 0x7d0
0x4a1da8 : push 0
0x4a1daa : push 4
0x4a1dac : call NewTextHeadupSlot2 (FUNCTION)
0x4a1db1 : add esp, 0x18
0x4a1db4 : -jmp 0x2d
0x4a1db9 : -push 1
0x4a1dbb : -push 0xf2
0x4a1dc0 : -call GetMiscString (FUNCTION)
0x4a1dc5 : -add esp, 4
0x4a1dc8 : -push eax
0x4a1dc9 : -push -4
0x4a1dcb : -push 0x7d0
0x4a1dd0 : -push 0
0x4a1dd2 : -push 4
0x4a1dd4 : -call NewTextHeadupSlot2 (FUNCTION)
0x4a1dd9 : -add esp, 0x18
0x4a1ddc : -mov dword ptr [gToo_late (DATA)], 1
0x4a1de6 : -jmp 0xc0
         : +jmp 0xf2 	(controls.c:1386)
0x4a1deb : call CheckRecoverCost (FUNCTION) 	(controls.c:1388)
0x4a1df0 : test eax, eax
0x4a1df2 : -je 0xb3
         : +jne 0x5
         : +jmp 0xe0 	(controls.c:1389)
0x4a1df8 : mov eax, dword ptr [gCurrent_net_game (DATA)] 	(controls.c:1391)
0x4a1dfd : cmp dword ptr [eax + 0x74], 6
0x4a1e01 : -jne 0x39
0x4a1e07 : -mov eax, dword ptr [gIt_or_fox (DATA)]
0x4a1e0c : -cmp dword ptr [gThis_net_player_index (DATA)], eax
0x4a1e12 : -jne 0x14
         : +jne 0x3e
         : +mov eax, dword ptr [gThis_net_player_index (DATA)] 	(controls.c:1392)
         : +cmp dword ptr [gIt_or_fox (DATA)], eax
         : +jne 0x28
0x4a1e18 : call GetRaceTime (FUNCTION) 	(controls.c:1393)
0x4a1e1d : add eax, 0x1388
0x4a1e22 : mov dword ptr [gProgram_state+6964 (OFFSET)], eax
0x4a1e27 : -jmp 0xf
0x4a1e2c : -call GetRaceTime (FUNCTION)
0x4a1e31 : -add eax, 0x3e8
0x4a1e36 : -mov dword ptr [gProgram_state+6964 (OFFSET)], eax
0x4a1e3b : -jmp 0x57
         : +mov dword ptr [gRecover_timer (DATA)], 0 	(controls.c:1394)
         : +mov dword ptr [gToo_late (DATA)], 0 	(controls.c:1395)
         : +jmp 0x98 	(controls.c:1396)
         : +jmp 0x70 	(controls.c:1398)
0x4a1e40 : mov eax, dword ptr [gCurrent_net_game (DATA)] 	(controls.c:1399)
0x4a1e45 : cmp dword ptr [eax + 0x74], 5
0x4a1e49 : -jne 0x39
0x4a1e4f : -mov eax, dword ptr [gIt_or_fox (DATA)]
0x4a1e54 : -cmp dword ptr [gThis_net_player_index (DATA)], eax
0x4a1e5a : -je 0x14
0x4a1e60 : -call GetRaceTime (FUNCTION)
0x4a1e65 : -add eax, 0x1388
0x4a1e6a : -mov dword ptr [gProgram_state+6964 (OFFSET)], eax
0x4a1e6f : -jmp 0xf
0x4a1e74 : -call GetRaceTime (FUNCTION)
0x4a1e79 : -add eax, 0x3e8
0x4a1e7e : -mov dword ptr [gProgram_state+6964 (OFFSET)], eax
0x4a1e83 : -jmp 0xf
         : +je 0x28
0x4a1e88 : call GetRaceTime (FUNCTION) 	(controls.c:1400)
0x4a1e8d : add eax, 0xbb8
0x4a1e92 : mov dword ptr [gProgram_state+6964 (OFFSET)], eax
0x4a1e97 : mov dword ptr [gRecover_timer (DATA)], 0 	(controls.c:1401)
0x4a1ea1 : mov dword ptr [gToo_late (DATA)], 0 	(controls.c:1402)
0x4a1eab : -jmp 0x14
0x4a1eb0 : -mov dword ptr [gRecover_car (DATA)], 1
         : +jmp 0x5c 	(controls.c:1403)
         : +mov eax, dword ptr [gThis_net_player_index (DATA)] 	(controls.c:1405)
         : +cmp dword ptr [gIt_or_fox (DATA)], eax
         : +je 0x28
         : +call GetRaceTime (FUNCTION) 	(controls.c:1406)
         : +add eax, 0x1388
         : +mov dword ptr [gProgram_state+6964 (OFFSET)], eax
0x4a1eba : mov dword ptr [gRecover_timer (DATA)], 0 	(controls.c:1407)
         : +mov dword ptr [gToo_late (DATA)], 0 	(controls.c:1408)
         : +jmp 0x23 	(controls.c:1409)
         : +call GetRaceTime (FUNCTION) 	(controls.c:1412)
         : +add eax, 0x3e8
         : +mov dword ptr [gProgram_state+6964 (OFFSET)], eax
         : +mov dword ptr [gRecover_timer (DATA)], 0 	(controls.c:1413)
         : +mov dword ptr [gToo_late (DATA)], 0 	(controls.c:1414)
0x4a1ec4 : pop edi 	(controls.c:1415)
0x4a1ec5 : pop esi
0x4a1ec6 : pop ebx
0x4a1ec7 : leave 
0x4a1ec8 : ret 


SetRecovery is only 50.26% similar to the original, diff above
```

*AI generated. Time taken: 844s, tokens: 28,550*
