### PR TITLE
LoadFont equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -3163,41 +3163,40 @@ void LoadFont(int pFont_ID) {
     FILE* f;
     tU32 the_size;
 
-    if (gFonts[pFont_ID].images != NULL) {
-        return;
-    }
-
-    PathCat(the_path, gApplication_path, gGraf_specs[gGraf_spec_index].data_dir_name);
-    PathCat(the_path, the_path, "FONTS");
-    PathCat(the_path, the_path, gFont_names[pFont_ID]);
-    number_of_chars = strlen(the_path);
-    strcat(the_path, ".PIX");
-    gFonts[pFont_ID].images = DRPixelmapLoad(the_path);
-
     if (gFonts[pFont_ID].images == NULL) {
-        FatalError(kFatalError_LoadFontImage_S, gFont_names[pFont_ID]);
-    }
-    if (!gFonts[pFont_ID].file_read_once) {
-        strcpy(&the_path[number_of_chars + 1], "TXT");
+        PathCat(the_path, gApplication_path, gGraf_specs[gGraf_spec_index].data_dir_name);
+        PathCat(the_path, the_path, "FONTS");
+        PathCat(the_path, the_path, gFont_names[pFont_ID]);
+        strcat(the_path, ".PIX");
+        gFonts[pFont_ID].images = DRPixelmapLoad(the_path);
 
-        f = DRfopen(the_path, "rt");
-        if (f == NULL) {
-            FatalError(kFatalError_LoadFontWidthTable_S, gFont_names[pFont_ID]);
+        if (gFonts[pFont_ID].images == NULL) {
+            FatalError(kFatalError_LoadFontImage_S, gFont_names[pFont_ID]);
         }
+        gFonts[pFont_ID].images->row_bytes = (gFonts[pFont_ID].images->row_bytes + 3) & ~3;
+        if (!gFonts[pFont_ID].file_read_once) {
+            the_path[strlen(the_path) - 3] = '\0';
+            strcat(the_path, "TXT");
 
-        gFonts[pFont_ID].height = GetAnInt(f);
-        gFonts[pFont_ID].width = GetAnInt(f);
-        gFonts[pFont_ID].spacing = GetAnInt(f);
-        gFonts[pFont_ID].offset = GetAnInt(f);
-        gFonts[pFont_ID].num_entries = GetAnInt(f);
-        if (gFonts[pFont_ID].width <= 0) {
-            for (i = 0; i < gFonts[pFont_ID].num_entries; i++) {
-                the_size = GetAnInt(f);
-                gFonts[pFont_ID].width_table[i] = the_size;
+            f = DRfopen(the_path, "rt");
+            if (f == NULL) {
+                FatalError(kFatalError_LoadFontWidthTable_S, gFont_names[pFont_ID]);
             }
+
+            gFonts[pFont_ID].height = GetAnInt(f);
+            gFonts[pFont_ID].width = GetAnInt(f);
+            gFonts[pFont_ID].spacing = GetAnInt(f);
+            gFonts[pFont_ID].offset = GetAnInt(f);
+            gFonts[pFont_ID].num_entries = GetAnInt(f);
+            if (gFonts[pFont_ID].width <= 0) {
+                the_size = pFont_ID;
+                for (i = 0; i < gFonts[pFont_ID].num_entries; i++) {
+                    gFonts[the_size].width_table[i] = GetAnInt(f);
+                }
+            }
+            fclose(f);
+            gFonts[pFont_ID].file_read_once = 1;
         }
-        fclose(f);
-        gFonts[pFont_ID].file_read_once = 1;
     }
 }
 


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4b968d,21 +0x48479b,21 @@
0x4b968d : push esi
0x4b968e : push edi
0x4b968f : mov eax, dword ptr [ebp + 8] 	(graphics.c:3166)
0x4b9692 : mov ecx, eax
0x4b9694 : lea eax, [eax + eax*8]
0x4b9697 : lea eax, [ecx + eax*4]
0x4b969a : lea eax, [eax + eax*4]
0x4b969d : lea eax, [eax + eax*4]
0x4b96a0 : sub eax, ecx
0x4b96a2 : cmp dword ptr [eax + gFonts[0].images (DATA)], 0
0x4b96a9 : -jne 0x317
         : +jne 0x31d
0x4b96af : mov eax, dword ptr [gGraf_spec_index (DATA)] 	(graphics.c:3167)
0x4b96b4 : mov ecx, eax
0x4b96b6 : lea eax, [eax + eax*2]
0x4b96b9 : lea eax, [ecx + eax*4]
0x4b96bc : mov eax, dword ptr [eax*4 + gGraf_specs[0].data_dir_name (OFFSET)]
0x4b96c3 : push eax
0x4b96c4 : push gApplication_path[0] (DATA)
0x4b96c9 : lea eax, [ebp - 0x110]
0x4b96cf : push eax
0x4b96d0 : call PathCat (FUNCTION)

---
+++
@@ -0x4b97c6,21 +0x4848d4,21 @@
0x4b97c6 : mov ecx, dword ptr [ecx + gFonts[0].images (DATA)]
0x4b97cc : mov word ptr [ecx + 0x28], ax
0x4b97d0 : mov eax, dword ptr [ebp + 8] 	(graphics.c:3177)
0x4b97d3 : mov ecx, eax
0x4b97d5 : lea eax, [eax + eax*8]
0x4b97d8 : lea eax, [ecx + eax*4]
0x4b97db : lea eax, [eax + eax*4]
0x4b97de : lea eax, [eax + eax*4]
0x4b97e1 : sub eax, ecx
0x4b97e3 : cmp dword ptr [eax + gFonts[0].file_read_once (OFFSET)], 0
0x4b97ea : -jne 0x1d6
         : +jne 0x1dc
0x4b97f0 : lea edi, [ebp - 0x110] 	(graphics.c:3178)
0x4b97f6 : mov ecx, 0xffffffff
0x4b97fb : sub eax, eax
0x4b97fd : repne scasb al, byte ptr es:[edi]
0x4b97ff : not ecx
0x4b9801 : lea eax, [ecx - 1]
0x4b9804 : mov dword ptr [ebp - 0x114], eax
0x4b980a : mov eax, dword ptr [ebp - 0x114]
0x4b9810 : mov byte ptr [ebp + eax - 0x113], 0
0x4b9818 : lea edi, [ebp - 0x110] 	(graphics.c:3179)

---
+++
@@ -0x4b9916,40 +0x484a24,42 @@
0x4b9916 : sub ecx, edx
0x4b9918 : mov dword ptr [ecx + gFonts[0].num_entries (OFFSET)], eax
0x4b991e : mov eax, dword ptr [ebp + 8] 	(graphics.c:3191)
0x4b9921 : mov ecx, eax
0x4b9923 : lea eax, [eax + eax*8]
0x4b9926 : lea eax, [ecx + eax*4]
0x4b9929 : lea eax, [eax + eax*4]
0x4b992c : lea eax, [eax + eax*4]
0x4b992f : sub eax, ecx
0x4b9931 : cmp dword ptr [eax + gFonts[0].width (OFFSET)], 0
0x4b9938 : -jg 0x5f
         : +jg 0x65
         : +mov eax, dword ptr [ebp + 8] 	(graphics.c:3192)
         : +mov dword ptr [ebp - 0x10], eax
0x4b993e : mov dword ptr [ebp - 0xc], 0 	(graphics.c:3193)
0x4b9945 : jmp 0x3
0x4b994a : inc dword ptr [ebp - 0xc]
0x4b994d : mov eax, dword ptr [ebp + 8]
0x4b9950 : mov ecx, eax
0x4b9952 : lea eax, [eax + eax*8]
0x4b9955 : lea eax, [ecx + eax*4]
0x4b9958 : lea eax, [eax + eax*4]
0x4b995b : lea eax, [eax + eax*4]
0x4b995e : sub eax, ecx
0x4b9960 : mov ecx, dword ptr [ebp - 0xc]
0x4b9963 : cmp dword ptr [eax + gFonts[0].num_entries (OFFSET)], ecx
0x4b9969 : jle 0x2e
0x4b996f : mov eax, dword ptr [ebp - 8] 	(graphics.c:3194)
0x4b9972 : push eax
0x4b9973 : call GetAnInt (FUNCTION)
0x4b9978 : add esp, 4
0x4b997b : mov ecx, dword ptr [ebp - 0xc]
0x4b997e : -mov edx, dword ptr [ebp + 8]
         : +mov edx, dword ptr [ebp - 0x10]
0x4b9981 : mov ebx, edx
0x4b9983 : lea edx, [edx + edx*8]
0x4b9986 : lea edx, [ebx + edx*4]
0x4b9989 : lea edx, [edx + edx*4]
0x4b998c : lea edx, [edx + edx*4]
0x4b998f : sub edx, ebx
0x4b9991 : mov dword ptr [edx + ecx*4 + gFonts[0].width_table (OFFSET)], eax
0x4b9998 : jmp -0x53 	(graphics.c:3195)
0x4b999d : mov eax, dword ptr [ebp - 8] 	(graphics.c:3197)
0x4b99a0 : push eax


LoadFont is only 98.01% similar to the original, diff above
```

#### Effective match analysis

The shown differences are consistent with address/offset shifts plus one added local copy of the same value. In the first two hunks, `jne` target displacements changed only because code size changed elsewhere; the branch condition and behavior are unchanged. In the third hunk, `mov eax, [ebp+8]; mov [ebp-0x10], eax` is added, and later `mov edx, [ebp+8]` becomes `mov edx, [ebp-0x10]`; this uses the same font index value, so computed table addresses and stored widths remain the same. No functional control-flow logic change is evident in the diff.

#### Original match

```
---
+++
@@ -0x4b9683,25 +0x48465d,26 @@
0x4b9683 : push ebp 	(graphics.c:3150)
0x4b9684 : mov ebp, esp
0x4b9686 : -sub esp, 0x114
         : +sub esp, 0x110
0x4b968c : push ebx
0x4b968d : push esi
0x4b968e : push edi
0x4b968f : mov eax, dword ptr [ebp + 8] 	(graphics.c:3157)
0x4b9692 : mov ecx, eax
0x4b9694 : lea eax, [eax + eax*8]
0x4b9697 : lea eax, [ecx + eax*4]
0x4b969a : lea eax, [eax + eax*4]
0x4b969d : lea eax, [eax + eax*4]
0x4b96a0 : sub eax, ecx
0x4b96a2 : cmp dword ptr [eax + gFonts[0].images (DATA)], 0
0x4b96a9 : -jne 0x317
         : +je 0x5
         : +jmp 0x2c5 	(graphics.c:3158)
0x4b96af : mov eax, dword ptr [gGraf_spec_index (DATA)] 	(graphics.c:3161)
0x4b96b4 : mov ecx, eax
0x4b96b6 : lea eax, [eax + eax*2]
0x4b96b9 : lea eax, [ecx + eax*4]
0x4b96bc : mov eax, dword ptr [eax*4 + gGraf_specs[0].data_dir_name (OFFSET)]
0x4b96c3 : push eax
0x4b96c4 : push gApplication_path[0] (DATA)
0x4b96c9 : lea eax, [ebp - 0x110]
0x4b96cf : push eax
0x4b96d0 : call PathCat (FUNCTION)

---
+++
@@ -0x4b96f0,20 +0x4846cf,27 @@
0x4b96f0 : add esp, 0xc
0x4b96f3 : mov eax, dword ptr [ebp + 8] 	(graphics.c:3163)
0x4b96f6 : mov eax, dword ptr [eax*4 + gFont_names[0] (DATA)]
0x4b96fd : push eax
0x4b96fe : lea eax, [ebp - 0x110]
0x4b9704 : push eax
0x4b9705 : lea eax, [ebp - 0x110]
0x4b970b : push eax
0x4b970c : call PathCat (FUNCTION)
0x4b9711 : add esp, 0xc
         : +lea edi, [ebp - 0x110] 	(graphics.c:3164)
         : +mov ecx, 0xffffffff
         : +sub eax, eax
         : +repne scasb al, byte ptr es:[edi]
         : +not ecx
         : +lea eax, [ecx - 1]
         : +mov dword ptr [ebp - 4], eax
0x4b9714 : mov edx, ".PIX" (STRING) 	(graphics.c:3165)
0x4b9719 : lea edi, [ebp - 0x110]
0x4b971f : mov ecx, 0xffffffff
0x4b9724 : sub eax, eax
0x4b9726 : repne scasb al, byte ptr es:[edi]
0x4b9728 : dec edi
0x4b9729 : mov eax, dword ptr [edx]
0x4b972b : mov dword ptr [edi], eax
0x4b972d : mov al, byte ptr [edx + 4]
0x4b9730 : mov byte ptr [edi + 4], al

---
+++
@@ -0x4b9786,57 +0x48477c,25 @@
0x4b9786 : push 0x14
0x4b9788 : call FatalError (FUNCTION)
0x4b978d : add esp, 8
0x4b9790 : mov eax, dword ptr [ebp + 8] 	(graphics.c:3171)
0x4b9793 : mov ecx, eax
0x4b9795 : lea eax, [eax + eax*8]
0x4b9798 : lea eax, [ecx + eax*4]
0x4b979b : lea eax, [eax + eax*4]
0x4b979e : lea eax, [eax + eax*4]
0x4b97a1 : sub eax, ecx
0x4b97a3 : -mov eax, dword ptr [eax + gFonts[0].images (DATA)]
0x4b97a9 : -movsx eax, word ptr [eax + 0x28]
0x4b97ad : -add eax, 3
0x4b97b0 : -and eax, 0xfffffffc
0x4b97b3 : -mov ecx, dword ptr [ebp + 8]
0x4b97b6 : -mov edx, ecx
0x4b97b8 : -lea ecx, [ecx + ecx*8]
0x4b97bb : -lea ecx, [edx + ecx*4]
0x4b97be : -lea ecx, [ecx + ecx*4]
0x4b97c1 : -lea ecx, [ecx + ecx*4]
0x4b97c4 : -sub ecx, edx
0x4b97c6 : -mov ecx, dword ptr [ecx + gFonts[0].images (DATA)]
0x4b97cc : -mov word ptr [ecx + 0x28], ax
0x4b97d0 : -mov eax, dword ptr [ebp + 8]
0x4b97d3 : -mov ecx, eax
0x4b97d5 : -lea eax, [eax + eax*8]
0x4b97d8 : -lea eax, [ecx + eax*4]
0x4b97db : -lea eax, [eax + eax*4]
0x4b97de : -lea eax, [eax + eax*4]
0x4b97e1 : -sub eax, ecx
0x4b97e3 : cmp dword ptr [eax + gFonts[0].file_read_once (OFFSET)], 0
0x4b97ea : -jne 0x1d6
0x4b97f0 : -lea edi, [ebp - 0x110]
0x4b97f6 : -mov ecx, 0xffffffff
0x4b97fb : -sub eax, eax
0x4b97fd : -repne scasb al, byte ptr es:[edi]
0x4b97ff : -not ecx
0x4b9801 : -lea eax, [ecx - 1]
0x4b9804 : -mov dword ptr [ebp - 0x114], eax
0x4b980a : -mov eax, dword ptr [ebp - 0x114]
0x4b9810 : -mov byte ptr [ebp + eax - 0x113], 0
0x4b9818 : -lea edi, [ebp - 0x110]
0x4b981e : -mov ecx, 0xffffffff
0x4b9823 : -sub eax, eax
0x4b9825 : -repne scasb al, byte ptr es:[edi]
0x4b9827 : -mov eax, dword ptr ["TXT" (STRING)]
0x4b982c : -mov dword ptr [edi - 1], eax
         : +jne 0x1ad
         : +mov eax, dword ptr [ebp - 4] 	(graphics.c:3172)
         : +mov ecx, dword ptr ["TXT" (STRING)]
         : +mov dword ptr [ebp + eax - 0x10f], ecx
0x4b982f : push "rt" (STRING) 	(graphics.c:3174)
0x4b9834 : lea eax, [ebp - 0x110]
0x4b983a : push eax
0x4b983b : call DRfopen (FUNCTION)
0x4b9840 : add esp, 8
0x4b9843 : mov dword ptr [ebp - 8], eax
0x4b9846 : cmp dword ptr [ebp - 8], 0 	(graphics.c:3175)
0x4b984a : jne 0x15
0x4b9850 : mov eax, dword ptr [ebp + 8] 	(graphics.c:3176)
0x4b9853 : mov eax, dword ptr [eax*4 + gFont_names[0] (DATA)]

---
+++
@@ -0x4b9916,29 +0x48489d,57 @@
0x4b9916 : sub ecx, edx
0x4b9918 : mov dword ptr [ecx + gFonts[0].num_entries (OFFSET)], eax
0x4b991e : mov eax, dword ptr [ebp + 8] 	(graphics.c:3184)
0x4b9921 : mov ecx, eax
0x4b9923 : lea eax, [eax + eax*8]
0x4b9926 : lea eax, [ecx + eax*4]
0x4b9929 : lea eax, [eax + eax*4]
0x4b992c : lea eax, [eax + eax*4]
0x4b992f : sub eax, ecx
0x4b9931 : cmp dword ptr [eax + gFonts[0].width (OFFSET)], 0
0x4b9938 : -jg 0x5f
         : +jg 0x65
0x4b993e : mov dword ptr [ebp - 0xc], 0 	(graphics.c:3185)
0x4b9945 : jmp 0x3
0x4b994a : inc dword ptr [ebp - 0xc]
0x4b994d : mov eax, dword ptr [ebp + 8]
0x4b9950 : mov ecx, eax
0x4b9952 : lea eax, [eax + eax*8]
0x4b9955 : lea eax, [ecx + eax*4]
0x4b9958 : lea eax, [eax + eax*4]
0x4b995b : lea eax, [eax + eax*4]
0x4b995e : sub eax, ecx
0x4b9960 : mov ecx, dword ptr [ebp - 0xc]
0x4b9963 : cmp dword ptr [eax + gFonts[0].num_entries (OFFSET)], ecx
0x4b9969 : -jle 0x2e
         : +jle 0x34
0x4b996f : mov eax, dword ptr [ebp - 8] 	(graphics.c:3186)
0x4b9972 : push eax
0x4b9973 : call GetAnInt (FUNCTION)
0x4b9978 : add esp, 4
         : +mov dword ptr [ebp - 0x10], eax
         : +mov eax, dword ptr [ebp - 0x10] 	(graphics.c:3187)
0x4b997b : mov ecx, dword ptr [ebp - 0xc]
         : +mov edx, dword ptr [ebp + 8]
         : +mov ebx, edx
         : +lea edx, [edx + edx*8]
         : +lea edx, [ebx + edx*4]
         : +lea edx, [edx + edx*4]
         : +lea edx, [edx + edx*4]
         : +sub edx, ebx
         : +mov dword ptr [edx + ecx*4 + gFonts[0].width_table (OFFSET)], eax
         : +jmp -0x59 	(graphics.c:3188)
         : +mov eax, dword ptr [ebp - 8] 	(graphics.c:3190)
         : +push eax
         : +call fclose (FUNCTION)
         : +add esp, 4
         : +mov eax, dword ptr [ebp + 8] 	(graphics.c:3191)
         : +mov ecx, eax
         : +lea eax, [eax + eax*8]
         : +lea eax, [ecx + eax*4]
         : +lea eax, [eax + eax*4]
         : +lea eax, [eax + eax*4]
         : +sub eax, ecx
         : +mov dword ptr [eax + gFonts[0].file_read_once (OFFSET)], 1
         : +pop edi 	(graphics.c:3193)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


LoadFont is only 81.42% similar to the original, diff above
```

*AI generated. Time taken: 839s, tokens: 168,554*
