### PR TITLE
PollKeys 100% match

### DIFF
--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -91,6 +91,7 @@ void SetJoystickArrays(int* pKeys, int pMark) {
 // IDA: void __cdecl PollKeys()
 // FUNCTION: CARM95 0x00471bbf
 void PollKeys(void) {
+    int i;
 
     gKey_poll_counter++;
     PDSetKeyArray(gKey_array, gKey_poll_counter);


### PR DESCRIPTION
## Match result

```
0x471bbf: PollKeys 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x471bbf,21 +0x486a5e,23 @@
0x471bbf : push ebp 	(input.c:93)
0x471bc0 : mov ebp, esp
0x471bc2 : -sub esp, 4
0x471bc5 : push ebx
0x471bc6 : push esi
0x471bc7 : push edi
0x471bc8 : inc dword ptr [gKey_poll_counter (DATA)] 	(input.c:95)
0x471bce : mov eax, dword ptr [gKey_poll_counter (DATA)] 	(input.c:96)
0x471bd3 : push eax
0x471bd4 : push gKey_array[0] (DATA)
0x471bd9 : call PDSetKeyArray (FUNCTION)
0x471bde : add esp, 8
0x471be1 : mov eax, dword ptr [gKey_poll_counter (DATA)] 	(input.c:97)
0x471be6 : push eax
0x471be7 : push gKey_array[0] (DATA)
0x471bec : call SetJoystickArrays (FUNCTION)
0x471bf1 : add esp, 8
0x471bf4 : call PDGetTotalTime (FUNCTION) 	(input.c:98)
0x471bf9 : mov dword ptr [gLast_poll_keys (DATA)], eax
0x471bfe : pop edi 	(input.c:99)
0x471bff : pop esi
         : +pop ebx
         : +leave 
         : +ret 


PollKeys is only 90.91% similar to the original, diff above
```

*AI generated. Time taken: 25s*
