### PR TITLE
BlendifyMaterialPrimitively 100% match

### DIFF
--- a/src/DETHRACE/common/utility.c
+++ b/src/DETHRACE/common/utility.c
@@ -1848,18 +1848,21 @@ void BlendifyMaterialTablishly(br_material* pMaterial, int pPercent) {
 // FUNCTION: CARM95 0x004c3fb5
 void BlendifyMaterialPrimitively(br_material* pMaterial, int pPercent) {
 
+    // GLOBAL: CARM95 0x005214c0
     static br_token_value alpha25[3] = {
         { BRT_BLEND_B, { 1 } },          // .b = 1
         { BRT_OPACITY_X, { 0x400000 } }, // .x = 0x400000
         { 0, { 0 } },
     };
 
+    // GLOBAL: CARM95 0x005214d8
     static br_token_value alpha50[3] = {
         { BRT_BLEND_B, { 1 } },
         { BRT_OPACITY_X, { 0x800000 } },
         { 0, { 0 } },
     };
 
+    // GLOBAL: CARM95 0x005214f0
     static br_token_value alpha75[3] = {
         { BRT_BLEND_B, { 1 } },
         { BRT_OPACITY_X, { 0xc00000 } },


### PR DESCRIPTION
## Match result

```
0x4c3fb5: BlendifyMaterialPrimitively 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4c3fb5,27 +0x4bc6be,27 @@
0x4c3fb5 : push ebp 	(utility.c:1854)
0x4c3fb6 : mov ebp, esp
0x4c3fb8 : sub esp, 4
0x4c3fbb : push ebx
0x4c3fbc : push esi
0x4c3fbd : push edi
0x4c3fbe : mov eax, dword ptr [ebp + 0xc] 	(utility.c:1874)
0x4c3fc1 : mov dword ptr [ebp - 4], eax
0x4c3fc4 : jmp 0x3f
0x4c3fc9 : mov eax, dword ptr [ebp + 8] 	(utility.c:1876)
0x4c3fcc : -mov dword ptr [eax + 0x58], <OFFSET1>
         : +mov dword ptr [eax + 0x58], alpha25 (DATA)
0x4c3fd3 : jmp 0x53 	(utility.c:1877)
0x4c3fd8 : mov eax, dword ptr [ebp + 8] 	(utility.c:1879)
0x4c3fdb : -mov dword ptr [eax + 0x58], <OFFSET2>
         : +mov dword ptr [eax + 0x58], alpha50 (DATA)
0x4c3fe2 : jmp 0x44 	(utility.c:1880)
0x4c3fe7 : mov eax, dword ptr [ebp + 8] 	(utility.c:1882)
0x4c3fea : -mov dword ptr [eax + 0x58], <OFFSET3>
         : +mov dword ptr [eax + 0x58], alpha75 (DATA)
0x4c3ff1 : jmp 0x35 	(utility.c:1883)
0x4c3ff6 : push "Invalid alpha" (STRING) 	(utility.c:1885)
0x4c3ffb : call PDFatalError (FUNCTION)
0x4c4000 : add esp, 4
0x4c4003 : jmp 0x23 	(utility.c:1886)
0x4c4008 : cmp dword ptr [ebp - 4], 0x19
0x4c400c : je -0x49
0x4c4012 : cmp dword ptr [ebp - 4], 0x32
0x4c4016 : je -0x44
0x4c401c : cmp dword ptr [ebp - 4], 0x4b


BlendifyMaterialPrimitively is only 91.18% similar to the original, diff above
```

*AI generated. Time taken: 412s, tokens: 90,716*
