### PR TITLE
RenderTrack equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/brucetrk.c
+++ b/src/DETHRACE/common/brucetrk.c
@@ -448,64 +448,61 @@ void RenderTrack(br_actor* pWorld, tTrack_spec* pTrack_spec, br_actor* pCamera, 
             min_z = column_z;
             max_z = column_z;
             tan_fov_ish = BR_DIV(BR_SIN(camera->field_of_view / 2), BR_COS(camera->field_of_view / 2));
-
-            edge_after.v[0] = tan_fov_ish * camera->aspect;
+            edge_after.v[0] = BR_MUL(camera->aspect, tan_fov_ish);
             edge_after.v[1] = tan_fov_ish;
             edge_after.v[2] = -1.0;
-            edge_before.v[0] = edge_after.v[0] * camera->yon_z * gYon_factor;
-            edge_before.v[1] = camera->yon_z * gYon_factor * tan_fov_ish;
-            edge_before.v[2] = camera->yon_z * gYon_factor * edge_after.v[2];
+            edge_before.v[0] = edge_after.v[0] * (camera->yon_z * gYon_factor);
+            edge_before.v[1] = edge_after.v[1] * (camera->yon_z * gYon_factor);
+            edge_before.v[2] = edge_after.v[2] * (camera->yon_z * gYon_factor);
             BrMatrix34ApplyV(&edge_after, &edge_before, pCamera_to_world);
             XZToColumnXZ(&column_x, &column_z, pCamera_to_world->m[3][0] + edge_after.v[0], pCamera_to_world->m[3][2] + edge_after.v[2], pTrack_spec);
-            if (column_x < min_x) {
+            if (min_x > 0 + column_x) {
                 min_x = column_x;
-            } else if (column_x > max_x) {
+            } else if (max_x < 0 + column_x) {
                 max_x = column_x;
             }
-            if (column_z < min_z) {
+            if (min_z > 0 + column_z) {
                 min_z = column_z;
-            } else if (column_z > max_z) {
+            } else if (max_z < 0 + column_z) {
                 max_z = column_z;
             }
             edge_before.v[0] = -edge_before.v[0];
             BrMatrix34ApplyV(&edge_after, &edge_before, pCamera_to_world);
             XZToColumnXZ(&column_x, &column_z, pCamera_to_world->m[3][0] + edge_after.v[0], pCamera_to_world->m[3][2] + edge_after.v[2], pTrack_spec);
-            if (column_x < min_x) {
+            if (min_x > 0 + column_x) {
                 min_x = column_x;
-            } else if (column_x > max_x) {
+            } else if (max_x < 0 + column_x) {
                 max_x = column_x;
             }
-            if (column_z < min_z) {
+            if (min_z > 0 + column_z) {
                 min_z = column_z;
-            } else {
-                if (column_z > max_z) {
-                    max_z = column_z;
-                }
+            } else if (max_z < 0 + column_z) {
+                max_z = column_z;
             }
             edge_before.v[1] = -edge_before.v[1];
             BrMatrix34ApplyV(&edge_after, &edge_before, pCamera_to_world);
             XZToColumnXZ(&column_x, &column_z, pCamera_to_world->m[3][0] + edge_after.v[0], pCamera_to_world->m[3][2] + edge_after.v[2], pTrack_spec);
-            if (column_x < min_x) {
+            if (min_x > 0 + column_x) {
                 min_x = column_x;
-            } else if (column_x > max_x) {
+            } else if (max_x < 0 + column_x) {
                 max_x = column_x;
             }
-            if (column_z < min_z) {
+            if (min_z > 0 + column_z) {
                 min_z = column_z;
-            } else if (column_z > max_z) {
+            } else if (max_z < 0 + column_z) {
                 max_z = column_z;
             }
             edge_before.v[0] = -edge_before.v[0];
             BrMatrix34ApplyV(&edge_after, &edge_before, pCamera_to_world);
             XZToColumnXZ(&column_x, &column_z, pCamera_to_world->m[3][0] + edge_after.v[0], pCamera_to_world->m[3][2] + edge_after.v[2], pTrack_spec);
-            if (column_x < min_x) {
+            if (min_x > 0 + column_x) {
                 min_x = column_x;
-            } else if (column_x > max_x) {
+            } else if (max_x < 0 + column_x) {
                 max_x = column_x;
             }
-            if (column_z < min_z) {
+            if (min_z > 0 + column_z) {
                 min_z = column_z;
-            } else if (column_z > max_z) {
+            } else if (max_z < 0 + column_z) {
                 max_z = column_z;
             }
             if (min_x > 0) {


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4a9450,21 +0x4466bf,21 @@
0x4a9450 : push ebx
0x4a9451 : push esi
0x4a9452 : push edi
0x4a9453 : mov eax, dword ptr [ebp + 0xc] 	(brucetrk.c:438)
0x4a9456 : cmp dword ptr [eax + 0x18], 0
0x4a945a : jne 0x11
0x4a9460 : mov eax, dword ptr [ebp + 8] 	(brucetrk.c:439)
0x4a9463 : push eax
0x4a9464 : call BrZbSceneRenderAdd (FUNCTION)
0x4a9469 : add esp, 4
0x4a946c : -jmp 0x58b
         : +jmp 0x585 	(brucetrk.c:440)
0x4a9471 : cmp dword ptr [ebp + 0x18], 0 	(brucetrk.c:441)
0x4a9475 : je 0x37
0x4a947b : mov eax, dword ptr [ebp + 0x14] 	(brucetrk.c:442)
0x4a947e : push eax
0x4a947f : xor eax, eax
0x4a9481 : mov al, byte ptr [max_z (DATA)]
0x4a9486 : push eax
0x4a9487 : xor eax, eax
0x4a9489 : mov al, byte ptr [min_z (DATA)]
0x4a948e : push eax

---
+++
@@ -0x4a9491,21 +0x446700,21 @@
0x4a9491 : mov al, byte ptr [max_x (DATA)]
0x4a9496 : push eax
0x4a9497 : xor eax, eax
0x4a9499 : mov al, byte ptr [min_x (DATA)]
0x4a949e : push eax
0x4a949f : mov eax, dword ptr [ebp + 0xc]
0x4a94a2 : push eax
0x4a94a3 : push 1
0x4a94a5 : call DrawColumns (FUNCTION)
0x4a94aa : add esp, 0x1c
0x4a94ad : -jmp 0x54a
         : +jmp 0x544 	(brucetrk.c:443)
0x4a94b2 : mov eax, dword ptr [ebp + 0x10] 	(brucetrk.c:444)
0x4a94b5 : mov eax, dword ptr [eax + 0x5c]
0x4a94b8 : mov dword ptr [camera (DATA)], eax
0x4a94bd : mov eax, dword ptr [ebp + 0xc] 	(brucetrk.c:445)
0x4a94c0 : push eax
0x4a94c1 : mov eax, dword ptr [ebp + 0x14]
0x4a94c4 : mov eax, dword ptr [eax + 0x2c]
0x4a94c7 : push eax
0x4a94c8 : mov eax, dword ptr [ebp + 0x14]
0x4a94cb : mov eax, dword ptr [eax + 0x24]

---
+++
@@ -0x4a9522,24 +0x446791,23 @@
0x4a9522 : call __CIsin (FUNCTION)
0x4a9527 : mov eax, dword ptr [camera (DATA)]
0x4a952c : xor ecx, ecx
0x4a952e : mov cx, word ptr [eax + 6]
0x4a9532 : sar ecx, 1
0x4a9534 : mov dword ptr [ebp - 8], ecx
0x4a9537 : fild dword ptr [ebp - 8]
0x4a953a : fmul qword ptr [9.587379924285257e-05 (FLOAT)]
0x4a9540 : call __CIcos (FUNCTION)
0x4a9545 : fdivp st(1)
0x4a9547 : -fstp dword ptr [tan_fov_ish (DATA)]
         : +fst dword ptr [tan_fov_ish (DATA)]
0x4a954d : mov eax, dword ptr [camera (DATA)] 	(brucetrk.c:451)
0x4a9552 : -fld dword ptr [eax + 0x10]
0x4a9555 : -fmul dword ptr [tan_fov_ish (DATA)]
         : +fmul dword ptr [eax + 0x10]
0x4a955b : fstp dword ptr [edge_after (DATA)]
0x4a9561 : mov eax, dword ptr [tan_fov_ish (DATA)] 	(brucetrk.c:452)
0x4a9566 : mov dword ptr [edge_after+4 (OFFSET)], eax
0x4a956b : mov dword ptr [edge_after+8 (OFFSET)], 0xbf800000 	(brucetrk.c:453)
0x4a9575 : mov eax, dword ptr [camera (DATA)] 	(brucetrk.c:454)
0x4a957a : fld dword ptr [eax + 0xc]
0x4a957d : fmul dword ptr [gYon_factor (DATA)]
0x4a9583 : fmul dword ptr [edge_after (DATA)]
0x4a9589 : fstp dword ptr [edge_before (DATA)]
0x4a958f : mov eax, dword ptr [camera (DATA)] 	(brucetrk.c:455)

---
+++
@@ -0x4a99de,10 +0x446c47,16 @@
0x4a99de : xor eax, eax
0x4a99e0 : mov al, byte ptr [max_x (DATA)]
0x4a99e5 : push eax
0x4a99e6 : xor eax, eax
0x4a99e8 : mov al, byte ptr [min_x (DATA)]
0x4a99ed : push eax
0x4a99ee : mov eax, dword ptr [ebp + 0xc]
0x4a99f1 : push eax
0x4a99f2 : push 0
0x4a99f4 : call DrawColumns (FUNCTION)
         : +add esp, 0x1c
         : +pop edi 	(brucetrk.c:523)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


RenderTrack is only 98.03% similar to the original, diff above
```

#### Effective match analysis

Yes. The only substantive arithmetic change is `fstp tan_fov_ish; fld camera->10h; fmul tan_fov_ish` becoming `fst tan_fov_ish; fmul [camera+10h]`. This keeps the same value in `st(0)` and computes the same product for `edge_after`, just avoiding a store/reload round-trip (difference limited to floating-point precision effects, which you said to ignore). The jump target offset changes appear to be address/layout shifts, and the added explicit epilogue after the final `DrawColumns` call matches normal stack/register cleanup/return behavior rather than changing outputs.

#### Original match

```
---
+++
@@ -0x4a9450,21 +0x4466bf,21 @@
0x4a9450 : push ebx
0x4a9451 : push esi
0x4a9452 : push edi
0x4a9453 : mov eax, dword ptr [ebp + 0xc] 	(brucetrk.c:440)
0x4a9456 : cmp dword ptr [eax + 0x18], 0
0x4a945a : jne 0x11
0x4a9460 : mov eax, dword ptr [ebp + 8] 	(brucetrk.c:441)
0x4a9463 : push eax
0x4a9464 : call BrZbSceneRenderAdd (FUNCTION)
0x4a9469 : add esp, 4
0x4a946c : -jmp 0x58b
         : +jmp 0x585 	(brucetrk.c:442)
0x4a9471 : cmp dword ptr [ebp + 0x18], 0 	(brucetrk.c:443)
0x4a9475 : je 0x37
0x4a947b : mov eax, dword ptr [ebp + 0x14] 	(brucetrk.c:444)
0x4a947e : push eax
0x4a947f : xor eax, eax
0x4a9481 : mov al, byte ptr [max_z (DATA)]
0x4a9486 : push eax
0x4a9487 : xor eax, eax
0x4a9489 : mov al, byte ptr [min_z (DATA)]
0x4a948e : push eax

---
+++
@@ -0x4a9491,21 +0x446700,21 @@
0x4a9491 : mov al, byte ptr [max_x (DATA)]
0x4a9496 : push eax
0x4a9497 : xor eax, eax
0x4a9499 : mov al, byte ptr [min_x (DATA)]
0x4a949e : push eax
0x4a949f : mov eax, dword ptr [ebp + 0xc]
0x4a94a2 : push eax
0x4a94a3 : push 1
0x4a94a5 : call DrawColumns (FUNCTION)
0x4a94aa : add esp, 0x1c
0x4a94ad : -jmp 0x54a
         : +jmp 0x544 	(brucetrk.c:445)
0x4a94b2 : mov eax, dword ptr [ebp + 0x10] 	(brucetrk.c:446)
0x4a94b5 : mov eax, dword ptr [eax + 0x5c]
0x4a94b8 : mov dword ptr [camera (DATA)], eax
0x4a94bd : mov eax, dword ptr [ebp + 0xc] 	(brucetrk.c:447)
0x4a94c0 : push eax
0x4a94c1 : mov eax, dword ptr [ebp + 0x14]
0x4a94c4 : mov eax, dword ptr [eax + 0x2c]
0x4a94c7 : push eax
0x4a94c8 : mov eax, dword ptr [ebp + 0x14]
0x4a94cb : mov eax, dword ptr [eax + 0x24]

---
+++
@@ -0x4a9522,42 +0x446791,41 @@
0x4a9522 : call __CIsin (FUNCTION)
0x4a9527 : mov eax, dword ptr [camera (DATA)]
0x4a952c : xor ecx, ecx
0x4a952e : mov cx, word ptr [eax + 6]
0x4a9532 : sar ecx, 1
0x4a9534 : mov dword ptr [ebp - 8], ecx
0x4a9537 : fild dword ptr [ebp - 8]
0x4a953a : fmul qword ptr [9.587379924285257e-05 (FLOAT)]
0x4a9540 : call __CIcos (FUNCTION)
0x4a9545 : fdivp st(1)
0x4a9547 : -fstp dword ptr [tan_fov_ish (DATA)]
         : +fst dword ptr [tan_fov_ish (DATA)]
0x4a954d : mov eax, dword ptr [camera (DATA)] 	(brucetrk.c:454)
0x4a9552 : -fld dword ptr [eax + 0x10]
0x4a9555 : -fmul dword ptr [tan_fov_ish (DATA)]
         : +fmul dword ptr [eax + 0x10]
0x4a955b : fstp dword ptr [edge_after (DATA)]
0x4a9561 : mov eax, dword ptr [tan_fov_ish (DATA)] 	(brucetrk.c:455)
0x4a9566 : mov dword ptr [edge_after+4 (OFFSET)], eax
0x4a956b : mov dword ptr [edge_after+8 (OFFSET)], 0xbf800000 	(brucetrk.c:456)
         : +fld dword ptr [edge_after (DATA)] 	(brucetrk.c:457)
0x4a9575 : mov eax, dword ptr [camera (DATA)]
0x4a957a : -fld dword ptr [eax + 0xc]
         : +fmul dword ptr [eax + 0xc]
0x4a957d : fmul dword ptr [gYon_factor (DATA)]
0x4a9583 : -fmul dword ptr [edge_after (DATA)]
0x4a9589 : fstp dword ptr [edge_before (DATA)]
0x4a958f : mov eax, dword ptr [camera (DATA)] 	(brucetrk.c:458)
0x4a9594 : fld dword ptr [eax + 0xc]
0x4a9597 : fmul dword ptr [gYon_factor (DATA)]
0x4a959d : -fmul dword ptr [edge_after+4 (OFFSET)]
         : +fmul dword ptr [tan_fov_ish (DATA)]
0x4a95a3 : fstp dword ptr [edge_before+4 (OFFSET)]
         : +fld dword ptr [edge_after+8 (OFFSET)] 	(brucetrk.c:459)
0x4a95a9 : mov eax, dword ptr [camera (DATA)]
0x4a95ae : -fld dword ptr [eax + 0xc]
         : +fmul dword ptr [eax + 0xc]
0x4a95b1 : fmul dword ptr [gYon_factor (DATA)]
0x4a95b7 : -fmul dword ptr [edge_after+8 (OFFSET)]
0x4a95bd : fstp dword ptr [edge_before+8 (OFFSET)]
0x4a95c3 : mov eax, dword ptr [ebp + 0x14] 	(brucetrk.c:460)
0x4a95c6 : push eax
0x4a95c7 : push edge_before (DATA)
0x4a95cc : push edge_after (DATA)
0x4a95d1 : call BrMatrix34ApplyV (FUNCTION)
0x4a95d6 : add esp, 0xc
0x4a95d9 : mov eax, dword ptr [ebp + 0xc] 	(brucetrk.c:461)
0x4a95dc : push eax
0x4a95dd : mov eax, dword ptr [ebp + 0x14]

---
+++
@@ -0x4a95ef,42 +0x446858,42 @@
0x4a95ef : mov eax, dword ptr [ebp + 0x14]
0x4a95f2 : fld dword ptr [eax + 0x24]
0x4a95f5 : fadd dword ptr [edge_after (DATA)]
0x4a95fb : sub esp, 4
0x4a95fe : fstp dword ptr [esp]
0x4a9601 : push column_z (DATA)
0x4a9606 : push column_x (DATA)
0x4a960b : call XZToColumnXZ (FUNCTION)
0x4a9610 : add esp, 0x14
0x4a9613 : xor eax, eax 	(brucetrk.c:462)
0x4a9615 : -mov al, byte ptr [column_x (DATA)]
         : +mov al, byte ptr [min_x (DATA)]
0x4a961a : xor ecx, ecx
0x4a961c : -mov cl, byte ptr [min_x (DATA)]
         : +mov cl, byte ptr [column_x (DATA)]
0x4a9622 : cmp eax, ecx
0x4a9624 : -jge 0xf
         : +jle 0xf
0x4a962a : mov al, byte ptr [column_x (DATA)] 	(brucetrk.c:463)
0x4a962f : mov byte ptr [min_x (DATA)], al
0x4a9634 : jmp 0x21 	(brucetrk.c:464)
0x4a9639 : xor eax, eax
0x4a963b : -mov al, byte ptr [column_x (DATA)]
         : +mov al, byte ptr [max_x (DATA)]
0x4a9640 : xor ecx, ecx
0x4a9642 : -mov cl, byte ptr [max_x (DATA)]
         : +mov cl, byte ptr [column_x (DATA)]
0x4a9648 : cmp eax, ecx
0x4a964a : -jle 0xa
         : +jge 0xa
0x4a9650 : mov al, byte ptr [column_x (DATA)] 	(brucetrk.c:465)
0x4a9655 : mov byte ptr [max_x (DATA)], al
0x4a965a : xor eax, eax 	(brucetrk.c:467)
0x4a965c : -mov al, byte ptr [column_z (DATA)]
         : +mov al, byte ptr [min_z (DATA)]
0x4a9661 : xor ecx, ecx
0x4a9663 : -mov cl, byte ptr [min_z (DATA)]
         : +mov cl, byte ptr [column_z (DATA)]
0x4a9669 : cmp eax, ecx
0x4a966b : -jge 0xf
         : +jle 0xf
0x4a9671 : mov al, byte ptr [column_z (DATA)] 	(brucetrk.c:468)
0x4a9676 : mov byte ptr [min_z (DATA)], al
0x4a967b : jmp 0x21 	(brucetrk.c:469)
0x4a9680 : xor eax, eax
0x4a9682 : mov al, byte ptr [column_z (DATA)]
0x4a9687 : xor ecx, ecx
0x4a9689 : mov cl, byte ptr [max_z (DATA)]
0x4a968f : cmp eax, ecx
0x4a9691 : jle 0xa
0x4a9697 : mov al, byte ptr [column_z (DATA)] 	(brucetrk.c:470)

---
+++
@@ -0x4a96db,42 +0x446944,42 @@
0x4a96db : mov eax, dword ptr [ebp + 0x14]
0x4a96de : fld dword ptr [eax + 0x24]
0x4a96e1 : fadd dword ptr [edge_after (DATA)]
0x4a96e7 : sub esp, 4
0x4a96ea : fstp dword ptr [esp]
0x4a96ed : push column_z (DATA)
0x4a96f2 : push column_x (DATA)
0x4a96f7 : call XZToColumnXZ (FUNCTION)
0x4a96fc : add esp, 0x14
0x4a96ff : xor eax, eax 	(brucetrk.c:475)
0x4a9701 : -mov al, byte ptr [column_x (DATA)]
         : +mov al, byte ptr [min_x (DATA)]
0x4a9706 : xor ecx, ecx
0x4a9708 : -mov cl, byte ptr [min_x (DATA)]
         : +mov cl, byte ptr [column_x (DATA)]
0x4a970e : cmp eax, ecx
0x4a9710 : -jge 0xf
         : +jle 0xf
0x4a9716 : mov al, byte ptr [column_x (DATA)] 	(brucetrk.c:476)
0x4a971b : mov byte ptr [min_x (DATA)], al
0x4a9720 : jmp 0x21 	(brucetrk.c:477)
0x4a9725 : xor eax, eax
0x4a9727 : -mov al, byte ptr [column_x (DATA)]
         : +mov al, byte ptr [max_x (DATA)]
0x4a972c : xor ecx, ecx
0x4a972e : -mov cl, byte ptr [max_x (DATA)]
         : +mov cl, byte ptr [column_x (DATA)]
0x4a9734 : cmp eax, ecx
0x4a9736 : -jle 0xa
         : +jge 0xa
0x4a973c : mov al, byte ptr [column_x (DATA)] 	(brucetrk.c:478)
0x4a9741 : mov byte ptr [max_x (DATA)], al
0x4a9746 : xor eax, eax 	(brucetrk.c:480)
0x4a9748 : -mov al, byte ptr [column_z (DATA)]
         : +mov al, byte ptr [min_z (DATA)]
0x4a974d : xor ecx, ecx
0x4a974f : -mov cl, byte ptr [min_z (DATA)]
         : +mov cl, byte ptr [column_z (DATA)]
0x4a9755 : cmp eax, ecx
0x4a9757 : -jge 0xf
         : +jle 0xf
0x4a975d : mov al, byte ptr [column_z (DATA)] 	(brucetrk.c:481)
0x4a9762 : mov byte ptr [min_z (DATA)], al
0x4a9767 : jmp 0x21 	(brucetrk.c:482)
0x4a976c : xor eax, eax 	(brucetrk.c:483)
0x4a976e : mov al, byte ptr [column_z (DATA)]
0x4a9773 : xor ecx, ecx
0x4a9775 : mov cl, byte ptr [max_z (DATA)]
0x4a977b : cmp eax, ecx
0x4a977d : jle 0xa
0x4a9783 : mov al, byte ptr [column_z (DATA)] 	(brucetrk.c:484)

---
+++
@@ -0x4a97c7,42 +0x446a30,42 @@
0x4a97c7 : mov eax, dword ptr [ebp + 0x14]
0x4a97ca : fld dword ptr [eax + 0x24]
0x4a97cd : fadd dword ptr [edge_after (DATA)]
0x4a97d3 : sub esp, 4
0x4a97d6 : fstp dword ptr [esp]
0x4a97d9 : push column_z (DATA)
0x4a97de : push column_x (DATA)
0x4a97e3 : call XZToColumnXZ (FUNCTION)
0x4a97e8 : add esp, 0x14
0x4a97eb : xor eax, eax 	(brucetrk.c:490)
0x4a97ed : -mov al, byte ptr [column_x (DATA)]
         : +mov al, byte ptr [min_x (DATA)]
0x4a97f2 : xor ecx, ecx
0x4a97f4 : -mov cl, byte ptr [min_x (DATA)]
         : +mov cl, byte ptr [column_x (DATA)]
0x4a97fa : cmp eax, ecx
0x4a97fc : -jge 0xf
         : +jle 0xf
0x4a9802 : mov al, byte ptr [column_x (DATA)] 	(brucetrk.c:491)
0x4a9807 : mov byte ptr [min_x (DATA)], al
0x4a980c : jmp 0x21 	(brucetrk.c:492)
0x4a9811 : xor eax, eax
0x4a9813 : -mov al, byte ptr [column_x (DATA)]
         : +mov al, byte ptr [max_x (DATA)]
0x4a9818 : xor ecx, ecx
0x4a981a : -mov cl, byte ptr [max_x (DATA)]
         : +mov cl, byte ptr [column_x (DATA)]
0x4a9820 : cmp eax, ecx
0x4a9822 : -jle 0xa
         : +jge 0xa
0x4a9828 : mov al, byte ptr [column_x (DATA)] 	(brucetrk.c:493)
0x4a982d : mov byte ptr [max_x (DATA)], al
0x4a9832 : xor eax, eax 	(brucetrk.c:495)
0x4a9834 : -mov al, byte ptr [column_z (DATA)]
         : +mov al, byte ptr [min_z (DATA)]
0x4a9839 : xor ecx, ecx
0x4a983b : -mov cl, byte ptr [min_z (DATA)]
         : +mov cl, byte ptr [column_z (DATA)]
0x4a9841 : cmp eax, ecx
0x4a9843 : -jge 0xf
         : +jle 0xf
0x4a9849 : mov al, byte ptr [column_z (DATA)] 	(brucetrk.c:496)
0x4a984e : mov byte ptr [min_z (DATA)], al
0x4a9853 : jmp 0x21 	(brucetrk.c:497)
0x4a9858 : xor eax, eax
0x4a985a : mov al, byte ptr [column_z (DATA)]
0x4a985f : xor ecx, ecx
0x4a9861 : mov cl, byte ptr [max_z (DATA)]
0x4a9867 : cmp eax, ecx
0x4a9869 : jle 0xa
0x4a986f : mov al, byte ptr [column_z (DATA)] 	(brucetrk.c:498)

---
+++
@@ -0x4a98b3,42 +0x446b1c,42 @@
0x4a98b3 : mov eax, dword ptr [ebp + 0x14]
0x4a98b6 : fld dword ptr [eax + 0x24]
0x4a98b9 : fadd dword ptr [edge_after (DATA)]
0x4a98bf : sub esp, 4
0x4a98c2 : fstp dword ptr [esp]
0x4a98c5 : push column_z (DATA)
0x4a98ca : push column_x (DATA)
0x4a98cf : call XZToColumnXZ (FUNCTION)
0x4a98d4 : add esp, 0x14
0x4a98d7 : xor eax, eax 	(brucetrk.c:503)
0x4a98d9 : -mov al, byte ptr [column_x (DATA)]
         : +mov al, byte ptr [min_x (DATA)]
0x4a98de : xor ecx, ecx
0x4a98e0 : -mov cl, byte ptr [min_x (DATA)]
         : +mov cl, byte ptr [column_x (DATA)]
0x4a98e6 : cmp eax, ecx
0x4a98e8 : -jge 0xf
         : +jle 0xf
0x4a98ee : mov al, byte ptr [column_x (DATA)] 	(brucetrk.c:504)
0x4a98f3 : mov byte ptr [min_x (DATA)], al
0x4a98f8 : jmp 0x21 	(brucetrk.c:505)
0x4a98fd : xor eax, eax
0x4a98ff : -mov al, byte ptr [column_x (DATA)]
         : +mov al, byte ptr [max_x (DATA)]
0x4a9904 : xor ecx, ecx
0x4a9906 : -mov cl, byte ptr [max_x (DATA)]
         : +mov cl, byte ptr [column_x (DATA)]
0x4a990c : cmp eax, ecx
0x4a990e : -jle 0xa
         : +jge 0xa
0x4a9914 : mov al, byte ptr [column_x (DATA)] 	(brucetrk.c:506)
0x4a9919 : mov byte ptr [max_x (DATA)], al
0x4a991e : xor eax, eax 	(brucetrk.c:508)
0x4a9920 : -mov al, byte ptr [column_z (DATA)]
         : +mov al, byte ptr [min_z (DATA)]
0x4a9925 : xor ecx, ecx
0x4a9927 : -mov cl, byte ptr [min_z (DATA)]
         : +mov cl, byte ptr [column_z (DATA)]
0x4a992d : cmp eax, ecx
0x4a992f : -jge 0xf
         : +jle 0xf
0x4a9935 : mov al, byte ptr [column_z (DATA)] 	(brucetrk.c:509)
0x4a993a : mov byte ptr [min_z (DATA)], al
0x4a993f : jmp 0x21 	(brucetrk.c:510)
0x4a9944 : xor eax, eax
0x4a9946 : mov al, byte ptr [column_z (DATA)]
0x4a994b : xor ecx, ecx
0x4a994d : mov cl, byte ptr [max_z (DATA)]
0x4a9953 : cmp eax, ecx
0x4a9955 : jle 0xa
0x4a995b : mov al, byte ptr [column_z (DATA)] 	(brucetrk.c:511)

---
+++
@@ -0x4a99de,10 +0x446c47,16 @@
0x4a99de : xor eax, eax
0x4a99e0 : mov al, byte ptr [max_x (DATA)]
0x4a99e5 : push eax
0x4a99e6 : xor eax, eax
0x4a99e8 : mov al, byte ptr [min_x (DATA)]
0x4a99ed : push eax
0x4a99ee : mov eax, dword ptr [ebp + 0xc]
0x4a99f1 : push eax
0x4a99f2 : push 0
0x4a99f4 : call DrawColumns (FUNCTION)
         : +add esp, 0x1c
         : +pop edi 	(brucetrk.c:528)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


RenderTrack is only 87.25% similar to the original, diff above
```

*AI generated. Time taken: 639s, tokens: 105,637*
