### PR TITLE
ConditionalSmokeColumn 100% match

### DIFF
--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -145,23 +145,17 @@ br_matrix34 gSmoke_camera_to_world;
 // Bugfix: At higher FPS, `CreatePuffOfSmoke` is called too often and causes smoke cirlces to be recycled too quickly so assume around 25fps
 #define SMOKE_COLUMN_NEW_PUFF_INTERVAL 30
 
-<<<<<<< HEAD
-=======
 #ifdef DETHRACE_FIX_BUGS
 #define TEST_BIT(var, pos) (var & (1u << pos))
 #define SET_BIT(var, pos) (var |= (1u << pos))
 #define FLIP_BIT(var, pos) (var ^= (1u << pos))
 #define CLEAR_BIT(var, pos) (var &= ~(1u << pos))
 #else
->>>>>>> main
 #define TEST_BIT(var, pos) (var & (1 << pos))
 #define SET_BIT(var, pos) (var |= (1 << pos))
 #define FLIP_BIT(var, pos) (var ^= (1 << pos))
 #define CLEAR_BIT(var, pos) (var &= ~(1 << pos))
-<<<<<<< HEAD
-=======
 #endif
->>>>>>> main
 
 // IDA: void __cdecl DrawDot(br_scalar z, tU8 *scr_ptr, tU16 *depth_ptr, tU8 *shade_ptr)
 // FUNCTION: CARM95 0x00466310

