### PR TITLE
DoDamage 100% match

### DIFF
--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -624,12 +624,14 @@ void RecordLastDamage(tCar_spec* pCar) {
 // FUNCTION: CARM95 0x004bf3b9
 void DoDamage(tCar_spec* pCar, tDamage_type pDamage_type, float pMagnitude, float pNastiness) {
 
-    if (pCar->driver < eDriver_net_human) {
-        DamageUnit2(pCar, pDamage_type, ((gCurrent_race.suggested_rank < 10 ? 0.5f : gCurrent_race.suggested_rank) / 20.0f + 1.0f) * (pNastiness * pMagnitude * 10.0f));
-    } else if (gNet_mode != eNet_mode_none) {
-        DamageUnit2(pCar, pDamage_type, pNastiness * pMagnitude * 15.0f);
-    } else if (PercentageChance(pNastiness * pMagnitude * 1500.0f)) {
-        DamageUnit2(pCar, pDamage_type, pNastiness * pMagnitude * 30.0f);
+    if (pCar->driver >= eDriver_net_human) {
+        if (gNet_mode != eNet_mode_none) {
+            DamageUnit2(pCar, pDamage_type, pNastiness * pMagnitude * 15.0f);
+        } else if (PercentageChance(pNastiness * pMagnitude * 1500.0f)) {
+            DamageUnit2(pCar, pDamage_type, pNastiness * pMagnitude * 30.0f);
+        }
+    } else {
+        DamageUnit2(pCar, pDamage_type, pNastiness * pMagnitude * 10.0f * ((gCurrent_race.suggested_rank < 10 ? 0.5 : gCurrent_race.suggested_rank) / 20.0 + 1.0));
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4bf3b9: DoDamage 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4bf3b9,67 +0x46c0ce,72 @@
0x4bf3b9 : push ebp 	(crush.c:616)
0x4bf3ba : mov ebp, esp
0x4bf3bc : -sub esp, 0xc
         : +sub esp, 8
0x4bf3bf : push ebx
0x4bf3c0 : push esi
0x4bf3c1 : push edi
0x4bf3c2 : mov eax, dword ptr [ebp + 8] 	(crush.c:618)
0x4bf3c5 : cmp dword ptr [eax + 8], 3
0x4bf3c9 : -jl 0x7d
         : +jge 0x5f
         : +cmp dword ptr [gCurrent_race+56 (OFFSET)], 0xa 	(crush.c:619)
         : +jl 0x13
         : +mov eax, dword ptr [gCurrent_race+56 (OFFSET)]
         : +mov dword ptr [ebp - 8], eax
         : +fild dword ptr [ebp - 8]
         : +fstp dword ptr [ebp - 4]
         : +jmp 0x7
         : +mov dword ptr [ebp - 4], 0x3f000000
         : +fld dword ptr [ebp - 4]
         : +fdiv dword ptr [20.0 (FLOAT)]
         : +fadd dword ptr [1.0 (FLOAT)]
         : +fld dword ptr [ebp + 0x10]
         : +fmul dword ptr [ebp + 0x14]
         : +fmul dword ptr [10.0 (FLOAT)]
         : +fmulp st(1)
         : +call __ftol (FUNCTION)
         : +push eax
         : +mov eax, dword ptr [ebp + 0xc]
         : +push eax
         : +mov eax, dword ptr [ebp + 8]
         : +push eax
         : +call DamageUnit2 (FUNCTION)
         : +add esp, 0xc
         : +jmp 0x78 	(crush.c:620)
0x4bf3cf : cmp dword ptr [gNet_mode (DATA)], 0
0x4bf3d6 : je 0x27
0x4bf3e2 : fmul dword ptr [15.0 (FLOAT)]
0x4bf3e8 : call __ftol (FUNCTION)
0x4bf3ed : push eax
0x4bf3ee : mov eax, dword ptr [ebp + 0xc]
0x4bf3f1 : push eax
0x4bf3f2 : mov eax, dword ptr [ebp + 8]
0x4bf3f5 : push eax
0x4bf3f6 : call DamageUnit2 (FUNCTION)
0x4bf3fb : add esp, 0xc
0x4bf3fe : jmp 0x44 	(crush.c:622)
0x4bf409 : fmul dword ptr [1500.0 (FLOAT)]
0x4bf40f : call __ftol (FUNCTION)
0x4bf414 : push eax
0x4bf415 : call PercentageChance (FUNCTION)
0x4bf41a : add esp, 4
0x4bf41d : test eax, eax
0x4bf41f : je 0x22
0x4bf42b : fmul dword ptr [30.0 (FLOAT)]
0x4bf431 : call __ftol (FUNCTION)
0x4bf436 : push eax
0x4bf437 : mov eax, dword ptr [ebp + 0xc]
0x4bf43a : push eax
0x4bf43b : mov eax, dword ptr [ebp + 8]
0x4bf43e : push eax
0x4bf43f : call DamageUnit2 (FUNCTION)
0x4bf444 : add esp, 0xc
0x4bf447 : -jmp 0x61
0x4bf44c : -cmp dword ptr [gCurrent_race+56 (OFFSET)], 0xa
0x4bf453 : -jl 0x13
0x4bf459 : -mov eax, dword ptr [gCurrent_race+56 (OFFSET)]
0x4bf45e : -mov dword ptr [ebp - 0xc], eax
0x4bf461 : -fild dword ptr [ebp - 0xc]
0x4bf464 : -fstp qword ptr [ebp - 8]
0x4bf467 : -jmp 0xe
0x4bf46c : -mov dword ptr [ebp - 8], 0
0x4bf473 : -mov dword ptr [ebp - 4], 0x3fe00000
0x4bf47a : -fld qword ptr [ebp - 8]
0x4bf47d : -fdiv qword ptr [20.0 (FLOAT)]
0x4bf483 : -fadd qword ptr [1.0 (FLOAT)]
0x4bf489 : -fld dword ptr [ebp + 0x14]
0x4bf48c : -fmul dword ptr [ebp + 0x10]
0x4bf48f : -fmul dword ptr [10.0 (FLOAT)]
0x4bf495 : -fmulp st(1)
0x4bf497 : -call __ftol (FUNCTION)
0x4bf49c : -push eax
0x4bf49d : -mov eax, dword ptr [ebp + 0xc]
0x4bf4a0 : -push eax
0x4bf4a1 : -mov eax, dword ptr [ebp + 8]
0x4bf4a4 : -push eax
0x4bf4a5 : -call DamageUnit2 (FUNCTION)
         : +pop edi 	(crush.c:625)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


DoDamage is only 50.36% similar to the original, diff above
```

*AI generated. Time taken: 307s, tokens: 24,360*
