### PR TITLE
LoadInterfaceStrings equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/flicplay.c
+++ b/src/DETHRACE/common/flicplay.c
@@ -2060,7 +2060,7 @@ void LoadInterfaceStrings(void) {
     gTranslation_count = 0;
     PathCat(the_path, gApplication_path, "TRNSLATE.TXT");
     f = fopen(the_path, "rt");
-    if (f != NULL) {
+    if (f) {
 
         while (!feof(f)) {
             GetALineAndDontArgue(f, s);
@@ -2095,16 +2095,16 @@ void LoadInterfaceStrings(void) {
             str = strtok(NULL, "\t ,/");
             sscanf(str, "%c", &ch);
             switch (ch) {
-            case 'L':
             case 'l':
+            case 'L':
                 gTranslations[i].justification = eJust_left;
                 break;
-            case 'R':
             case 'r':
+            case 'R':
                 gTranslations[i].justification = eJust_right;
                 break;
-            case 'C':
             case 'c':
+            case 'C':
                 gTranslations[i].justification = eJust_centre;
                 break;
             }
@@ -2114,7 +2114,7 @@ void LoadInterfaceStrings(void) {
             gTranslations[i].every_frame = strlen(str) > 1 && (str[1] == 'e' || str[1] == 'E');
             str += strlen(str) + 1;
             comment = strstr(str, "//");
-            if (comment != NULL) {
+            if (comment) {
                 *comment = '\0';
             }
             len = strlen(str);


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4981f5,21 +0x47d866,21 @@
0x4981f5 : push eax
0x4981f6 : call PathCat (FUNCTION)
0x4981fb : add esp, 0xc
0x4981fe : push "rt" (STRING) 	(flicplay.c:2062)
0x498203 : lea eax, [ebp - 0x31c]
0x498209 : push eax
0x49820a : call fopen (FUNCTION)
0x49820f : add esp, 8
0x498212 : mov dword ptr [ebp - 0x208], eax
0x498218 : cmp dword ptr [ebp - 0x208], 0 	(flicplay.c:2063)
0x49821f : -je 0x737
         : +je 0x738
0x498225 : mov eax, dword ptr [ebp - 0x208] 	(flicplay.c:2065)
0x49822b : test byte ptr [eax + 0xc], 0x10
0x49822f : jne 0x21
0x498235 : lea eax, [ebp - 0x104] 	(flicplay.c:2066)
0x49823b : push eax
0x49823c : mov eax, dword ptr [ebp - 0x208]
0x498242 : push eax
0x498243 : call GetALineAndDontArgue (FUNCTION)
0x498248 : add esp, 8
0x49824b : inc dword ptr [gTranslation_count (DATA)] 	(flicplay.c:2067)

---
+++
@@ -0x498265,23 +0x47d8d6,23 @@
0x498265 : push 0x94 	(flicplay.c:2070)
0x49826a : mov eax, dword ptr [gTranslation_count (DATA)]
0x49826f : shl eax, 5
0x498272 : push eax
0x498273 : call BrMemAllocate (FUNCTION)
0x498278 : add esp, 8
0x49827b : mov dword ptr [gTranslations (DATA)], eax
0x498280 : mov dword ptr [ebp - 0x20c], 0 	(flicplay.c:2071)
0x49828a : jmp 0x6
0x49828f : inc dword ptr [ebp - 0x20c]
0x498295 : -mov eax, dword ptr [gTranslation_count (DATA)]
0x49829a : -cmp dword ptr [ebp - 0x20c], eax
0x4982a0 : -jge 0x55d
         : +mov eax, dword ptr [ebp - 0x20c]
         : +cmp dword ptr [gTranslation_count (DATA)], eax
         : +jle 0x55d
0x4982a6 : lea eax, [ebp - 0x104] 	(flicplay.c:2072)
0x4982ac : push eax
0x4982ad : mov eax, dword ptr [ebp - 0x208]
0x4982b3 : push eax
0x4982b4 : call GetALineAndDontArgue (FUNCTION)
0x4982b9 : add esp, 8
0x4982bc : push "\t ,/" (STRING) 	(flicplay.c:2073)
0x4982c1 : lea eax, [ebp - 0x104]
0x4982c7 : push eax
0x4982c8 : call strtok (FUNCTION)

---
+++
@@ -,27 +,27 @@
0x498573 : jmp 0x7a 	(flicplay.c:2109)
0x498578 : jmp 0x75 	(flicplay.c:2110)
0x49857d : sub dword ptr [ebp - 0x324], 0x43
0x498584 : cmp dword ptr [ebp - 0x324], 0x2f
0x49858b : ja 0x61
0x498591 : mov eax, dword ptr [ebp - 0x324]
0x498597 : xor ecx, ecx
0x498599 : mov cl, byte ptr [eax + <OFFSET27>]
0x49859f : jmp dword ptr [ecx*4 + <OFFSET28>]
 : Jump table:
0x4985a6 : -start + 0x38d
0x4985aa : -start + 0x355
0x4985ae : -start + 0x371
0x4985b2 : -start + 0x38d
0x4985b6 : -start + 0x355
0x4985ba : -start + 0x371
0x4985be : -start + 0x423
         : +start + 0x38e
         : +start + 0x356
         : +start + 0x372
         : +start + 0x38e
         : +start + 0x356
         : +start + 0x372
         : +start + 0x424
 : Data table:
0x4985c2 : 0x0
0x4985c3 : 0x6
0x4985c4 : 0x6
0x4985c5 : 0x6
0x4985c6 : 0x6
0x4985c7 : 0x6
0x4985c8 : 0x6
0x4985c9 : 0x6
0x4985ca : 0x6

---
+++
@@ -0x4987dd,21 +0x47de4f,21 @@
0x4987dd : mov ebx, dword ptr [ebp - 0x20c]
0x4987e3 : shl ebx, 5
0x4987e6 : mov esi, dword ptr [gTranslations (DATA)]
0x4987ec : mov edi, dword ptr [ebx + esi + 0x1c]
0x4987f0 : mov esi, edx
0x4987f2 : shr ecx, 2
0x4987f5 : rep movsd dword ptr es:[edi], dword ptr [esi]
0x4987f7 : mov ecx, eax
0x4987f9 : and ecx, 3
0x4987fc : rep movsb byte ptr es:[edi], byte ptr [esi]
0x4987fe : -jmp -0x574
         : +jmp -0x575 	(flicplay.c:2129)
0x498803 : push 2 	(flicplay.c:2130)
0x498805 : call LoadFont (FUNCTION)
0x49880a : add esp, 4
0x49880d : push 1 	(flicplay.c:2131)
0x49880f : call LoadFont (FUNCTION)
0x498814 : add esp, 4
0x498817 : push 3 	(flicplay.c:2132)
0x498819 : call LoadFont (FUNCTION)
0x49881e : add esp, 4
0x498821 : push 0xf 	(flicplay.c:2133)


LoadInterfaceStrings is only 97.66% similar to the original, diff above
```

#### Effective match analysis

All shown changes preserve the same branch conditions and loop bounds, with only encoding/address shifts. Specifically: (1) `je 0x737` -> `je 0x738` and `jmp -0x574` -> `jmp -0x575` are consistent with one-byte layout shifts, not logic changes; (2) `cmp i, count; jge exit` was rewritten as `cmp count, i; jle exit`, which is conditionally equivalent (`i >= count`); (3) jump-table entries all shifted by +1, matching code-position drift rather than different dispatch behavior. No functional-result change is evident from this diff.

#### Original match

```
---
+++
@@ -0x4981f5,21 +0x47d4b3,21 @@
0x4981f5 : push eax
0x4981f6 : call PathCat (FUNCTION)
0x4981fb : add esp, 0xc
0x4981fe : push "rt" (STRING) 	(flicplay.c:2059)
0x498203 : lea eax, [ebp - 0x31c]
0x498209 : push eax
0x49820a : call fopen (FUNCTION)
0x49820f : add esp, 8
0x498212 : mov dword ptr [ebp - 0x208], eax
0x498218 : cmp dword ptr [ebp - 0x208], 0 	(flicplay.c:2060)
0x49821f : -je 0x737
         : +je 0x738
0x498225 : mov eax, dword ptr [ebp - 0x208] 	(flicplay.c:2062)
0x49822b : test byte ptr [eax + 0xc], 0x10
0x49822f : jne 0x21
0x498235 : lea eax, [ebp - 0x104] 	(flicplay.c:2063)
0x49823b : push eax
0x49823c : mov eax, dword ptr [ebp - 0x208]
0x498242 : push eax
0x498243 : call GetALineAndDontArgue (FUNCTION)
0x498248 : add esp, 8
0x49824b : inc dword ptr [gTranslation_count (DATA)] 	(flicplay.c:2064)

---
+++
@@ -0x498265,23 +0x47d523,23 @@
0x498265 : push 0x94 	(flicplay.c:2067)
0x49826a : mov eax, dword ptr [gTranslation_count (DATA)]
0x49826f : shl eax, 5
0x498272 : push eax
0x498273 : call BrMemAllocate (FUNCTION)
0x498278 : add esp, 8
0x49827b : mov dword ptr [gTranslations (DATA)], eax
0x498280 : mov dword ptr [ebp - 0x20c], 0 	(flicplay.c:2068)
0x49828a : jmp 0x6
0x49828f : inc dword ptr [ebp - 0x20c]
0x498295 : -mov eax, dword ptr [gTranslation_count (DATA)]
0x49829a : -cmp dword ptr [ebp - 0x20c], eax
0x4982a0 : -jge 0x55d
         : +mov eax, dword ptr [ebp - 0x20c]
         : +cmp dword ptr [gTranslation_count (DATA)], eax
         : +jle 0x55d
0x4982a6 : lea eax, [ebp - 0x104] 	(flicplay.c:2069)
0x4982ac : push eax
0x4982ad : mov eax, dword ptr [ebp - 0x208]
0x4982b3 : push eax
0x4982b4 : call GetALineAndDontArgue (FUNCTION)
0x4982b9 : add esp, 8
0x4982bc : push "\t ,/" (STRING) 	(flicplay.c:2070)
0x4982c1 : lea eax, [ebp - 0x104]
0x4982c7 : push eax
0x4982c8 : call strtok (FUNCTION)

---
+++
@@ -,27 +,27 @@
0x498573 : jmp 0x7a 	(flicplay.c:2106)
0x498578 : jmp 0x75 	(flicplay.c:2107)
0x49857d : sub dword ptr [ebp - 0x324], 0x43
0x498584 : cmp dword ptr [ebp - 0x324], 0x2f
0x49858b : ja 0x61
0x498591 : mov eax, dword ptr [ebp - 0x324]
0x498597 : xor ecx, ecx
0x498599 : mov cl, byte ptr [eax + <OFFSET27>]
0x49859f : jmp dword ptr [ecx*4 + <OFFSET28>]
 : Jump table:
0x4985a6 : -start + 0x38d
0x4985aa : -start + 0x355
0x4985ae : -start + 0x371
0x4985b2 : -start + 0x38d
0x4985b6 : -start + 0x355
0x4985ba : -start + 0x371
0x4985be : -start + 0x423
         : +start + 0x38e
         : +start + 0x356
         : +start + 0x372
         : +start + 0x38e
         : +start + 0x356
         : +start + 0x372
         : +start + 0x424
 : Data table:
0x4985c2 : 0x0
0x4985c3 : 0x6
0x4985c4 : 0x6
0x4985c5 : 0x6
0x4985c6 : 0x6
0x4985c7 : 0x6
0x4985c8 : 0x6
0x4985c9 : 0x6
0x4985ca : 0x6

---
+++
@@ -0x4987dd,21 +0x47da9c,21 @@
0x4987dd : mov ebx, dword ptr [ebp - 0x20c]
0x4987e3 : shl ebx, 5
0x4987e6 : mov esi, dword ptr [gTranslations (DATA)]
0x4987ec : mov edi, dword ptr [ebx + esi + 0x1c]
0x4987f0 : mov esi, edx
0x4987f2 : shr ecx, 2
0x4987f5 : rep movsd dword ptr es:[edi], dword ptr [esi]
0x4987f7 : mov ecx, eax
0x4987f9 : and ecx, 3
0x4987fc : rep movsb byte ptr es:[edi], byte ptr [esi]
0x4987fe : -jmp -0x574
         : +jmp -0x575 	(flicplay.c:2126)
0x498803 : push 2 	(flicplay.c:2127)
0x498805 : call LoadFont (FUNCTION)
0x49880a : add esp, 4
0x49880d : push 1 	(flicplay.c:2128)
0x49880f : call LoadFont (FUNCTION)
0x498814 : add esp, 4
0x498817 : push 3 	(flicplay.c:2129)
0x498819 : call LoadFont (FUNCTION)
0x49881e : add esp, 4
0x498821 : push 0xf 	(flicplay.c:2130)


LoadInterfaceStrings is only 97.66% similar to the original, diff above
```

*AI generated. Time taken: 672s, tokens: 75,874*
