### PR TITLE
GetPedPosition equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -2560,25 +2560,20 @@ int GetPedPosition(int pIndex, br_vector3* pPos) {
 
     pedestrian = &gPedestrian_array[pIndex];
     if (pedestrian->ref_number < 100) {
-
-        // Item is a human
-        if (pedestrian->hit_points == -100
-            || pedestrian->current_action == pedestrian->fatal_car_impact_action
-            || pedestrian->current_action == pedestrian->fatal_ground_impact_action
-            || pedestrian->current_action == pedestrian->giblets_action) {
-            return 0;
-        } else {
+        if (pedestrian->hit_points != -100
+            && pedestrian->current_action != pedestrian->fatal_car_impact_action
+            && pedestrian->current_action != pedestrian->fatal_ground_impact_action
+            && pedestrian->current_action != pedestrian->giblets_action) {
             BrVector3Copy(pPos, &pedestrian->pos);
             return 1;
         }
+        return 0;
     } else {
-        // Item is a power-up/mine
-        if (pedestrian->hit_points == -100) {
-            return 0;
-        } else {
+        if (pedestrian->hit_points != -100) {
             BrVector3Copy(pPos, &pedestrian->pos);
             return -1;
         }
+        return 0;
     }
 }
 

--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -2566,14 +2566,16 @@ int GetPedPosition(int pIndex, br_vector3* pPos) {
             && pedestrian->current_action != pedestrian->giblets_action) {
             BrVector3Copy(pPos, &pedestrian->pos);
             return 1;
+        } else {
+            return 0;
         }
-        return 0;
     } else {
         if (pedestrian->hit_points != -100) {
             BrVector3Copy(pPos, &pedestrian->pos);
             return -1;
+        } else {
+            return 0;
         }
-        return 0;
     }
 }
 


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x45ca2a,23 +0x49ddcf,23 @@
0x45ca2a : mov dword ptr [ebp - 4], eax
0x45ca2d : mov eax, dword ptr [ebp - 4] 	(pedestrn.c:2611)
0x45ca30 : xor ecx, ecx
0x45ca32 : mov cl, byte ptr [eax + 0x58]
0x45ca35 : cmp ecx, 0x64
0x45ca38 : jge 0x96
0x45ca3e : mov eax, dword ptr [ebp - 4] 	(pedestrn.c:2615)
0x45ca41 : cmp dword ptr [eax + 0x1c], -0x64
0x45ca45 : je 0x7d
0x45ca4b : mov eax, dword ptr [ebp - 4]
0x45ca4e : -movsx eax, byte ptr [eax + 0x6b]
         : +movsx eax, byte ptr [eax + 0x64]
0x45ca52 : mov ecx, dword ptr [ebp - 4]
0x45ca55 : -movsx ecx, byte ptr [ecx + 0x64]
         : +movsx ecx, byte ptr [ecx + 0x6b]
0x45ca59 : cmp eax, ecx
0x45ca5b : je 0x67
0x45ca61 : mov eax, dword ptr [ebp - 4]
0x45ca64 : movsx eax, byte ptr [eax + 0x6b]
0x45ca68 : mov ecx, dword ptr [ebp - 4]
0x45ca6b : movsx ecx, byte ptr [ecx + 0x67]
0x45ca6f : cmp eax, ecx
0x45ca71 : je 0x51
0x45ca77 : mov eax, dword ptr [ebp - 4]
0x45ca7a : movsx eax, byte ptr [eax + 0x69]


GetPedPosition is only 97.59% similar to the original, diff above
```

#### Effective match analysis

The only semantic change shown is swapping which field is loaded into `eax` vs `ecx` before `cmp eax, ecx` (`[+0x6b]` and `[+0x64]` are exchanged). Since this comparison is immediately used for equality (`je`) and equality is symmetric, the branch outcome is unchanged. No control-flow restructuring is shown, and the subsequent logic remains the same.

#### Original match

```
---
+++
@@ -0x45ca21,72 +0x49d789,72 @@
0x45ca21 : shl eax, 2
0x45ca24 : add eax, dword ptr [gPedestrian_array (DATA)]
0x45ca2a : mov dword ptr [ebp - 4], eax
0x45ca2d : mov eax, dword ptr [ebp - 4] 	(pedestrn.c:2562)
0x45ca30 : xor ecx, ecx
0x45ca32 : mov cl, byte ptr [eax + 0x58]
0x45ca35 : cmp ecx, 0x64
0x45ca38 : jge 0x96
0x45ca3e : mov eax, dword ptr [ebp - 4] 	(pedestrn.c:2568)
0x45ca41 : cmp dword ptr [eax + 0x1c], -0x64
0x45ca45 : -je 0x7d
         : +je 0x42
