### PR TITLE
AwardTime equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -1558,25 +1558,27 @@ void AwardTime(tU32 pTime) {
     tU32 the_time;
     int i;
 
-    if (gRace_finished || gFreeze_timer || gNet_mode != eNet_mode_none || pTime == 0) {
+    if (gRace_finished || gFreeze_timer || gNet_mode != eNet_mode_none) {
         return;
     }
 
-    original_amount = pTime;
     the_time = GetTotalTime();
-    for (i = COUNT_OF(gOld_times) - 1; i > 0; i--) {
-        gOld_times[i] = gOld_times[i - 1];
+    if (pTime != 0) {
+        for (i = COUNT_OF(gOld_times) - 1; i > 0; i--) {
+            gOld_times[i] = gOld_times[i - 1];
+        }
+        gOld_times[0] = pTime;
+        original_amount = pTime;
+        if (gLast_time_credit_headup >= 0 && (the_time - gLast_time_earn_time) < 2000) {
+            pTime += gLast_time_credit_amount;
+        }
+        gLast_time_credit_amount = pTime;
+        gTimer += original_amount * 1000;
+        s[0] = '+';
+        TimerString(1000 * pTime, &s[1], 0, 0);
+        gLast_time_credit_headup = NewTextHeadupSlot(eHeadupSlot_time_award, 0, 2000, -kFont_BLUEHEAD, s);
+        gLast_time_earn_time = the_time;
     }
-    gOld_times[0] = pTime;
-    if (gLast_time_credit_headup >= 0 && (the_time - gLast_time_earn_time) < 2000) {
-        pTime += gLast_time_credit_amount;
-    }
-    gLast_time_credit_amount = pTime;
-    gTimer += original_amount * 1000;
-    s[0] = '+';
-    TimerString(1000 * pTime, &s[1], 0, 0);
-    gLast_time_credit_headup = NewTextHeadupSlot(eHeadupSlot_time_award, 0, 2000, -kFont_BLUEHEAD, s);
-    gLast_time_earn_time = the_time;
 }
 
 // IDA: void __usercall DrawRectangle(br_pixelmap *pPixelmap@<EAX>, int pLeft@<EDX>, int pTop@<EBX>, int pRight@<ECX>, int pBottom, int pColour)


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4c7956,21 +0x475627,21 @@
0x4c7956 : call GetTotalTime (FUNCTION) 	(displays.c:1565)
0x4c795b : mov dword ptr [ebp - 0x10c], eax
0x4c7961 : cmp dword ptr [ebp + 8], 0 	(displays.c:1566)
0x4c7965 : je 0xf1
0x4c796b : mov dword ptr [ebp - 0x108], 9 	(displays.c:1567)
0x4c7975 : jmp 0x6
0x4c797a : dec dword ptr [ebp - 0x108]
0x4c7980 : cmp dword ptr [ebp - 0x108], 0
0x4c7987 : jle 0x1f
0x4c798d : mov eax, dword ptr [ebp - 0x108] 	(displays.c:1568)
0x4c7993 : -mov eax, dword ptr [eax*4 + <OFFSET5>]
         : +mov eax, dword ptr [eax*4 + gCredits_won_headup (DATA)]
0x4c799a : mov ecx, dword ptr [ebp - 0x108]
0x4c79a0 : mov dword ptr [ecx*4 + gOld_times[0] (DATA)], eax
0x4c79a7 : jmp -0x32 	(displays.c:1569)
0x4c79ac : mov eax, dword ptr [ebp + 8] 	(displays.c:1570)
0x4c79af : mov dword ptr [gOld_times[0] (DATA)], eax
0x4c79b4 : mov eax, dword ptr [ebp + 8] 	(displays.c:1571)
0x4c79b7 : mov dword ptr [ebp - 4], eax
0x4c79ba : cmp dword ptr [gLast_time_credit_headup (DATA)], 0 	(displays.c:1572)
0x4c79c1 : jl 0x1f
0x4c79c7 : mov eax, dword ptr [ebp - 0x10c]


AwardTime is only 98.70% similar to the original, diff above
```

#### Effective match analysis

Yes. The only shown change is the same indexed memory load with a different symbol label (`<OFFSET5>` vs `gCredits_won_headup`). Control flow and data movement in the snippet are otherwise identical, and there is no behavioral change implied by this diff.

#### Original match

```
---
+++
@@ -0x4c791e,41 +0x47565f,41 @@
0x4c791e : push ebp 	(displays.c:1542)
0x4c791f : mov ebp, esp
0x4c7921 : sub esp, 0x10c
0x4c7927 : push ebx
0x4c7928 : push esi
0x4c7929 : push edi
0x4c792a : cmp dword ptr [gRace_finished (DATA)], 0 	(displays.c:1548)
0x4c7931 : -jne 0x1a
         : +jne 0x24
0x4c7937 : cmp dword ptr [gFreeze_timer (DATA)], 0
0x4c793e : -jne 0xd
         : +jne 0x17
0x4c7944 : cmp dword ptr [gNet_mode (DATA)], 0
0x4c794b : -je 0x5
0x4c7951 : -jmp 0x106
         : +jne 0xa
         : +cmp dword ptr [ebp + 8], 0
         : +jne 0x5
         : +jmp 0xfc 	(displays.c:1549)
         : +mov eax, dword ptr [ebp + 8] 	(displays.c:1552)
         : +mov dword ptr [ebp - 4], eax
0x4c7956 : call GetTotalTime (FUNCTION) 	(displays.c:1553)
0x4c795b : mov dword ptr [ebp - 0x10c], eax
0x4c7961 : -cmp dword ptr [ebp + 8], 0
0x4c7965 : -je 0xf1
0x4c796b : mov dword ptr [ebp - 0x108], 9 	(displays.c:1554)
0x4c7975 : jmp 0x6
0x4c797a : dec dword ptr [ebp - 0x108]
0x4c7980 : cmp dword ptr [ebp - 0x108], 0
0x4c7987 : jle 0x1f
0x4c798d : mov eax, dword ptr [ebp - 0x108] 	(displays.c:1555)
0x4c7993 : -mov eax, dword ptr [eax*4 + <OFFSET5>]
         : +mov eax, dword ptr [eax*4 + gCredits_won_headup (DATA)]
0x4c799a : mov ecx, dword ptr [ebp - 0x108]
0x4c79a0 : mov dword ptr [ecx*4 + gOld_times[0] (DATA)], eax
0x4c79a7 : jmp -0x32 	(displays.c:1556)
0x4c79ac : mov eax, dword ptr [ebp + 8] 	(displays.c:1557)
0x4c79af : mov dword ptr [gOld_times[0] (DATA)], eax
0x4c79b4 : -mov eax, dword ptr [ebp + 8]
0x4c79b7 : -mov dword ptr [ebp - 4], eax
0x4c79ba : cmp dword ptr [gLast_time_credit_headup (DATA)], 0 	(displays.c:1558)
0x4c79c1 : jl 0x1f
0x4c79c7 : mov eax, dword ptr [ebp - 0x10c]
0x4c79cd : sub eax, dword ptr [gLast_time_earn_time (DATA)]
0x4c79d3 : cmp eax, 0x7d0
0x4c79d8 : jae 0x8
0x4c79de : mov eax, dword ptr [gLast_time_credit_amount (DATA)] 	(displays.c:1559)
0x4c79e3 : add dword ptr [ebp + 8], eax
0x4c79e6 : mov eax, dword ptr [ebp + 8] 	(displays.c:1561)
0x4c79e9 : mov dword ptr [gLast_time_credit_amount (DATA)], eax


AwardTime is only 88.31% similar to the original, diff above
```

*AI generated. Time taken: 594s, tokens: 38,320*
