### PR TITLE
RenderSparks equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -495,12 +495,12 @@ void RenderSparks(br_pixelmap* pRender_screen, br_pixelmap* pDepth_buffer, br_ac
             gSparks[i].count = 0;
             CLEAR_BIT(gSpark_flags, i);
         }
-        ts = BrVector3Dot(&gSparks[i].normal, &gSparks[i].v);
+        ts = gSparks[i].normal.v[2] * gSparks[i].v.v[2] + gSparks[i].normal.v[1] * gSparks[i].v.v[1] + gSparks[i].normal.v[0] * gSparks[i].v.v[0];
         BrVector3Scale(&tv, &gSparks[i].normal, ts);
         BrVector3Sub(&gSparks[i].v, &gSparks[i].v, &tv);
         if (gSparks[i].time_sync) {
             BrVector3Scale(&pos, &gSparks[i].v, gSparks[i].time_sync / 1000.0f);
-            gSparks[i].count = gSparks[i].time_sync + gSparks[i].count + -pTime;
+            gSparks[i].count = gSparks[i].count + gSparks[i].time_sync + -pTime;
             gSparks[i].time_sync = 0;
         } else {
             BrVector3Scale(&pos, &gSparks[i].v, pTime / 1000.0f);
@@ -537,7 +537,7 @@ void RenderSparks(br_pixelmap* pRender_screen, br_pixelmap* pDepth_buffer, br_ac
         BrMatrix34TApplyV(&o, &tv, &gCamera_to_world);
         BrVector3SetFloat(&tv, FRandomBetween(-0.1f, 0.1f), FRandomBetween(-0.1f, 0.1f), FRandomBetween(-0.1f, 0.1f));
         BrVector3Accumulate(&gSparks[i].v, &tv);
-        ts = 1.0f - BrVector3Length(&gSparks[i].v) / 1.4f * pTime / 1000.0f;
+        ts = 1.0f - (br_scalar)sqrt(BrVector3LengthSquared(&gSparks[i].v)) / 1.4f * pTime / 1000.0f;
         if (ts < 0.1f) {
             ts = 0.1f;
         }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x466a81,30 +0x4ad4e5,30 @@
0x466a81 : fstp dword ptr [eax + gSparks[0].v+4 (OFFSET)]
0x466a87 : mov eax, dword ptr [ebp - 0x20]
0x466a8a : shl eax, 6
0x466a8d : fld dword ptr [eax + gSparks[0].v+8 (OFFSET)]
0x466a93 : fadd dword ptr [ebp - 0x28]
0x466a96 : mov eax, dword ptr [ebp - 0x20]
0x466a99 : shl eax, 6
0x466a9c : fstp dword ptr [eax + gSparks[0].v+8 (OFFSET)]
0x466aa2 : mov eax, dword ptr [ebp - 0x20] 	(spark.c:551)
0x466aa5 : shl eax, 6
         : +fld dword ptr [eax + gSparks[0].v+4 (OFFSET)]
         : +mov eax, dword ptr [ebp - 0x20]
         : +shl eax, 6
         : +fmul dword ptr [eax + gSparks[0].v+4 (OFFSET)]
         : +mov eax, dword ptr [ebp - 0x20]
         : +shl eax, 6
0x466aa8 : fld dword ptr [eax + gSparks[0].v+8 (OFFSET)]
0x466aae : mov eax, dword ptr [ebp - 0x20]
0x466ab1 : shl eax, 6
0x466ab4 : fmul dword ptr [eax + gSparks[0].v+8 (OFFSET)]
0x466aba : -mov eax, dword ptr [ebp - 0x20]
0x466abd : -shl eax, 6
0x466ac0 : -fld dword ptr [eax + gSparks[0].v+4 (OFFSET)]
0x466ac6 : -mov eax, dword ptr [ebp - 0x20]
0x466ac9 : -shl eax, 6
0x466acc : -fmul dword ptr [eax + gSparks[0].v+4 (OFFSET)]
0x466ad2 : faddp st(1)
0x466ad4 : mov eax, dword ptr [ebp - 0x20]
0x466ad7 : shl eax, 6
0x466ada : fld dword ptr [eax + gSparks[0].v (OFFSET)]
0x466ae0 : mov eax, dword ptr [ebp - 0x20]
0x466ae3 : shl eax, 6
0x466ae6 : fmul dword ptr [eax + gSparks[0].v (OFFSET)]
0x466aec : faddp st(1)
0x466aee : call __CIsqrt (FUNCTION)
0x466af3 : fdiv dword ptr [1.399999976158142 (FLOAT)]


RenderSparks is only 98.95% similar to the original, diff above
```

#### Effective match analysis

The diff only reorders independent floating-point operations in the same basic block: it now computes `v4*v4` before `v8*v8` instead of after. Both products are still summed with `faddp`, then `v*v` is added, then `sqrt`, then division by 1.4. No branches, memory writes, or operand identities changed, so functional behavior is the same aside from insignificant floating-point ordering effects (which you said to ignore).

#### Original match

```
---
+++
@@ -0x46641c,30 +0x4ac86d,30 @@
0x46641c : mov eax, dword ptr [ebp - 0x20] 	(spark.c:495)
0x46641f : shl eax, 6
0x466422 : mov dword ptr [eax + gSparks[0].count (DATA)], 0
0x46642c : mov eax, 1 	(spark.c:496)
0x466431 : mov cl, byte ptr [ebp - 0x20]
0x466434 : shl eax, cl
0x466436 : not eax
0x466438 : and dword ptr [gSpark_flags (DATA)], eax
0x46643e : mov eax, dword ptr [ebp - 0x20] 	(spark.c:498)
0x466441 : shl eax, 6
         : +fld dword ptr [eax + gSparks[0].normal+8 (OFFSET)]
         : +mov eax, dword ptr [ebp - 0x20]
         : +shl eax, 6
         : +fmul dword ptr [eax + gSparks[0].v+8 (OFFSET)]
         : +mov eax, dword ptr [ebp - 0x20]
         : +shl eax, 6
0x466444 : fld dword ptr [eax + gSparks[0].normal+4 (OFFSET)]
0x46644a : mov eax, dword ptr [ebp - 0x20]
0x46644d : shl eax, 6
0x466450 : fmul dword ptr [eax + gSparks[0].v+4 (OFFSET)]
0x466456 : -mov eax, dword ptr [ebp - 0x20]
0x466459 : -shl eax, 6
0x46645c : -fld dword ptr [eax + gSparks[0].normal+8 (OFFSET)]
0x466462 : -mov eax, dword ptr [ebp - 0x20]
0x466465 : -shl eax, 6
0x466468 : -fmul dword ptr [eax + gSparks[0].v+8 (OFFSET)]
0x46646e : faddp st(1)
0x466470 : mov eax, dword ptr [ebp - 0x20]
0x466473 : shl eax, 6
0x466476 : fld dword ptr [eax + gSparks[0].normal (OFFSET)]
0x46647c : mov eax, dword ptr [ebp - 0x20]
0x46647f : shl eax, 6
0x466482 : fmul dword ptr [eax + gSparks[0].v (OFFSET)]
0x466488 : faddp st(1)
0x46648a : fstp dword ptr [ebp - 0x24]
0x46648d : mov eax, dword ptr [ebp - 0x20] 	(spark.c:499)

---
+++
@@ -0x46658f,24 +0x4ac9e0,24 @@
0x46658f : mov dword ptr [ebp - 0x64], eax
0x466592 : mov dword ptr [ebp - 0x60], 0
0x466599 : fild qword ptr [ebp - 0x64]
0x46659c : fdiv dword ptr [1000.0 (FLOAT)]
0x4665a2 : mov eax, dword ptr [ebp - 0x20]
0x4665a5 : shl eax, 6
0x4665a8 : fmul dword ptr [eax + gSparks[0].v+8 (OFFSET)]
0x4665ae : fstp dword ptr [ebp - 0x34]
0x4665b1 : mov eax, dword ptr [ebp - 0x20] 	(spark.c:503)
0x4665b4 : shl eax, 6
0x4665b7 : -mov eax, dword ptr [eax + gSparks[0].count (DATA)]
         : +mov eax, dword ptr [eax + gSparks[0].time_sync (OFFSET)]
0x4665bd : mov ecx, dword ptr [ebp - 0x20]
0x4665c0 : shl ecx, 6
0x4665c3 : -add eax, dword ptr [ecx + gSparks[0].time_sync (OFFSET)]
         : +add eax, dword ptr [ecx + gSparks[0].count (DATA)]
0x4665c9 : mov ecx, dword ptr [ebp + 0x18]
0x4665cc : neg ecx
0x4665ce : add eax, ecx
0x4665d0 : mov ecx, dword ptr [ebp - 0x20]
0x4665d3 : shl ecx, 6
0x4665d6 : mov dword ptr [ecx + gSparks[0].count (DATA)], eax
0x4665dc : mov eax, dword ptr [ebp - 0x20] 	(spark.c:504)
0x4665df : shl eax, 6
0x4665e2 : mov dword ptr [eax + gSparks[0].time_sync (OFFSET)], 0
0x4665ec : jmp 0x8a 	(spark.c:505)

---
+++
@@ -0x466a81,30 +0x4aced2,30 @@
0x466a81 : fstp dword ptr [eax + gSparks[0].v+4 (OFFSET)]
0x466a87 : mov eax, dword ptr [ebp - 0x20]
0x466a8a : shl eax, 6
0x466a8d : fld dword ptr [eax + gSparks[0].v+8 (OFFSET)]
0x466a93 : fadd dword ptr [ebp - 0x28]
0x466a96 : mov eax, dword ptr [ebp - 0x20]
0x466a99 : shl eax, 6
0x466a9c : fstp dword ptr [eax + gSparks[0].v+8 (OFFSET)]
0x466aa2 : mov eax, dword ptr [ebp - 0x20] 	(spark.c:540)
0x466aa5 : shl eax, 6
         : +fld dword ptr [eax + gSparks[0].v+4 (OFFSET)]
         : +mov eax, dword ptr [ebp - 0x20]
         : +shl eax, 6
         : +fmul dword ptr [eax + gSparks[0].v+4 (OFFSET)]
         : +mov eax, dword ptr [ebp - 0x20]
         : +shl eax, 6
0x466aa8 : fld dword ptr [eax + gSparks[0].v+8 (OFFSET)]
0x466aae : mov eax, dword ptr [ebp - 0x20]
0x466ab1 : shl eax, 6
0x466ab4 : fmul dword ptr [eax + gSparks[0].v+8 (OFFSET)]
0x466aba : -mov eax, dword ptr [ebp - 0x20]
0x466abd : -shl eax, 6
0x466ac0 : -fld dword ptr [eax + gSparks[0].v+4 (OFFSET)]
0x466ac6 : -mov eax, dword ptr [ebp - 0x20]
0x466ac9 : -shl eax, 6
0x466acc : -fmul dword ptr [eax + gSparks[0].v+4 (OFFSET)]
0x466ad2 : faddp st(1)
0x466ad4 : mov eax, dword ptr [ebp - 0x20]
0x466ad7 : shl eax, 6
0x466ada : fld dword ptr [eax + gSparks[0].v (OFFSET)]
0x466ae0 : mov eax, dword ptr [ebp - 0x20]
0x466ae3 : shl eax, 6
0x466ae6 : fmul dword ptr [eax + gSparks[0].v (OFFSET)]
0x466aec : faddp st(1)
0x466aee : call __CIsqrt (FUNCTION)
0x466af3 : fdiv dword ptr [1.399999976158142 (FLOAT)]


RenderSparks is only 97.55% similar to the original, diff above
```

*AI generated. Time taken: 637s, tokens: 96,211*
