### PR TITLE
KeyIsDown 100% match

### DIFF
--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -334,17 +334,16 @@ int KeyIsDown(int pKey_index) {
     int i;
 
     CheckKeysForMouldiness();
-    switch (pKey_index) {
-    case -2:
+    if (pKey_index == -2) {
         return 1;
-    case -1:
+    } else if (pKey_index == -1) {
         for (i = 0; i < BR_ASIZE(gGo_ahead_keys); i++) {
             if (gKey_array[gGo_ahead_keys[i]]) {
                 return 1;
             }
         }
         return 0;
-    default:
+    } else {
         return gKey_array[gKey_mapping[pKey_index]];
     }
 }


### PR DESCRIPTION
## Match result

```
0x472293: KeyIsDown 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x472293,38 +0x487138,41 @@
0x472293 : push ebp 	(input.c:333)
0x472294 : mov ebp, esp
0x472296 : -sub esp, 4
         : +sub esp, 8
0x472299 : push ebx
0x47229a : push esi
0x47229b : push edi
0x47229c : call CheckKeysForMouldiness (FUNCTION) 	(input.c:336)
0x4722a1 : -cmp dword ptr [ebp + 8], -2
0x4722a5 : -jne 0xf
         : +mov eax, dword ptr [ebp + 8] 	(input.c:337)
         : +mov dword ptr [ebp - 8], eax
         : +jmp 0x6c
0x4722ab : mov eax, 1 	(input.c:339)
0x4722b0 : -jmp 0x71
0x4722b5 : -jmp 0x6c
0x4722ba : -cmp dword ptr [ebp + 8], -1
0x4722be : -jne 0x4c
         : +jmp 0x7b
0x4722c4 : mov dword ptr [ebp - 4], 0 	(input.c:341)
0x4722cb : jmp 0x3
0x4722d0 : inc dword ptr [ebp - 4]
0x4722d3 : cmp dword ptr [ebp - 4], 3
0x4722d7 : jae 0x27
0x4722dd : mov eax, dword ptr [ebp - 4] 	(input.c:342)
0x4722e0 : mov eax, dword ptr [eax*4 + gGo_ahead_keys[0] (DATA)]
0x4722e7 : cmp dword ptr [eax*4 + gKey_array[0] (DATA)], 0
0x4722ef : je 0xa
0x4722f5 : mov eax, 1 	(input.c:343)
0x4722fa : -jmp 0x27
         : +jmp 0x40
0x4722ff : jmp -0x34 	(input.c:345)
0x472304 : xor eax, eax 	(input.c:346)
0x472306 : -jmp 0x1b
0x47230b : -jmp 0x16
         : +jmp 0x34
0x472310 : mov eax, dword ptr [ebp + 8] 	(input.c:348)
0x472313 : mov eax, dword ptr [eax*4 + gKey_mapping[0] (DATA)]
0x47231a : mov eax, dword ptr [eax*4 + gKey_array[0] (DATA)]
0x472321 : -jmp 0x0
         : +jmp 0x1e
         : +jmp 0x19 	(input.c:349)
         : +cmp dword ptr [ebp - 8], -2
         : +je -0x76
         : +cmp dword ptr [ebp - 8], -1
         : +je -0x76
         : +jmp -0x34
0x472326 : pop edi 	(input.c:350)
0x472327 : pop esi
0x472328 : pop ebx
0x472329 : leave 
0x47232a : ret 


KeyIsDown is only 68.35% similar to the original, diff above
```

*AI generated. Time taken: 202s, tokens: 18,822*
