### PR TITLE
RenderSmoke equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -138,10 +138,10 @@ tShrapnel gShrapnel[15];
 // Bugfix: At higher FPS, `CreatePuffOfSmoke` is called too often and causes smoke cirlces to be recycled too quickly so assume around 25fps
 #define SMOKE_COLUMN_NEW_PUFF_INTERVAL 30
 
-#define TEST_BIT(var, pos)   (var & (1 << pos))
-#define SET_BIT(var, pos)    (var |= (1 << pos))
-#define FLIP_BIT(var, pos)   (var ^= (1 << pos))
-#define CLEAR_BIT(var, pos)  (var &= ~(1 << pos))
+#define TEST_BIT(var, pos) (var & (1 << pos))
+#define SET_BIT(var, pos) (var |= (1 << pos))
+#define FLIP_BIT(var, pos) (var ^= (1 << pos))
+#define CLEAR_BIT(var, pos) (var &= ~(1 << pos))
 
 // IDA: void __cdecl DrawDot(br_scalar z, tU8 *scr_ptr, tU16 *depth_ptr, tU8 *shade_ptr)
 // FUNCTION: CARM95 0x00466310
@@ -1474,7 +1474,7 @@ void RenderSmoke(br_pixelmap* pRender_screen, br_pixelmap* pDepth_buffer, br_act
                 }
                 BrVector3Sub(&tv, &gSmoke[i].pos, &gSmoke[i].pos);
                 ts = BrVector3LengthSquared(&tv);
