### PR TITLE
InitHeadups 100% match

### DIFF
--- a/src/library_brender.h
+++ b/src/library_brender.h
@@ -420,3 +420,9 @@
 
 // LIBRARY: CARM95 0x004D2880
 // BrMatrix34PostTransform
+
+// GLOBAL: CARM95 0x00521ab0
+// BrFontProp7x9
+
+// GLOBAL: CARM95 0x00521ab4
+// BrFontFixed3x5


### PR DESCRIPTION
## Match result

```
0x4c4053: InitHeadups 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4c406b,23 +0x471efb,23 @@
0x4c406b : cmp dword ptr [ebp - 4], 0xf
0x4c406f : jge 0x1f
0x4c4075 : mov eax, dword ptr [ebp - 4] 	(displays.c:119)
0x4c4078 : mov ecx, eax
0x4c407a : lea eax, [eax + eax*8]
0x4c407d : lea eax, [ecx + eax*4]
0x4c4080 : lea eax, [eax + eax*8]
0x4c4083 : sub eax, ecx
0x4c4085 : mov dword ptr [eax + gHeadups[0].type (DATA)], 0
0x4c408f : jmp -0x2c 	(displays.c:120)
0x4c4094 : -mov eax, dword ptr [<OFFSET2>]
         : +mov eax, dword ptr [BrFontProp7x9 (DATA)] 	(displays.c:121)
0x4c4099 : mov dword ptr [gBR_fonts[0] (DATA)], eax
0x4c409e : -mov eax, dword ptr [<OFFSET4>]
         : +mov eax, dword ptr [BrFontFixed3x5 (DATA)] 	(displays.c:122)
0x4c40a3 : mov dword ptr [gBR_fonts[1] (OFFSET)], eax
0x4c40a8 : mov eax, dword ptr [gFont_7 (DATA)] 	(displays.c:123)
0x4c40ad : mov dword ptr [gBR_fonts[2] (OFFSET)], eax
0x4c40b2 : mov eax, dword ptr [gHeadup_font (DATA)] 	(displays.c:124)
0x4c40b7 : mov dword ptr [gBR_fonts[3] (OFFSET)], eax
0x4c40bc : pop edi 	(displays.c:125)
0x4c40bd : pop esi
0x4c40be : pop ebx
0x4c40bf : leave 
0x4c40c0 : ret 


InitHeadups is only 93.75% similar to the original, diff above
```

*AI generated. Time taken: 273s, tokens: 165,998*
