### PR TITLE
DrawNOptInitialRadios 100% match

### DIFF
--- a/src/DETHRACE/common/newgame.c
+++ b/src/DETHRACE/common/newgame.c
@@ -1003,18 +1003,18 @@ void DrawNOptInitialRadios(void) {
     DontLetFlicFuckWithPalettes();
     TurnFlicTransparencyOn();
     for (i = 0; i < COUNT_OF(gRadio_bastards__newgame); i++) {
-        if (gRadio_bastards__newgame[i].count < 2) {
-            if (gRadio_bastards__newgame[i].current_value) {
-                NetPlayCheckboxOn2(i);
-            } else {
-                NetPlayCheckboxOff2(i);
-            }
-        } else {
+        if (gRadio_bastards__newgame[i].count > 1) {
             NetPlayRadioOn2(i, gRadio_bastards__newgame[i].current_value);
             for (j = 0; j < gRadio_bastards__newgame[i].count; j++) {
                 if (j != gRadio_bastards__newgame[i].current_value) {
                     NetPlayRadioOff2(i, j);
                 }
+            }
+        } else {
+            if (gRadio_bastards__newgame[i].current_value) {
+                NetPlayCheckboxOn2(i);
+            } else {
+                NetPlayCheckboxOff2(i);
             }
         }
     }


### PR DESCRIPTION
## Match result

```
0x4b12ec: DrawNOptInitialRadios 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4b12fc,22 +0x48f8c5,36 @@
0x4b12fc : add esp, 4
0x4b12ff : call DontLetFlicFuckWithPalettes (FUNCTION) 	(newgame.c:1006)
0x4b1304 : call TurnFlicTransparencyOn (FUNCTION) 	(newgame.c:1007)
0x4b1309 : mov dword ptr [ebp - 4], 0 	(newgame.c:1008)
0x4b1310 : jmp 0x3
0x4b1315 : inc dword ptr [ebp - 4]
0x4b1318 : cmp dword ptr [ebp - 4], 0xb
0x4b131c : jge 0xb4
0x4b1322 : mov eax, dword ptr [ebp - 4] 	(newgame.c:1009)
0x4b1325 : shl eax, 5
0x4b1328 : -cmp dword ptr [eax + gRadio_bastards__newgame[0].count (DATA)], 1
0x4b132f : -jle 0x6c
         : +cmp dword ptr [eax + gRadio_bastards__newgame[0].count (DATA)], 2
         : +jge 0x35
         : +mov eax, dword ptr [ebp - 4] 	(newgame.c:1010)
         : +shl eax, 5
         : +cmp dword ptr [eax + gRadio_bastards__newgame[0].current_value (OFFSET)], 0
         : +je 0x11
         : +mov eax, dword ptr [ebp - 4] 	(newgame.c:1011)
         : +push eax
         : +call NetPlayCheckboxOn2 (FUNCTION)
         : +add esp, 4
         : +jmp 0xc 	(newgame.c:1012)
         : +mov eax, dword ptr [ebp - 4] 	(newgame.c:1013)
         : +push eax
         : +call NetPlayCheckboxOff2 (FUNCTION)
         : +add esp, 4
         : +jmp 0x67 	(newgame.c:1015)
0x4b1335 : mov eax, dword ptr [ebp - 4] 	(newgame.c:1016)
0x4b1338 : shl eax, 5
0x4b133b : mov eax, dword ptr [eax + gRadio_bastards__newgame[0].current_value (OFFSET)]
0x4b1341 : push eax
0x4b1342 : mov eax, dword ptr [ebp - 4]
0x4b1345 : push eax
0x4b1346 : call NetPlayRadioOn2 (FUNCTION)
0x4b134b : add esp, 8
0x4b134e : mov dword ptr [ebp - 8], 0 	(newgame.c:1017)
0x4b1355 : jmp 0x3

---
+++
@@ -0x4b1378,32 +0x48f976,18 @@
0x4b1378 : mov ecx, dword ptr [ebp - 8]
0x4b137b : cmp dword ptr [eax + gRadio_bastards__newgame[0].current_value (OFFSET)], ecx
0x4b1381 : je 0x10
0x4b1387 : mov eax, dword ptr [ebp - 8] 	(newgame.c:1019)
0x4b138a : push eax
0x4b138b : mov eax, dword ptr [ebp - 4]
0x4b138e : push eax
0x4b138f : call NetPlayRadioOff2 (FUNCTION)
0x4b1394 : add esp, 8
0x4b1397 : jmp -0x42 	(newgame.c:1021)
0x4b139c : -jmp 0x30
0x4b13a1 : -mov eax, dword ptr [ebp - 4]
0x4b13a4 : -shl eax, 5
0x4b13a7 : -cmp dword ptr [eax + gRadio_bastards__newgame[0].current_value (OFFSET)], 0
0x4b13ae : -je 0x11
0x4b13b4 : -mov eax, dword ptr [ebp - 4]
0x4b13b7 : -push eax
0x4b13b8 : -call NetPlayCheckboxOn2 (FUNCTION)
0x4b13bd : -add esp, 4
0x4b13c0 : -jmp 0xc
0x4b13c5 : -mov eax, dword ptr [ebp - 4]
0x4b13c8 : -push eax
0x4b13c9 : -call NetPlayCheckboxOff2 (FUNCTION)
0x4b13ce : -add esp, 4
0x4b13d1 : jmp -0xc1 	(newgame.c:1023)
0x4b13d6 : call TurnFlicTransparencyOff (FUNCTION) 	(newgame.c:1024)
0x4b13db : call LetFlicFuckWithPalettes (FUNCTION) 	(newgame.c:1025)
0x4b13e0 : pop edi 	(newgame.c:1026)
0x4b13e1 : pop esi
0x4b13e2 : pop ebx
0x4b13e3 : leave 
0x4b13e4 : ret 


DrawNOptInitialRadios is only 77.14% similar to the original, diff above
```

*AI generated. Time taken: 722s, tokens: 10,017*
