### PR TITLE
RollLettersIn 100% match

### DIFF
--- a/src/DETHRACE/common/input.c
+++ b/src/DETHRACE/common/input.c
@@ -513,47 +513,46 @@ void RollLettersIn(void) {
     tU8* source_ptr;
     tU8 the_byte;
 
+    let = gRolling_letters;
     new_time = PDGetTotalTime();
     if (gLast_roll) {
         period = new_time - gLast_roll;
     } else {
         period = 0;
     }
-    font_height = gFonts[FONT_TYPEABLE].height;
     font_width = gFonts[FONT_TYPEABLE].width;
+    font_height = gFonts[FONT_TYPEABLE].height;
     the_row_bytes = gFonts[FONT_TYPEABLE].images->row_bytes;
 
-    for (i = 0; i < NBR_ROLLING_LETTERS; i++) {
-        let = &gRolling_letters[i];
+    for (i = 0; i < NBR_ROLLING_LETTERS; i++, let++) {
         if (let->number_of_letters >= 0) {
-            char_ptr = gBack_screen->pixels;
-            char_ptr += let->y_coord * gBack_screen->row_bytes + let->x_coord;
-            if (let->current_offset > 0.0f) {
-                let->current_offset -= period * 0.18f;
+            char_ptr = (tU8*)gBack_screen->pixels + let->y_coord * gBack_screen->row_bytes + let->x_coord;
+            if (let->current_offset != 0.0f) {
+                let->current_offset -= period * 0.18;
                 if (let->current_offset <= 0.0f) {
-                    if (let->rolling_type == eRT_looping_random || let->rolling_type == eRT_looping_single) {
-                        let->current_offset = (gCurrent_graf_data->save_slot_letter_height * let->number_of_letters) + let->current_offset;
-                    } else {
+                    if (let->rolling_type != eRT_looping_random && let->rolling_type != eRT_looping_single) {
                         let->current_offset = 0.0f;
+                    } else {
+                        let->current_offset = let->current_offset + (float)(gCurrent_graf_data->save_slot_letter_height * let->number_of_letters);
                     }
                 }
             }
             for (j = 0; j < gCurrent_graf_data->save_slot_height; j++) {
+                saved_char_ptr = char_ptr;
                 offset = gCurrent_graf_data->save_slot_table[j] + let->current_offset;
                 which_letter = offset / gCurrent_graf_data->save_slot_letter_height;
                 letter_offset = offset % gCurrent_graf_data->save_slot_letter_height - (gCurrent_graf_data->save_slot_letter_height - font_height) / 2;
-                saved_char_ptr = char_ptr;
                 if (which_letter < let->number_of_letters && which_letter >= 0 && letter_offset >= 0 && letter_offset < font_height) {
 
                     // LOG_DEBUG("chars %d, %d, %d, %d", let->letters[0], let->letters[1], let->letters[2], let->letters[3]);
                     source_ptr = (tU8*)gFonts[FONT_TYPEABLE].images->pixels + (font_height * (let->letters[which_letter] - ' ') + letter_offset) * the_row_bytes;
                     for (k = 0; k < font_width; k++) {
                         the_byte = *source_ptr;
+                        source_ptr++;
                         if (the_byte) {
                             *char_ptr = the_byte;
                         }
                         char_ptr++;
-                        source_ptr++;
                     }
                 }
                 char_ptr = saved_char_ptr + gBack_screen->row_bytes;


### PR DESCRIPTION
## Match result

```
0x472766: RollLettersIn 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x472766,101 +0x487612,104 @@
0x472766 : push ebp 	(input.c:498)
0x472767 : mov ebp, esp
0x472769 : sub esp, 0x50
0x47276c : push ebx
0x47276d : push esi
0x47276e : push edi
0x47276f : -mov eax, dword ptr [gRolling_letters (DATA)]
0x472774 : -mov dword ptr [ebp - 0x10], eax
0x472777 : call PDGetTotalTime (FUNCTION) 	(input.c:516)
0x47277c : mov dword ptr [ebp - 0x40], eax
0x47277f : cmp dword ptr [gLast_roll (DATA)], 0 	(input.c:517)
0x472786 : je 0x11
0x47278c : mov eax, dword ptr [ebp - 0x40] 	(input.c:518)
0x47278f : sub eax, dword ptr [gLast_roll (DATA)]
0x472795 : mov dword ptr [ebp - 0x14], eax
0x472798 : jmp 0x7 	(input.c:519)
0x47279d : mov dword ptr [ebp - 0x14], 0 	(input.c:520)
         : +mov eax, dword ptr [gFonts[0].height (OFFSET)] 	(input.c:522)
         : +mov dword ptr [ebp - 4], eax
0x4727a4 : mov eax, dword ptr [gFonts[0].width (OFFSET)] 	(input.c:523)
0x4727a9 : mov dword ptr [ebp - 0xc], eax
0x4727ac : -mov eax, dword ptr [gFonts[0].height (OFFSET)]
0x4727b1 : -mov dword ptr [ebp - 4], eax
0x4727b4 : mov eax, dword ptr [gFonts[0].images (DATA)] 	(input.c:524)
0x4727b9 : movsx eax, word ptr [eax + 0x28]
0x4727bd : mov dword ptr [ebp - 0x20], eax
0x4727c0 : mov dword ptr [ebp - 0x2c], 0 	(input.c:526)
0x4727c7 : -jmp 0x7
         : +jmp 0x3
0x4727cc : inc dword ptr [ebp - 0x2c]
0x4727cf : -add dword ptr [ebp - 0x10], 0x38
0x4727d3 : cmp dword ptr [ebp - 0x2c], 0x1f4
0x4727da : -jge 0x1f2
         : +jge 0x20b
         : +mov eax, dword ptr [ebp - 0x2c] 	(input.c:527)
         : +mov ecx, eax
         : +shl eax, 3
         : +sub eax, ecx
         : +shl eax, 3
         : +add eax, dword ptr [gRolling_letters (DATA)]
         : +mov dword ptr [ebp - 0x10], eax
0x4727e0 : mov eax, dword ptr [ebp - 0x10] 	(input.c:528)
0x4727e3 : cmp dword ptr [eax + 0x2c], 0
0x4727e7 : -jl 0x1e0
         : +jl 0x1e3
         : +mov eax, dword ptr [gBack_screen (DATA)] 	(input.c:529)
         : +mov eax, dword ptr [eax + 8]
         : +mov dword ptr [ebp - 0x1c], eax
0x4727ed : mov eax, dword ptr [gBack_screen (DATA)] 	(input.c:530)
0x4727f2 : movsx eax, word ptr [eax + 0x28]
0x4727f6 : mov ecx, dword ptr [ebp - 0x10]
0x4727f9 : imul eax, dword ptr [ecx + 0x28]
0x4727fd : mov ecx, dword ptr [ebp - 0x10]
0x472800 : add eax, dword ptr [ecx + 0x24]
0x472803 : -mov ecx, dword ptr [gBack_screen (DATA)]
0x472809 : -add eax, dword ptr [ecx + 8]
0x47280c : -mov dword ptr [ebp - 0x1c], eax
         : +add dword ptr [ebp - 0x1c], eax
0x47280f : mov eax, dword ptr [ebp - 0x10] 	(input.c:531)
0x472812 : fld dword ptr [eax + 0x34]
0x472815 : fcomp dword ptr [0.0 (FLOAT)]
0x47281b : fnstsw ax
0x47281d : -test ah, 0x40
0x472820 : -jne 0x83
         : +test ah, 0x41
         : +jne 0x84
0x472826 : mov eax, dword ptr [ebp - 0x14] 	(input.c:532)
0x472829 : mov dword ptr [ebp - 0x48], eax
0x47282c : mov dword ptr [ebp - 0x44], 0
0x472833 : fild qword ptr [ebp - 0x48]
0x472836 : -fmul qword ptr [0.18 (FLOAT)]
         : +fmul dword ptr [0.18000000715255737 (FLOAT)]
0x47283c : mov eax, dword ptr [ebp - 0x10]
0x47283f : fsubr dword ptr [eax + 0x34]
0x472842 : mov eax, dword ptr [ebp - 0x10]
0x472845 : fstp dword ptr [eax + 0x34]
0x472848 : mov eax, dword ptr [ebp - 0x10] 	(input.c:533)
0x47284b : fld dword ptr [eax + 0x34]
0x47284e : fcomp dword ptr [0.0 (FLOAT)]
0x472854 : fnstsw ax
0x472856 : test ah, 0x41
0x472859 : -je 0x4a
         : +je 0x4b
0x47285f : mov eax, dword ptr [ebp - 0x10] 	(input.c:534)
0x472862 : cmp dword ptr [eax + 0x30], 2
0x472866 : -je 0x1c
         : +je 0xd
0x47286c : mov eax, dword ptr [ebp - 0x10]
0x47286f : cmp dword ptr [eax + 0x30], 3
0x472873 : -je 0xf
         : +jne 0x27
0x472879 : mov eax, dword ptr [ebp - 0x10] 	(input.c:535)
0x47287c : -mov dword ptr [eax + 0x34], 0
0x472883 : -jmp 0x21
0x472888 : -mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x47288d : -mov eax, dword ptr [eax + 0x24]
0x472890 : -mov ecx, dword ptr [ebp - 0x10]
0x472893 : -imul eax, dword ptr [ecx + 0x2c]
         : +mov eax, dword ptr [eax + 0x2c]
         : +mov ecx, dword ptr [gCurrent_graf_data (DATA)]
         : +imul eax, dword ptr [ecx + 0x24]
0x472897 : mov dword ptr [ebp - 0x4c], eax
0x47289a : fild dword ptr [ebp - 0x4c]
0x47289d : mov eax, dword ptr [ebp - 0x10]
0x4728a0 : fadd dword ptr [eax + 0x34]
0x4728a3 : mov eax, dword ptr [ebp - 0x10]
0x4728a6 : fstp dword ptr [eax + 0x34]
         : +jmp 0xa 	(input.c:536)
         : +mov eax, dword ptr [ebp - 0x10] 	(input.c:537)
         : +mov dword ptr [eax + 0x34], 0
0x4728a9 : mov dword ptr [ebp - 0x34], 0 	(input.c:541)
0x4728b0 : jmp 0x3
0x4728b5 : inc dword ptr [ebp - 0x34]
0x4728b8 : mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x4728bd : mov ecx, dword ptr [ebp - 0x34]
0x4728c0 : cmp dword ptr [eax + 0x20], ecx
0x4728c3 : jle 0x104
0x4728c9 : -mov eax, dword ptr [ebp - 0x1c]
0x4728cc : -mov dword ptr [ebp - 8], eax
0x4728cf : mov eax, dword ptr [ebp - 0x34] 	(input.c:542)
0x4728d2 : mov ecx, dword ptr [gCurrent_graf_data (DATA)]
0x4728d8 : mov eax, dword ptr [ecx + eax*4 + 0x28]
0x4728dc : mov dword ptr [ebp - 0x50], eax
0x4728df : fild dword ptr [ebp - 0x50]
0x4728e2 : mov eax, dword ptr [ebp - 0x10]
0x4728e5 : fadd dword ptr [eax + 0x34]
0x4728e8 : call __ftol (FUNCTION)
0x4728ed : mov dword ptr [ebp - 0x28], eax
0x4728f0 : mov ecx, dword ptr [gCurrent_graf_data (DATA)] 	(input.c:543)

---
+++
@@ -0x47290a,20 +0x4877bd,22 @@
0x47290a : idiv dword ptr [ecx + 0x24]
0x47290d : mov ecx, edx
0x47290f : mov eax, dword ptr [gCurrent_graf_data (DATA)]
0x472914 : mov eax, dword ptr [eax + 0x24]
0x472917 : sub eax, dword ptr [ebp - 4]
0x47291a : cdq 
0x47291b : sub eax, edx
0x47291d : sar eax, 1
0x47291f : sub ecx, eax
0x472921 : mov dword ptr [ebp - 0x3c], ecx
         : +mov eax, dword ptr [ebp - 0x1c] 	(input.c:545)
         : +mov dword ptr [ebp - 8], eax
0x472924 : mov eax, dword ptr [ebp - 0x10] 	(input.c:546)
0x472927 : mov ecx, dword ptr [ebp - 0x30]
0x47292a : cmp dword ptr [eax + 0x2c], ecx
0x47292d : jle 0x86
0x472933 : cmp dword ptr [ebp - 0x30], 0
0x472937 : jl 0x7c
0x47293d : cmp dword ptr [ebp - 0x3c], 0
0x472941 : jl 0x72
0x472947 : mov eax, dword ptr [ebp - 0x3c]
0x47294a : cmp dword ptr [ebp - 4], eax

---
+++
@@ -0x472973,33 +0x48782c,33 @@
0x472973 : mov dword ptr [ebp - 0x18], eax
0x472976 : mov dword ptr [ebp - 0x38], 0 	(input.c:550)
0x47297d : jmp 0x3
0x472982 : inc dword ptr [ebp - 0x38]
0x472985 : mov eax, dword ptr [ebp - 0x38]
0x472988 : cmp dword ptr [ebp - 0xc], eax
0x47298b : jle 0x28
0x472991 : mov eax, dword ptr [ebp - 0x18] 	(input.c:551)
0x472994 : mov al, byte ptr [eax]
0x472996 : mov byte ptr [ebp - 0x24], al
0x472999 : -inc dword ptr [ebp - 0x18]
0x47299c : xor eax, eax 	(input.c:552)
0x47299e : mov al, byte ptr [ebp - 0x24]
0x4729a1 : test eax, eax
0x4729a3 : je 0x8
0x4729a9 : mov al, byte ptr [ebp - 0x24] 	(input.c:553)
0x4729ac : mov ecx, dword ptr [ebp - 0x1c]
0x4729af : mov byte ptr [ecx], al
0x4729b1 : inc dword ptr [ebp - 0x1c] 	(input.c:555)
         : +inc dword ptr [ebp - 0x18] 	(input.c:556)
0x4729b4 : jmp -0x37 	(input.c:557)
0x4729b9 : mov eax, dword ptr [gBack_screen (DATA)] 	(input.c:559)
0x4729be : movsx eax, word ptr [eax + 0x28]
0x4729c2 : add eax, dword ptr [ebp - 8]
0x4729c5 : mov dword ptr [ebp - 0x1c], eax
0x4729c8 : jmp -0x118 	(input.c:560)
0x4729cd : -jmp -0x206
         : +jmp -0x21b 	(input.c:562)
0x4729d2 : mov eax, dword ptr [ebp - 0x40] 	(input.c:563)
0x4729d5 : mov dword ptr [gLast_roll (DATA)], eax
0x4729da : pop edi 	(input.c:564)
0x4729db : pop esi
0x4729dc : pop ebx
0x4729dd : leave 
0x4729de : ret 


RollLettersIn is only 83.00% similar to the original, diff above
```

*AI generated. Time taken: 412s, tokens: 99,194*
