### PR TITLE
AddRollingString 100% match

### DIFF
--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -475,8 +475,7 @@ void AddRollingString(char* pStr, int pX, int pY, tRolling_type rolling_type) {
     int i;
 
     for (i = 0; i < strlen(pStr); i++) {
-        AddRollingLetter(pStr[i], pX, pY, rolling_type);
-        pX += gCurrent_graf_data->rolling_letter_x_pitch;
+        AddRollingLetter(pStr[i], pX + gCurrent_graf_data->rolling_letter_x_pitch * i, pY, rolling_type);
     }
 }
 


### PR DESCRIPTION
## Match result

```
0x4726c3: AddRollingString 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4726cc,31 +0x487579,32 @@
0x4726cc : mov dword ptr [ebp - 4], 0 	(input.c:481)
0x4726d3 : jmp 0x3
0x4726d8 : inc dword ptr [ebp - 4]
0x4726db : mov edi, dword ptr [ebp + 8]
0x4726de : mov ecx, 0xffffffff
0x4726e3 : sub eax, eax
0x4726e5 : repne scasb al, byte ptr es:[edi]
0x4726e7 : not ecx
0x4726e9 : lea eax, [ecx - 1]
0x4726ec : cmp eax, dword ptr [ebp - 4]
0x4726ef : -jbe 0x2f
         : +jbe 0x2e
0x4726f5 : mov eax, dword ptr [ebp + 0x14] 	(input.c:482)
0x4726f8 : push eax
0x4726f9 : mov eax, dword ptr [ebp + 0x10]
0x4726fc : push eax
0x4726fd : -mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x472702 : -mov eax, dword ptr [eax + 0x10]
0x472705 : -imul eax, dword ptr [ebp - 4]
0x472709 : -add eax, dword ptr [ebp + 0xc]
         : +mov eax, dword ptr [ebp + 0xc]
0x47270c : push eax
0x47270d : mov eax, dword ptr [ebp - 4]
0x472710 : mov ecx, dword ptr [ebp + 8]
0x472713 : mov al, byte ptr [eax + ecx]
0x472716 : push eax
0x472717 : call AddRollingLetter (FUNCTION)
0x47271c : add esp, 0x10
0x47271f : -jmp -0x4c
         : +mov eax, dword ptr [gCurrent_graf_data (DATA)] 	(input.c:483)
         : +mov eax, dword ptr [eax + 0x10]
         : +add dword ptr [ebp + 0xc], eax
         : +jmp -0x4b 	(input.c:484)
0x472724 : pop edi 	(input.c:485)
0x472725 : pop esi
0x472726 : pop ebx
0x472727 : leave 
         : +ret 


AddRollingString is only 82.67% similar to the original, diff above
```

*AI generated. Time taken: 82s*
