### PR TITLE
CreateHorizonModel equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -336,7 +336,7 @@ void MungeSkyModel(br_actor* pCamera, br_model* pModel) {
     min_angle = -gSky_image_underground;
     angle_range = gSky_image_height;
     nbands = 18;
-    for (band = 0; band < nbands; band++) {
+    for (band = 0; (int)band < (int)nbands; band++) {
         vertex = 4 * band + 8;
         pModel->vertices[vertex].p.v[1] = sin(BrAngleToRadian(min_angle + angle_range * band / nbands)) * sky_distance;
         pModel->vertices[vertex].p.v[2] = -cos(BrAngleToRadian(min_angle + angle_range * band / nbands)) * sky_distance;
@@ -370,9 +370,10 @@ br_model* CreateHorizonModel(br_actor* pCamera) {
     tU8 stripe;
     br_model* model;
 
-    model = BrModelAllocate(NULL, 88, 126);
+    nbands = 21;
+    model = BrModelAllocate(NULL, 4 * nbands + 4, 6 * nbands);
     model->flags |= BR_MODF_KEEP_ORIGINAL;
-    for (band = 0; band < 21; band++) {
+    for (band = 0; band < nbands; band++) {
         for (stripe = 0; stripe < 3; stripe++) {
             model->faces[6 * band + 2 * stripe].vertices[0] = stripe + 4 * band + 0;
             model->faces[6 * band + 2 * stripe].vertices[1] = stripe + 4 * band + 1;
@@ -389,13 +390,14 @@ br_model* CreateHorizonModel(br_actor* pCamera) {
     for (vertex = 0; vertex < 12; vertex++) {
         model->vertices[vertex].map.v[1] = 0.9999999f;
     }
-    for (vertex = 80; vertex < 88; vertex++) {
+    for (vertex = 80; vertex < 4 * nbands + 4; vertex++) {
         model->vertices[vertex].map.v[1] = 0.f;
     }
     for (band = 1; band < 18; band++) {
-        model->vertices[4 * band + 8].map.v[1] = (float)(18 - band) / 18.f;
+        vertex = 4 * band + 8;
+        model->vertices[vertex].map.v[1] = (float)(18 - band) / 18.f;
         for (stripe = 1; stripe < 4; stripe++) {
-            model->vertices[4 * band + 8 + stripe].map.v[1] = model->vertices[4 * band + 8].map.v[1];
+            model->vertices[vertex + stripe].map.v[1] = model->vertices[vertex].map.v[1];
         }
     }
     return model;

--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -374,7 +374,7 @@ br_model* CreateHorizonModel(br_actor* pCamera) {
     br_model* model;
 
     nbands = 21;
-    model = BrModelAllocate(NULL, 4 * nbands + 4, 6 * nbands);
+    model = BrModelAllocate(NULL, 4 * (nbands + 1), 6 * nbands);
     model->flags |= BR_MODF_KEEP_ORIGINAL;
     for (band = 0; band < nbands; band++) {
         for (stripe = 0; stripe < 3; stripe++) {
@@ -393,12 +393,12 @@ br_model* CreateHorizonModel(br_actor* pCamera) {
     for (vertex = 0; vertex < 12; vertex++) {
         model->vertices[vertex].map.v[1] = 0.9999999f;
     }
-    for (vertex = 80; vertex < 4 * nbands + 4; vertex++) {
-        model->vertices[vertex].map.v[1] = 0.f;
+    for (vertex = 80; vertex < 4 * (nbands + 1); vertex++) {
+        model->vertices[vertex].map.v[1] = 0.0f;
     }
     for (band = 1; band < 18; band++) {
-        vertex = 4 * band + 8;
-        model->vertices[vertex].map.v[1] = (float)(18 - band) / 18.f;
+        vertex = 4 * (band + 2);
+        model->vertices[vertex].map.v[1] = (float)(18 - band) / 18.0f;
         for (stripe = 1; stripe < 4; stripe++) {
             model->vertices[vertex + stripe].map.v[1] = model->vertices[vertex].map.v[1];
         }

--- a/src/DETHRACE/common/depth.c
+++ b/src/DETHRACE/common/depth.c
@@ -338,19 +338,11 @@ void MungeSkyModel(br_actor* pCamera, br_model* pModel) {
     }
     min_angle = -gSky_image_underground;
     angle_range = gSky_image_height;
-<<<<<<< HEAD
-    nbands = 18;
-    for (band = 0; (int)band < (int)nbands; band++) {
-        vertex = 4 * band + 8;
-        pModel->vertices[vertex].p.v[1] = sin(BrAngleToRadian(min_angle + angle_range * band / nbands)) * sky_distance;
-        pModel->vertices[vertex].p.v[2] = -cos(BrAngleToRadian(min_angle + angle_range * band / nbands)) * sky_distance;
-=======
     for (band = 0; band < 18; band++) {
         angle = min_angle + angle_range * band / 18;
         vertex = 4 * (band + 2);
         pModel->vertices[vertex].p.v[1] = sin(BrAngleToRadian(angle)) * sky_distance;
         pModel->vertices[vertex].p.v[2] = (-cos(BrAngleToRadian(angle))) * sky_distance;
->>>>>>> main
     }
     min_angle = gSky_image_height - gSky_image_underground;
     angle_range = half_diag_fov + BR_ANGLE_DEG(90) - min_angle;


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x461952,21 +0x470106,22 @@
0x461952 : push esi
0x461953 : push edi
0x461954 : mov byte ptr [ebp - 8], 0x15 	(depth.c:376)
0x461958 : xor eax, eax 	(depth.c:377)
0x46195a : mov al, byte ptr [ebp - 8]
0x46195d : lea eax, [eax + eax*2]
0x461960 : add eax, eax
0x461962 : push eax
0x461963 : xor eax, eax
0x461965 : mov al, byte ptr [ebp - 8]
0x461968 : -lea eax, [eax*4 + 4]
         : +shl eax, 2
         : +add eax, 4
0x46196f : push eax
0x461970 : push 0
0x461972 : call BrModelAllocate (FUNCTION)
0x461977 : add esp, 0xc
0x46197a : mov dword ptr [ebp - 4], eax
0x46197d : mov eax, dword ptr [ebp - 4] 	(depth.c:378)
0x461980 : xor ecx, ecx
0x461982 : mov cx, word ptr [eax + 0x20]
0x461986 : or ecx, 2
0x461989 : mov eax, dword ptr [ebp - 4]

---
+++
@@ -0x461b96,42 +0x470349,44 @@
0x461b96 : lea eax, [eax + eax*4]
0x461b99 : mov ecx, dword ptr [ebp - 4]
0x461b9c : mov ecx, dword ptr [ecx + 8]
0x461b9f : mov dword ptr [ecx + eax*8 + 0x10], 0x3f7ffffe
0x461ba7 : jmp -0x2c 	(depth.c:395)
0x461bac : mov byte ptr [ebp - 0x14], 0x50 	(depth.c:396)
0x461bb0 : jmp 0x3
0x461bb5 : inc byte ptr [ebp - 0x14]
0x461bb8 : xor eax, eax
0x461bba : mov al, byte ptr [ebp - 8]
0x461bbd : -lea eax, [eax*4 + 4]
         : +shl eax, 2
         : +add eax, 4
0x461bc4 : xor ecx, ecx
0x461bc6 : mov cl, byte ptr [ebp - 0x14]
0x461bc9 : cmp eax, ecx
0x461bcb : jle 0x1b
0x461bd1 : xor eax, eax 	(depth.c:397)
0x461bd3 : mov al, byte ptr [ebp - 0x14]
0x461bd6 : lea eax, [eax + eax*4]
0x461bd9 : mov ecx, dword ptr [ebp - 4]
0x461bdc : mov ecx, dword ptr [ecx + 8]
0x461bdf : mov dword ptr [ecx + eax*8 + 0x10], 0
0x461be7 : -jmp -0x37
         : +jmp -0x36 	(depth.c:398)
0x461bec : mov byte ptr [ebp - 0x10], 1 	(depth.c:399)
0x461bf0 : jmp 0x3
0x461bf5 : inc byte ptr [ebp - 0x10]
0x461bf8 : xor eax, eax
0x461bfa : mov al, byte ptr [ebp - 0x10]
0x461bfd : cmp eax, 0x12
0x461c00 : -jge 0x88
         : +jge 0x87
0x461c06 : xor eax, eax 	(depth.c:400)
0x461c08 : mov al, byte ptr [ebp - 0x10]
0x461c0b : -lea eax, [eax*4 + 8]
         : +shl eax, 2
         : +add eax, 8
0x461c12 : mov byte ptr [ebp - 0x14], al
0x461c15 : mov eax, 0x12 	(depth.c:401)
0x461c1a : xor ecx, ecx
0x461c1c : mov cl, byte ptr [ebp - 0x10]
0x461c1f : sub eax, ecx
0x461c21 : mov dword ptr [ebp - 0x18], eax
0x461c24 : fild dword ptr [ebp - 0x18]
0x461c27 : fdiv dword ptr [18.0 (FLOAT)]
0x461c2d : xor eax, eax
0x461c2f : mov al, byte ptr [ebp - 0x14]

---
+++
@@ -0x461c69,15 +0x47041a,18 @@
0x461c69 : mov dl, byte ptr [ebp - 0xc]
0x461c6c : xor ebx, ebx
0x461c6e : mov bl, byte ptr [ebp - 0x14]
0x461c71 : add edx, ebx
0x461c73 : lea edx, [edx + edx*4]
0x461c76 : mov ebx, dword ptr [ebp - 4]
0x461c79 : mov ebx, dword ptr [ebx + 8]
0x461c7c : mov eax, dword ptr [ecx + eax*8 + 0x10]
0x461c80 : mov dword ptr [ebx + edx*8 + 0x10], eax
0x461c84 : jmp -0x41 	(depth.c:404)
0x461c89 : -jmp -0x99
         : +jmp -0x98 	(depth.c:405)
0x461c8e : mov eax, dword ptr [ebp - 4] 	(depth.c:406)
0x461c91 : jmp 0x0
0x461c96 : pop edi 	(depth.c:407)
0x461c97 : pop esi
         : +pop ebx
         : +leave 
         : +ret 


CreateHorizonModel is only 96.72% similar to the original, diff above
```

#### Effective match analysis

All substantive instruction changes are algebraically equivalent (`lea eax,[eax*4+4]` -> `shl eax,2` + `add eax,4`, and similarly for `+8`). The jump displacement changes are only by 1 byte (e.g., `-0x37` to `-0x36`, `0x88` to `0x87`), which is consistent with instruction-size changes, not control-flow restructuring. No changed condition codes or dataflow semantics are visible. The tail `pop ebx; leave; ret` appears to be function epilogue materialization rather than altered logic. Overall, this diff indicates equivalent functional behavior.

#### Original match

```
---
+++
@@ -0x46194b,44 +0x46fdf9,34 @@
0x46194b : push ebp 	(depth.c:366)
0x46194c : mov ebp, esp
0x46194e : sub esp, 0x18
0x461951 : push ebx
0x461952 : push esi
0x461953 : push edi
0x461954 : -mov byte ptr [ebp - 8], 0x15
0x461958 : -xor eax, eax
0x46195a : -mov al, byte ptr [ebp - 8]
0x46195d : -lea eax, [eax + eax*2]
0x461960 : -add eax, eax
0x461962 : -push eax
0x461963 : -xor eax, eax
0x461965 : -mov al, byte ptr [ebp - 8]
0x461968 : -lea eax, [eax*4 + 4]
0x46196f : -push eax
         : +push 0x7e 	(depth.c:373)
         : +push 0x58
0x461970 : push 0
0x461972 : call BrModelAllocate (FUNCTION)
0x461977 : add esp, 0xc
0x46197a : mov dword ptr [ebp - 4], eax
0x46197d : mov eax, dword ptr [ebp - 4] 	(depth.c:374)
0x461980 : xor ecx, ecx
0x461982 : mov cx, word ptr [eax + 0x20]
0x461986 : or ecx, 2
0x461989 : mov eax, dword ptr [ebp - 4]
0x46198c : mov word ptr [eax + 0x20], cx
0x461990 : mov byte ptr [ebp - 0x10], 0 	(depth.c:375)
0x461994 : jmp 0x3
0x461999 : inc byte ptr [ebp - 0x10]
0x46199c : xor eax, eax
0x46199e : mov al, byte ptr [ebp - 0x10]
0x4619a1 : -xor ecx, ecx
0x4619a3 : -mov cl, byte ptr [ebp - 8]
0x4619a6 : -cmp eax, ecx
         : +cmp eax, 0x15
0x4619a8 : jge 0x1c9
0x4619ae : mov byte ptr [ebp - 0xc], 0 	(depth.c:376)
0x4619b2 : jmp 0x3
0x4619b7 : inc byte ptr [ebp - 0xc]
0x4619ba : xor eax, eax
0x4619bc : mov al, byte ptr [ebp - 0xc]
0x4619bf : cmp eax, 3
0x4619c2 : jge 0x1aa
0x4619c8 : xor eax, eax 	(depth.c:377)
0x4619ca : mov al, byte ptr [ebp - 0x10]

---
+++
@@ -0x461b4e,81 +0x46ffe0,92 @@
0x461b4e : xor ecx, ecx
0x461b50 : mov cl, byte ptr [ebp - 0x10]
0x461b53 : lea ecx, [ecx + ecx*2]
0x461b56 : add ecx, ecx
0x461b58 : lea eax, [ecx + eax*2]
0x461b5b : lea eax, [eax + eax*4 + 5]
0x461b5f : mov ecx, dword ptr [ebp - 4]
0x461b62 : mov ecx, dword ptr [ecx + 0xc]
0x461b65 : mov dword ptr [ecx + eax*8 + 8], 0
0x461b6d : jmp -0x1bb 	(depth.c:387)
0x461b72 : -jmp -0x1de
         : +jmp -0x1da 	(depth.c:388)
0x461b77 : mov byte ptr [ebp - 0x14], 0 	(depth.c:389)
0x461b7b : jmp 0x3
0x461b80 : inc byte ptr [ebp - 0x14]
0x461b83 : xor eax, eax
0x461b85 : mov al, byte ptr [ebp - 0x14]
0x461b88 : cmp eax, 0xc
0x461b8b : jge 0x1b
0x461b91 : xor eax, eax 	(depth.c:390)
0x461b93 : mov al, byte ptr [ebp - 0x14]
0x461b96 : lea eax, [eax + eax*4]
0x461b99 : mov ecx, dword ptr [ebp - 4]
0x461b9c : mov ecx, dword ptr [ecx + 8]
0x461b9f : mov dword ptr [ecx + eax*8 + 0x10], 0x3f7ffffe
0x461ba7 : jmp -0x2c 	(depth.c:391)
0x461bac : mov byte ptr [ebp - 0x14], 0x50 	(depth.c:392)
0x461bb0 : jmp 0x3
0x461bb5 : inc byte ptr [ebp - 0x14]
0x461bb8 : xor eax, eax
0x461bba : -mov al, byte ptr [ebp - 8]
0x461bbd : -lea eax, [eax*4 + 4]
0x461bc4 : -xor ecx, ecx
0x461bc6 : -mov cl, byte ptr [ebp - 0x14]
0x461bc9 : -cmp eax, ecx
0x461bcb : -jle 0x1b
         : +mov al, byte ptr [ebp - 0x14]
         : +cmp eax, 0x58
         : +jge 0x1b
0x461bd1 : xor eax, eax 	(depth.c:393)
0x461bd3 : mov al, byte ptr [ebp - 0x14]
0x461bd6 : lea eax, [eax + eax*4]
0x461bd9 : mov ecx, dword ptr [ebp - 4]
0x461bdc : mov ecx, dword ptr [ecx + 8]
0x461bdf : mov dword ptr [ecx + eax*8 + 0x10], 0
0x461be7 : -jmp -0x37
         : +jmp -0x2c 	(depth.c:394)
0x461bec : mov byte ptr [ebp - 0x10], 1 	(depth.c:395)
0x461bf0 : jmp 0x3
0x461bf5 : inc byte ptr [ebp - 0x10]
0x461bf8 : xor eax, eax
0x461bfa : mov al, byte ptr [ebp - 0x10]
0x461bfd : cmp eax, 0x12
0x461c00 : -jge 0x88
0x461c06 : -xor eax, eax
0x461c08 : -mov al, byte ptr [ebp - 0x10]
0x461c0b : -lea eax, [eax*4 + 8]
0x461c12 : -mov byte ptr [ebp - 0x14], al
         : +jge 0x83
0x461c15 : mov eax, 0x12 	(depth.c:396)
0x461c1a : xor ecx, ecx
0x461c1c : mov cl, byte ptr [ebp - 0x10]
0x461c1f : sub eax, ecx
0x461c21 : mov dword ptr [ebp - 0x18], eax
0x461c24 : fild dword ptr [ebp - 0x18]
0x461c27 : fdiv dword ptr [18.0 (FLOAT)]
0x461c2d : xor eax, eax
0x461c2f : -mov al, byte ptr [ebp - 0x14]
0x461c32 : -lea eax, [eax + eax*4]
         : +mov al, byte ptr [ebp - 0x10]
         : +shl eax, 2
         : +lea eax, [eax + eax*4 + 0x28]
0x461c35 : mov ecx, dword ptr [ebp - 4]
0x461c38 : mov ecx, dword ptr [ecx + 8]
0x461c3b : fstp dword ptr [ecx + eax*8 + 0x10]
0x461c3f : mov byte ptr [ebp - 0xc], 1 	(depth.c:397)
0x461c43 : jmp 0x3
0x461c48 : inc byte ptr [ebp - 0xc]
0x461c4b : xor eax, eax
0x461c4d : mov al, byte ptr [ebp - 0xc]
0x461c50 : cmp eax, 4
0x461c53 : -jge 0x30
         : +jge 0x36
0x461c59 : xor eax, eax 	(depth.c:398)
0x461c5b : -mov al, byte ptr [ebp - 0x14]
0x461c5e : -lea eax, [eax + eax*4]
         : +mov al, byte ptr [ebp - 0x10]
         : +shl eax, 2
         : +lea eax, [eax + eax*4 + 0x28]
0x461c61 : mov ecx, dword ptr [ebp - 4]
0x461c64 : mov ecx, dword ptr [ecx + 8]
0x461c67 : xor edx, edx
0x461c69 : -mov dl, byte ptr [ebp - 0xc]
         : +mov dl, byte ptr [ebp - 0x10]
0x461c6c : xor ebx, ebx
         : +mov bl, byte ptr [ebp - 0xc]
         : +lea edx, [ebx + edx*4]
         : +lea edx, [edx + edx*4 + 0x28]
         : +mov ebx, dword ptr [ebp - 4]
         : +mov ebx, dword ptr [ebx + 8]
         : +mov eax, dword ptr [ecx + eax*8 + 0x10]
         : +mov dword ptr [ebx + edx*8 + 0x10], eax
         : +jmp -0x47 	(depth.c:399)
         : +jmp -0x94 	(depth.c:400)
         : +mov eax, dword ptr [ebp - 4] 	(depth.c:401)
         : +jmp 0x0
         : +pop edi 	(depth.c:402)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


CreateHorizonModel is only 87.43% similar to the original, diff above
```

*AI generated. Time taken: 634s*
