### PR TITLE
GetFacesInBox equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -745,16 +745,13 @@ void GetFacesInBox(tCollision_info* c) {
     GetNewBoundingBox(&c->bounds_world_space, &bnds.original_bounds, &mat);
     c->bounds_ws_type = eBounds_ws;
 
-    if (c->box_face_ref != gFace_num__car && (c->box_face_ref != gFace_num__car - 1 || c->box_face_start <= gFace_count)) {
-        goto condition_met;
-    }
+    if (c->box_face_ref == gFace_num__car || (c->box_face_ref == gFace_num__car - 1 && c->box_face_start > gFace_count)) {
+        BrMatrix34Mul(&mat5, &mat, &c->last_box_inv_mat);
+        GetNewBoundingBox(&new_in_old, &bnds.original_bounds, &mat5);
 
-    /* Second group (was comma-expression) */
-    BrMatrix34Mul(&mat5, &mat, &c->last_box_inv_mat);
-    GetNewBoundingBox(&new_in_old, &bnds.original_bounds, &mat5);
-
-    if (c->last_box.max.v[0] > new_in_old.max.v[0] && c->last_box.max.v[1] > new_in_old.max.v[1] && c->last_box.max.v[2] > new_in_old.max.v[2] && c->last_box.min.v[0] < new_in_old.min.v[0] && c->last_box.min.v[1] < new_in_old.min.v[1] && c->last_box.min.v[2] < new_in_old.min.v[2]) {
-        return;
+        if (c->last_box.max.v[0] > new_in_old.max.v[0] && c->last_box.max.v[1] > new_in_old.max.v[1] && c->last_box.max.v[2] > new_in_old.max.v[2] && c->last_box.min.v[0] < new_in_old.min.v[0] && c->last_box.min.v[1] < new_in_old.min.v[1] && c->last_box.min.v[2] < new_in_old.min.v[2]) {
+            return;
+        }
     }
 
 condition_met:
@@ -785,7 +782,9 @@ condition_met:
     if (c->driver == eDriver_local_human
         && c->water_d != 10000.f
         && gDouble_pling_water
-        && BrVector3Dot(&c->bounds_world_space.max, &c->water_normal) - c->water_d <= 0.f) {
+        && (c->bounds_world_space.max.v[1] * c->water_normal.v[1]
+                   + c->bounds_world_space.max.v[2] * c->water_normal.v[2])
+                + (c->water_normal.v[0] + 0.0f) * c->bounds_world_space.max.v[0] - c->water_d <= 0.f) {
         gInTheSea = 1;
         FreezeCamera();
     }
@@ -794,12 +793,18 @@ condition_met:
         if (c->water_normal.v[1] < 0.f) {
             BrVector3Negate(&c->water_normal, &c->water_normal);
         }
-        c->water_d = BrVector3Dot(&gPling_face->v[0], &c->water_normal);
+        c->water_d = gPling_face->v[0].v[2] * c->water_normal.v[2]
+            + gPling_face->v[0].v[1] * c->water_normal.v[1]
+            + gPling_face->v[0].v[0] * c->water_normal.v[0];
         if (c->driver == eDriver_local_human) {
             if (gPling_face->material->identifier[1] == '!') {
-                if (BrVector3Dot(&c->bounds_world_space.min, &c->water_normal) - c->water_d < 0.0f) {
+                if ((c->water_normal.v[2] * c->bounds_world_space.min.v[2]
+                            + c->bounds_world_space.min.v[1] * c->water_normal.v[1])
+                        + (c->water_normal.v[0] + 0.0f) * c->bounds_world_space.min.v[0] - c->water_d < 0.0f) {
                     GetNewBoundingBox(&current_bounds, &c->bounds[1], &c->car_master_actor->t.t.mat);
-                    if (BrVector3Dot(&current_bounds.min, &c->water_normal) / WORLD_SCALE_D - c->water_d < 0.0) {
+                    if ((c->water_normal.v[2] * current_bounds.min.v[2]
+                            + c->water_normal.v[1] * current_bounds.min.v[1]
+                            + c->water_normal.v[0] * current_bounds.min.v[0]) / WORLD_SCALE_D - c->water_d < 0.0) {
                         gInTheSea = 1;
                         FreezeCamera();
                     }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x47674f,26 +0x448265,26 @@
0x47674f : fcomp dword ptr [ebp - 0xf0]
0x476755 : fnstsw ax
0x476757 : test ah, 0x41
0x47675a : jne 0x53
0x476760 : mov eax, dword ptr [ebp + 8]
0x476763 : fld dword ptr [eax + 0x210]
0x476769 : fcomp dword ptr [ebp - 0x104]
0x47676f : fnstsw ax
0x476771 : test ah, 1
0x476774 : je 0x39
         : +fld dword ptr [ebp - 0x100]
0x47677a : mov eax, dword ptr [ebp + 8]
0x47677d : -fld dword ptr [eax + 0x214]
0x476783 : -fcomp dword ptr [ebp - 0x100]
         : +fcomp dword ptr [eax + 0x214]
0x476789 : fnstsw ax
0x47678b : -test ah, 1
0x47678e : -je 0x1f
         : +test ah, 0x41
         : +jne 0x1f
0x476794 : mov eax, dword ptr [ebp + 8]
0x476797 : fld dword ptr [eax + 0x218]
0x47679d : fcomp dword ptr [ebp - 0xfc]
0x4767a3 : fnstsw ax
0x4767a5 : test ah, 1
0x4767a8 : je 0x5
0x4767ae : jmp 0x53c 	(car.c:756)
0x4767b3 : lea eax, [ebp - 0x134] 	(car.c:762)
0x4767b9 : push eax
0x4767ba : lea eax, [ebp - 0x134]

---
+++
@@ -0x476857,23 +0x44836d,23 @@
0x476857 : fld dword ptr [ebp + eax*4 - 0x1b4]
0x47685e : fcom st(1)
0x476860 : fnstsw ax
0x476862 : test ah, 0x41
0x476865 : je 0x2
0x47686b : fxch st(1)
0x47686d : fstp st(0)
0x47686f : mov eax, dword ptr [ebp - 0x138]
0x476875 : fstp dword ptr [ebp + eax*4 - 0xb8]
0x47687c : mov eax, dword ptr [ebp - 0x138] 	(car.c:768)
         : +fld dword ptr [ebp + eax*4 - 0xac]
         : +mov eax, dword ptr [ebp - 0x138]
0x476882 : fld dword ptr [ebp + eax*4 - 0x1a8]
0x476889 : -mov eax, dword ptr [ebp - 0x138]
0x47688f : -fld dword ptr [ebp + eax*4 - 0xac]
0x476896 : fcom st(1)
0x476898 : fnstsw ax
0x47689a : test ah, 1
0x47689d : jne 0x2
0x4768a3 : fxch st(1)
0x4768a5 : fstp st(0)
0x4768a7 : mov eax, dword ptr [ebp - 0x138]
0x4768ad : fstp dword ptr [ebp + eax*4 - 0xac]
0x4768b4 : mov eax, dword ptr [ebp - 0x138] 	(car.c:770)
0x4768ba : fld dword ptr [ebp + eax*4 - 0xb8]


GetFacesInBox is only 98.77% similar to the original, diff above
```

#### Effective match analysis

Yes. The shown changes are functionally equivalent for normal (non-NaN) inputs. In the first hunk, the `fcomp` operand order is reversed, and the condition changes from `test ah,1` + `je` to `test ah,0x41` + `jne`; this preserves the same ordered comparison outcome after swapping compare direction (it only differs on unordered/NaN, which you said to ignore). In the second hunk, the loads are reordered so `st(0)`/`st(1)` are swapped before `fcom st(1)`, but the subsequent conditional `fxch`/`fstp` selection logic still keeps/stores the same value. No meaningful control-flow reshuffle is evident from the provided snippet (branch structure and short jumps remain aligned).

#### Original match

```
---
+++
@@ -0x47667b,30 +0x44816f,31 @@
0x47667b : mov eax, dword ptr [ebp + 8]
0x47667e : add eax, 0x260
0x476683 : push eax
0x476684 : call GetNewBoundingBox (FUNCTION)
0x476689 : add esp, 0xc
0x47668c : mov eax, dword ptr [ebp + 8] 	(car.c:746)
0x47668f : mov dword ptr [eax + 0x278], 1
0x476699 : mov eax, dword ptr [ebp + 8] 	(car.c:748)
0x47669c : mov ecx, dword ptr [gFace_num__car (DATA)]
0x4766a2 : cmp dword ptr [eax + 0x1dc], ecx
0x4766a8 : -je 0x2b
         : +je 0x30
0x4766ae : mov eax, dword ptr [ebp + 8]
0x4766b1 : mov ecx, dword ptr [gFace_num__car (DATA)]
0x4766b7 : dec ecx
0x4766b8 : cmp dword ptr [eax + 0x1dc], ecx
0x4766be : -jne 0xef
         : +jne 0x15
0x4766c4 : mov eax, dword ptr [ebp + 8]
0x4766c7 : mov ecx, dword ptr [gFace_count (DATA)]
0x4766cd : cmp dword ptr [eax + 0x1d4], ecx
0x4766d3 : -jle 0xda
         : +jg 0x5
         : +jmp 0xda 	(car.c:749)
0x4766d9 : mov eax, dword ptr [ebp + 8] 	(car.c:753)
0x4766dc : add eax, 0x1e0
0x4766e1 : push eax
0x4766e2 : lea eax, [ebp - 0x30]
0x4766e5 : push eax
0x4766e6 : lea eax, [ebp - 0x168]
0x4766ec : push eax
0x4766ed : call BrMatrix34Mul (FUNCTION)
0x4766f2 : add esp, 0xc
0x4766f5 : lea eax, [ebp - 0x168] 	(car.c:754)

---
+++
@@ -0x4769d1,32 +0x4484ca,32 @@
0x4769d1 : jne 0x8a
0x4769d7 : mov eax, dword ptr [ebp + 8]
0x4769da : fld dword ptr [eax + 0x2a4]
0x4769e0 : fcomp dword ptr [10000.0 (FLOAT)]
0x4769e6 : fnstsw ax
0x4769e8 : test ah, 0x40
0x4769eb : jne 0x70
0x4769f1 : cmp dword ptr [gDouble_pling_water (DATA)], 0
0x4769f8 : je 0x63
0x4769fe : mov eax, dword ptr [ebp + 8]
0x476a01 : -fld dword ptr [eax + 0x274]
         : +fld dword ptr [eax + 0x2a0]
0x476a07 : mov eax, dword ptr [ebp + 8]
0x476a0a : -fmul dword ptr [eax + 0x2a0]
         : +fmul dword ptr [eax + 0x274]
         : +mov eax, dword ptr [ebp + 8]
         : +fld dword ptr [eax + 0x26c]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 0x298]
         : +faddp st(1)
0x476a10 : mov eax, dword ptr [ebp + 8]
0x476a13 : fld dword ptr [eax + 0x270]
0x476a19 : mov eax, dword ptr [ebp + 8]
0x476a1c : fmul dword ptr [eax + 0x29c]
0x476a22 : -faddp st(1)
0x476a24 : -mov eax, dword ptr [ebp + 8]
0x476a27 : -fld dword ptr [eax + 0x298]
0x476a2d : -mov eax, dword ptr [ebp + 8]
0x476a30 : -fmul dword ptr [eax + 0x26c]
0x476a36 : faddp st(1)
0x476a38 : mov eax, dword ptr [ebp + 8]
0x476a3b : fsub dword ptr [eax + 0x2a4]
0x476a41 : fcomp dword ptr [0.0 (FLOAT)]
0x476a47 : fnstsw ax
0x476a49 : test ah, 0x41
0x476a4c : je 0xf
0x476a52 : mov dword ptr [gInTheSea (DATA)], 1 	(car.c:789)
0x476a5c : call FreezeCamera (FUNCTION) 	(car.c:790)
0x476a61 : cmp dword ptr [gPling_face (DATA)], 0 	(car.c:792)

---
+++
@@ -0x476aed,81 +0x4485e6,81 @@
0x476aed : fld dword ptr [eax + 0x29c]
0x476af3 : fchs 
0x476af5 : mov eax, dword ptr [ebp + 8]
0x476af8 : fstp dword ptr [eax + 0x29c]
0x476afe : mov eax, dword ptr [ebp + 8]
0x476b01 : fld dword ptr [eax + 0x2a0]
0x476b07 : fchs 
0x476b09 : mov eax, dword ptr [ebp + 8]
0x476b0c : fstp dword ptr [eax + 0x2a0]
0x476b12 : mov eax, dword ptr [gPling_face (DATA)] 	(car.c:797)
         : +fld dword ptr [eax + 0xc]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 0x2a0]
         : +mov eax, dword ptr [gPling_face (DATA)]
0x476b17 : fld dword ptr [eax + 8]
0x476b1a : mov eax, dword ptr [ebp + 8]
0x476b1d : fmul dword ptr [eax + 0x29c]
0x476b23 : -mov eax, dword ptr [gPling_face (DATA)]
0x476b28 : -fld dword ptr [eax + 0xc]
0x476b2b : -mov eax, dword ptr [ebp + 8]
0x476b2e : -fmul dword ptr [eax + 0x2a0]
0x476b34 : faddp st(1)
0x476b36 : mov eax, dword ptr [gPling_face (DATA)]
0x476b3b : fld dword ptr [eax + 4]
0x476b3e : mov eax, dword ptr [ebp + 8]
0x476b41 : fmul dword ptr [eax + 0x298]
0x476b47 : faddp st(1)
0x476b49 : mov eax, dword ptr [ebp + 8]
0x476b4c : fstp dword ptr [eax + 0x2a4]
0x476b52 : mov eax, dword ptr [ebp + 8] 	(car.c:798)
0x476b55 : cmp dword ptr [eax + 8], 4
0x476b59 : jne 0xfa
0x476b5f : mov eax, dword ptr [gPling_face (DATA)] 	(car.c:799)
0x476b64 : mov eax, dword ptr [eax]
0x476b66 : mov eax, dword ptr [eax + 4]
0x476b69 : movsx eax, byte ptr [eax + 1]
0x476b6d : cmp eax, 0x21
0x476b70 : jne 0xd9
0x476b76 : mov eax, dword ptr [ebp + 8] 	(car.c:800)
         : +fld dword ptr [eax + 0x2a0]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 0x268]
         : +mov eax, dword ptr [ebp + 8]
0x476b79 : fld dword ptr [eax + 0x264]
0x476b7f : mov eax, dword ptr [ebp + 8]
0x476b82 : fmul dword ptr [eax + 0x29c]
0x476b88 : -mov eax, dword ptr [ebp + 8]
0x476b8b : -fld dword ptr [eax + 0x268]
0x476b91 : -mov eax, dword ptr [ebp + 8]
0x476b94 : -fmul dword ptr [eax + 0x2a0]
0x476b9a : faddp st(1)
0x476b9c : mov eax, dword ptr [ebp + 8]
0x476b9f : -fld dword ptr [eax + 0x298]
         : +fld dword ptr [eax + 0x260]
0x476ba5 : mov eax, dword ptr [ebp + 8]
0x476ba8 : -fmul dword ptr [eax + 0x260]
         : +fmul dword ptr [eax + 0x298]
0x476bae : faddp st(1)
0x476bb0 : mov eax, dword ptr [ebp + 8]
0x476bb3 : fsub dword ptr [eax + 0x2a4]
0x476bb9 : fcomp dword ptr [0.0 (FLOAT)]
0x476bbf : fnstsw ax
0x476bc1 : test ah, 1
0x476bc4 : je 0x76
0x476bca : mov eax, dword ptr [ebp + 8] 	(car.c:801)
0x476bcd : mov eax, dword ptr [eax + 0xc]
0x476bd0 : add eax, 0x2c
0x476bd3 : push eax
0x476bd4 : mov eax, dword ptr [ebp + 8]
0x476bd7 : add eax, 0xfc
0x476bdc : push eax
0x476bdd : lea eax, [ebp - 0x48]
0x476be0 : push eax
0x476be1 : call GetNewBoundingBox (FUNCTION)
0x476be6 : add esp, 0xc
0x476be9 : mov eax, dword ptr [ebp + 8] 	(car.c:802)
         : +fld dword ptr [eax + 0x2a0]
         : +fmul dword ptr [ebp - 0x40]
         : +mov eax, dword ptr [ebp + 8]
0x476bec : fld dword ptr [eax + 0x29c]
0x476bf2 : fmul dword ptr [ebp - 0x44]
0x476bf5 : -mov eax, dword ptr [ebp + 8]
0x476bf8 : -fld dword ptr [eax + 0x2a0]
0x476bfe : -fmul dword ptr [ebp - 0x40]
0x476c01 : faddp st(1)
0x476c03 : mov eax, dword ptr [ebp + 8]
0x476c06 : fld dword ptr [eax + 0x298]
0x476c0c : fmul dword ptr [ebp - 0x48]
0x476c0f : faddp st(1)
0x476c11 : fdiv qword ptr [6.9 (FLOAT)]
0x476c17 : mov eax, dword ptr [ebp + 8]
0x476c1a : fsub dword ptr [eax + 0x2a4]
0x476c20 : fcomp qword ptr [0.0 (FLOAT)]
0x476c26 : fnstsw ax


GetFacesInBox is only 95.20% similar to the original, diff above
```

*AI generated. Time taken: 427s, tokens: 56,084*
