### PR TITLE
MoveHeadupTo 100% match

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -1015,11 +1015,13 @@ void MoveHeadupTo(int pHeadup_index, int pNew_x, int pNew_y) {
     int delta_x;
     tHeadup* the_headup;
 
-    if (pHeadup_index >= 0) {
-        delta_x = gHeadups[pHeadup_index].x - gHeadups[pHeadup_index].original_x;
-        gHeadups[pHeadup_index].original_x = pNew_x;
-        gHeadups[pHeadup_index].x = pNew_x + delta_x;
-        gHeadups[pHeadup_index].y = pNew_y;
+    if (pHeadup_index < 0) {
+    } else {
+        the_headup = &gHeadups[pHeadup_index];
+        delta_x = the_headup->x - the_headup->original_x;
+        the_headup->original_x = pNew_x;
+        the_headup->x = pNew_x + delta_x;
+        the_headup->y = pNew_y;
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4c6107: MoveHeadupTo 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4c6107,37 +0x473e50,53 @@
0x4c6107 : push ebp 	(displays.c:1018)
0x4c6108 : mov ebp, esp
0x4c610a : sub esp, 8
0x4c610d : push ebx
0x4c610e : push esi
0x4c610f : push edi
0x4c6110 : cmp dword ptr [ebp + 8], 0 	(displays.c:1022)
0x4c6114 : -jge 0x5
0x4c611a : -jmp 0x45
         : +jl 0x7d
0x4c611f : mov eax, dword ptr [ebp + 8] 	(displays.c:1023)
0x4c6122 : mov ecx, eax
0x4c6124 : lea eax, [eax + eax*8]
0x4c6127 : lea eax, [ecx + eax*4]
0x4c612a : lea eax, [eax + eax*8]
0x4c612d : sub eax, ecx
0x4c612f : -add eax, gHeadups[0].type (DATA)
0x4c6134 : -mov dword ptr [ebp - 8], eax
0x4c6137 : -mov eax, dword ptr [ebp - 8]
0x4c613a : -mov eax, dword ptr [eax + 4]
0x4c613d : -mov ecx, dword ptr [ebp - 8]
0x4c6140 : -sub eax, dword ptr [ecx + 0xc]
         : +mov eax, dword ptr [eax + gHeadups[0].x (OFFSET)]
         : +mov ecx, dword ptr [ebp + 8]
         : +mov edx, ecx
         : +lea ecx, [ecx + ecx*8]
         : +lea ecx, [edx + ecx*4]
         : +lea ecx, [ecx + ecx*8]
         : +sub ecx, edx
         : +sub eax, dword ptr [ecx + gHeadups[0].original_x (OFFSET)]
0x4c6143 : mov dword ptr [ebp - 4], eax
0x4c6146 : mov eax, dword ptr [ebp + 0xc] 	(displays.c:1024)
0x4c6149 : -mov ecx, dword ptr [ebp - 8]
0x4c614c : -mov dword ptr [ecx + 0xc], eax
         : +mov ecx, dword ptr [ebp + 8]
         : +mov edx, ecx
         : +lea ecx, [ecx + ecx*8]
         : +lea ecx, [edx + ecx*4]
         : +lea ecx, [ecx + ecx*8]
         : +sub ecx, edx
         : +mov dword ptr [ecx + gHeadups[0].original_x (OFFSET)], eax
0x4c614f : mov eax, dword ptr [ebp - 4] 	(displays.c:1025)
0x4c6152 : add eax, dword ptr [ebp + 0xc]
0x4c6155 : -mov ecx, dword ptr [ebp - 8]
0x4c6158 : -mov dword ptr [ecx + 4], eax
         : +mov ecx, dword ptr [ebp + 8]
         : +mov edx, ecx
         : +lea ecx, [ecx + ecx*8]
         : +lea ecx, [edx + ecx*4]
         : +lea ecx, [ecx + ecx*8]
         : +sub ecx, edx
         : +mov dword ptr [ecx + gHeadups[0].x (OFFSET)], eax
0x4c615b : mov eax, dword ptr [ebp + 0x10] 	(displays.c:1026)
0x4c615e : -mov ecx, dword ptr [ebp - 8]
0x4c6161 : -mov dword ptr [ecx + 8], eax
         : +mov ecx, dword ptr [ebp + 8]
         : +mov edx, ecx
         : +lea ecx, [ecx + ecx*8]
         : +lea ecx, [edx + ecx*4]
         : +lea ecx, [ecx + ecx*8]
         : +sub ecx, edx
         : +mov dword ptr [ecx + gHeadups[0].y (OFFSET)], eax
0x4c6164 : pop edi 	(displays.c:1028)
0x4c6165 : pop esi
0x4c6166 : pop ebx
0x4c6167 : leave 
0x4c6168 : ret 


MoveHeadupTo is only 51.11% similar to the original, diff above
```

*AI generated. Time taken: 100s, tokens: 28,335*
