### PR TITLE
KillOldestQueuedHeadup 100% match

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -381,7 +381,11 @@ void DimAFewBits(void) {
 void KillOldestQueuedHeadup(void) {
 
     gQueued_headup_count--;
+#ifdef DETHRACE_FIX_BUGS
+    memmove(&gQueued_headups[0], &gQueued_headups[1], gQueued_headup_count * sizeof(tQueued_headup));
+#else
     memcpy(&gQueued_headups[0], &gQueued_headups[1], gQueued_headup_count * sizeof(tQueued_headup));
+#endif
 }
 
 // IDA: void __usercall DubreyBar(int pX_index@<EAX>, int pY@<EDX>, int pColour@<EBX>)

--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -381,7 +381,7 @@ void DimAFewBits(void) {
 void KillOldestQueuedHeadup(void) {
 
     gQueued_headup_count--;
-    memmove(&gQueued_headups[0], &gQueued_headups[1], gQueued_headup_count * sizeof(tQueued_headup));
+    memcpy(&gQueued_headups[0], &gQueued_headups[1], gQueued_headup_count * sizeof(tQueued_headup));
 }
 
 // IDA: void __usercall DubreyBar(int pX_index@<EAX>, int pY@<EDX>, int pColour@<EBX>)


### PR DESCRIPTION
## Match result

```
0x4c524c: KillOldestQueuedHeadup 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4c524f,23 +0x4726f3,22 @@
0x4c524f : push ebx
0x4c5250 : push esi
0x4c5251 : push edi
0x4c5252 : dec dword ptr [gQueued_headup_count (DATA)] 	(displays.c:386)
0x4c5258 : mov eax, dword ptr [gQueued_headup_count (DATA)] 	(displays.c:387)
0x4c525d : mov ecx, eax
0x4c525f : shl eax, 5
0x4c5262 : add eax, ecx
0x4c5264 : lea eax, [ecx + eax*2]
0x4c5267 : shl eax, 2
0x4c526a : -mov edi, gQueued_headups[0].flash_rate (DATA)
0x4c526f : -lea esi, [gQueued_headups[1].flash_rate (OFFSET)]
0x4c5275 : -mov ecx, eax
0x4c5277 : -shr ecx, 2
0x4c527a : -rep movsd dword ptr es:[edi], dword ptr [esi]
0x4c527c : -mov ecx, eax
0x4c527e : -and ecx, 3
0x4c5281 : -rep movsb byte ptr es:[edi], byte ptr [esi]
         : +push eax
         : +mov eax, gQueued_headups[0].flash_rate (DATA)
         : +add eax, 0x10c
         : +push eax
         : +push gQueued_headups[0].flash_rate (DATA)
         : +call memmove (FUNCTION)
         : +add esp, 0xc
0x4c5283 : pop edi 	(displays.c:388)
0x4c5284 : pop esi
0x4c5285 : pop ebx
0x4c5286 : leave 
0x4c5287 : ret 


KillOldestQueuedHeadup is only 69.39% similar to the original, diff above
```

*AI generated. Time taken: 73s, tokens: 7,518*
