### PR TITLE
InitRace 100% match

### DIFF
--- a/src/DETHRACE/common/init.c
+++ b/src/DETHRACE/common/init.c
@@ -74,6 +74,12 @@ int gNet_mode_of_last_game;
 // GLOBAL: CARM95 0x0054b29c
 br_material* gDefault_track_material;
 
+// GLOBAL: CARM95 0x005454c4
+int gINT_005454c4;
+
+// GLOBAL: CARM95 0x0055142c
+int gINT_0055142c;
+
 // IDA: void __cdecl AllocateSelf()
 // FUNCTION: CARM95 0x004bbebf
 void AllocateSelf(void) {
@@ -762,7 +768,7 @@ void CopyMaterialColourFromIndex(br_material* pMaterial) {
 void InitRace(void) {
 
     SwitchToRealResolution();
-    // TODO: dword_5454C4 = 0;
+    gINT_005454c4 = 0;
     ClearConcussion();
     ClearWobbles();
     ClearHeadups();
@@ -771,17 +777,15 @@ void InitRace(void) {
     PossibleService();
     BuildColourTable(gRender_palette);
     PossibleService();
-    // TODO: dword_55142C = 0;
+    gINT_0055142c = 0;
     gStart_race_sent = 0;
     gProgram_state.frame_rate_headup = NewTextHeadupSlot(eHeadupSlot_development, 0, 0, -kFont_ORANGHED, "");
-    if (TranslationMode()) {
-        if (gAusterity_mode) {
-            FlushInterfaceFonts();
-        }
-    } else {
+    if (!TranslationMode()) {
         LoadFont(kFont_ORANGHED);
         LoadFont(kFont_BLUEHEAD);
         LoadFont(kFont_GREENHED);
+    } else if (gAusterity_mode) {
+        FlushInterfaceFonts();
     }
     LoadFont(kFont_MEDIUMHD);
     LoadFont(kFont_TIMER);
@@ -828,7 +832,7 @@ void InitRace(void) {
     AdjustRenderScreenSize();
     PrintMemoryDump(0, "DIRECTLY BEFORE LOADING IN TRACK");
     LoadInTrack();
-    if (gYon_multiplier != 1.0) {
+    if (gYon_multiplier != 1.0f) {
         AdjustRenderScreenSize();
     }
     PrintMemoryDump(0, "DIRECTLY AFTER LOADING IN TRACK");


### PR DESCRIPTION
## Match result

```
0x4bc4b1: InitRace 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4bc4b1,54 +0x486842,52 @@
0x4bc4b1 : push ebp 	(init.c:762)
0x4bc4b2 : mov ebp, esp
0x4bc4b4 : push ebx
0x4bc4b5 : push esi
0x4bc4b6 : push edi
0x4bc4b7 : call SwitchToRealResolution (FUNCTION) 	(init.c:764)
0x4bc4bc : -mov dword ptr [<OFFSET2>], 0
0x4bc4c6 : call ClearConcussion (FUNCTION) 	(init.c:766)
0x4bc4cb : call ClearWobbles (FUNCTION) 	(init.c:767)
0x4bc4d0 : call ClearHeadups (FUNCTION) 	(init.c:768)
0x4bc4d5 : call ResetOilSpills (FUNCTION) 	(init.c:769)
0x4bc4da : call HideSkids (FUNCTION) 	(init.c:770)
0x4bc4df : call PossibleService (FUNCTION) 	(init.c:771)
0x4bc4e4 : mov eax, dword ptr [gRender_palette (DATA)] 	(init.c:772)
0x4bc4e9 : push eax
0x4bc4ea : call BuildColourTable (FUNCTION)
0x4bc4ef : add esp, 4
0x4bc4f2 : call PossibleService (FUNCTION) 	(init.c:773)
0x4bc4f7 : -mov dword ptr [<OFFSET11>], 0
0x4bc501 : mov dword ptr [gStart_race_sent (DATA)], 0 	(init.c:775)
0x4bc50b : -push <OFFSET13>
         : +push <OFFSET11> 	(init.c:776)
0x4bc510 : push -1
0x4bc512 : push 0
0x4bc514 : push 0
0x4bc516 : push 0
0x4bc518 : call NewTextHeadupSlot (FUNCTION)
0x4bc51d : add esp, 0x14
0x4bc520 : mov dword ptr [gProgram_state+104 (OFFSET)], eax
0x4bc525 : call TranslationMode (FUNCTION) 	(init.c:777)
0x4bc52a : test eax, eax
0x4bc52c : -jne 0x23
         : +je 0x17
         : +cmp dword ptr [gAusterity_mode (DATA)], 0 	(init.c:778)
         : +je 0x5
         : +call FlushInterfaceFonts (FUNCTION) 	(init.c:779)
         : +jmp 0x1e 	(init.c:781)
0x4bc532 : push 1 	(init.c:782)
0x4bc534 : call LoadFont (FUNCTION)
0x4bc539 : add esp, 4
0x4bc53c : push 2 	(init.c:783)
0x4bc53e : call LoadFont (FUNCTION)
0x4bc543 : add esp, 4
0x4bc546 : push 3 	(init.c:784)
0x4bc548 : call LoadFont (FUNCTION)
0x4bc54d : add esp, 4
0x4bc550 : -jmp 0x12
0x4bc555 : -cmp dword ptr [gAusterity_mode (DATA)], 0
0x4bc55c : -je 0x5
0x4bc562 : -call FlushInterfaceFonts (FUNCTION)
0x4bc567 : push 4 	(init.c:786)
0x4bc569 : call LoadFont (FUNCTION)
0x4bc56e : add esp, 4
0x4bc571 : push 5 	(init.c:787)
0x4bc573 : call LoadFont (FUNCTION)
0x4bc578 : add esp, 4
0x4bc57b : call PossibleService (FUNCTION) 	(init.c:788)
0x4bc580 : push 6 	(init.c:789)
0x4bc582 : call LoadFont (FUNCTION)
0x4bc587 : add esp, 4

---
+++
@@ -0x4bc591,78 +0x48690e,78 @@
0x4bc591 : add esp, 4
0x4bc594 : push 8 	(init.c:791)
0x4bc596 : call LoadFont (FUNCTION)
0x4bc59b : add esp, 4
0x4bc59e : call PossibleService (FUNCTION) 	(init.c:792)
0x4bc5a3 : call ResetRecoveryVouchers (FUNCTION) 	(init.c:793)
0x4bc5a8 : mov dword ptr [gMap_mode (DATA)], 0 	(init.c:794)
0x4bc5b2 : mov dword ptr [gProgram_state+84 (OFFSET)], 0 	(init.c:795)
0x4bc5bc : cmp dword ptr [gNet_mode (DATA)], 0 	(init.c:796)
0x4bc5c3 : je 0x39
0x4bc5c9 : -push <OFFSET24>
         : +push <OFFSET22> 	(init.c:797)
0x4bc5ce : push -6
0x4bc5d0 : push 0
0x4bc5d2 : push 0
0x4bc5d4 : push 0xd
0x4bc5d6 : call NewTextHeadupSlot (FUNCTION)
0x4bc5db : add esp, 0x14
0x4bc5de : mov dword ptr [gNet_cash_headup (DATA)], eax
0x4bc5e3 : -push <OFFSET26>
         : +push <OFFSET24> 	(init.c:798)
0x4bc5e8 : push -6
0x4bc5ea : push 0
0x4bc5ec : push 0
0x4bc5ee : push 0xe
0x4bc5f0 : call NewTextHeadupSlot (FUNCTION)
0x4bc5f5 : add esp, 0x14
0x4bc5f8 : mov dword ptr [gNet_ped_headup (DATA)], eax
0x4bc5fd : jmp 0x9c 	(init.c:799)
0x4bc602 : -push <OFFSET28>
         : +push <OFFSET26> 	(init.c:800)
0x4bc607 : push -6
0x4bc609 : push 0
0x4bc60b : push 0
0x4bc60d : push 1
0x4bc60f : call NewTextHeadupSlot (FUNCTION)
0x4bc614 : add esp, 0x14
0x4bc617 : mov dword ptr [gCredits_won_headup (DATA)], eax
0x4bc61c : -push <OFFSET30>
         : +push <OFFSET28> 	(init.c:801)
0x4bc621 : push -6
0x4bc623 : push 0
0x4bc625 : push 0
0x4bc627 : push 2
0x4bc629 : call NewTextHeadupSlot (FUNCTION)
0x4bc62e : add esp, 0x14
0x4bc631 : mov dword ptr [gPed_kill_count_headup (DATA)], eax
0x4bc636 : -push <OFFSET32>
         : +push <OFFSET30> 	(init.c:802)
0x4bc63b : push -6
0x4bc63d : push 0
0x4bc63f : push 0
0x4bc641 : push 0xc
0x4bc643 : call NewTextHeadupSlot (FUNCTION)
0x4bc648 : add esp, 0x14
0x4bc64b : mov dword ptr [gCar_kill_count_headup (DATA)], eax
0x4bc650 : -push <OFFSET34>
         : +push <OFFSET32> 	(init.c:803)
0x4bc655 : push -5
0x4bc657 : push 0
0x4bc659 : push 0
0x4bc65b : push 7
0x4bc65d : call NewTextHeadupSlot (FUNCTION)
0x4bc662 : add esp, 0x14
0x4bc665 : mov dword ptr [gTimer_headup (DATA)], eax
0x4bc66a : -push <OFFSET36>
         : +push <OFFSET34> 	(init.c:804)
0x4bc66f : push -2
0x4bc671 : push 0
0x4bc673 : push 0
0x4bc675 : push 0xb
0x4bc677 : call NewTextHeadupSlot (FUNCTION)
0x4bc67c : add esp, 0x14
0x4bc67f : mov dword ptr [gTime_awarded_headup (DATA)], eax
0x4bc684 : -push <OFFSET38>
         : +push <OFFSET36> 	(init.c:805)
0x4bc689 : push -6
0x4bc68b : push 0
0x4bc68d : push 0
0x4bc68f : push 8
0x4bc691 : call NewTextHeadupSlot (FUNCTION)
0x4bc696 : add esp, 0x14
0x4bc699 : mov dword ptr [gLaps_headup (DATA)], eax
0x4bc69e : call PossibleService (FUNCTION) 	(init.c:807)
0x4bc6a3 : mov dword ptr [gProgram_state+144 (OFFSET)], 2 	(init.c:808)
0x4bc6ad : mov dword ptr [gProgram_state+148 (OFFSET)], 0 	(init.c:809)

---
+++
@@ -0x4bc73e,21 +0x486abb,21 @@
0x4bc73e : call PossibleService (FUNCTION) 	(init.c:825)
0x4bc743 : mov dword ptr [gAuto_repair (DATA)], 0 	(init.c:826)
0x4bc74d : call SetIntegerMapRenders (FUNCTION) 	(init.c:827)
0x4bc752 : call AdjustRenderScreenSize (FUNCTION) 	(init.c:828)
0x4bc757 : push "DIRECTLY BEFORE LOADING IN TRACK" (STRING) 	(init.c:829)
0x4bc75c : push 0
0x4bc75e : call PrintMemoryDump (FUNCTION)
0x4bc763 : add esp, 8
0x4bc766 : call LoadInTrack (FUNCTION) 	(init.c:830)
0x4bc76b : fld dword ptr [gYon_multiplier (DATA)] 	(init.c:831)
0x4bc771 : -fcomp dword ptr [1.0 (FLOAT)]
         : +fcomp qword ptr [1.0 (FLOAT)]
0x4bc777 : fnstsw ax
0x4bc779 : test ah, 0x40
0x4bc77c : jne 0x5
0x4bc782 : call AdjustRenderScreenSize (FUNCTION) 	(init.c:832)
0x4bc787 : push "DIRECTLY AFTER LOADING IN TRACK" (STRING) 	(init.c:834)
0x4bc78c : push 0
0x4bc78e : call PrintMemoryDump (FUNCTION)
0x4bc793 : add esp, 8
0x4bc796 : call LoadCopCars (FUNCTION) 	(init.c:835)
0x4bc79b : push "AFTER LOADING IN COPS" (STRING) 	(init.c:853)

---
+++
@@ -0x4bc8f3,10 +0x486c70,17 @@
0x4bc8f3 : add esp, 4
0x4bc8f6 : call PossibleService (FUNCTION) 	(init.c:887)
0x4bc8fb : call InitPlayers (FUNCTION) 	(init.c:888)
0x4bc900 : cmp dword ptr [gNet_mode (DATA)], 0 	(init.c:889)
0x4bc907 : je 0x19
0x4bc90d : mov eax, dword ptr [gCurrent_net_game (DATA)] 	(init.c:890)
0x4bc912 : mov eax, dword ptr [eax + 0x5c]
0x4bc915 : mov eax, dword ptr [eax*4 + gInitial_net_credits[0] (DATA)]
0x4bc91c : mov dword ptr [gProgram_state+4 (OFFSET)], eax
0x4bc921 : call InitNetGameplayStuff (FUNCTION) 	(init.c:891)
         : +mov dword ptr [gInitialised_grid (DATA)], 0 	(init.c:893)
         : +call SwitchToLoresMode (FUNCTION) 	(init.c:894)
         : +pop edi 	(init.c:895)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


InitRace is only 91.93% similar to the original, diff above
```

*AI generated. Time taken: 558s, tokens: 174,923*
