### PR TITLE
GetMousePosition 100% match

### DIFF
--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -382,16 +382,20 @@ void GetMousePosition(int* pX_coord, int* pY_coord) {
     int y_top_margin;
     int y_bottom_margin;
 
+    x_left_margin = 0;
+    x_right_margin = 0;
+    y_top_margin = 0;
+    y_bottom_margin = 0;
     PDGetMousePosition(pX_coord, pY_coord);
-    if (*pX_coord < 0) {
-        *pX_coord = 0;
-    } else if (gGraf_specs[gGraf_spec_index].total_width < *pX_coord) {
-        *pX_coord = gGraf_specs[gGraf_spec_index].total_width;
+    if (*pX_coord < x_left_margin) {
+        *pX_coord = x_left_margin;
+    } else if (gGraf_specs[gGraf_spec_index].total_width - x_right_margin < *pX_coord) {
+        *pX_coord = gGraf_specs[gGraf_spec_index].total_width - x_right_margin;
     }
-    if (*pY_coord < 0) {
+    if (y_top_margin > *pY_coord) {
         *pY_coord = 0;
-    } else if (gGraf_specs[gGraf_spec_index].total_height < *pY_coord) {
-        *pY_coord = gGraf_specs[gGraf_spec_index].total_height;
+    } else if (gGraf_specs[gGraf_spec_index].total_height - y_bottom_margin < *pY_coord) {
+        *pY_coord = gGraf_specs[gGraf_spec_index].total_height - y_bottom_margin;
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4723e4: GetMousePosition 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4723e4,54 +0x4872a8,59 @@
0x4723e4 : push ebp 	(input.c:387)
0x4723e5 : mov ebp, esp
0x4723e7 : sub esp, 0x10
0x4723ea : push ebx
0x4723eb : push esi
0x4723ec : push edi
0x4723ed : -mov dword ptr [ebp - 0x10], 0
0x4723f4 : -mov dword ptr [ebp - 0xc], 0
0x4723fb : -mov dword ptr [ebp - 4], 0
0x472402 : -mov dword ptr [ebp - 8], 0
0x472409 : mov eax, dword ptr [ebp + 0xc] 	(input.c:393)
0x47240c : push eax
0x47240d : mov eax, dword ptr [ebp + 8]
0x472410 : push eax
0x472411 : call PDGetMousePosition (FUNCTION)
0x472416 : add esp, 8
0x472419 : mov eax, dword ptr [ebp + 8] 	(input.c:394)
0x47241c : -mov ecx, dword ptr [ebp - 0x10]
0x47241f : -cmp dword ptr [eax], ecx
0x472421 : -jge 0xd
0x472427 : -mov eax, dword ptr [ebp - 0x10]
         : +cmp dword ptr [eax], 0
         : +jge 0xe
         : +mov eax, dword ptr [ebp + 8] 	(input.c:395)
         : +mov dword ptr [eax], 0
         : +jmp 0x38 	(input.c:396)
         : +mov eax, dword ptr [gGraf_spec_index (DATA)]
         : +mov ecx, eax
         : +lea eax, [eax + eax*2]
         : +lea eax, [ecx + eax*4]
0x47242a : mov ecx, dword ptr [ebp + 8]
0x47242d : -mov dword ptr [ecx], eax
0x47242f : -jmp 0x3e
         : +mov ecx, dword ptr [ecx]
         : +cmp dword ptr [eax*4 + gGraf_specs[0].total_width (OFFSET)], ecx
         : +jge 0x19
0x472434 : mov eax, dword ptr [gGraf_spec_index (DATA)] 	(input.c:397)
0x472439 : mov ecx, eax
0x47243b : lea eax, [eax + eax*2]
0x47243e : lea eax, [ecx + eax*4]
0x472441 : mov eax, dword ptr [eax*4 + gGraf_specs[0].total_width (OFFSET)]
0x472448 : -sub eax, dword ptr [ebp - 0xc]
0x47244b : mov ecx, dword ptr [ebp + 8]
0x47244e : -cmp eax, dword ptr [ecx]
0x472450 : -jge 0x1c
         : +mov dword ptr [ecx], eax
         : +mov eax, dword ptr [ebp + 0xc] 	(input.c:399)
         : +cmp dword ptr [eax], 0
         : +jge 0xe
         : +mov eax, dword ptr [ebp + 0xc] 	(input.c:400)
         : +mov dword ptr [eax], 0
         : +jmp 0x38 	(input.c:401)
0x472456 : mov eax, dword ptr [gGraf_spec_index (DATA)]
0x47245b : mov ecx, eax
0x47245d : lea eax, [eax + eax*2]
0x472460 : lea eax, [ecx + eax*4]
0x472463 : -mov eax, dword ptr [eax*4 + gGraf_specs[0].total_width (OFFSET)]
0x47246a : -sub eax, dword ptr [ebp - 0xc]
0x47246d : -mov ecx, dword ptr [ebp + 8]
0x472470 : -mov dword ptr [ecx], eax
0x472472 : -mov eax, dword ptr [ebp + 0xc]
0x472475 : -mov ecx, dword ptr [ebp - 4]
0x472478 : -cmp dword ptr [eax], ecx
0x47247a : -jge 0xe
0x472480 : -mov eax, dword ptr [ebp + 0xc]
0x472483 : -mov dword ptr [eax], 0
0x472489 : -jmp 0x3e
         : +mov ecx, dword ptr [ebp + 0xc]
         : +mov ecx, dword ptr [ecx]
         : +cmp dword ptr [eax*4 + gGraf_specs[0].total_height (OFFSET)], ecx
         : +jge 0x19
0x47248e : mov eax, dword ptr [gGraf_spec_index (DATA)] 	(input.c:402)
0x472493 : mov ecx, eax
0x472495 : lea eax, [eax + eax*2]
0x472498 : lea eax, [ecx + eax*4]
0x47249b : mov eax, dword ptr [eax*4 + gGraf_specs[0].total_height (OFFSET)]
0x4724a2 : -sub eax, dword ptr [ebp - 8]
         : +mov ecx, dword ptr [ebp + 0xc]
         : +mov dword ptr [ecx], eax
         : +pop edi 	(input.c:404)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


GetMousePosition is only 51.33% similar to the original, diff above
```

*AI generated. Time taken: 319s, tokens: 34,086*
