### PR TITLE
CycleWallTexturingLevel 100% match

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -2339,8 +2339,6 @@ void CycleWallTexturingLevel(void) {
     case eWTL_full:
         NewTextHeadupSlot(eHeadupSlot_misc, 0, 2000, -kFont_MEDIUMHD, GetMiscString(kMiscString_BestWallTextures));
         break;
-    case eWTL_count:
-        break;
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4a4b28: CycleWallTexturingLevel 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4a4b42,57 +,60 @@
0x4a4b42 : mov eax, dword ptr [ebp - 4] 	(controls.c:2332)
0x4a4b45 : push eax
0x4a4b46 : call ReallySetWallTexturingLevel (FUNCTION)
0x4a4b4b : add esp, 4
0x4a4b4e : mov eax, dword ptr [ebp - 4] 	(controls.c:2333)
0x4a4b51 : push eax
0x4a4b52 : call SetWallTexturingLevel (FUNCTION)
0x4a4b57 : add esp, 4
0x4a4b5a : mov eax, dword ptr [ebp - 4] 	(controls.c:2334)
0x4a4b5d : mov dword ptr [ebp - 8], eax
0x4a4b60 : -jmp 0x6e
         : +jmp 0x73
0x4a4b65 : push 0x37 	(controls.c:2336)
0x4a4b67 : call GetMiscString (FUNCTION)
0x4a4b6c : add esp, 4
0x4a4b6f : push eax
0x4a4b70 : push -4
0x4a4b72 : push 0x7d0
0x4a4b77 : push 0
0x4a4b79 : push 4
0x4a4b7b : call NewTextHeadupSlot (FUNCTION)
0x4a4b80 : add esp, 0x14
0x4a4b83 : -jmp 0x6e
         : +jmp 0x74 	(controls.c:2337)
0x4a4b88 : push 0x38 	(controls.c:2339)
0x4a4b8a : call GetMiscString (FUNCTION)
0x4a4b8f : add esp, 4
0x4a4b92 : push eax
0x4a4b93 : push -4
0x4a4b95 : push 0x7d0
0x4a4b9a : push 0
0x4a4b9c : push 4
0x4a4b9e : call NewTextHeadupSlot (FUNCTION)
0x4a4ba3 : add esp, 0x14
0x4a4ba6 : -jmp 0x4b
         : +jmp 0x51 	(controls.c:2340)
0x4a4bab : push 0x39 	(controls.c:2342)
0x4a4bad : call GetMiscString (FUNCTION)
0x4a4bb2 : add esp, 4
0x4a4bb5 : push eax
0x4a4bb6 : push -4
0x4a4bb8 : push 0x7d0
0x4a4bbd : push 0
0x4a4bbf : push 4
0x4a4bc1 : call NewTextHeadupSlot (FUNCTION)
0x4a4bc6 : add esp, 0x14
0x4a4bc9 : -jmp 0x28
0x4a4bce : -jmp 0x23
0x4a4bd3 : -cmp dword ptr [ebp - 8], 0
0x4a4bd7 : -je -0x78
0x4a4bdd : -cmp dword ptr [ebp - 8], 1
0x4a4be1 : -je -0x5f
0x4a4be7 : -cmp dword ptr [ebp - 8], 2
0x4a4beb : -je -0x46
0x4a4bf1 : -jmp 0x0
         : +jmp 0x2e 	(controls.c:2343)
         : +jmp 0x29 	(controls.c:2345)
         : +jmp 0x24 	(controls.c:2346)
         : +cmp dword ptr [ebp - 8], 3
         : +ja 0x1a
         : +mov eax, dword ptr [ebp - 8]
         : +jmp dword ptr [eax*4 + <OFFSET6>]
         : +Jump table:
         : +start + 0x3d
         : +start + 0x60
         : +start + 0x83
         : +start + 0xa6
0x4a4bf6 : pop edi 	(controls.c:2347)
0x4a4bf7 : pop esi
0x4a4bf8 : pop ebx
0x4a4bf9 : leave 
0x4a4bfa : ret 


CycleWallTexturingLevel is only 80.85% similar to the original, diff above
```

*AI generated. Time taken: 111s, tokens: 11,889*
