### PR TITLE
ReinitialiseRenderStuff 100% match

### DIFF
--- a/src/DETHRACE/common/init.c
+++ b/src/DETHRACE/common/init.c
@@ -270,12 +270,12 @@ void ReinitialiseRenderStuff(void) {
             return;
         }
 #endif
-        gProgram_state.current_render_top = (gGraf_specs[gGraf_spec_index].total_height / 18 & ~1) * gRender_indent;
-        gProgram_state.current_render_left = (gGraf_specs[gGraf_spec_index].total_width / 18 & ~3) * gRender_indent;
-        x_diff = gGraf_specs[gGraf_spec_index].total_width - gProgram_state.current_render_left;
-        y_diff = gGraf_specs[gGraf_spec_index].total_height - gProgram_state.current_render_top;
-        gProgram_state.current_render_right = x_diff;
-        gProgram_state.current_render_bottom = y_diff;
+        x_diff = gGraf_specs[gGraf_spec_index].total_width / 18 & ~3;
+        y_diff = gGraf_specs[gGraf_spec_index].total_height / 18 & ~1;
+        gProgram_state.current_render_left = gRender_indent * x_diff;
+        gProgram_state.current_render_top = gRender_indent * y_diff;
+        gProgram_state.current_render_right = gGraf_specs[gGraf_spec_index].total_width - gRender_indent * x_diff;
+        gProgram_state.current_render_bottom = gGraf_specs[gGraf_spec_index].total_height - gRender_indent * y_diff;
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4bb916: ReinitialiseRenderStuff 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4bb938,54 +0x485e2e,56 @@
0x4bb938 : mov dword ptr [gProgram_state+88 (OFFSET)], eax
0x4bb93d : mov eax, dword ptr [gProgram_state+84 (OFFSET)] 	(init.c:260)
0x4bb942 : mov eax, dword ptr [eax*4 + gProgram_state+1276 (OFFSET)]
0x4bb949 : mov dword ptr [gProgram_state+92 (OFFSET)], eax
0x4bb94e : mov eax, dword ptr [gProgram_state+84 (OFFSET)] 	(init.c:261)
0x4bb953 : mov eax, dword ptr [eax*4 + gProgram_state+1288 (OFFSET)]
0x4bb95a : mov dword ptr [gProgram_state+96 (OFFSET)], eax
0x4bb95f : mov eax, dword ptr [gProgram_state+84 (OFFSET)] 	(init.c:262)
0x4bb964 : mov eax, dword ptr [eax*4 + gProgram_state+1300 (OFFSET)]
0x4bb96b : mov dword ptr [gProgram_state+100 (OFFSET)], eax
0x4bb970 : -jmp 0xaa
         : +jmp 0xa0 	(init.c:263)
         : +mov eax, dword ptr [gGraf_spec_index (DATA)] 	(init.c:273)
         : +mov ecx, eax
         : +lea eax, [eax + eax*2]
         : +lea eax, [ecx + eax*4]
         : +mov ecx, 0x12
         : +mov eax, dword ptr [eax*4 + gGraf_specs[0].total_height (OFFSET)]
         : +cdq 
         : +idiv ecx
         : +and eax, 0xfffffffe
         : +imul eax, dword ptr [gRender_indent (DATA)]
         : +mov dword ptr [gProgram_state+92 (OFFSET)], eax
0x4bb975 : mov eax, dword ptr [gGraf_spec_index (DATA)] 	(init.c:274)
0x4bb97a : mov ecx, eax
0x4bb97c : lea eax, [eax + eax*2]
0x4bb97f : lea eax, [ecx + eax*4]
0x4bb982 : mov ecx, 0x12
0x4bb987 : mov eax, dword ptr [eax*4 + gGraf_specs[0].total_width (OFFSET)]
0x4bb98e : cdq 
0x4bb98f : idiv ecx
0x4bb991 : and eax, 0xfffffffc
         : +imul eax, dword ptr [gRender_indent (DATA)]
         : +mov dword ptr [gProgram_state+88 (OFFSET)], eax
         : +mov eax, dword ptr [gGraf_spec_index (DATA)] 	(init.c:275)
         : +mov ecx, eax
         : +lea eax, [eax + eax*2]
         : +lea eax, [ecx + eax*4]
         : +mov eax, dword ptr [eax*4 + gGraf_specs[0].total_width (OFFSET)]
         : +sub eax, dword ptr [gProgram_state+88 (OFFSET)]
0x4bb994 : mov dword ptr [ebp - 4], eax
0x4bb997 : mov eax, dword ptr [gGraf_spec_index (DATA)] 	(init.c:276)
0x4bb99c : mov ecx, eax
0x4bb99e : lea eax, [eax + eax*2]
0x4bb9a1 : lea eax, [ecx + eax*4]
0x4bb9a4 : -mov ecx, 0x12
0x4bb9a9 : mov eax, dword ptr [eax*4 + gGraf_specs[0].total_height (OFFSET)]
0x4bb9b0 : -cdq 
0x4bb9b1 : -idiv ecx
0x4bb9b3 : -and eax, 0xfffffffe
         : +sub eax, dword ptr [gProgram_state+92 (OFFSET)]
0x4bb9b6 : mov dword ptr [ebp - 8], eax
0x4bb9b9 : -mov eax, dword ptr [gRender_indent (DATA)]
0x4bb9be : -imul eax, dword ptr [ebp - 4]
0x4bb9c2 : -mov dword ptr [gProgram_state+88 (OFFSET)], eax
0x4bb9c7 : -mov eax, dword ptr [gRender_indent (DATA)]
0x4bb9cc : -imul eax, dword ptr [ebp - 8]
0x4bb9d0 : -mov dword ptr [gProgram_state+92 (OFFSET)], eax
0x4bb9d5 : -mov eax, dword ptr [gGraf_spec_index (DATA)]
0x4bb9da : -mov ecx, eax
0x4bb9dc : -lea eax, [eax + eax*2]
0x4bb9df : -lea eax, [ecx + eax*4]
0x4bb9e2 : -mov eax, dword ptr [eax*4 + gGraf_specs[0].total_width (OFFSET)]
0x4bb9e9 : -mov ecx, dword ptr [gRender_indent (DATA)]
0x4bb9ef : -imul ecx, dword ptr [ebp - 4]
0x4bb9f3 : -sub eax, ecx
         : +mov eax, dword ptr [ebp - 4] 	(init.c:277)
0x4bb9f5 : mov dword ptr [gProgram_state+96 (OFFSET)], eax
0x4bb9fa : -mov eax, dword ptr [gGraf_spec_index (DATA)]
0x4bb9ff : -mov ecx, eax
0x4bba01 : -lea eax, [eax + eax*2]
0x4bba04 : -lea eax, [ecx + eax*4]
0x4bba07 : -mov eax, dword ptr [eax*4 + gGraf_specs[0].total_height (OFFSET)]
0x4bba0e : -mov ecx, dword ptr [gRender_indent (DATA)]
0x4bba14 : -imul ecx, dword ptr [ebp - 8]
0x4bba18 : -sub eax, ecx
         : +mov eax, dword ptr [ebp - 8] 	(init.c:278)
         : +mov dword ptr [gProgram_state+100 (OFFSET)], eax
         : +pop edi 	(init.c:280)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


ReinitialiseRenderStuff is only 56.92% similar to the original, diff above
```

*AI generated. Time taken: 88s, tokens: 10,270*
