### PR TITLE
DoDamageScreen 100% match

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -1080,7 +1080,10 @@ void DoDamageScreen(tU32 pThe_time) {
     br_pixelmap* the_image;
     tDamage_unit* the_damage;
 
-    if (&gProgram_state.current_car != gCar_to_view || gProgram_state.current_car_index != gProgram_state.current_car.index) {
+    if (&gProgram_state.current_car != gCar_to_view) {
+        return;
+    }
+    if (gProgram_state.current_car_index != gProgram_state.current_car.index) {
         return;
     }
     if (gProgram_state.cockpit_on && gProgram_state.cockpit_image_index >= 0) {
@@ -1105,15 +1108,15 @@ void DoDamageScreen(tU32 pThe_time) {
         }
     }
     for (i = 0; i < COUNT_OF(gProgram_state.current_car.damage_units); i++) {
-        the_damage = &gProgram_state.current_car.damage_units[i];
         if (i != eDamage_driver) {
+            the_damage = &gProgram_state.current_car.damage_units[i];
             the_image = the_damage->images;
             the_step = 5 * the_damage->damage_level / 100;
             y_pitch = (the_image->height / 2) / 5;
             DRPixelmapRectangleMaskedCopy(
                 gBack_screen,
-                the_wobble_x + gProgram_state.current_car.damage_units[i].x_coord,
-                the_wobble_y + gProgram_state.current_car.damage_units[i].y_coord,
+                the_wobble_x + the_damage->x_coord,
+                the_wobble_y + the_damage->y_coord,
                 the_image,
                 0,
                 y_pitch * (2 * the_step + ((pThe_time / the_damage->periods[the_step]) & 1)),


### PR DESCRIPTION
## Match result

```
0x4c62d8: DoDamageScreen 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4c62d8,32 +0x474045,31 @@
0x4c62d8 : push ebp 	(displays.c:1075)
0x4c62d9 : mov ebp, esp
0x4c62db : sub esp, 0x1c
0x4c62de : push ebx
0x4c62df : push esi
0x4c62e0 : push edi
0x4c62e1 : mov eax, gProgram_state (DATA) 	(displays.c:1084)
0x4c62e6 : add eax, 0xb0
0x4c62eb : cmp eax, dword ptr [gCar_to_view (DATA)]
0x4c62f1 : -je 0x5
0x4c62f7 : -jmp 0x173
         : +jne 0x11
0x4c62fc : mov eax, dword ptr [gProgram_state+176 (OFFSET)]
0x4c6301 : cmp dword ptr [gProgram_state+140 (OFFSET)], eax
0x4c6307 : je 0x5
0x4c630d : -jmp 0x15d
         : +jmp 0x178 	(displays.c:1085)
0x4c6312 : cmp dword ptr [gProgram_state+80 (OFFSET)], 0 	(displays.c:1087)
0x4c6319 : je 0x34
0x4c631f : cmp dword ptr [gProgram_state+84 (OFFSET)], 0
0x4c6326 : jl 0x27
0x4c632c : cmp dword ptr [gProgram_state+144 (OFFSET)], 2 	(displays.c:1088)
0x4c6333 : je 0x5
0x4c6339 : -jmp 0x131
         : +jmp 0x14c 	(displays.c:1089)
0x4c633e : mov eax, dword ptr [gScreen_wobble_x (DATA)] 	(displays.c:1091)
0x4c6343 : mov dword ptr [ebp - 0x14], eax
0x4c6346 : mov eax, dword ptr [gScreen_wobble_y (DATA)] 	(displays.c:1092)
0x4c634b : mov dword ptr [ebp - 0x1c], eax
0x4c634e : jmp 0x55 	(displays.c:1093)
0x4c6353 : mov eax, dword ptr [gProgram_state+1660 (OFFSET)] 	(displays.c:1094)
0x4c6358 : mov dword ptr [ebp - 0x14], eax
0x4c635b : mov eax, dword ptr [gProgram_state+1664 (OFFSET)] 	(displays.c:1095)
0x4c6360 : mov dword ptr [ebp - 0x1c], eax
0x4c6363 : cmp dword ptr [gProgram_state+1160 (OFFSET)], 0 	(displays.c:1096)

---
+++
@@ -0x4c6394,31 +0x4740fc,31 @@
0x4c6394 : mov eax, dword ptr [gProgram_state+1668 (OFFSET)]
0x4c6399 : push eax
0x4c639a : mov eax, dword ptr [gBack_screen (DATA)]
0x4c639f : push eax
0x4c63a0 : call DRPixelmapRectangleMaskedCopy (FUNCTION)
0x4c63a5 : add esp, 0x20
0x4c63a8 : mov dword ptr [ebp - 0x10], 0 	(displays.c:1108)
0x4c63af : jmp 0x3
0x4c63b4 : inc dword ptr [ebp - 0x10]
0x4c63b7 : cmp dword ptr [ebp - 0x10], 0xc
0x4c63bb : -jge 0xae
0x4c63c1 : -cmp dword ptr [ebp - 0x10], 2
0x4c63c5 : -je 0x9f
         : +jge 0xc9
0x4c63cb : mov eax, dword ptr [ebp - 0x10] 	(displays.c:1109)
0x4c63ce : mov ecx, eax
0x4c63d0 : lea eax, [eax + eax*4]
0x4c63d3 : lea eax, [eax + eax*8]
0x4c63d6 : sub eax, ecx
0x4c63d8 : add eax, gProgram_state (DATA)
0x4c63dd : add eax, 0x7f8
0x4c63e2 : mov dword ptr [ebp - 0x18], eax
         : +cmp dword ptr [ebp - 0x10], 2 	(displays.c:1110)
         : +je 0xa0
0x4c63e5 : mov eax, dword ptr [ebp - 0x18] 	(displays.c:1111)
0x4c63e8 : mov eax, dword ptr [eax + 0x28]
0x4c63eb : mov dword ptr [ebp - 4], eax
0x4c63ee : mov eax, dword ptr [ebp - 0x18] 	(displays.c:1112)
0x4c63f1 : mov eax, dword ptr [eax + 8]
0x4c63f4 : lea eax, [eax + eax*4]
0x4c63f7 : mov ecx, 0x64
0x4c63fc : cdq 
0x4c63fd : idiv ecx
0x4c63ff : mov dword ptr [ebp - 8], eax

---
+++
@@ -0x4c642f,28 +0x474197,36 @@
0x4c642f : sub edx, edx
0x4c6431 : div dword ptr [ebx + ecx*4 + 0x14]
0x4c6435 : and eax, 1
0x4c6438 : mov ecx, dword ptr [ebp - 8]
0x4c643b : lea eax, [eax + ecx*2]
0x4c643e : imul eax, dword ptr [ebp - 0xc]
0x4c6442 : push eax
0x4c6443 : push 0
0x4c6445 : mov eax, dword ptr [ebp - 4]
0x4c6448 : push eax
0x4c6449 : -mov eax, dword ptr [ebp - 0x18]
0x4c644c : -mov eax, dword ptr [eax + 4]
         : +mov eax, dword ptr [ebp - 0x10]
         : +mov ecx, eax
         : +lea eax, [eax + eax*4]
         : +lea eax, [eax + eax*8]
         : +sub eax, ecx
         : +mov eax, dword ptr [eax + gProgram_state+2044 (OFFSET)]
0x4c644f : add eax, dword ptr [ebp - 0x1c]
0x4c6452 : push eax
0x4c6453 : -mov eax, dword ptr [ebp - 0x18]
0x4c6456 : -mov eax, dword ptr [eax]
         : +mov eax, dword ptr [ebp - 0x10]
         : +mov ecx, eax
         : +lea eax, [eax + eax*4]
         : +lea eax, [eax + eax*8]
         : +sub eax, ecx
         : +mov eax, dword ptr [eax + gProgram_state+2040 (OFFSET)]
0x4c6458 : add eax, dword ptr [ebp - 0x14]
0x4c645b : push eax
0x4c645c : mov eax, dword ptr [gBack_screen (DATA)]
0x4c6461 : push eax
0x4c6462 : call DRPixelmapRectangleMaskedCopy (FUNCTION)
0x4c6467 : add esp, 0x20
0x4c646a : -jmp -0xbb
         : +jmp -0xd6 	(displays.c:1124)
0x4c646f : pop edi 	(displays.c:1125)
0x4c6470 : pop esi
0x4c6471 : pop ebx
0x4c6472 : leave 
0x4c6473 : ret 


DoDamageScreen is only 87.55% similar to the original, diff above
```

*AI generated. Time taken: 340s, tokens: 28,336*
