### PR TITLE
ReinitialiseForwardCamera 100% match

### DIFF
--- a/src/DETHRACE/common/init.c
+++ b/src/DETHRACE/common/init.c
@@ -146,33 +146,35 @@ void ReinitialiseForwardCamera(void) {
 
     camera_ptr = (br_camera*)gCamera->type_data;
     if (gProgram_state.cockpit_on) {
-        the_angle = gCamera_angle / 2.0;
-
-        d = atan(
-                tandeg(the_angle)
+        the_angle = atan(
+                tandeg(gCamera_angle / 2.0f)
                 * (double)gRender_screen->height
                 / (double)(gProgram_state.current_car.render_bottom[0] - gProgram_state.current_car.render_top[0]))
-            * 114.5915590261646;
-        camera_ptr->field_of_view = BrDegreeToAngle(d);
+            * 114.59155902616465;
+        camera_ptr->field_of_view = BrDegreeToAngle(the_angle);
         BrMatrix34Identity(&gCamera->t.t.mat);
         gCamera->t.t.mat.m[3][0] = gProgram_state.current_car.driver_x_offset;
         gCamera->t.t.mat.m[3][1] = gProgram_state.current_car.driver_y_offset;
         gCamera->t.t.mat.m[3][2] = gProgram_state.current_car.driver_z_offset;
-        w = (float)(gRender_screen->base_y
+        d = (float)(gRender_screen->base_y
             + (gRender_screen->height / 2)
             - (gProgram_state.current_car.render_bottom[0] + gProgram_state.current_car.render_top[0]) / 2);
+        w = (float)gRender_screen->height;
 
-        gCamera->t.t.mat.m[2][1] = tandeg(d / 2.0) * w * 2.0 / (float)gRender_screen->height;
-        camera_ptr->aspect = (float)gWidth / gHeight;
+        gCamera->t.t.mat.m[2][1] = tandeg(the_angle / 2.0f) * d * 2.0f / w;
+        camera_ptr->aspect = (float)gWidth / (float)gHeight;
         camera_ptr->yon_z = gYon_multiplier * gCamera_yon;
-        if (gProgram_state.which_view == eView_left) {
+        switch (gProgram_state.which_view) {
+        case eView_left:
             DRMatrix34PostRotateY(
                 &gCamera->t.t.mat,
                 BrDegreeToAngle(gProgram_state.current_car.head_left_angle));
-        } else if (gProgram_state.which_view == eView_right) {
+            break;
+        case eView_right:
             DRMatrix34PostRotateY(
                 &gCamera->t.t.mat,
                 BrDegreeToAngle(gProgram_state.current_car.head_right_angle));
+            break;
         }
         gCamera->t.t.mat.m[3][0] = gProgram_state.current_car.driver_x_offset;
         gCamera->t.t.mat.m[3][1] = gProgram_state.current_car.driver_y_offset;


### PR DESCRIPTION
## Match result

```
0x4bb510: ReinitialiseForwardCamera 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4bb510,42 +0x485a22,43 @@
0x4bb510 : push ebp 	(init.c:141)
0x4bb511 : mov ebp, esp
0x4bb513 : -sub esp, 0x34
         : +sub esp, 0x30
0x4bb516 : push ebx
0x4bb517 : push esi
0x4bb518 : push edi
0x4bb519 : mov eax, dword ptr [gCamera (DATA)] 	(init.c:147)
0x4bb51e : mov eax, dword ptr [eax + 0x5c]
0x4bb521 : mov dword ptr [ebp - 0x10], eax
0x4bb524 : cmp dword ptr [gProgram_state+80 (OFFSET)], 0 	(init.c:148)
0x4bb52b : -je 0x206
         : +je 0x1ed
0x4bb531 : fld dword ptr [gCamera_angle (DATA)] 	(init.c:149)
0x4bb537 : -fdiv dword ptr [2.0 (FLOAT)]
0x4bb53d : -sub esp, 4
0x4bb540 : -fstp dword ptr [esp]
         : +fdiv qword ptr [2.0 (FLOAT)]
         : +fstp dword ptr [ebp - 0xc]
         : +mov eax, dword ptr [ebp - 0xc] 	(init.c:155)
         : +push eax
0x4bb543 : call tandeg (FUNCTION)
0x4bb548 : add esp, 4
0x4bb54b : mov eax, dword ptr [gRender_screen (DATA)]
0x4bb550 : xor ecx, ecx
0x4bb552 : mov cx, word ptr [eax + 0x36]
0x4bb556 : -mov dword ptr [ebp - 0x1c], ecx
0x4bb559 : -mov dword ptr [ebp - 0x18], 0
0x4bb560 : -fild qword ptr [ebp - 0x1c]
         : +mov dword ptr [ebp - 0x18], ecx
         : +mov dword ptr [ebp - 0x14], 0
         : +fild qword ptr [ebp - 0x18]
0x4bb563 : fmulp st(1)
0x4bb565 : mov eax, dword ptr [gProgram_state+1300 (OFFSET)]
0x4bb56a : sub eax, dword ptr [gProgram_state+1276 (OFFSET)]
0x4bb570 : -mov dword ptr [ebp - 0x20], eax
0x4bb573 : -fild dword ptr [ebp - 0x20]
         : +mov dword ptr [ebp - 0x1c], eax
         : +fild dword ptr [ebp - 0x1c]
0x4bb576 : fdivp st(1)
0x4bb578 : call __CIatan (FUNCTION)
0x4bb57d : -fmul qword ptr [114.59155902616465 (FLOAT)]
0x4bb583 : -fst dword ptr [ebp - 0xc]
         : +fmul qword ptr [114.5915590261646 (FLOAT)]
         : +fst dword ptr [ebp - 4]
0x4bb586 : fmul qword ptr [182.04444444444445 (FLOAT)] 	(init.c:156)
0x4bb58c : call __ftol (FUNCTION)
0x4bb591 : mov ecx, dword ptr [ebp - 0x10]
0x4bb594 : mov word ptr [ecx + 6], ax
0x4bb598 : mov eax, dword ptr [gCamera (DATA)] 	(init.c:157)
0x4bb59d : add eax, 0x2c
0x4bb5a0 : push eax
0x4bb5a1 : call BrMatrix34Identity (FUNCTION)
0x4bb5a6 : add esp, 4
0x4bb5a9 : mov eax, dword ptr [gCamera (DATA)] 	(init.c:158)

---
+++
@@ -0x4bb5e0,83 +0x485af3,87 @@
0x4bb5e0 : mov eax, dword ptr [gRender_screen (DATA)]
0x4bb5e5 : xor edx, edx
0x4bb5e7 : mov dx, word ptr [eax + 0x32]
0x4bb5eb : add ecx, edx
0x4bb5ed : mov eax, dword ptr [gProgram_state+1276 (OFFSET)]
0x4bb5f2 : add eax, dword ptr [gProgram_state+1300 (OFFSET)]
0x4bb5f8 : cdq 
0x4bb5f9 : sub eax, edx
0x4bb5fb : sar eax, 1
0x4bb5fd : sub ecx, eax
0x4bb5ff : -mov dword ptr [ebp - 0x24], ecx
0x4bb602 : -fild dword ptr [ebp - 0x24]
0x4bb605 : -fstp dword ptr [ebp - 4]
0x4bb608 : -mov eax, dword ptr [gRender_screen (DATA)]
0x4bb60d : -xor ecx, ecx
0x4bb60f : -mov cx, word ptr [eax + 0x36]
0x4bb613 : -mov dword ptr [ebp - 0x2c], ecx
0x4bb616 : -mov dword ptr [ebp - 0x28], 0
0x4bb61d : -fild qword ptr [ebp - 0x2c]
         : +mov dword ptr [ebp - 0x20], ecx
         : +fild dword ptr [ebp - 0x20]
0x4bb620 : fstp dword ptr [ebp - 8]
0x4bb623 : -fld dword ptr [ebp - 0xc]
0x4bb626 : -fdiv dword ptr [2.0 (FLOAT)]
         : +fld dword ptr [ebp - 4] 	(init.c:165)
         : +fdiv qword ptr [2.0 (FLOAT)]
0x4bb62c : sub esp, 4
0x4bb62f : fstp dword ptr [esp]
0x4bb632 : call tandeg (FUNCTION)
0x4bb637 : add esp, 4
0x4bb63a : -fmul dword ptr [ebp - 4]
0x4bb63d : -fmul dword ptr [2.0 (FLOAT)]
0x4bb643 : -fdiv dword ptr [ebp - 8]
         : +fmul dword ptr [ebp - 8]
         : +fmul qword ptr [2.0 (FLOAT)]
         : +mov eax, dword ptr [gRender_screen (DATA)]
         : +xor ecx, ecx
         : +mov cx, word ptr [eax + 0x36]
         : +mov dword ptr [ebp - 0x28], ecx
         : +mov dword ptr [ebp - 0x24], 0
         : +fild qword ptr [ebp - 0x28]
         : +fdivp st(1)
0x4bb646 : mov eax, dword ptr [gCamera (DATA)]
0x4bb64b : fstp dword ptr [eax + 0x48]
0x4bb64e : mov eax, dword ptr [gWidth (DATA)] 	(init.c:166)
         : +mov dword ptr [ebp - 0x2c], eax
         : +fild dword ptr [ebp - 0x2c]
         : +mov eax, dword ptr [gHeight (DATA)]
0x4bb653 : mov dword ptr [ebp - 0x30], eax
0x4bb656 : fild dword ptr [ebp - 0x30]
0x4bb659 : -mov eax, dword ptr [gHeight (DATA)]
0x4bb65e : -mov dword ptr [ebp - 0x34], eax
0x4bb661 : -fild dword ptr [ebp - 0x34]
0x4bb664 : fdivp st(1)
0x4bb666 : mov eax, dword ptr [ebp - 0x10]
0x4bb669 : fstp dword ptr [eax + 0x10]
0x4bb66c : fld dword ptr [gYon_multiplier (DATA)] 	(init.c:167)
0x4bb672 : fmul dword ptr [gCamera_yon (DATA)]
0x4bb678 : mov eax, dword ptr [ebp - 0x10]
0x4bb67b : fstp dword ptr [eax + 0xc]
0x4bb67e : -mov eax, dword ptr [gProgram_state+144 (OFFSET)]
0x4bb683 : -mov dword ptr [ebp - 0x14], eax
0x4bb686 : -jmp 0x55
         : +cmp dword ptr [gProgram_state+144 (OFFSET)], 1 	(init.c:168)
         : +jne 0x28
0x4bb68b : fld dword ptr [gProgram_state+1976 (OFFSET)] 	(init.c:171)
0x4bb691 : fmul qword ptr [182.04444444444445 (FLOAT)]
0x4bb697 : call __ftol (FUNCTION)
0x4bb69c : push eax
0x4bb69d : mov eax, dword ptr [gCamera (DATA)]
0x4bb6a2 : add eax, 0x2c
0x4bb6a5 : push eax
0x4bb6a6 : call DRMatrix34PostRotateY (FUNCTION)
0x4bb6ab : add esp, 8
0x4bb6ae : -jmp 0x46
         : +jmp 0x30 	(init.c:172)
         : +cmp dword ptr [gProgram_state+144 (OFFSET)], 3
         : +jne 0x23
0x4bb6b3 : fld dword ptr [gProgram_state+1980 (OFFSET)] 	(init.c:175)
0x4bb6b9 : fmul qword ptr [182.04444444444445 (FLOAT)]
0x4bb6bf : call __ftol (FUNCTION)
0x4bb6c4 : push eax
0x4bb6c5 : mov eax, dword ptr [gCamera (DATA)]
0x4bb6ca : add eax, 0x2c
0x4bb6cd : push eax
0x4bb6ce : call DRMatrix34PostRotateY (FUNCTION)
0x4bb6d3 : add esp, 8
0x4bb6d6 : -jmp 0x1e
0x4bb6db : -jmp 0x19
0x4bb6e0 : -cmp dword ptr [ebp - 0x14], 1
0x4bb6e4 : -je -0x5f
0x4bb6ea : -cmp dword ptr [ebp - 0x14], 3
0x4bb6ee : -je -0x41
0x4bb6f4 : -jmp 0x0
0x4bb6f9 : mov eax, dword ptr [gCamera (DATA)] 	(init.c:177)
0x4bb6fe : mov ecx, dword ptr [gProgram_state+1948 (OFFSET)]
0x4bb704 : mov dword ptr [eax + 0x50], ecx
0x4bb707 : mov eax, dword ptr [gCamera (DATA)] 	(init.c:178)
0x4bb70c : mov ecx, dword ptr [gProgram_state+1952 (OFFSET)]
0x4bb712 : mov dword ptr [eax + 0x54], ecx
0x4bb715 : mov eax, dword ptr [gCamera (DATA)] 	(init.c:179)
0x4bb71a : mov ecx, dword ptr [gProgram_state+1956 (OFFSET)]
0x4bb720 : mov dword ptr [eax + 0x58], ecx
0x4bb723 : mov eax, dword ptr [ebp - 0x10] 	(init.c:180)
         : +mov eax, dword ptr [eax + 0xc]
         : +push eax
         : +call SetSightDistance (FUNCTION)
         : +add esp, 4
         : +call MungeForwardSky (FUNCTION) 	(init.c:181)
         : +call AssertYons (FUNCTION) 	(init.c:183)
         : +pop edi 	(init.c:184)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


ReinitialiseForwardCamera is only 69.53% similar to the original, diff above
```

*AI generated. Time taken: 180s, tokens: 23,134*
