### PR TITLE
CycleCarTexturingLevel 100% match

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -2316,8 +2316,6 @@ void CycleCarTexturingLevel(void) {
     case eCTL_full:
         NewTextHeadupSlot(eHeadupSlot_misc, 0, 2000, -kFont_MEDIUMHD, GetMiscString(kMiscString_FullCarTextures));
         break;
-    case eCTL_count:
-        break;
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4a4a61: CycleCarTexturingLevel 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4a4a70,57 +,60 @@
0x4a4a70 : mov ecx, 3
0x4a4a75 : cdq 
0x4a4a76 : idiv ecx
0x4a4a78 : mov dword ptr [ebp - 4], edx
0x4a4a7b : mov eax, dword ptr [ebp - 4] 	(controls.c:2310)
0x4a4a7e : push eax
0x4a4a7f : call SetCarTexturingLevel (FUNCTION)
0x4a4a84 : add esp, 4
0x4a4a87 : mov eax, dword ptr [ebp - 4] 	(controls.c:2311)
0x4a4a8a : mov dword ptr [ebp - 8], eax
0x4a4a8d : -jmp 0x6e
         : +jmp 0x73
0x4a4a92 : push 0x32 	(controls.c:2313)
0x4a4a94 : call GetMiscString (FUNCTION)
0x4a4a99 : add esp, 4
0x4a4a9c : push eax
0x4a4a9d : push -4
0x4a4a9f : push 0x7d0
0x4a4aa4 : push 0
0x4a4aa6 : push 4
0x4a4aa8 : call NewTextHeadupSlot (FUNCTION)
0x4a4aad : add esp, 0x14
0x4a4ab0 : -jmp 0x6e
         : +jmp 0x74 	(controls.c:2314)
0x4a4ab5 : push 0x33 	(controls.c:2316)
0x4a4ab7 : call GetMiscString (FUNCTION)
0x4a4abc : add esp, 4
0x4a4abf : push eax
0x4a4ac0 : push -4
0x4a4ac2 : push 0x7d0
0x4a4ac7 : push 0
0x4a4ac9 : push 4
0x4a4acb : call NewTextHeadupSlot (FUNCTION)
0x4a4ad0 : add esp, 0x14
0x4a4ad3 : -jmp 0x4b
         : +jmp 0x51 	(controls.c:2317)
0x4a4ad8 : push 0x34 	(controls.c:2319)
0x4a4ada : call GetMiscString (FUNCTION)
0x4a4adf : add esp, 4
0x4a4ae2 : push eax
0x4a4ae3 : push -4
0x4a4ae5 : push 0x7d0
0x4a4aea : push 0
0x4a4aec : push 4
0x4a4aee : call NewTextHeadupSlot (FUNCTION)
0x4a4af3 : add esp, 0x14
0x4a4af6 : -jmp 0x28
0x4a4afb : -jmp 0x23
0x4a4b00 : -cmp dword ptr [ebp - 8], 0
0x4a4b04 : -je -0x78
0x4a4b0a : -cmp dword ptr [ebp - 8], 1
0x4a4b0e : -je -0x5f
0x4a4b14 : -cmp dword ptr [ebp - 8], 2
0x4a4b18 : -je -0x46
0x4a4b1e : -jmp 0x0
         : +jmp 0x2e 	(controls.c:2320)
         : +jmp 0x29 	(controls.c:2322)
         : +jmp 0x24 	(controls.c:2323)
         : +cmp dword ptr [ebp - 8], 3
         : +ja 0x1a
         : +mov eax, dword ptr [ebp - 8]
         : +jmp dword ptr [eax*4 + <OFFSET5>]
         : +Jump table:
         : +start + 0x31
         : +start + 0x54
         : +start + 0x77
         : +start + 0x9a
0x4a4b23 : pop edi 	(controls.c:2324)
0x4a4b24 : pop esi
0x4a4b25 : pop ebx
0x4a4b26 : leave 
0x4a4b27 : ret 


CycleCarTexturingLevel is only 79.70% similar to the original, diff above
```

*AI generated. Time taken: 101s, tokens: 9,352*
