### PR TITLE
InitDRFonts 100% match

### DIFF
--- a/src/DETHRACE/common/graphics.c
+++ b/src/DETHRACE/common/graphics.c
@@ -3217,8 +3217,8 @@ void InitDRFonts(void) {
     int i;
 
     for (i = 0; i < 21; i++) {
-        gFonts[i].file_read_once = 0;
         gFonts[i].images = NULL;
+        gFonts[i].file_read_once = 0;
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4b9a79: InitDRFonts 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4b9a8e,25 +0x484a1b,25 @@
0x4b9a8e : inc dword ptr [ebp - 4]
0x4b9a91 : cmp dword ptr [ebp - 4], 0x15
0x4b9a95 : jge 0x3f
0x4b9a9b : mov eax, dword ptr [ebp - 4] 	(graphics.c:3211)
0x4b9a9e : mov ecx, eax
0x4b9aa0 : lea eax, [eax + eax*8]
0x4b9aa3 : lea eax, [ecx + eax*4]
0x4b9aa6 : lea eax, [eax + eax*4]
0x4b9aa9 : lea eax, [eax + eax*4]
0x4b9aac : sub eax, ecx
0x4b9aae : -mov dword ptr [eax + gFonts[0].images (DATA)], 0
         : +mov dword ptr [eax + gFonts[0].file_read_once (OFFSET)], 0
0x4b9ab8 : mov eax, dword ptr [ebp - 4] 	(graphics.c:3212)
0x4b9abb : mov ecx, eax
0x4b9abd : lea eax, [eax + eax*8]
0x4b9ac0 : lea eax, [ecx + eax*4]
0x4b9ac3 : lea eax, [eax + eax*4]
0x4b9ac6 : lea eax, [eax + eax*4]
0x4b9ac9 : sub eax, ecx
0x4b9acb : -mov dword ptr [eax + gFonts[0].file_read_once (OFFSET)], 0
         : +mov dword ptr [eax + gFonts[0].images (DATA)], 0
0x4b9ad5 : jmp -0x4c 	(graphics.c:3213)
0x4b9ada : pop edi 	(graphics.c:3214)
0x4b9adb : pop esi
0x4b9adc : pop ebx
0x4b9add : leave 
0x4b9ade : ret 


InitDRFonts is only 93.94% similar to the original, diff above
```

*AI generated. Time taken: 69s, tokens: 22,249*
