### PR TITLE
ToggleMap 100% effective match

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -2217,27 +2217,25 @@ void ToggleMap(void) {
     // GLOBAL: CARM95 0x53d634
     static int was_in_cockpit;
 
-    if (gMap_mode == 0) {
-        if (!gAction_replay_mode) {
-            if (gNet_mode != eNet_mode_none && gCurrent_net_game->type == eNet_game_type_foxy && gThis_net_player_index == gIt_or_fox) {
-                NewTextHeadupSlot(eHeadupSlot_misc, 0, 1000, -kFont_MEDIUMHD, GetMiscString(kMiscString_THE_FOX_CANNOT_DO_THAT));
-            } else if (gNet_mode != eNet_mode_none && gCurrent_net_game->type == eNet_game_type_tag && gThis_net_player_index != gIt_or_fox) {
-                NewTextHeadupSlot(eHeadupSlot_misc, 0, 1000, -kFont_MEDIUMHD, GetMiscString(kMiscString_ONLY_IT_CAN_DO_THAT));
-            } else {
-                old_indent = gRender_indent;
-                gRender_indent = 0;
-                was_in_cockpit = gProgram_state.cockpit_on;
-                if (gProgram_state.cockpit_on) {
-                    ToggleCockpit();
-                }
-                gMap_mode = PDGetTotalTime();
-            }
-        }
-    } else {
+    if (gMap_mode != 0) {
         gMap_mode = 0;
         gRender_indent = old_indent;
         if (was_in_cockpit) {
             ToggleCockpit();
+        }
+    } else if (!gAction_replay_mode) {
+        if (gNet_mode != eNet_mode_none && gCurrent_net_game->type == eNet_game_type_foxy && gThis_net_player_index == gIt_or_fox) {
+            NewTextHeadupSlot(eHeadupSlot_misc, 0, 1000, -kFont_MEDIUMHD, GetMiscString(kMiscString_THE_FOX_CANNOT_DO_THAT));
+        } else if (gNet_mode != eNet_mode_none && gCurrent_net_game->type == eNet_game_type_tag && gThis_net_player_index != gIt_or_fox) {
+            NewTextHeadupSlot(eHeadupSlot_misc, 0, 1000, -kFont_MEDIUMHD, GetMiscString(kMiscString_ONLY_IT_CAN_DO_THAT));
+        } else {
+            old_indent = gRender_indent;
+            gRender_indent = 0;
+            was_in_cockpit = gProgram_state.cockpit_on;
+            if (was_in_cockpit) {
+                ToggleCockpit();
+            }
+            gMap_mode = PDGetTotalTime();
         }
     }
     AdjustRenderScreenSize();


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4a4825,41 +0x469167,41 @@
0x4a4825 : je 0x5
0x4a482b : call ToggleCockpit (FUNCTION) 	(controls.c:2224)
0x4a4830 : jmp 0xed 	(controls.c:2226)
0x4a4835 : cmp dword ptr [gAction_replay_mode (DATA)], 0
0x4a483c : jne 0xe0
0x4a4842 : cmp dword ptr [gNet_mode (DATA)], 0 	(controls.c:2227)
0x4a4849 : je 0x46
0x4a484f : mov eax, dword ptr [gCurrent_net_game (DATA)]
0x4a4854 : cmp dword ptr [eax + 0x74], 6
0x4a4858 : jne 0x37
0x4a485e : -mov eax, dword ptr [gIt_or_fox (DATA)]
0x4a4863 : -cmp dword ptr [gThis_net_player_index (DATA)], eax
         : +mov eax, dword ptr [gThis_net_player_index (DATA)]
         : +cmp dword ptr [gIt_or_fox (DATA)], eax
0x4a4869 : jne 0x26
0x4a486f : push 0xd6 	(controls.c:2228)
0x4a4874 : call GetMiscString (FUNCTION)
0x4a4879 : add esp, 4
0x4a487c : push eax
0x4a487d : push -4
0x4a487f : push 0x3e8
0x4a4884 : push 0
0x4a4886 : push 4
0x4a4888 : call NewTextHeadupSlot (FUNCTION)
0x4a488d : add esp, 0x14
0x4a4890 : jmp 0x8d 	(controls.c:2229)
0x4a4895 : cmp dword ptr [gNet_mode (DATA)], 0
0x4a489c : je 0x46
0x4a48a2 : mov eax, dword ptr [gCurrent_net_game (DATA)]
0x4a48a7 : cmp dword ptr [eax + 0x74], 5
0x4a48ab : jne 0x37
0x4a48b1 : -mov eax, dword ptr [gIt_or_fox (DATA)]
0x4a48b6 : -cmp dword ptr [gThis_net_player_index (DATA)], eax
         : +mov eax, dword ptr [gThis_net_player_index (DATA)]
         : +cmp dword ptr [gIt_or_fox (DATA)], eax
0x4a48bc : je 0x26
0x4a48c2 : push 0xd7 	(controls.c:2230)
0x4a48c7 : call GetMiscString (FUNCTION)
0x4a48cc : add esp, 4
0x4a48cf : push eax
0x4a48d0 : push -4
0x4a48d2 : push 0x3e8
0x4a48d7 : push 0
0x4a48d9 : push 4
0x4a48db : call NewTextHeadupSlot (FUNCTION)


0x4a47f7: ToggleMap 100% effective match (differs, but only in ways that don't affect behavior).

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4a47f7,70 +0x468fa9,70 @@
0x4a47f7 : push ebp 	(controls.c:2216)
0x4a47f8 : mov ebp, esp
0x4a47fa : push ebx
0x4a47fb : push esi
0x4a47fc : push edi
0x4a47fd : cmp dword ptr [gMap_mode (DATA)], 0 	(controls.c:2222)
0x4a4804 : -je 0x2b
0x4a480a : -mov dword ptr [gMap_mode (DATA)], 0
0x4a4814 : -mov eax, dword ptr [old_indent (DATA)]
0x4a4819 : -mov dword ptr [gRender_indent (DATA)], eax
0x4a481e : -cmp dword ptr [was_in_cockpit (DATA)], 0
0x4a4825 : -je 0x5
0x4a482b : -call ToggleCockpit (FUNCTION)
0x4a4830 : -jmp 0xed
         : +jne 0xf2
0x4a4835 : cmp dword ptr [gAction_replay_mode (DATA)], 0 	(controls.c:2223)
0x4a483c : jne 0xe0
0x4a4842 : cmp dword ptr [gNet_mode (DATA)], 0 	(controls.c:2224)
0x4a4849 : je 0x46
0x4a484f : mov eax, dword ptr [gCurrent_net_game (DATA)]
0x4a4854 : cmp dword ptr [eax + 0x74], 6
0x4a4858 : jne 0x37
0x4a485e : -mov eax, dword ptr [gIt_or_fox (DATA)]
0x4a4863 : -cmp dword ptr [gThis_net_player_index (DATA)], eax
         : +mov eax, dword ptr [gThis_net_player_index (DATA)]
         : +cmp dword ptr [gIt_or_fox (DATA)], eax
0x4a4869 : jne 0x26
0x4a486f : push 0xd6 	(controls.c:2225)
0x4a4874 : call GetMiscString (FUNCTION)
0x4a4879 : add esp, 4
0x4a487c : push eax
0x4a487d : push -4
0x4a487f : push 0x3e8
0x4a4884 : push 0
0x4a4886 : push 4
0x4a4888 : call NewTextHeadupSlot (FUNCTION)
0x4a488d : add esp, 0x14
0x4a4890 : jmp 0x8d 	(controls.c:2226)
0x4a4895 : cmp dword ptr [gNet_mode (DATA)], 0
0x4a489c : je 0x46
0x4a48a2 : mov eax, dword ptr [gCurrent_net_game (DATA)]
0x4a48a7 : cmp dword ptr [eax + 0x74], 5
0x4a48ab : jne 0x37
0x4a48b1 : -mov eax, dword ptr [gIt_or_fox (DATA)]
0x4a48b6 : -cmp dword ptr [gThis_net_player_index (DATA)], eax
         : +mov eax, dword ptr [gThis_net_player_index (DATA)]
         : +cmp dword ptr [gIt_or_fox (DATA)], eax
0x4a48bc : je 0x26
0x4a48c2 : push 0xd7 	(controls.c:2227)
0x4a48c7 : call GetMiscString (FUNCTION)
0x4a48cc : add esp, 4
0x4a48cf : push eax
0x4a48d0 : push -4
0x4a48d2 : push 0x3e8
0x4a48d7 : push 0
0x4a48d9 : push 4
0x4a48db : call NewTextHeadupSlot (FUNCTION)
0x4a48e0 : add esp, 0x14
0x4a48e3 : jmp 0x3a 	(controls.c:2228)
0x4a48e8 : mov eax, dword ptr [gRender_indent (DATA)] 	(controls.c:2229)
0x4a48ed : mov dword ptr [old_indent (DATA)], eax
0x4a48f2 : mov dword ptr [gRender_indent (DATA)], 0 	(controls.c:2230)
0x4a48fc : mov eax, dword ptr [gProgram_state+80 (OFFSET)] 	(controls.c:2231)
0x4a4901 : mov dword ptr [was_in_cockpit (DATA)], eax
0x4a4906 : -cmp dword ptr [was_in_cockpit (DATA)], 0
         : +cmp dword ptr [gProgram_state+80 (OFFSET)], 0 	(controls.c:2232)
0x4a490d : je 0x5
0x4a4913 : call ToggleCockpit (FUNCTION) 	(controls.c:2233)
0x4a4918 : call PDGetTotalTime (FUNCTION) 	(controls.c:2235)
0x4a491d : mov dword ptr [gMap_mode (DATA)], eax
         : +jmp 0x26 	(controls.c:2238)
         : +mov dword ptr [gMap_mode (DATA)], 0 	(controls.c:2239)
         : +mov eax, dword ptr [old_indent (DATA)] 	(controls.c:2240)
         : +mov dword ptr [gRender_indent (DATA)], eax
         : +cmp dword ptr [was_in_cockpit (DATA)], 0 	(controls.c:2241)
         : +je 0x5
         : +call ToggleCockpit (FUNCTION) 	(controls.c:2242)
0x4a4922 : call AdjustRenderScreenSize (FUNCTION) 	(controls.c:2245)
0x4a4927 : pop edi 	(controls.c:2246)
0x4a4928 : pop esi
0x4a4929 : pop ebx
0x4a492a : leave 
0x4a492b : ret 


ToggleMap is only 81.43% similar to the original, diff above
```

*AI generated. Time taken: 84s, tokens: 18,709*
