### PR TITLE
TypeKey 100% match

### DIFF
--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -818,26 +818,26 @@ void StartTyping(int pSlot_index, char* pText, int pVisible_length) {
 void TypeKey(int pSlot_index, char pKey) {
 
     switch (pKey) {
-    case KEY_GRAVE:
-        break;
     case KEY_BACKSPACE:
         DoRLBackspace(pSlot_index);
-        break;
+        return;
     case KEY_DELETE:
         DoRLDelete(pSlot_index);
-        break;
+        return;
     case KEY_INSERT:
         DoRLInsert(pSlot_index);
-        break;
+        return;
     case KEY_LEFT:
         DoRLCursorLeft(pSlot_index);
-        break;
+        return;
     case KEY_RIGHT:
         DoRLCursorRight(pSlot_index);
-        break;
+        return;
+    case KEY_GRAVE:
+        return;
     default:
         DoRLTypeLetter(PDGetASCIIFromKey(pKey), pSlot_index);
-        break;
+        return;
     }
 }
 

--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -835,11 +835,11 @@ void TypeKey(int pSlot_index, char pKey) {
     case KEY_BACKSPACE:
         DoRLBackspace(pSlot_index);
         break;
-    case KEY_INSERT:
-        DoRLInsert(pSlot_index);
-        break;
     case KEY_DELETE:
         DoRLDelete(pSlot_index);
+        break;
+    case KEY_INSERT:
+        DoRLInsert(pSlot_index);
         break;
     case KEY_LEFT:
         DoRLCursorLeft(pSlot_index);


### PR DESCRIPTION
## Match result

```
0x472ecc: TypeKey 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -,70 +,70 @@
0x472ecc : push ebp 	(input.c:830)
0x472ecd : mov ebp, esp
0x472ecf : sub esp, 4
0x472ed2 : push ebx
0x472ed3 : push esi
0x472ed4 : push edi
0x472ed5 : movsx eax, byte ptr [ebp + 0xc] 	(input.c:832)
0x472ed9 : mov dword ptr [ebp - 4], eax
0x472edc : jmp 0x7e
         : +jmp 0xce 	(input.c:834)
0x472ee1 : mov eax, dword ptr [ebp + 8] 	(input.c:836)
0x472ee4 : push eax
0x472ee5 : call DoRLBackspace (FUNCTION)
0x472eea : add esp, 4
0x472eed : -jmp 0xc2
         : +jmp 0xbd 	(input.c:837)
         : +mov eax, dword ptr [ebp + 8] 	(input.c:839)
         : +push eax
         : +call DoRLInsert (FUNCTION)
         : +add esp, 4
         : +jmp 0xac 	(input.c:840)
0x472ef2 : mov eax, dword ptr [ebp + 8] 	(input.c:842)
0x472ef5 : push eax
0x472ef6 : call DoRLDelete (FUNCTION)
0x472efb : add esp, 4
0x472efe : -jmp 0xb1
0x472f03 : -mov eax, dword ptr [ebp + 8]
0x472f06 : -push eax
0x472f07 : -call DoRLInsert (FUNCTION)
0x472f0c : -add esp, 4
0x472f0f : -jmp 0xa0
         : +jmp 0x9b 	(input.c:843)
0x472f14 : mov eax, dword ptr [ebp + 8] 	(input.c:845)
0x472f17 : push eax
0x472f18 : call DoRLCursorLeft (FUNCTION)
0x472f1d : add esp, 4
0x472f20 : -jmp 0x8f
         : +jmp 0x8a 	(input.c:846)
0x472f25 : mov eax, dword ptr [ebp + 8] 	(input.c:848)
0x472f28 : push eax
0x472f29 : call DoRLCursorRight (FUNCTION)
0x472f2e : add esp, 4
0x472f31 : -jmp 0x7e
0x472f36 : jmp 0x79 	(input.c:849)
0x472f3b : mov eax, dword ptr [ebp + 8] 	(input.c:851)
0x472f3e : push eax
0x472f3f : movsx eax, byte ptr [ebp + 0xc]
0x472f43 : push eax
0x472f44 : call PDGetASCIIFromKey (FUNCTION)
0x472f49 : add esp, 4
0x472f4c : push eax
0x472f4d : call DoRLTypeLetter (FUNCTION)
0x472f52 : add esp, 8
0x472f55 : jmp 0x5a 	(input.c:852)
0x472f5a : jmp 0x55 	(input.c:853)
0x472f5f : sub dword ptr [ebp - 4], 0x2f
0x472f63 : cmp dword ptr [ebp - 4], 0x18
0x472f67 : ja -0x32
0x472f6d : mov eax, dword ptr [ebp - 4]
0x472f70 : xor ecx, ecx
0x472f72 : mov cl, byte ptr [eax + <OFFSET8>]
0x472f78 : jmp dword ptr [ecx*4 + <OFFSET9>]
 : Jump table:
0x472f7f : -start + 0x6a
0x472f83 : start + 0x15
0x472f87 : -start + 0x37
0x472f8b : -start + 0x26
0x472f8f : -start + 0x48
0x472f93 : -start + 0x59
         : +start + 0x1a
         : +start + 0x2b
         : +start + 0x3c
         : +start + 0x4d
         : +start + 0x5e
0x472f97 : start + 0x6f
 : Data table:
0x472f9b : 0x0
0x472f9c : 0x6
0x472f9d : 0x6
0x472f9e : 0x1
0x472f9f : 0x6
0x472fa0 : 0x6
0x472fa1 : 0x6
0x472fa2 : 0x6


TypeKey is only 84.78% similar to the original, diff above
```

*AI generated. Time taken: 874s, tokens: 70,113*