-                if ((gSmoke[i].radius + gSmoke[j].radius) * (gSmoke[i].radius + gSmoke[j].radius) > ts) {
+                if (BR_SQR(gSmoke[i].radius + gSmoke[j].radius) > ts) {
                     SET_BIT(not_lonely, i);
                     SET_BIT(not_lonely, j);
                     break;

--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -145,23 +145,17 @@ br_matrix34 gSmoke_camera_to_world;
 // Bugfix: At higher FPS, `CreatePuffOfSmoke` is called too often and causes smoke cirlces to be recycled too quickly so assume around 25fps
 #define SMOKE_COLUMN_NEW_PUFF_INTERVAL 30
 
-<<<<<<< HEAD
-=======
 #ifdef DETHRACE_FIX_BUGS
 #define TEST_BIT(var, pos) (var & (1u << pos))
 #define SET_BIT(var, pos) (var |= (1u << pos))
 #define FLIP_BIT(var, pos) (var ^= (1u << pos))
 #define CLEAR_BIT(var, pos) (var &= ~(1u << pos))
 #else
->>>>>>> main
 #define TEST_BIT(var, pos) (var & (1 << pos))
 #define SET_BIT(var, pos) (var |= (1 << pos))
 #define FLIP_BIT(var, pos) (var ^= (1 << pos))
 #define CLEAR_BIT(var, pos) (var &= ~(1 << pos))
-<<<<<<< HEAD
-=======
 #endif
->>>>>>> main
 
 // IDA: void __cdecl DrawDot(br_scalar z, tU8 *scr_ptr, tU16 *depth_ptr, tU8 *shade_ptr)
 // FUNCTION: CARM95 0x00466310
@@ -1528,7 +1522,7 @@ void RenderSmoke(br_pixelmap* pRender_screen, br_pixelmap* pDepth_buffer, br_act
                 }
                 BrVector3Sub(&tv, &gSmoke[i].pos, &gSmoke[i].pos);
                 ts = BrVector3LengthSquared(&tv);
-                if (BR_SQR(gSmoke[i].radius + gSmoke[j].radius) > ts) {
+                if (ts < BR_SQR(gSmoke[i].radius + gSmoke[j].radius)) {
                     SET_BIT(not_lonely, i);
                     SET_BIT(not_lonely, j);
                     break;
@@ -1547,7 +1541,7 @@ void RenderSmoke(br_pixelmap* pRender_screen, br_pixelmap* pDepth_buffer, br_act
         if (gSmoke[i].pipe_me) {
             AddSmokeToPipingSession(i, gSmoke[i].type, &gSmoke[i].pos, gSmoke[i].radius, gSmoke[i].strength);
         }
-        gSmoke[i].radius = pTime / 1000.0f * gSmoke[i].strength * 0.5 + gSmoke[i].radius;
+        gSmoke[i].radius = pTime / 1000.0f * gSmoke[i].strength * 0.5000000000000001 + gSmoke[i].radius;
         gSmoke[i].strength = gSmoke[i].strength - pTime * gSmoke[i].decay_factor / 1000.0f;
         if (gSmoke[i].radius > 0.3f) {
             gSmoke[i].radius = 0.3f;


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x46901b,39 +0x4b0c7d,39 @@
0x46901b : fstp dword ptr [ebp - 0x1c]
0x46901e : fld dword ptr [ebp - 0x1c] 	(spark.c:1524)
0x469021 : fmul dword ptr [ebp - 0x1c]
0x469024 : fld dword ptr [ebp - 0x20]
0x469027 : fmul dword ptr [ebp - 0x20]
0x46902a : faddp st(1)
0x46902c : fld dword ptr [ebp - 0x24]
0x46902f : fmul dword ptr [ebp - 0x24]
0x469032 : faddp st(1)
0x469034 : fstp dword ptr [ebp - 0x14]
         : +mov eax, dword ptr [ebp - 0x18] 	(spark.c:1525)
         : +mov ecx, eax
         : +lea eax, [eax + eax*4]
         : +lea eax, [eax + eax*8]
         : +sub eax, ecx
         : +fld dword ptr [eax + gSmoke[0].radius (OFFSET)]
0x469037 : mov eax, dword ptr [ebp - 0xc]
0x46903a : mov ecx, eax
0x46903c : lea eax, [eax + eax*4]
0x46903f : lea eax, [eax + eax*8]
0x469042 : sub eax, ecx
0x469044 : -fld dword ptr [eax + gSmoke[0].radius (OFFSET)]
         : +fadd dword ptr [eax + gSmoke[0].radius (OFFSET)]
0x46904a : mov eax, dword ptr [ebp - 0x18]
0x46904d : mov ecx, eax
0x46904f : lea eax, [eax + eax*4]
0x469052 : lea eax, [eax + eax*8]
0x469055 : sub eax, ecx
0x469057 : -fadd dword ptr [eax + gSmoke[0].radius (OFFSET)]
         : +fld dword ptr [eax + gSmoke[0].radius (OFFSET)]
0x46905d : mov eax, dword ptr [ebp - 0xc]
0x469060 : -mov ecx, eax
0x469062 : -lea eax, [eax + eax*4]
0x469065 : -lea eax, [eax + eax*8]
0x469068 : -sub eax, ecx
0x46906a : -fld dword ptr [eax + gSmoke[0].radius (OFFSET)]
0x469070 : -mov eax, dword ptr [ebp - 0x18]
0x469073 : mov ecx, eax
0x469075 : lea eax, [eax + eax*4]
0x469078 : lea eax, [eax + eax*8]
0x46907b : sub eax, ecx
0x46907d : fadd dword ptr [eax + gSmoke[0].radius (OFFSET)]
0x469083 : fmulp st(1)
0x469085 : fcomp dword ptr [ebp - 0x14]
0x469088 : fnstsw ax
0x46908a : test ah, 0x41
0x46908d : jne 0x1f


RenderSmoke is only 98.86% similar to the original, diff above
```

#### Effective match analysis

Both versions compute the same value before the branch: they form two sums of the same two smoke radii, multiply those sums, and compare the product against `[ebp-0x14]` via `fcomp`/`fnstsw`/`test ah,0x41`/`jne`. The diff only swaps the order of loading/adding the two radii (from `[ebp-0xc]` and `[ebp-0x18]`) and removes duplicated address-calculation instructions; no control-flow change is introduced. Since addition here is commutative (and you asked to ignore tiny FP-order effects and NaN behavior), the functional result is equivalent.

#### Original match

```
---
+++
@@ -0x468ffd,48 +0x4b0654,48 @@
0x468ffd : lea eax, [eax + eax*8]
0x469000 : sub eax, ecx
0x469002 : fld dword ptr [eax + gSmoke[0].pos+8 (OFFSET)]
0x469008 : mov eax, dword ptr [ebp - 0xc]
0x46900b : mov ecx, eax
0x46900d : lea eax, [eax + eax*4]
0x469010 : lea eax, [eax + eax*8]
0x469013 : sub eax, ecx
0x469015 : fsub dword ptr [eax + gSmoke[0].pos+8 (OFFSET)]
0x46901b : fstp dword ptr [ebp - 0x1c]
         : +fld dword ptr [ebp - 0x20] 	(spark.c:1476)
         : +fmul dword ptr [ebp - 0x20]
0x46901e : fld dword ptr [ebp - 0x1c]
0x469021 : fmul dword ptr [ebp - 0x1c]
0x469024 : -fld dword ptr [ebp - 0x20]
0x469027 : -fmul dword ptr [ebp - 0x20]
0x46902a : faddp st(1)
0x46902c : fld dword ptr [ebp - 0x24]
0x46902f : fmul dword ptr [ebp - 0x24]
0x469032 : faddp st(1)
0x469034 : fstp dword ptr [ebp - 0x14]
         : +mov eax, dword ptr [ebp - 0x18] 	(spark.c:1477)
         : +mov ecx, eax
         : +lea eax, [eax + eax*4]
         : +lea eax, [eax + eax*8]
         : +sub eax, ecx
         : +fld dword ptr [eax + gSmoke[0].radius (OFFSET)]
0x469037 : mov eax, dword ptr [ebp - 0xc]
0x46903a : mov ecx, eax
0x46903c : lea eax, [eax + eax*4]
0x46903f : lea eax, [eax + eax*8]
0x469042 : sub eax, ecx
0x469044 : -fld dword ptr [eax + gSmoke[0].radius (OFFSET)]
         : +fadd dword ptr [eax + gSmoke[0].radius (OFFSET)]
0x46904a : mov eax, dword ptr [ebp - 0x18]
0x46904d : mov ecx, eax
0x46904f : lea eax, [eax + eax*4]
0x469052 : lea eax, [eax + eax*8]
0x469055 : sub eax, ecx
0x469057 : -fadd dword ptr [eax + gSmoke[0].radius (OFFSET)]
         : +fld dword ptr [eax + gSmoke[0].radius (OFFSET)]
0x46905d : mov eax, dword ptr [ebp - 0xc]
0x469060 : -mov ecx, eax
0x469062 : -lea eax, [eax + eax*4]
0x469065 : -lea eax, [eax + eax*8]
0x469068 : -sub eax, ecx
0x46906a : -fld dword ptr [eax + gSmoke[0].radius (OFFSET)]
0x469070 : -mov eax, dword ptr [ebp - 0x18]
0x469073 : mov ecx, eax
0x469075 : lea eax, [eax + eax*4]
0x469078 : lea eax, [eax + eax*8]
0x46907b : sub eax, ecx
0x46907d : fadd dword ptr [eax + gSmoke[0].radius (OFFSET)]
0x469083 : fmulp st(1)
0x469085 : fcomp dword ptr [ebp - 0x14]
0x469088 : fnstsw ax
0x46908a : test ah, 0x41
0x46908d : jne 0x1f

---
+++
@@ -0x4692ba,21 +0x4b0911,21 @@
0x4692ba : mov dword ptr [ebp - 0x5c], eax
0x4692bd : mov dword ptr [ebp - 0x58], 0
0x4692c4 : fild qword ptr [ebp - 0x5c]
0x4692c7 : fdiv dword ptr [1000.0 (FLOAT)]
0x4692cd : mov eax, dword ptr [ebp - 0xc]
0x4692d0 : mov ecx, eax
0x4692d2 : lea eax, [eax + eax*4]
0x4692d5 : lea eax, [eax + eax*8]
0x4692d8 : sub eax, ecx
0x4692da : fmul dword ptr [eax + gSmoke[0].strength (OFFSET)]
0x4692e0 : -fmul qword ptr [0.5000000000000001 (FLOAT)]
         : +fmul qword ptr [0.5 (FLOAT)]
0x4692e6 : mov eax, dword ptr [ebp - 0xc]
0x4692e9 : mov ecx, eax
0x4692eb : lea eax, [eax + eax*4]
0x4692ee : lea eax, [eax + eax*8]
0x4692f1 : sub eax, ecx
0x4692f3 : fadd dword ptr [eax + gSmoke[0].radius (OFFSET)]
0x4692f9 : mov eax, dword ptr [ebp - 0xc]
0x4692fc : mov ecx, eax
0x4692fe : lea eax, [eax + eax*4]
0x469301 : lea eax, [eax + eax*8]


RenderSmoke is only 98.43% similar to the original, diff above
```

*AI generated. Time taken: 1070s, tokens: 147,398*