0x45ca4b : mov eax, dword ptr [ebp - 4]
0x45ca4e : movsx eax, byte ptr [eax + 0x6b]
0x45ca52 : mov ecx, dword ptr [ebp - 4]
0x45ca55 : movsx ecx, byte ptr [ecx + 0x64]
0x45ca59 : cmp eax, ecx
0x45ca5b : -je 0x67
         : +je 0x2c
0x45ca61 : mov eax, dword ptr [ebp - 4]
0x45ca64 : movsx eax, byte ptr [eax + 0x6b]
0x45ca68 : mov ecx, dword ptr [ebp - 4]
0x45ca6b : movsx ecx, byte ptr [ecx + 0x67]
0x45ca6f : cmp eax, ecx
0x45ca71 : -je 0x51
         : +je 0x16
0x45ca77 : mov eax, dword ptr [ebp - 4]
0x45ca7a : movsx eax, byte ptr [eax + 0x69]
0x45ca7e : mov ecx, dword ptr [ebp - 4]
0x45ca81 : movsx ecx, byte ptr [ecx + 0x6b]
0x45ca85 : cmp eax, ecx
0x45ca87 : -je 0x3b
         : +jne 0xc
         : +xor eax, eax 	(pedestrn.c:2569)
         : +jmp 0x8f
         : +jmp 0x36 	(pedestrn.c:2570)
0x45ca8d : mov eax, dword ptr [ebp - 4] 	(pedestrn.c:2571)
0x45ca90 : mov ecx, dword ptr [ebp + 0xc]
0x45ca93 : mov eax, dword ptr [eax + 0x94]
0x45ca99 : mov dword ptr [ecx], eax
0x45ca9b : mov eax, dword ptr [ebp - 4]
0x45ca9e : mov ecx, dword ptr [ebp + 0xc]
0x45caa1 : mov eax, dword ptr [eax + 0x98]
0x45caa7 : mov dword ptr [ecx + 4], eax
0x45caaa : mov eax, dword ptr [ebp - 4]
0x45caad : mov ecx, dword ptr [ebp + 0xc]
0x45cab0 : mov eax, dword ptr [eax + 0x9c]
0x45cab6 : mov dword ptr [ecx + 8], eax
0x45cab9 : mov eax, 1 	(pedestrn.c:2572)
0x45cabe : -jmp 0x60
0x45cac3 : -jmp 0x7
0x45cac8 : -xor eax, eax
0x45caca : jmp 0x54
0x45cacf : jmp 0x4f 	(pedestrn.c:2574)
0x45cad4 : mov eax, dword ptr [ebp - 4] 	(pedestrn.c:2576)
0x45cad7 : cmp dword ptr [eax + 0x1c], -0x64
0x45cadb : -je 0x3b
         : +jne 0xc
         : +xor eax, eax 	(pedestrn.c:2577)
         : +jmp 0x3b
         : +jmp 0x36 	(pedestrn.c:2578)
0x45cae1 : mov eax, dword ptr [ebp - 4] 	(pedestrn.c:2579)
0x45cae4 : mov ecx, dword ptr [ebp + 0xc]
0x45cae7 : mov eax, dword ptr [eax + 0x94]
0x45caed : mov dword ptr [ecx], eax
0x45caef : mov eax, dword ptr [ebp - 4]
0x45caf2 : mov ecx, dword ptr [ebp + 0xc]
0x45caf5 : mov eax, dword ptr [eax + 0x98]
0x45cafb : mov dword ptr [ecx + 4], eax
0x45cafe : mov eax, dword ptr [ebp - 4]
0x45cb01 : mov ecx, dword ptr [ebp + 0xc]
0x45cb04 : mov eax, dword ptr [eax + 0x9c]
0x45cb0a : mov dword ptr [ecx + 8], eax
0x45cb0d : mov eax, 0xffffffff 	(pedestrn.c:2580)
0x45cb12 : -jmp 0xc
0x45cb17 : -jmp 0x7
0x45cb1c : -xor eax, eax
0x45cb1e : jmp 0x0
0x45cb23 : pop edi 	(pedestrn.c:2583)
0x45cb24 : pop esi
0x45cb25 : pop ebx
0x45cb26 : leave 
0x45cb27 : ret 


GetPedPosition is only 86.75% similar to the original, diff above
```

*AI generated. Time taken: 195s*
