### PR TITLE
ShowPedPaths 100% match

### DIFF
--- a/src/DETHRACE/common/pedestrn.c
+++ b/src/DETHRACE/common/pedestrn.c
@@ -3679,10 +3679,10 @@ void ShowPedPaths(void) {
                 gPedestrian_array[i].first_instruction);
         }
     }
-    if (gPath_actor->render_style == BR_RSTYLE_FACES) {
-        gPath_actor->render_style = BR_RSTYLE_NONE;
-    } else {
+    if (gPath_actor->render_style != BR_RSTYLE_FACES) {
         gPath_actor->render_style = BR_RSTYLE_FACES;
+    } else {
+        gPath_actor->render_style = BR_RSTYLE_NONE;
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x45fcf5: ShowPedPaths 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x45fd21,51 +0x4a0609,51 @@
0x45fd21 : push eax
0x45fd22 : mov eax, dword ptr [gNon_track_actor (DATA)]
0x45fd27 : push eax
0x45fd28 : call BrActorAdd (FUNCTION)
0x45fd2d : add esp, 8
0x45fd30 : push 0 	(pedestrn.c:3658)
0x45fd32 : call BrMaterialAllocate (FUNCTION)
0x45fd37 : add esp, 4
0x45fd3a : mov dword ptr [gPath_mat_normal (DATA)], eax
0x45fd3f : mov eax, dword ptr [gPath_mat_normal (DATA)] 	(pedestrn.c:3659)
0x45fd44 : -mov byte ptr [eax + 0x3c], 3
         : +mov byte ptr [eax + 0x3e], 3
0x45fd48 : mov eax, dword ptr [gPath_mat_normal (DATA)] 	(pedestrn.c:3660)
0x45fd4d : -mov byte ptr [eax + 0x3d], 4
         : +mov byte ptr [eax + 0x3f], 4
0x45fd51 : mov eax, dword ptr [gPath_mat_normal (DATA)] 	(pedestrn.c:3661)
0x45fd56 : or dword ptr [eax + 0x20], 0x1000
0x45fd5d : mov eax, dword ptr [gPath_mat_normal (DATA)] 	(pedestrn.c:3662)
0x45fd62 : push eax
0x45fd63 : call BrMaterialAdd (FUNCTION)
0x45fd68 : add esp, 4
0x45fd6b : push 0 	(pedestrn.c:3664)
0x45fd6d : call BrMaterialAllocate (FUNCTION)
0x45fd72 : add esp, 4
0x45fd75 : mov dword ptr [gPath_mat_calc (DATA)], eax
0x45fd7a : mov eax, dword ptr [gPath_mat_calc (DATA)] 	(pedestrn.c:3665)
0x45fd7f : -mov byte ptr [eax + 0x3c], 0x5d
         : +mov byte ptr [eax + 0x3e], 0x5d
0x45fd83 : mov eax, dword ptr [gPath_mat_calc (DATA)] 	(pedestrn.c:3666)
0x45fd88 : -mov byte ptr [eax + 0x3d], 4
         : +mov byte ptr [eax + 0x3f], 4
0x45fd8c : mov eax, dword ptr [gPath_mat_calc (DATA)] 	(pedestrn.c:3667)
0x45fd91 : or dword ptr [eax + 0x20], 0x1000
0x45fd98 : mov eax, dword ptr [gPath_mat_calc (DATA)] 	(pedestrn.c:3668)
0x45fd9d : push eax
0x45fd9e : call BrMaterialAdd (FUNCTION)
0x45fda3 : add esp, 4
0x45fda6 : push 0 	(pedestrn.c:3670)
0x45fda8 : call BrMaterialAllocate (FUNCTION)
0x45fdad : add esp, 4
0x45fdb0 : mov dword ptr [gInit_pos_mat_calc (DATA)], eax
0x45fdb5 : mov eax, dword ptr [gInit_pos_mat_calc (DATA)] 	(pedestrn.c:3671)
0x45fdba : -mov byte ptr [eax + 0x3c], 0x33
         : +mov byte ptr [eax + 0x3e], 0x33
0x45fdbe : mov eax, dword ptr [gInit_pos_mat_calc (DATA)] 	(pedestrn.c:3672)
0x45fdc3 : -mov byte ptr [eax + 0x3d], 4
         : +mov byte ptr [eax + 0x3f], 4
0x45fdc7 : mov eax, dword ptr [gInit_pos_mat_calc (DATA)] 	(pedestrn.c:3673)
0x45fdcc : or dword ptr [eax + 0x20], 0x1000
0x45fdd3 : mov eax, dword ptr [gInit_pos_mat_calc (DATA)] 	(pedestrn.c:3674)
0x45fdd8 : push eax
0x45fdd9 : call BrMaterialAdd (FUNCTION)
0x45fdde : add esp, 4
0x45fde1 : mov dword ptr [ebp - 8], 0 	(pedestrn.c:3676)
0x45fde8 : jmp 0x3
0x45fded : inc dword ptr [ebp - 8]
0x45fdf0 : mov eax, dword ptr [gPed_count (DATA)]

---
+++
@@ -0x45fe3d,21 +0x4a0725,21 @@
0x45fe3d : mov ecx, dword ptr [gPedestrian_array (DATA)]
0x45fe43 : mov eax, dword ptr [ecx + eax*4 + 0x50]
0x45fe47 : push eax
0x45fe48 : call BuildPedPaths (FUNCTION)
0x45fe4d : add esp, 0xc
0x45fe50 : jmp -0x68 	(pedestrn.c:3680)
0x45fe55 : mov eax, dword ptr [gPath_actor (DATA)] 	(pedestrn.c:3682)
0x45fe5a : xor ecx, ecx
0x45fe5c : mov cl, byte ptr [eax + 0x20]
0x45fe5f : cmp ecx, 4
0x45fe62 : -je 0xe
         : +jne 0xe
         : +mov eax, dword ptr [gPath_actor (DATA)] 	(pedestrn.c:3683)
         : +mov byte ptr [eax + 0x20], 1
         : +jmp 0x9 	(pedestrn.c:3684)
0x45fe68 : mov eax, dword ptr [gPath_actor (DATA)] 	(pedestrn.c:3685)
0x45fe6d : mov byte ptr [eax + 0x20], 4
0x45fe71 : -jmp 0x9
0x45fe76 : -mov eax, dword ptr [gPath_actor (DATA)]
0x45fe7b : -mov byte ptr [eax + 0x20], 1
0x45fe7f : pop edi 	(pedestrn.c:3687)
0x45fe80 : pop esi
0x45fe81 : pop ebx
0x45fe82 : leave 
0x45fe83 : ret 


ShowPedPaths is only 90.83% similar to the original, diff above
```

*AI generated. Time taken: 301s, tokens: 18,211*
