### PR TITLE
DRStdlibFree 100% match

### DIFF
--- a/src/library_msvc.h
+++ b/src/library_msvc.h
@@ -244,4 +244,4 @@
 // _filbuf
 
 // LIBRARY: CARM95 0x004ED550
-// _free
+// free

--- a/src/library_msvc.h
+++ b/src/library_msvc.h
@@ -242,3 +242,6 @@
 
 // LIBRARY: CARM95 0x004EC160
 // _filbuf
+
+// LIBRARY: CARM95 0x004ED550
+// _free


### PR DESCRIPTION
## Match result

```
0x463ea1: DRStdlibFree 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x463ea1,15 +0x475e24,15 @@
0x463ea1 : push ebp 	(drmem.c:322)
0x463ea2 : mov ebp, esp
0x463ea4 : sub esp, 4
0x463ea7 : push ebx
0x463ea8 : push esi
0x463ea9 : push edi
0x463eaa : mov eax, dword ptr [ebp + 8] 	(drmem.c:324)
0x463ead : push eax
0x463eae : -call <OFFSET1>
         : +call free (FUNCTION)
0x463eb3 : add esp, 4
0x463eb6 : pop edi 	(drmem.c:325)
0x463eb7 : pop esi
0x463eb8 : pop ebx
0x463eb9 : leave 
0x463eba : ret 


DRStdlibFree is only 93.33% similar to the original, diff above
```

*AI generated. Time taken: 536s, tokens: 111,673*
