### PR TITLE
RecopyAreas 100% match

### DIFF
--- a/src/DETHRACE/common/intrface.c
+++ b/src/DETHRACE/common/intrface.c
@@ -130,8 +130,8 @@ void RecopyAreas(tInterface_spec* pSpec, br_pixelmap** pCopy_areas) {
             pCopy_areas[i],
             0,
             0,
-            pSpec->recopy_areas[i].right[gGraf_data_index] + -pSpec->recopy_areas[i].left[gGraf_data_index],
-            pSpec->recopy_areas[i].bottom[gGraf_data_index] + -pSpec->recopy_areas[i].top[gGraf_data_index]);
+            pSpec->recopy_areas[i].right[gGraf_data_index] - pSpec->recopy_areas[i].left[gGraf_data_index],
+            pSpec->recopy_areas[i].bottom[gGraf_data_index] - pSpec->recopy_areas[i].top[gGraf_data_index]);
     }
 }
 

--- a/src/DETHRACE/common/intrface.c
+++ b/src/DETHRACE/common/intrface.c
@@ -122,7 +122,7 @@ void ChangeSelection(tInterface_spec* pSpec, int* pOld_selection, int* pNew_sele
 void RecopyAreas(tInterface_spec* pSpec, br_pixelmap** pCopy_areas) {
     int i;
 
-    for (i = 0; i < pSpec->number_of_recopy_areas; i++) {
+    for (i = 0; i < pSpec->number_of_recopy_areas; ++i) {
         BrPixelmapRectangleCopy(
             gBack_screen,
             pSpec->recopy_areas[i].left[gGraf_data_index],
@@ -130,8 +130,8 @@ void RecopyAreas(tInterface_spec* pSpec, br_pixelmap** pCopy_areas) {
             pCopy_areas[i],
             0,
             0,
-            pSpec->recopy_areas[i].right[gGraf_data_index] - pSpec->recopy_areas[i].left[gGraf_data_index],
-            pSpec->recopy_areas[i].bottom[gGraf_data_index] - pSpec->recopy_areas[i].top[gGraf_data_index]);
+            pSpec->recopy_areas[i].right[gGraf_data_index] + -pSpec->recopy_areas[i].left[gGraf_data_index],
+            pSpec->recopy_areas[i].bottom[gGraf_data_index] + -pSpec->recopy_areas[i].top[gGraf_data_index]);
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x47507b: RecopyAreas 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x47507e,67 +0x48879c,73 @@
0x47507e : sub esp, 4
0x475081 : push ebx
0x475082 : push esi
0x475083 : push edi
0x475084 : mov dword ptr [ebp - 4], 0 	(intrface.c:125)
0x47508b : jmp 0x3
0x475090 : inc dword ptr [ebp - 4]
0x475093 : mov eax, dword ptr [ebp + 8]
0x475096 : mov ecx, dword ptr [ebp - 4]
0x475099 : cmp dword ptr [eax + 0x124], ecx
0x47509f : -jle 0xcb
         : +jle 0xc5
0x4750a5 : mov eax, dword ptr [ebp + 8] 	(intrface.c:134)
0x4750a8 : mov eax, dword ptr [eax + 0x128]
0x4750ae : -mov ecx, dword ptr [gGraf_data_index (DATA)]
0x4750b4 : -lea eax, [eax + ecx*4]
0x4750b7 : mov ecx, dword ptr [ebp - 4]
0x4750ba : shl ecx, 5
0x4750bd : -mov eax, dword ptr [eax + ecx + 0x18]
         : +add eax, ecx
         : +mov ecx, dword ptr [gGraf_data_index (DATA)]
         : +mov eax, dword ptr [eax + ecx*4 + 0x18]
0x4750c1 : mov ecx, dword ptr [ebp + 8]
0x4750c4 : mov ecx, dword ptr [ecx + 0x128]
0x4750ca : -mov edx, dword ptr [gGraf_data_index (DATA)]
0x4750d0 : -lea ecx, [ecx + edx*4]
0x4750d3 : mov edx, dword ptr [ebp - 4]
0x4750d6 : shl edx, 5
0x4750d9 : -sub eax, dword ptr [ecx + edx + 8]
         : +add ecx, edx
         : +mov edx, dword ptr [gGraf_data_index (DATA)]
         : +sub eax, dword ptr [ecx + edx*4 + 8]
0x4750dd : push eax
0x4750de : mov eax, dword ptr [ebp + 8]
0x4750e1 : mov eax, dword ptr [eax + 0x128]
0x4750e7 : -mov ecx, dword ptr [gGraf_data_index (DATA)]
0x4750ed : -lea eax, [eax + ecx*4]
0x4750f0 : mov ecx, dword ptr [ebp - 4]
0x4750f3 : shl ecx, 5
0x4750f6 : -mov eax, dword ptr [eax + ecx + 0x10]
         : +add eax, ecx
         : +mov ecx, dword ptr [gGraf_data_index (DATA)]
         : +mov eax, dword ptr [eax + ecx*4 + 0x10]
0x4750fa : mov ecx, dword ptr [ebp + 8]
0x4750fd : mov ecx, dword ptr [ecx + 0x128]
0x475103 : -mov edx, dword ptr [gGraf_data_index (DATA)]
0x475109 : -lea ecx, [ecx + edx*4]
0x47510c : mov edx, dword ptr [ebp - 4]
0x47510f : shl edx, 5
0x475112 : -sub eax, dword ptr [ecx + edx]
         : +add ecx, edx
         : +mov edx, dword ptr [gGraf_data_index (DATA)]
         : +sub eax, dword ptr [ecx + edx*4]
0x475115 : push eax
0x475116 : push 0
0x475118 : push 0
0x47511a : mov eax, dword ptr [ebp - 4]
0x47511d : mov ecx, dword ptr [ebp + 0xc]
0x475120 : mov eax, dword ptr [ecx + eax*4]
0x475123 : push eax
0x475124 : mov eax, dword ptr [ebp + 8]
0x475127 : mov eax, dword ptr [eax + 0x128]
0x47512d : -mov ecx, dword ptr [gGraf_data_index (DATA)]
0x475133 : -lea eax, [eax + ecx*4]
0x475136 : mov ecx, dword ptr [ebp - 4]
0x475139 : shl ecx, 5
0x47513c : -mov eax, dword ptr [eax + ecx + 8]
         : +add eax, ecx
         : +mov ecx, dword ptr [gGraf_data_index (DATA)]
         : +mov eax, dword ptr [eax + ecx*4 + 8]
0x475140 : push eax
0x475141 : mov eax, dword ptr [ebp + 8]
0x475144 : mov eax, dword ptr [eax + 0x128]
0x47514a : -mov ecx, dword ptr [gGraf_data_index (DATA)]
0x475150 : -lea eax, [eax + ecx*4]
0x475153 : mov ecx, dword ptr [ebp - 4]
0x475156 : shl ecx, 5
0x475159 : -mov eax, dword ptr [eax + ecx]
         : +add eax, ecx
         : +mov ecx, dword ptr [gGraf_data_index (DATA)]
         : +mov eax, dword ptr [eax + ecx*4]
0x47515c : push eax
0x47515d : mov eax, dword ptr [gBack_screen (DATA)]
0x475162 : push eax
0x475163 : call BrPixelmapRectangleCopy (FUNCTION)
0x475168 : add esp, 0x20
         : +jmp -0xda 	(intrface.c:135)
         : +pop edi 	(intrface.c:136)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


RecopyAreas is only 69.44% similar to the original, diff above
```

*AI generated. Time taken: 626s, tokens: 77,146*
