### PR TITLE
DoEndRaceAnimation 100% match

### DIFF
--- a/src/DETHRACE/common/cutscene.c
+++ b/src/DETHRACE/common/cutscene.c
@@ -167,21 +167,22 @@ void DoEndRaceAnimation(void) {
     int made_a_profit;
     int went_up_a_rank;
 
-    made_a_profit = gProgram_state.credits_earned >= gProgram_state.credits_lost;
-    went_up_a_rank = gProgram_state.credits_earned >= gProgram_state.credits_per_rank;
-
     FadePaletteDown();
 
-    if (gAusterity_mode || gNet_mode != eNet_mode_none) {
-        return;
-    }
-    if (gProgram_state.credits + gProgram_state.credits_earned - gProgram_state.credits_lost >= 0) {
-        if (made_a_profit && went_up_a_rank) {
-            PlaySmackerFile("SUCCESS.SMK");
-        } else if (made_a_profit || went_up_a_rank) {
-            PlaySmackerFile("MUNDANE.SMK");
-        } else {
-            PlaySmackerFile("UNSUCSES.SMK");
+    if (!gAusterity_mode) {
+        if (gNet_mode == eNet_mode_none) {
+            if (gProgram_state.credits_earned - gProgram_state.credits_lost + gProgram_state.credits >= 0) {
+                made_a_profit = gProgram_state.credits_earned >= gProgram_state.credits_lost;
+                went_up_a_rank = gProgram_state.credits_earned >= gProgram_state.credits_per_rank;
+
+                if (made_a_profit && went_up_a_rank) {
+                    PlaySmackerFile("SUCCESS.SMK");
+                } else if (made_a_profit || went_up_a_rank) {
+                    PlaySmackerFile("MUNDANE.SMK");
+                } else {
+                    PlaySmackerFile("UNSUCSES.SMK");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Match result

```
0x4a5df1: DoEndRaceAnimation 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4a5df1,37 +0x46efba,38 @@
0x4a5df1 : push ebp 	(cutscene.c:166)
0x4a5df2 : mov ebp, esp
0x4a5df4 : sub esp, 8
0x4a5df7 : push ebx
0x4a5df8 : push esi
0x4a5df9 : push edi
0x4a5dfa : -call FadePaletteDown (FUNCTION)
0x4a5dff : -cmp dword ptr [gAusterity_mode (DATA)], 0
0x4a5e06 : -jne 0xc5
0x4a5e0c : -cmp dword ptr [gNet_mode (DATA)], 0
0x4a5e13 : -jne 0xb8
0x4a5e19 : -mov eax, dword ptr [gProgram_state+4 (OFFSET)]
0x4a5e1e : -sub eax, dword ptr [gProgram_state+8 (OFFSET)]
0x4a5e24 : -add eax, dword ptr [gProgram_state (DATA)]
0x4a5e2a : -js 0xa1
0x4a5e30 : mov eax, dword ptr [gProgram_state+8 (OFFSET)] 	(cutscene.c:170)
0x4a5e35 : cmp dword ptr [gProgram_state+4 (OFFSET)], eax
0x4a5e3b : jl 0xc
0x4a5e41 : mov dword ptr [ebp - 8], 1
0x4a5e48 : jmp 0x7
0x4a5e4d : mov dword ptr [ebp - 8], 0
0x4a5e54 : mov eax, dword ptr [gProgram_state+128 (OFFSET)] 	(cutscene.c:171)
0x4a5e59 : cmp dword ptr [gProgram_state+4 (OFFSET)], eax
0x4a5e5f : jl 0xc
0x4a5e65 : mov dword ptr [ebp - 4], 1
0x4a5e6c : jmp 0x7
0x4a5e71 : mov dword ptr [ebp - 4], 0
         : +call FadePaletteDown (FUNCTION) 	(cutscene.c:173)
         : +cmp dword ptr [gAusterity_mode (DATA)], 0 	(cutscene.c:175)
         : +jne 0xd
         : +cmp dword ptr [gNet_mode (DATA)], 0
         : +je 0x5
         : +jmp 0x70 	(cutscene.c:176)
         : +mov eax, dword ptr [gProgram_state+4 (OFFSET)] 	(cutscene.c:178)
         : +add eax, dword ptr [gProgram_state (DATA)]
         : +sub eax, dword ptr [gProgram_state+8 (OFFSET)]
         : +js 0x59
0x4a5e78 : cmp dword ptr [ebp - 8], 0 	(cutscene.c:179)
0x4a5e7c : je 0x1c
0x4a5e82 : cmp dword ptr [ebp - 4], 0
0x4a5e86 : je 0x12
0x4a5e8c : push "SUCCESS.SMK" (STRING) 	(cutscene.c:180)
0x4a5e91 : call PlaySmackerFile (FUNCTION)
0x4a5e96 : add esp, 4
0x4a5e99 : jmp 0x33 	(cutscene.c:181)
0x4a5e9e : cmp dword ptr [ebp - 8], 0
0x4a5ea2 : jne 0xa


DoEndRaceAnimation is only 81.55% similar to the original, diff above
```

*AI generated. Time taken: 102s, tokens: 11,556*
