### PR TITLE
ChangeSelection equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/intrface.c
+++ b/src/DETHRACE/common/intrface.c
@@ -74,7 +74,7 @@ void ChangeSelection(tInterface_spec* pSpec, int* pOld_selection, int* pNew_sele
 
     if (ChoiceDisabled(*pNew_selection)) {
         if (pSkip_disabled) {
-            if (*pOld_selection > *pNew_selection) {
+            if (*pOld_selection < *pNew_selection) {
                 do {
                     *pNew_selection = *pNew_selection + 1;
                     if (*pNew_selection < pSpec->move_up_min[pMode]) {

--- a/src/DETHRACE/common/intrface.c
+++ b/src/DETHRACE/common/intrface.c
@@ -74,7 +74,7 @@ void ChangeSelection(tInterface_spec* pSpec, int* pOld_selection, int* pNew_sele
 
     if (ChoiceDisabled(*pNew_selection)) {
         if (pSkip_disabled) {
-            if (*pNew_selection < *pOld_selection) {
+            if (*pOld_selection > *pNew_selection) {
                 do {
                     *pNew_selection = *pNew_selection + 1;
                     if (*pNew_selection < pSpec->move_up_min[pMode]) {
@@ -110,11 +110,12 @@ void ChangeSelection(tInterface_spec* pSpec, int* pOld_selection, int* pNew_sele
             pSpec->flicker_off_flics[*pOld_selection].x[gGraf_data_index],
             pSpec->flicker_off_flics[*pOld_selection].y[gGraf_data_index], 0);
     }
-    if (*pNew_selection >= 0 && *pNew_selection < pSpec->number_of_button_flics
-        && pSpec->flicker_on_flics[*pNew_selection].flic_index >= 0) {
-        AddToFlicQueue(pSpec->flicker_on_flics[*pNew_selection].flic_index,
-            pSpec->flicker_on_flics[*pNew_selection].x[gGraf_data_index],
-            pSpec->flicker_on_flics[*pNew_selection].y[gGraf_data_index], 0);
+    if (*pNew_selection >= 0 && *pNew_selection < pSpec->number_of_button_flics) {
+        if (pSpec->flicker_on_flics[*pNew_selection].flic_index >= 0) {
+            AddToFlicQueue(pSpec->flicker_on_flics[*pNew_selection].flic_index,
+                pSpec->flicker_on_flics[*pNew_selection].x[gGraf_data_index],
+                pSpec->flicker_on_flics[*pNew_selection].y[gGraf_data_index], 0);
+        }
     }
     *pOld_selection = *pNew_selection;
 }

--- a/src/DETHRACE/common/intrface.c
+++ b/src/DETHRACE/common/intrface.c
@@ -73,48 +73,50 @@ void ChangeSelection(tInterface_spec* pSpec, int* pOld_selection, int* pNew_sele
     int i;
 
     if (ChoiceDisabled(*pNew_selection)) {
-        if (!pSkip_disabled) {
-            *pNew_selection = *pOld_selection;
-        } else if (*pOld_selection < *pNew_selection) {
-            do {
-                *pNew_selection = *pNew_selection + 1;
-                if (*pNew_selection < pSpec->move_up_min[pMode]) {
-                    *pNew_selection = pSpec->move_up_max[pMode];
-                }
-                if (*pNew_selection > pSpec->move_up_max[pMode]) {
-                    *pNew_selection = pSpec->move_up_min[pMode];
-                }
-            } while (*pNew_selection != *pOld_selection && ChoiceDisabled(*pNew_selection));
+        if (pSkip_disabled) {
+            if (*pNew_selection < *pOld_selection) {
+                do {
+                    *pNew_selection = *pNew_selection + 1;
+                    if (*pNew_selection < pSpec->move_up_min[pMode]) {
+                        *pNew_selection = pSpec->move_up_max[pMode];
+                    }
+                    if (*pNew_selection > pSpec->move_up_max[pMode]) {
+                        *pNew_selection = pSpec->move_up_min[pMode];
+                    }
+                } while (*pNew_selection != *pOld_selection && ChoiceDisabled(*pNew_selection));
+            } else {
+                do {
+                    *pNew_selection = *pNew_selection - 1;
+                    if (*pNew_selection < pSpec->move_up_min[pMode]) {
+                        *pNew_selection = pSpec->move_up_max[pMode];
+                    }
+                    if (*pNew_selection > pSpec->move_up_max[pMode]) {
+                        *pNew_selection = pSpec->move_up_min[pMode];
+                    }
+                } while (*pNew_selection != *pOld_selection && ChoiceDisabled(*pNew_selection));
+            }
         } else {
-            do {
-                *pNew_selection = *pNew_selection - 1;
-                if (*pNew_selection < pSpec->move_up_min[pMode]) {
-                    *pNew_selection = pSpec->move_up_max[pMode];
-                }
-                if (*pNew_selection > pSpec->move_up_max[pMode]) {
-                    *pNew_selection = pSpec->move_up_min[pMode];
-                }
-            } while (*pNew_selection != *pOld_selection && ChoiceDisabled(*pNew_selection));
+            *pNew_selection = *pOld_selection;
         }
     }
 
-    if (*pOld_selection != *pNew_selection) {
-        if (*pOld_selection >= 0 && *pOld_selection < pSpec->number_of_button_flics) {
-            if (pSpec->flicker_off_flics[*pOld_selection].flic_index >= 0) {
-                AddToFlicQueue(pSpec->flicker_off_flics[*pOld_selection].flic_index,
-                    pSpec->flicker_off_flics[*pOld_selection].x[gGraf_data_index],
-                    pSpec->flicker_off_flics[*pOld_selection].y[gGraf_data_index], 0);
-            }
-        }
-        if (*pNew_selection >= 0 && *pNew_selection < pSpec->number_of_button_flics) {
-            if (pSpec->flicker_on_flics[*pNew_selection].flic_index >= 0) {
-                AddToFlicQueue(pSpec->flicker_on_flics[*pNew_selection].flic_index,
-                    pSpec->flicker_on_flics[*pNew_selection].x[gGraf_data_index],
-                    pSpec->flicker_on_flics[*pNew_selection].y[gGraf_data_index], 0);
-            }
-        }
-        *pOld_selection = *pNew_selection;
+    if (*pOld_selection == *pNew_selection) {
+        return;
     }
+
+    if (*pOld_selection >= 0 && *pOld_selection < pSpec->number_of_button_flics
+        && pSpec->flicker_off_flics[*pOld_selection].flic_index >= 0) {
+        AddToFlicQueue(pSpec->flicker_off_flics[*pOld_selection].flic_index,
+            pSpec->flicker_off_flics[*pOld_selection].x[gGraf_data_index],
+            pSpec->flicker_off_flics[*pOld_selection].y[gGraf_data_index], 0);
+    }
+    if (*pNew_selection >= 0 && *pNew_selection < pSpec->number_of_button_flics
+        && pSpec->flicker_on_flics[*pNew_selection].flic_index >= 0) {
+        AddToFlicQueue(pSpec->flicker_on_flics[*pNew_selection].flic_index,
+            pSpec->flicker_on_flics[*pNew_selection].x[gGraf_data_index],
+            pSpec->flicker_on_flics[*pNew_selection].y[gGraf_data_index], 0);
+    }
+    *pOld_selection = *pNew_selection;
 }
 
 // IDA: void __usercall RecopyAreas(tInterface_spec *pSpec@<EAX>, br_pixelmap **pCopy_areas@<EDX>)


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x474d8c,25 +0x488a9b,25 @@
0x474d8c : push edi
0x474d8d : mov eax, dword ptr [ebp + 0x10] 	(intrface.c:75)
0x474d90 : mov eax, dword ptr [eax]
0x474d92 : push eax
0x474d93 : call ChoiceDisabled (FUNCTION)
0x474d98 : add esp, 4
0x474d9b : test eax, eax
0x474d9d : je 0x120
0x474da3 : cmp dword ptr [ebp + 0x18], 0 	(intrface.c:76)
0x474da7 : je 0x10c
0x474dad : -mov eax, dword ptr [ebp + 0xc]
0x474db0 : -mov ecx, dword ptr [ebp + 0x10]
         : +mov eax, dword ptr [ebp + 0x10] 	(intrface.c:77)
         : +mov ecx, dword ptr [ebp + 0xc]
0x474db3 : mov ecx, dword ptr [ecx]
0x474db5 : cmp dword ptr [eax], ecx
0x474db7 : -jge 0x7e
         : +jle 0x7e
0x474dbd : mov eax, dword ptr [ebp + 0x10] 	(intrface.c:79)
0x474dc0 : inc dword ptr [eax]
0x474dc2 : mov eax, dword ptr [ebp + 0x14] 	(intrface.c:80)
0x474dc5 : mov ecx, dword ptr [ebp + 8]
0x474dc8 : mov edx, dword ptr [ebp + 0x10]
0x474dcb : mov edx, dword ptr [edx]
0x474dcd : cmp dword ptr [ecx + eax*4 + 0x7c], edx
0x474dd1 : jle 0x12
0x474dd7 : mov eax, dword ptr [ebp + 0x14] 	(intrface.c:81)
0x474dda : mov ecx, dword ptr [ebp + 8]

---
+++
@@ -0x474ea3,26 +0x488bb2,26 @@
0x474ea3 : push eax
0x474ea4 : call ChoiceDisabled (FUNCTION)
0x474ea9 : add esp, 4
0x474eac : test eax, eax
0x474eae : jne -0x79
0x474eb4 : jmp 0xa 	(intrface.c:98)
0x474eb9 : mov eax, dword ptr [ebp + 0xc] 	(intrface.c:99)
0x474ebc : mov eax, dword ptr [eax]
0x474ebe : mov ecx, dword ptr [ebp + 0x10]
0x474ec1 : mov dword ptr [ecx], eax
0x474ec3 : -mov eax, dword ptr [ebp + 0xc]
0x474ec6 : -mov ecx, dword ptr [ebp + 0x10]
         : +mov eax, dword ptr [ebp + 0x10] 	(intrface.c:103)
         : +mov ecx, dword ptr [ebp + 0xc]
0x474ec9 : mov ecx, dword ptr [ecx]
0x474ecb : cmp dword ptr [eax], ecx
0x474ecd : jne 0x5
0x474ed3 : -jmp 0x14a
         : +jmp 0x150 	(intrface.c:104)
0x474ed8 : mov eax, dword ptr [ebp + 0xc] 	(intrface.c:108)
0x474edb : cmp dword ptr [eax], 0
0x474ede : jl 0x96
0x474ee4 : mov eax, dword ptr [ebp + 8]
0x474ee7 : mov ecx, dword ptr [ebp + 0xc]
0x474eea : mov ecx, dword ptr [ecx]
0x474eec : cmp dword ptr [eax + 0x10c], ecx
0x474ef2 : jle 0x82
0x474ef8 : mov eax, dword ptr [ebp + 8]
0x474efb : mov eax, dword ptr [eax + 0x114]

---
+++
@@ -0x474f63,52 +0x488c72,54 @@
0x474f63 : mov ecx, dword ptr [ebp + 0xc]
0x474f66 : mov ecx, dword ptr [ecx]
0x474f68 : shl ecx, 2
0x474f6b : lea ecx, [ecx + ecx*4]
0x474f6e : mov eax, dword ptr [eax + ecx]
0x474f71 : push eax
0x474f72 : call AddToFlicQueue (FUNCTION)
0x474f77 : add esp, 0x10
0x474f7a : mov eax, dword ptr [ebp + 0x10] 	(intrface.c:113)
0x474f7d : cmp dword ptr [eax], 0
0x474f80 : -jl 0x92
         : +jl 0x98
0x474f86 : mov eax, dword ptr [ebp + 8]
0x474f89 : mov ecx, dword ptr [ebp + 0x10]
0x474f8c : mov ecx, dword ptr [ecx]
0x474f8e : cmp dword ptr [eax + 0x10c], ecx
0x474f94 : -jle 0x7e
         : +jle 0x84
0x474f9a : mov eax, dword ptr [ebp + 0x10] 	(intrface.c:114)
0x474f9d : mov eax, dword ptr [eax]
0x474f9f : shl eax, 2
0x474fa2 : lea eax, [eax + eax*4]
0x474fa5 : mov ecx, dword ptr [ebp + 8]
0x474fa8 : mov ecx, dword ptr [ecx + 0x110]
0x474fae : cmp dword ptr [eax + ecx], 0
0x474fb2 : -jl 0x60
         : +jl 0x66
0x474fb8 : push 0 	(intrface.c:117)
0x474fba : mov eax, dword ptr [ebp + 0x10]
0x474fbd : mov eax, dword ptr [eax]
0x474fbf : shl eax, 2
0x474fc2 : lea eax, [eax + eax*4]
         : +mov ecx, dword ptr [gGraf_data_index (DATA)]
         : +lea eax, [eax + ecx*4]
0x474fc5 : mov ecx, dword ptr [ebp + 8]
0x474fc8 : -add eax, dword ptr [ecx + 0x110]
0x474fce : -mov ecx, dword ptr [gGraf_data_index (DATA)]
0x474fd4 : -mov eax, dword ptr [eax + ecx*4 + 0xc]
         : +mov ecx, dword ptr [ecx + 0x110]
         : +mov eax, dword ptr [eax + ecx + 0xc]
0x474fd8 : push eax
0x474fd9 : mov eax, dword ptr [ebp + 0x10]
0x474fdc : mov eax, dword ptr [eax]
0x474fde : shl eax, 2
0x474fe1 : lea eax, [eax + eax*4]
         : +mov ecx, dword ptr [gGraf_data_index (DATA)]
         : +lea eax, [eax + ecx*4]
0x474fe4 : mov ecx, dword ptr [ebp + 8]
0x474fe7 : -add eax, dword ptr [ecx + 0x110]
0x474fed : -mov ecx, dword ptr [gGraf_data_index (DATA)]
0x474ff3 : -mov eax, dword ptr [eax + ecx*4 + 4]
         : +mov ecx, dword ptr [ecx + 0x110]
         : +mov eax, dword ptr [eax + ecx + 4]
0x474ff7 : push eax
0x474ff8 : mov eax, dword ptr [ebp + 0x10]
0x474ffb : mov eax, dword ptr [eax]
0x474ffd : shl eax, 2
0x475000 : lea eax, [eax + eax*4]
0x475003 : mov ecx, dword ptr [ebp + 8]
0x475006 : mov ecx, dword ptr [ecx + 0x110]
0x47500c : mov eax, dword ptr [eax + ecx]
0x47500f : push eax
0x475010 : call AddToFlicQueue (FUNCTION)


ChangeSelection is only 92.23% similar to the original, diff above
```

#### Effective match analysis

Yes. The meaningful changes are algebraic/encoding-preserving, not behavioral. In the first and second hunks, pointer loads from `[ebp+0xc]` and `[ebp+0x10]` are swapped, and the compare/jump condition is correspondingly inverted (`jge` ↔ `jle`) or left logically matched, which preserves the same branch decision. In the later hunk, address computation is reassociated (`add` vs `lea` with reordered additions of `gGraf_data_index*4` and `[obj+0x110]`), but it computes the same effective addresses before loads. The changed short jump displacements (`jl/jle` targets, `jmp 0x14a`→`0x150`) are consistent with instruction layout shifts, not control-flow logic changes. So functionally it is equivalent under your stated ignore rules.

#### Original match

```
---
+++
@@ -0x474d8b,26 +0x4884fa,31 @@
0x474d8b : push esi
0x474d8c : push edi
0x474d8d : mov eax, dword ptr [ebp + 0x10] 	(intrface.c:75)
0x474d90 : mov eax, dword ptr [eax]
0x474d92 : push eax
0x474d93 : call ChoiceDisabled (FUNCTION)
0x474d98 : add esp, 4
0x474d9b : test eax, eax
0x474d9d : je 0x120
0x474da3 : cmp dword ptr [ebp + 0x18], 0 	(intrface.c:76)
0x474da7 : -je 0x10c
         : +jne 0xf
0x474dad : mov eax, dword ptr [ebp + 0xc] 	(intrface.c:77)
         : +mov eax, dword ptr [eax]
0x474db0 : mov ecx, dword ptr [ebp + 0x10]
         : +mov dword ptr [ecx], eax
         : +jmp 0x107 	(intrface.c:78)
         : +mov eax, dword ptr [ebp + 0x10]
         : +mov ecx, dword ptr [ebp + 0xc]
0x474db3 : mov ecx, dword ptr [ecx]
0x474db5 : cmp dword ptr [eax], ecx
0x474db7 : -jge 0x7e
         : +jle 0x7e
0x474dbd : mov eax, dword ptr [ebp + 0x10] 	(intrface.c:80)
0x474dc0 : inc dword ptr [eax]
0x474dc2 : mov eax, dword ptr [ebp + 0x14] 	(intrface.c:81)
0x474dc5 : mov ecx, dword ptr [ebp + 8]
0x474dc8 : mov edx, dword ptr [ebp + 0x10]
0x474dcb : mov edx, dword ptr [edx]
0x474dcd : cmp dword ptr [ecx + eax*4 + 0x7c], edx
0x474dd1 : jle 0x12
0x474dd7 : mov eax, dword ptr [ebp + 0x14] 	(intrface.c:82)
0x474dda : mov ecx, dword ptr [ebp + 8]

---
+++
@@ -0x474e94,112 +0x488612,108 @@
0x474e94 : mov ecx, dword ptr [ecx]
0x474e96 : cmp dword ptr [eax], ecx
0x474e98 : je 0x16
0x474e9e : mov eax, dword ptr [ebp + 0x10]
0x474ea1 : mov eax, dword ptr [eax]
0x474ea3 : push eax
0x474ea4 : call ChoiceDisabled (FUNCTION)
0x474ea9 : add esp, 4
0x474eac : test eax, eax
0x474eae : jne -0x79
0x474eb4 : -jmp 0xa
0x474eb9 : -mov eax, dword ptr [ebp + 0xc]
0x474ebc : -mov eax, dword ptr [eax]
0x474ebe : -mov ecx, dword ptr [ebp + 0x10]
0x474ec1 : -mov dword ptr [ecx], eax
0x474ec3 : -mov eax, dword ptr [ebp + 0xc]
0x474ec6 : -mov ecx, dword ptr [ebp + 0x10]
         : +mov eax, dword ptr [ebp + 0x10] 	(intrface.c:101)
         : +mov ecx, dword ptr [ebp + 0xc]
0x474ec9 : mov ecx, dword ptr [ecx]
0x474ecb : cmp dword ptr [eax], ecx
0x474ecd : -jne 0x5
0x474ed3 : -jmp 0x14a
         : +je 0x152
0x474ed8 : mov eax, dword ptr [ebp + 0xc] 	(intrface.c:102)
0x474edb : cmp dword ptr [eax], 0
0x474ede : -jl 0x96
         : +jl 0x98
0x474ee4 : mov eax, dword ptr [ebp + 8]
0x474ee7 : mov ecx, dword ptr [ebp + 0xc]
0x474eea : mov ecx, dword ptr [ecx]
0x474eec : cmp dword ptr [eax + 0x10c], ecx
0x474ef2 : -jle 0x82
0x474ef8 : -mov eax, dword ptr [ebp + 8]
0x474efb : -mov eax, dword ptr [eax + 0x114]
0x474f01 : -mov ecx, dword ptr [ebp + 0xc]
0x474f04 : -mov ecx, dword ptr [ecx]
0x474f06 : -shl ecx, 2
0x474f09 : -lea ecx, [ecx + ecx*4]
         : +jle 0x84
         : +mov eax, dword ptr [ebp + 0xc] 	(intrface.c:103)
         : +mov eax, dword ptr [eax]
         : +shl eax, 2
         : +lea eax, [eax + eax*4]
         : +mov ecx, dword ptr [ebp + 8]
         : +mov ecx, dword ptr [ecx + 0x114]
0x474f0c : cmp dword ptr [eax + ecx], 0
0x474f10 : -jl 0x64
         : +jl 0x66
0x474f16 : push 0 	(intrface.c:106)
0x474f18 : -mov eax, dword ptr [ebp + 8]
0x474f1b : -mov eax, dword ptr [eax + 0x114]
0x474f21 : -mov ecx, dword ptr [ebp + 0xc]
0x474f24 : -mov ecx, dword ptr [ecx]
0x474f26 : -shl ecx, 2
0x474f29 : -lea ecx, [ecx + ecx*4]
0x474f2c : -add eax, ecx
         : +mov eax, dword ptr [ebp + 0xc]
         : +mov eax, dword ptr [eax]
         : +shl eax, 2
         : +lea eax, [eax + eax*4]
0x474f2e : mov ecx, dword ptr [gGraf_data_index (DATA)]
0x474f34 : -mov eax, dword ptr [eax + ecx*4 + 0xc]
         : +lea eax, [eax + ecx*4]
         : +mov ecx, dword ptr [ebp + 8]
         : +mov ecx, dword ptr [ecx + 0x114]
         : +mov eax, dword ptr [eax + ecx + 0xc]
0x474f38 : push eax
0x474f39 : -mov eax, dword ptr [ebp + 8]
0x474f3c : -mov eax, dword ptr [eax + 0x114]
0x474f42 : -mov ecx, dword ptr [ebp + 0xc]
0x474f45 : -mov ecx, dword ptr [ecx]
0x474f47 : -shl ecx, 2
0x474f4a : -lea ecx, [ecx + ecx*4]
0x474f4d : -add eax, ecx
         : +mov eax, dword ptr [ebp + 0xc]
         : +mov eax, dword ptr [eax]
         : +shl eax, 2
         : +lea eax, [eax + eax*4]
0x474f4f : mov ecx, dword ptr [gGraf_data_index (DATA)]
0x474f55 : -mov eax, dword ptr [eax + ecx*4 + 4]
         : +lea eax, [eax + ecx*4]
         : +mov ecx, dword ptr [ebp + 8]
         : +mov ecx, dword ptr [ecx + 0x114]
         : +mov eax, dword ptr [eax + ecx + 4]
0x474f59 : push eax
0x474f5a : -mov eax, dword ptr [ebp + 8]
0x474f5d : -mov eax, dword ptr [eax + 0x114]
0x474f63 : -mov ecx, dword ptr [ebp + 0xc]
0x474f66 : -mov ecx, dword ptr [ecx]
0x474f68 : -shl ecx, 2
0x474f6b : -lea ecx, [ecx + ecx*4]
         : +mov eax, dword ptr [ebp + 0xc]
         : +mov eax, dword ptr [eax]
         : +shl eax, 2
         : +lea eax, [eax + eax*4]
         : +mov ecx, dword ptr [ebp + 8]
         : +mov ecx, dword ptr [ecx + 0x114]
0x474f6e : mov eax, dword ptr [eax + ecx]
0x474f71 : push eax
0x474f72 : call AddToFlicQueue (FUNCTION)
0x474f77 : add esp, 0x10
0x474f7a : mov eax, dword ptr [ebp + 0x10] 	(intrface.c:109)
0x474f7d : cmp dword ptr [eax], 0
0x474f80 : -jl 0x92
         : +jl 0x98
0x474f86 : mov eax, dword ptr [ebp + 8]
0x474f89 : mov ecx, dword ptr [ebp + 0x10]
0x474f8c : mov ecx, dword ptr [ecx]
0x474f8e : cmp dword ptr [eax + 0x10c], ecx
0x474f94 : -jle 0x7e
         : +jle 0x84
0x474f9a : mov eax, dword ptr [ebp + 0x10] 	(intrface.c:110)
0x474f9d : mov eax, dword ptr [eax]
0x474f9f : shl eax, 2
0x474fa2 : lea eax, [eax + eax*4]
0x474fa5 : mov ecx, dword ptr [ebp + 8]
0x474fa8 : mov ecx, dword ptr [ecx + 0x110]
0x474fae : cmp dword ptr [eax + ecx], 0
0x474fb2 : -jl 0x60
         : +jl 0x66
0x474fb8 : push 0 	(intrface.c:113)
0x474fba : mov eax, dword ptr [ebp + 0x10]
0x474fbd : mov eax, dword ptr [eax]
0x474fbf : shl eax, 2
0x474fc2 : lea eax, [eax + eax*4]
         : +mov ecx, dword ptr [gGraf_data_index (DATA)]
         : +lea eax, [eax + ecx*4]
0x474fc5 : mov ecx, dword ptr [ebp + 8]
0x474fc8 : -add eax, dword ptr [ecx + 0x110]
0x474fce : -mov ecx, dword ptr [gGraf_data_index (DATA)]
0x474fd4 : -mov eax, dword ptr [eax + ecx*4 + 0xc]
         : +mov ecx, dword ptr [ecx + 0x110]
         : +mov eax, dword ptr [eax + ecx + 0xc]
0x474fd8 : push eax
0x474fd9 : mov eax, dword ptr [ebp + 0x10]
0x474fdc : mov eax, dword ptr [eax]
0x474fde : shl eax, 2
0x474fe1 : lea eax, [eax + eax*4]
         : +mov ecx, dword ptr [gGraf_data_index (DATA)]
         : +lea eax, [eax + ecx*4]
0x474fe4 : mov ecx, dword ptr [ebp + 8]
0x474fe7 : -add eax, dword ptr [ecx + 0x110]
0x474fed : -mov ecx, dword ptr [gGraf_data_index (DATA)]
0x474ff3 : -mov eax, dword ptr [eax + ecx*4 + 4]
         : +mov ecx, dword ptr [ecx + 0x110]
         : +mov eax, dword ptr [eax + ecx + 4]
0x474ff7 : push eax
0x474ff8 : mov eax, dword ptr [ebp + 0x10]
0x474ffb : mov eax, dword ptr [eax]
0x474ffd : shl eax, 2
0x475000 : lea eax, [eax + eax*4]
0x475003 : mov ecx, dword ptr [ebp + 8]
0x475006 : mov ecx, dword ptr [ecx + 0x110]
0x47500c : mov eax, dword ptr [eax + ecx]
0x47500f : push eax
0x475010 : call AddToFlicQueue (FUNCTION)


ChangeSelection is only 74.94% similar to the original, diff above
```

*AI generated. Time taken: 851s, tokens: 141,409*
