### PR TITLE
PollCarControls equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -1971,71 +1971,69 @@ void PollCarControls(tU32 pTime_difference) {
     tJoystick joystick;
     tCar_spec* c;
 
-    c = &gProgram_state.current_car;
+    decay_steering = 1;
+    decay_speed = 1;
 
     memset(&keys, 0, sizeof(tCar_controls));
     joystick.left = -1;
     joystick.right = -1;
     joystick.acc = -1;
     joystick.dec = -1;
+    c = &gProgram_state.current_car;
     if (gEntering_message) {
-        memset(&c->keys, 0, sizeof(tCar_controls));
-        c->joystick.left = -1;
-        c->joystick.right = -1;
-        c->joystick.acc = -1;
-        c->joystick.dec = -1;
+        c->keys = keys;
+        c->joystick = joystick;
     } else {
-        if (gKey_mapping[46] >= 115 || gKey_mapping[47] >= 115) {
-            joystick.left = gJoy_array[gKey_mapping[46] - 115];
-            joystick.right = gJoy_array[gKey_mapping[47] - 115];
-            if (joystick.left < 0 && joystick.right < 0) {
-                joystick.left = 0;
-            }
-        } else {
+        if (gKey_mapping[46] < 115 && gKey_mapping[47] < 115) {
             if (KeyIsDown(46)) {
                 keys.left = 1;
             }
             if (KeyIsDown(47)) {
                 keys.right = 1;
             }
+        } else {
+            joystick.left = gJoy_array[gKey_mapping[46] - 115];
+            joystick.right = gJoy_array[gKey_mapping[47] - 115];
+            if (joystick.left < 0 && joystick.right < 0) {
+                joystick.left = 0;
+            }
         }
         if (KeyIsDown(12)) {
             keys.holdw = 1;
         }
         if (KeyIsDown(53) || gRace_finished) {
-            if (!gInstant_handbrake || gRace_finished) {
-                keys.brake = 1;
-            } else {
+            if (gInstant_handbrake && !gRace_finished) {
                 BrakeInstantly();
+            } else {
+                keys.brake = 1;
             }
         }
-        if (gKey_mapping[48] < 115) {
-            if (KeyIsDown(48) && !gRace_finished && !c->knackered && !gWait_for_it) {
-                keys.acc = 1;
-            }
-        } else {
+        if (gKey_mapping[48] >= 115) {
             joystick.acc = gJoy_array[gKey_mapping[48] - 115];
             if (joystick.acc > 0xFFFF) {
                 joystick.acc = 0xFFFF;
             }
+        } else if (KeyIsDown(48) && !gRace_finished && !gProgram_state.current_car.knackered && !gWait_for_it) {
+            keys.acc = 1;
         }
-        if (gKey_mapping[49] < 115) {
-            if (KeyIsDown(49) && !gRace_finished && !c->knackered && !gWait_for_it) {
-                keys.dec = 1;
-            }
-        } else {
+        if (gKey_mapping[49] >= 115) {
             joystick.dec = gJoy_array[gKey_mapping[49] - 115];
             if (joystick.dec > 0xFFFF) {
                 joystick.dec = 0xFFFF;
             }
+        } else if (KeyIsDown(49) && !gRace_finished && !gProgram_state.current_car.knackered && !gWait_for_it) {
+            keys.dec = 1;
         }
         if (KeyIsDown(55) && c->gear >= 0) {
             keys.change_down = 1;
             c->just_changed_gear = 1;
-            if (keys.acc || joystick.acc > 32000) {
+            if (!keys.acc && joystick.acc <= 32000) {
+                if (c->gear > 1 && !c->keys.change_down) {
+                    --c->gear;
+                } else {
+                }
+            } else {
                 c->traction_control = 0;
-            } else if (c->gear > 1 && !c->keys.change_down) {
-                --c->gear;
             }
             if (gCountdown && !c->keys.change_down) {
                 JumpTheStart();


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4a3e3e,24 +0x468841,24 @@
0x4a3e3e : push 0x2f 	(controls.c:1991)
0x4a3e40 : call KeyIsDown (FUNCTION)
0x4a3e45 : add esp, 4
0x4a3e48 : test eax, eax
0x4a3e4a : je 0xb
0x4a3e50 : mov eax, dword ptr [ebp - 0x2c] 	(controls.c:1992)
0x4a3e53 : or eax, 0x20000
0x4a3e58 : mov dword ptr [ebp - 0x2c], eax
0x4a3e5b : jmp 0x39 	(controls.c:1994)
0x4a3e60 : mov eax, dword ptr [gKey_mapping[46] (OFFSET)] 	(controls.c:1995)
0x4a3e65 : -mov eax, dword ptr [eax*4 + <OFFSET6>]
         : +mov eax, dword ptr [eax*4 + gGames_to_join[0].time (OFFSET)]
0x4a3e6c : mov dword ptr [ebp - 0x28], eax
0x4a3e6f : mov eax, dword ptr [gKey_mapping[47] (OFFSET)] 	(controls.c:1996)
0x4a3e74 : -mov eax, dword ptr [eax*4 + <OFFSET6>]
         : +mov eax, dword ptr [eax*4 + gGames_to_join[0].time (OFFSET)]
0x4a3e7b : mov dword ptr [ebp - 0x24], eax
0x4a3e7e : cmp dword ptr [ebp - 0x28], 0 	(controls.c:1997)
0x4a3e82 : jge 0x11
0x4a3e88 : cmp dword ptr [ebp - 0x24], 0
0x4a3e8c : jge 0x7
0x4a3e92 : mov dword ptr [ebp - 0x28], 0 	(controls.c:1998)
0x4a3e99 : push 0xc 	(controls.c:2001)
0x4a3e9b : call KeyIsDown (FUNCTION)
0x4a3ea0 : add esp, 4
0x4a3ea3 : test eax, eax

---
+++
@@ -0x4a3ee2,21 +0x4688e5,21 @@
0x4a3ee2 : cmp dword ptr [gRace_finished (DATA)], 0
0x4a3ee9 : jne 0xa
0x4a3eef : call BrakeInstantly (FUNCTION) 	(controls.c:2006)
0x4a3ef4 : jmp 0xb 	(controls.c:2007)
0x4a3ef9 : mov eax, dword ptr [ebp - 0x2c] 	(controls.c:2008)
0x4a3efc : or eax, 0x100000
0x4a3f01 : mov dword ptr [ebp - 0x2c], eax
0x4a3f04 : cmp dword ptr [gKey_mapping[48] (OFFSET)], 0x73 	(controls.c:2011)
0x4a3f0b : jl 0x28
0x4a3f11 : mov eax, dword ptr [gKey_mapping[48] (OFFSET)] 	(controls.c:2012)
0x4a3f16 : -mov eax, dword ptr [eax*4 + <OFFSET6>]
         : +mov eax, dword ptr [eax*4 + gGames_to_join[0].time (OFFSET)]
0x4a3f1d : mov dword ptr [ebp - 0x20], eax
0x4a3f20 : cmp dword ptr [ebp - 0x20], 0xffff 	(controls.c:2013)
0x4a3f27 : jle 0x7
0x4a3f2d : mov dword ptr [ebp - 0x20], 0xffff 	(controls.c:2014)
0x4a3f34 : jmp 0x44 	(controls.c:2016)
0x4a3f39 : push 0x30
0x4a3f3b : call KeyIsDown (FUNCTION)
0x4a3f40 : add esp, 4
0x4a3f43 : test eax, eax
0x4a3f45 : je 0x32

---
+++
@@ -0x4a3f58,21 +0x46895b,21 @@
0x4a3f58 : cmp dword ptr [gProgram_state+1256 (OFFSET)], 0
0x4a3f5f : jne 0x18
0x4a3f65 : cmp dword ptr [gWait_for_it (DATA)], 0
0x4a3f6c : jne 0xb
0x4a3f72 : mov eax, dword ptr [ebp - 0x2c] 	(controls.c:2017)
0x4a3f75 : or eax, 0x40000
0x4a3f7a : mov dword ptr [ebp - 0x2c], eax
0x4a3f7d : cmp dword ptr [gKey_mapping[49] (OFFSET)], 0x73 	(controls.c:2019)
0x4a3f84 : jl 0x28
0x4a3f8a : mov eax, dword ptr [gKey_mapping[49] (OFFSET)] 	(controls.c:2020)
0x4a3f8f : -mov eax, dword ptr [eax*4 + <OFFSET6>]
         : +mov eax, dword ptr [eax*4 + gGames_to_join[0].time (OFFSET)]
0x4a3f96 : mov dword ptr [ebp - 0x1c], eax
0x4a3f99 : cmp dword ptr [ebp - 0x1c], 0xffff 	(controls.c:2021)
0x4a3fa0 : jle 0x7
0x4a3fa6 : mov dword ptr [ebp - 0x1c], 0xffff 	(controls.c:2022)
0x4a3fad : jmp 0x44 	(controls.c:2024)
0x4a3fb2 : push 0x31
0x4a3fb4 : call KeyIsDown (FUNCTION)
0x4a3fb9 : add esp, 4
0x4a3fbc : test eax, eax
0x4a3fbe : je 0x32


PollCarControls is only 98.21% similar to the original, diff above
```

#### Effective match analysis

The shown differences are only in symbolic annotation of the same indexed memory operand (`[eax*4 + <OFFSET6>]` vs `[eax*4 + gGames_to_join[0].time (OFFSET)]`) at the same instruction points. Control flow, comparisons, branches, and value clamping logic are unchanged in the diff. So this snippet is functionally equivalent, assuming `<OFFSET6>` resolves to that same offset (which this kind of relabeling indicates).

#### Original match

```
---
+++
@@ -0x4a3d80,178 +0x4685f3,173 @@
0x4a3d80 : push ebp 	(controls.c:1966)
0x4a3d81 : mov ebp, esp
0x4a3d83 : sub esp, 0x2c
0x4a3d86 : push ebx
0x4a3d87 : push esi
0x4a3d88 : push edi
0x4a3d89 : -mov dword ptr [ebp - 0x18], 1
0x4a3d90 : -mov dword ptr [ebp - 0x14], 1
         : +mov eax, gProgram_state (DATA) 	(controls.c:1976)
         : +add eax, 0xb0
         : +mov dword ptr [ebp - 0xc], eax
0x4a3d97 : mov dword ptr [ebp - 0x2c], 0 	(controls.c:1978)
0x4a3d9e : mov dword ptr [ebp - 0x28], 0xffffffff 	(controls.c:1979)
0x4a3da5 : mov dword ptr [ebp - 0x24], 0xffffffff 	(controls.c:1980)
0x4a3dac : mov dword ptr [ebp - 0x20], 0xffffffff 	(controls.c:1981)
0x4a3db3 : mov dword ptr [ebp - 0x1c], 0xffffffff 	(controls.c:1982)
0x4a3dba : -mov eax, gProgram_state (DATA)
0x4a3dbf : -add eax, 0xb0
0x4a3dc4 : -mov dword ptr [ebp - 0xc], eax
0x4a3dc7 : cmp dword ptr [gEntering_message (DATA)], 0 	(controls.c:1983)
0x4a3dce : -je 0x33
0x4a3dd4 : -mov eax, dword ptr [ebp - 0x2c]
0x4a3dd7 : -mov ecx, dword ptr [ebp - 0xc]
0x4a3dda : -mov dword ptr [ecx + 0x1574], eax
0x4a3de0 : -lea eax, [ebp - 0x28]
0x4a3de3 : -mov ecx, dword ptr [ebp - 0xc]
0x4a3de6 : -add ecx, 0x1578
0x4a3dec : -mov edx, dword ptr [eax]
0x4a3dee : -mov dword ptr [ecx], edx
0x4a3df0 : -mov edx, dword ptr [eax + 4]
0x4a3df3 : -mov dword ptr [ecx + 4], edx
0x4a3df6 : -mov edx, dword ptr [eax + 8]
0x4a3df9 : -mov dword ptr [ecx + 8], edx
0x4a3dfc : -mov eax, dword ptr [eax + 0xc]
0x4a3dff : -mov dword ptr [ecx + 0xc], eax
0x4a3e02 : -jmp 0x34d
         : +je 0x46
         : +mov eax, dword ptr [ebp - 0xc] 	(controls.c:1984)
         : +mov dword ptr [eax + 0x1574], 0
         : +mov eax, dword ptr [ebp - 0xc] 	(controls.c:1985)
         : +mov dword ptr [eax + 0x1578], 0xffffffff
         : +mov eax, dword ptr [ebp - 0xc] 	(controls.c:1986)
         : +mov dword ptr [eax + 0x157c], 0xffffffff
         : +mov eax, dword ptr [ebp - 0xc] 	(controls.c:1987)
         : +mov dword ptr [eax + 0x1580], 0xffffffff
         : +mov eax, dword ptr [ebp - 0xc] 	(controls.c:1988)
         : +mov dword ptr [eax + 0x1584], 0xffffffff
         : +jmp 0x34e 	(controls.c:1989)
0x4a3e07 : cmp dword ptr [gKey_mapping[46] (OFFSET)], 0x73 	(controls.c:1990)
0x4a3e0e : -jge 0x4c
         : +jge 0xd
0x4a3e14 : cmp dword ptr [gKey_mapping[47] (OFFSET)], 0x73
0x4a3e1b : -jge 0x3f
         : +jl 0x3e
         : +mov eax, dword ptr [gKey_mapping[46] (OFFSET)] 	(controls.c:1991)
         : +mov eax, dword ptr [eax*4 + gGames_to_join[0].time (OFFSET)]
         : +mov dword ptr [ebp - 0x28], eax
         : +mov eax, dword ptr [gKey_mapping[47] (OFFSET)] 	(controls.c:1992)
         : +mov eax, dword ptr [eax*4 + gGames_to_join[0].time (OFFSET)]
         : +mov dword ptr [ebp - 0x24], eax
         : +cmp dword ptr [ebp - 0x28], 0 	(controls.c:1993)
         : +jge 0x11
         : +cmp dword ptr [ebp - 0x24], 0
         : +jge 0x7
         : +mov dword ptr [ebp - 0x28], 0 	(controls.c:1994)
         : +jmp 0x3a 	(controls.c:1996)
0x4a3e21 : push 0x2e 	(controls.c:1997)
0x4a3e23 : call KeyIsDown (FUNCTION)
0x4a3e28 : add esp, 4
0x4a3e2b : test eax, eax
0x4a3e2d : je 0xb
0x4a3e33 : mov eax, dword ptr [ebp - 0x2c] 	(controls.c:1998)
0x4a3e36 : or eax, 0x10000
0x4a3e3b : mov dword ptr [ebp - 0x2c], eax
0x4a3e3e : push 0x2f 	(controls.c:2000)
0x4a3e40 : call KeyIsDown (FUNCTION)
0x4a3e45 : add esp, 4
0x4a3e48 : test eax, eax
0x4a3e4a : je 0xb
0x4a3e50 : mov eax, dword ptr [ebp - 0x2c] 	(controls.c:2001)
0x4a3e53 : or eax, 0x20000
0x4a3e58 : mov dword ptr [ebp - 0x2c], eax
0x4a3e5b : -jmp 0x39
0x4a3e60 : -mov eax, dword ptr [gKey_mapping[46] (OFFSET)]
0x4a3e65 : -mov eax, dword ptr [eax*4 + <OFFSET6>]
0x4a3e6c : -mov dword ptr [ebp - 0x28], eax
0x4a3e6f : -mov eax, dword ptr [gKey_mapping[47] (OFFSET)]
0x4a3e74 : -mov eax, dword ptr [eax*4 + <OFFSET6>]
0x4a3e7b : -mov dword ptr [ebp - 0x24], eax
0x4a3e7e : -cmp dword ptr [ebp - 0x28], 0
0x4a3e82 : -jge 0x11
0x4a3e88 : -cmp dword ptr [ebp - 0x24], 0
0x4a3e8c : -jge 0x7
0x4a3e92 : -mov dword ptr [ebp - 0x28], 0
0x4a3e99 : push 0xc 	(controls.c:2004)
0x4a3e9b : call KeyIsDown (FUNCTION)
0x4a3ea0 : add esp, 4
0x4a3ea3 : test eax, eax
0x4a3ea5 : je 0xb
0x4a3eab : mov eax, dword ptr [ebp - 0x2c] 	(controls.c:2005)
0x4a3eae : or eax, 0x800000
0x4a3eb3 : mov dword ptr [ebp - 0x2c], eax
0x4a3eb6 : push 0x35 	(controls.c:2007)
0x4a3eb8 : call KeyIsDown (FUNCTION)
0x4a3ebd : add esp, 4
0x4a3ec0 : test eax, eax
0x4a3ec2 : jne 0xd
0x4a3ec8 : cmp dword ptr [gRace_finished (DATA)], 0
0x4a3ecf : je 0x2f
0x4a3ed5 : cmp dword ptr [gInstant_handbrake (DATA)], 0 	(controls.c:2008)
0x4a3edc : -je 0x17
         : +je 0xd
0x4a3ee2 : cmp dword ptr [gRace_finished (DATA)], 0
0x4a3ee9 : -jne 0xa
0x4a3eef : -call BrakeInstantly (FUNCTION)
0x4a3ef4 : -jmp 0xb
         : +je 0x10
0x4a3ef9 : mov eax, dword ptr [ebp - 0x2c] 	(controls.c:2009)
0x4a3efc : or eax, 0x100000
0x4a3f01 : mov dword ptr [ebp - 0x2c], eax
         : +jmp 0x5 	(controls.c:2010)
         : +call BrakeInstantly (FUNCTION) 	(controls.c:2011)
0x4a3f04 : cmp dword ptr [gKey_mapping[48] (OFFSET)], 0x73 	(controls.c:2014)
0x4a3f0b : -jl 0x28
0x4a3f11 : -mov eax, dword ptr [gKey_mapping[48] (OFFSET)]
0x4a3f16 : -mov eax, dword ptr [eax*4 + <OFFSET6>]
0x4a3f1d : -mov dword ptr [ebp - 0x20], eax
0x4a3f20 : -cmp dword ptr [ebp - 0x20], 0xffff
0x4a3f27 : -jle 0x7
0x4a3f2d : -mov dword ptr [ebp - 0x20], 0xffff
0x4a3f34 : -jmp 0x44
         : +jge 0x4c
0x4a3f39 : push 0x30 	(controls.c:2015)
0x4a3f3b : call KeyIsDown (FUNCTION)
0x4a3f40 : add esp, 4
0x4a3f43 : test eax, eax
0x4a3f45 : -je 0x32
         : +je 0x35
0x4a3f4b : cmp dword ptr [gRace_finished (DATA)], 0
0x4a3f52 : -jne 0x25
0x4a3f58 : -cmp dword ptr [gProgram_state+1256 (OFFSET)], 0
         : +jne 0x28
         : +mov eax, dword ptr [ebp - 0xc]
         : +cmp dword ptr [eax + 0x438], 0
0x4a3f5f : jne 0x18
0x4a3f65 : cmp dword ptr [gWait_for_it (DATA)], 0
0x4a3f6c : jne 0xb
0x4a3f72 : mov eax, dword ptr [ebp - 0x2c] 	(controls.c:2016)
0x4a3f75 : or eax, 0x40000
0x4a3f7a : mov dword ptr [ebp - 0x2c], eax
         : +jmp 0x23 	(controls.c:2018)
         : +mov eax, dword ptr [gKey_mapping[48] (OFFSET)] 	(controls.c:2019)
         : +mov eax, dword ptr [eax*4 + gGames_to_join[0].time (OFFSET)]
         : +mov dword ptr [ebp - 0x20], eax
         : +cmp dword ptr [ebp - 0x20], 0xffff 	(controls.c:2020)
         : +jle 0x7
         : +mov dword ptr [ebp - 0x20], 0xffff 	(controls.c:2021)
0x4a3f7d : cmp dword ptr [gKey_mapping[49] (OFFSET)], 0x73 	(controls.c:2024)
0x4a3f84 : -jl 0x28
0x4a3f8a : -mov eax, dword ptr [gKey_mapping[49] (OFFSET)]
0x4a3f8f : -mov eax, dword ptr [eax*4 + <OFFSET6>]
0x4a3f96 : -mov dword ptr [ebp - 0x1c], eax
0x4a3f99 : -cmp dword ptr [ebp - 0x1c], 0xffff
0x4a3fa0 : -jle 0x7
0x4a3fa6 : -mov dword ptr [ebp - 0x1c], 0xffff
0x4a3fad : -jmp 0x44
         : +jge 0x4c
0x4a3fb2 : push 0x31 	(controls.c:2025)
0x4a3fb4 : call KeyIsDown (FUNCTION)
0x4a3fb9 : add esp, 4
0x4a3fbc : test eax, eax
0x4a3fbe : -je 0x32
         : +je 0x35
0x4a3fc4 : cmp dword ptr [gRace_finished (DATA)], 0
0x4a3fcb : -jne 0x25
0x4a3fd1 : -cmp dword ptr [gProgram_state+1256 (OFFSET)], 0
         : +jne 0x28
         : +mov eax, dword ptr [ebp - 0xc]
         : +cmp dword ptr [eax + 0x438], 0
0x4a3fd8 : jne 0x18
0x4a3fde : cmp dword ptr [gWait_for_it (DATA)], 0
0x4a3fe5 : jne 0xb
0x4a3feb : mov eax, dword ptr [ebp - 0x2c] 	(controls.c:2026)
0x4a3fee : or eax, 0x80000
0x4a3ff3 : mov dword ptr [ebp - 0x2c], eax
         : +jmp 0x23 	(controls.c:2028)
         : +mov eax, dword ptr [gKey_mapping[49] (OFFSET)] 	(controls.c:2029)
         : +mov eax, dword ptr [eax*4 + gGames_to_join[0].time (OFFSET)]
         : +mov dword ptr [ebp - 0x1c], eax
         : +cmp dword ptr [ebp - 0x1c], 0xffff 	(controls.c:2030)
         : +jle 0x7
         : +mov dword ptr [ebp - 0x1c], 0xffff 	(controls.c:2031)
0x4a3ff6 : push 0x37 	(controls.c:2034)
0x4a3ff8 : call KeyIsDown (FUNCTION)
0x4a3ffd : add esp, 4
0x4a4000 : test eax, eax
0x4a4002 : -je 0xad
         : +je 0xa8
0x4a4008 : mov eax, dword ptr [ebp - 0xc]
0x4a400b : cmp dword ptr [eax + 0x15e8], 0
0x4a4012 : -jl 0x9d
         : +jl 0x98
0x4a4018 : mov eax, dword ptr [ebp - 0x2c] 	(controls.c:2035)
0x4a401b : or eax, 0x4000000
0x4a4020 : mov dword ptr [ebp - 0x2c], eax
0x4a4023 : mov eax, dword ptr [ebp - 0xc] 	(controls.c:2036)
0x4a4026 : mov dword ptr [eax + 0x15ec], 1
0x4a4030 : mov eax, dword ptr [ebp - 0x2c] 	(controls.c:2037)
0x4a4033 : shr eax, 0x12
0x4a4036 : test al, 1
0x4a4038 : -jne 0x44
         : +jne 0xd
0x4a403e : cmp dword ptr [ebp - 0x20], 0x7d00
0x4a4045 : -jg 0x37
         : +jle 0x12
         : +mov eax, dword ptr [ebp - 0xc] 	(controls.c:2038)
         : +mov dword ptr [eax + 0x1568], 0
         : +jmp 0x2d 	(controls.c:2039)
0x4a404b : mov eax, dword ptr [ebp - 0xc]
0x4a404e : cmp dword ptr [eax + 0x15e8], 1
0x4a4055 : -jle 0x22
         : +jle 0x1d
0x4a405b : mov eax, dword ptr [ebp - 0xc]
0x4a405e : mov eax, dword ptr [eax + 0x1574]
0x4a4064 : shr eax, 0x1a
0x4a4067 : test al, 1
0x4a4069 : -jne 0xe
         : +jne 0x9
0x4a406f : mov eax, dword ptr [ebp - 0xc] 	(controls.c:2040)
0x4a4072 : dec dword ptr [eax + 0x15e8]
0x4a4078 : -jmp 0x0
0x4a407d : -jmp 0xd
0x4a4082 : -mov eax, dword ptr [ebp - 0xc]
0x4a4085 : -mov dword ptr [eax + 0x1568], 0
0x4a408f : cmp dword ptr [gCountdown (DATA)], 0 	(controls.c:2042)
0x4a4096 : je 0x19
0x4a409c : mov eax, dword ptr [ebp - 0xc]
0x4a409f : mov eax, dword ptr [eax + 0x1574]
0x4a40a5 : shr eax, 0x1a
0x4a40a8 : test al, 1
0x4a40aa : jne 0x5
0x4a40b0 : call JumpTheStart (FUNCTION) 	(controls.c:2043)
0x4a40b5 : cmp dword ptr [gCar_flying (DATA)], 0 	(controls.c:2046)
0x4a40bc : je 0x3a


PollCarControls is only 68.93% similar to the original, diff above
```

*AI generated. Time taken: 690s, tokens: 276,889*