--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -2466,13 +2466,20 @@ void ConditionalSmokeColumn(tCar_spec* pCar, int pDamage_index, int pColour) {
     int i;
 
     if (!pColour) {
-        pColour = pCar->driver < eDriver_net_human;
+        if (pCar->driver < eDriver_net_human) {
+            pColour = 1;
+        }
     }
-    if (pCar->num_smoke_columns != 0) {
+    if (pCar->num_smoke_columns > 0) {
         for (i = 0; i < MAX_SMOKE_COLUMNS; i++) {
             if (gSmoke_column[i].car == pCar) {
-                if (TEST_BIT(gColumn_flags, i) && gSmoke_column[i].colour <= pColour && gSmoke_column[i].lifetime) {
-                    return;
+                if (TEST_BIT(gColumn_flags, i)) {
+                    if (gSmoke_column[i].colour <= pColour) {
+                        if (gSmoke_column[i].lifetime != 0) {
+                            return;
+                        } else {
+                        }
+                    }
                 }
                 gSmoke_column[i].lifetime = 2000;
             }

--- a/src/DETHRACE/common/spark.c
+++ b/src/DETHRACE/common/spark.c
@@ -138,10 +138,10 @@ tShrapnel gShrapnel[15];
 // Bugfix: At higher FPS, `CreatePuffOfSmoke` is called too often and causes smoke cirlces to be recycled too quickly so assume around 25fps
 #define SMOKE_COLUMN_NEW_PUFF_INTERVAL 30
 
-#define TEST_BIT(var, pos)   (var & (1 << pos))
-#define SET_BIT(var, pos)    (var |= (1 << pos))
-#define FLIP_BIT(var, pos)   (var ^= (1 << pos))
-#define CLEAR_BIT(var, pos)  (var &= ~(1 << pos))
+#define TEST_BIT(var, pos) (var & (1 << pos))
+#define SET_BIT(var, pos) (var |= (1 << pos))
+#define FLIP_BIT(var, pos) (var ^= (1 << pos))
+#define CLEAR_BIT(var, pos) (var &= ~(1 << pos))
 
 // IDA: void __cdecl DrawDot(br_scalar z, tU8 *scr_ptr, tU16 *depth_ptr, tU8 *shade_ptr)
 // FUNCTION: CARM95 0x00466310
@@ -2473,15 +2473,11 @@ void ConditionalSmokeColumn(tCar_spec* pCar, int pDamage_index, int pColour) {
     if (pCar->num_smoke_columns > 0) {
         for (i = 0; i < MAX_SMOKE_COLUMNS; i++) {
             if (gSmoke_column[i].car == pCar) {
-                if (TEST_BIT(gColumn_flags, i)) {
-                    if (gSmoke_column[i].colour <= pColour) {
-                        if (gSmoke_column[i].lifetime != 0) {
-                            return;
-                        } else {
-                        }
-                    }
+                if (TEST_BIT(gColumn_flags, i) && gSmoke_column[i].colour <= pColour && gSmoke_column[i].lifetime != 0) {
+                    return;
+                } else {
+                    gSmoke_column[i].lifetime = 2000;
                 }
-                gSmoke_column[i].lifetime = 2000;
             }
         }
     }


### PR DESCRIPTION
## Match result

```
0x46d19e: ConditionalSmokeColumn 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x46d19e,69 +0x4b3fba,70 @@
0x46d19e : push ebp 	(spark.c:2465)
0x46d19f : mov ebp, esp
0x46d1a1 : sub esp, 4
0x46d1a4 : push ebx
0x46d1a5 : push esi
0x46d1a6 : push edi
0x46d1a7 : cmp dword ptr [ebp + 0x10], 0 	(spark.c:2468)
0x46d1ab : -jne 0x14
         : +jne 0x20
0x46d1b1 : mov eax, dword ptr [ebp + 8] 	(spark.c:2469)
0x46d1b4 : cmp dword ptr [eax + 8], 3
0x46d1b8 : -jge 0x7
         : +jge 0xc
0x46d1be : mov dword ptr [ebp + 0x10], 1
         : +jmp 0x7
         : +mov dword ptr [ebp + 0x10], 0
0x46d1c5 : mov eax, dword ptr [ebp + 8] 	(spark.c:2471)
0x46d1c8 : xor ecx, ecx
0x46d1ca : mov cx, word ptr [eax + 0x294]
0x46d1d1 : test ecx, ecx
0x46d1d3 : -jle 0xa7
         : +je 0xa2
0x46d1d9 : mov dword ptr [ebp - 4], 0 	(spark.c:2472)
0x46d1e0 : jmp 0x3
0x46d1e5 : inc dword ptr [ebp - 4]
0x46d1e8 : cmp dword ptr [ebp - 4], 5
0x46d1ec : -jge 0x8e
         : +jge 0x89
0x46d1f2 : mov eax, dword ptr [ebp - 4] 	(spark.c:2473)
0x46d1f5 : mov ecx, eax
0x46d1f7 : shl eax, 3
0x46d1fa : sub eax, ecx
0x46d1fc : shl eax, 4
0x46d1ff : mov ecx, dword ptr [ebp + 8]
0x46d202 : cmp dword ptr [eax + gSmoke_column[0].car (DATA)], ecx
0x46d208 : -jne 0x6d
         : +jne 0x68
0x46d20e : mov eax, 1 	(spark.c:2474)
0x46d213 : mov cl, byte ptr [ebp - 4]
0x46d216 : shl eax, cl
0x46d218 : test dword ptr [gColumn_flags (DATA)], eax
0x46d21e : -je 0x40
         : +je 0x3b
0x46d224 : mov eax, dword ptr [ebp - 4]
0x46d227 : mov ecx, eax
0x46d229 : shl eax, 3
0x46d22c : sub eax, ecx
0x46d22e : shl eax, 4
0x46d231 : mov ecx, dword ptr [ebp + 0x10]
0x46d234 : cmp dword ptr [eax + gSmoke_column[0].colour (OFFSET)], ecx
0x46d23a : -jg 0x24
         : +jg 0x1f
0x46d240 : mov eax, dword ptr [ebp - 4]
0x46d243 : mov ecx, eax
0x46d245 : shl eax, 3
0x46d248 : sub eax, ecx
0x46d24a : shl eax, 4
0x46d24d : cmp dword ptr [eax + gSmoke_column[0].lifetime (OFFSET)], 0
0x46d254 : -je 0xa
0x46d25a : -jmp 0x47
0x46d25f : -jmp 0x17
         : +je 0x5
         : +jmp 0x42 	(spark.c:2475)
0x46d264 : mov eax, dword ptr [ebp - 4] 	(spark.c:2477)
0x46d267 : mov ecx, eax
0x46d269 : shl eax, 3
0x46d26c : sub eax, ecx
0x46d26e : shl eax, 4
0x46d271 : mov dword ptr [eax + gSmoke_column[0].lifetime (OFFSET)], 0x7d0
0x46d27b : -jmp -0x9b
         : +jmp -0x96 	(spark.c:2479)
0x46d280 : push 0x989680 	(spark.c:2481)
0x46d285 : mov eax, dword ptr [ebp + 0xc]
0x46d288 : mov ecx, dword ptr [ebp + 8]
0x46d28b : xor edx, edx
0x46d28d : mov dx, word ptr [ecx + eax*2 + 0x27c]
0x46d295 : push edx
0x46d296 : mov eax, dword ptr [ebp + 0x10]
0x46d299 : push eax
0x46d29a : mov eax, dword ptr [ebp + 8]
0x46d29d : push eax


ConditionalSmokeColumn is only 84.97% similar to the original, diff above
```

*AI generated. Time taken: 1009s, tokens: 83,299*
