### PR TITLE
ApplyPhysicsToCars equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -1289,7 +1289,7 @@ void ApplyPhysicsToCars(tU32 last_frame_time, tU32 pTime_difference) {
     tU32 frame_end_time;
 
     step_number = 0;
-    frame_end_time = last_frame_time + pTime_difference;
+    frame_end_time = pTime_difference + last_frame_time;
     if (gFreeze_mechanics) {
         return;
     }
@@ -1330,7 +1330,7 @@ void ApplyPhysicsToCars(tU32 last_frame_time, tU32 pTime_difference) {
         if (&gProgram_state.current_car != gCar_to_view) {
             BrVector3Copy(&gCar_to_view->old_v, &gCar_to_view->v);
         }
-        for (i = 0; i < gNum_active_cars; i++) {
+        for (i = 0; i <= gNum_active_cars - 1; i++) {
             car = gActive_car_list[i];
             car_info = (tCollision_info*)car;
             car->dt = -1.f;
@@ -1341,7 +1341,8 @@ void ApplyPhysicsToCars(tU32 last_frame_time, tU32 pTime_difference) {
                 if (car->dt < gDt - 0.0001) {
                     if (gNet_mode != eNet_mode_host) {
                         for (dam_index = 0; dam_index < COUNT_OF(car->damage_units); dam_index++) {
-                            if (car->damage_units[dam_index].damage_level < car->message.damage[dam_index]) {
+                            old_num_cars = dam_index;
+                            if ((int)car->damage_units[dam_index].damage_level < (unsigned char)car->message.damage[old_num_cars]) {
                                 car->dt = -1.f;
                                 break;
                             }

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -1335,7 +1335,7 @@ void ApplyPhysicsToCars(tU32 last_frame_time, tU32 pTime_difference) {
         if (&gProgram_state.current_car != gCar_to_view) {
             BrVector3Copy(&gCar_to_view->old_v, &gCar_to_view->v);
         }
-        for (i = 0; i <= gNum_active_cars - 1; i++) {
+        for (i = 0; i < gNum_active_cars; i++) {
             car = gActive_car_list[i];
             car_info = (tCollision_info*)car;
             car->dt = -1.f;
@@ -1346,8 +1346,7 @@ void ApplyPhysicsToCars(tU32 last_frame_time, tU32 pTime_difference) {
                 if (car->dt < gDt - 0.0001) {
                     if (gNet_mode != eNet_mode_host) {
                         for (dam_index = 0; dam_index < COUNT_OF(car->damage_units); dam_index++) {
-                            old_num_cars = dam_index;
-                            if ((int)car->damage_units[dam_index].damage_level < (unsigned char)car->message.damage[old_num_cars]) {
+                            if (car->damage_units[dam_index].damage_level < car->message.damage[dam_index]) {
                                 car->dt = -1.f;
                                 break;
                             }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x47839e,21 +0x44a5ab,21 @@
0x47839e : sub esp, 0x44
0x4783a1 : push ebx
0x4783a2 : push esi
0x4783a3 : push edi
0x4783a4 : mov dword ptr [ebp - 0x24], 0 	(car.c:1293)
0x4783ab : mov eax, dword ptr [ebp + 0xc] 	(car.c:1294)
0x4783ae : add eax, dword ptr [ebp + 8]
0x4783b1 : mov dword ptr [ebp - 0x14], eax
0x4783b4 : cmp dword ptr [gFreeze_mechanics (DATA)], 0 	(car.c:1295)
0x4783bb : je 0x5
0x4783c1 : -jmp 0x55d
         : +jmp 0x563 	(car.c:1296)
0x4783c6 : cmp dword ptr [gNet_mode (DATA)], 3 	(car.c:1298)
0x4783cd : jne 0x5
0x4783d3 : call ForceRebuildActiveCarList (FUNCTION) 	(car.c:1299)
0x4783d8 : mov eax, dword ptr [ebp + 8] 	(car.c:1301)
0x4783db : cmp dword ptr [gLast_mechanics_time (DATA)], eax
0x4783e1 : jae 0x17
0x4783e7 : mov ecx, 0x28 	(car.c:1302)
0x4783ec : mov eax, dword ptr [ebp + 8]
0x4783ef : sub edx, edx
0x4783f1 : div ecx

---
+++
@@ -0x478422,38 +0x44a62f,38 @@
0x478422 : mov eax, dword ptr [ebp - 0x14]
0x478425 : push eax
0x478426 : call InterpolateCars (FUNCTION)
0x47842b : add esp, 8
0x47842e : mov eax, dword ptr [ebp + 0xc] 	(car.c:1313)
0x478431 : push eax
0x478432 : mov eax, dword ptr [ebp - 0x14]
0x478435 : push eax
0x478436 : call FinishCars (FUNCTION)
0x47843b : add esp, 8
0x47843e : -jmp 0x4e0
         : +jmp 0x4e6 	(car.c:1314)
0x478443 : mov dword ptr [gDoing_physics (DATA)], 1 	(car.c:1317)
0x47844d : mov eax, dword ptr [ebp + 8] 	(car.c:1318)
0x478450 : push eax
0x478451 : call PrepareCars (FUNCTION)
0x478456 : add esp, 4
0x478459 : mov dword ptr [ebp - 4], 0x28 	(car.c:1320)
0x478460 : mov dword ptr [gDt (DATA)], 0x3d23d70a 	(car.c:1321)
0x47846a : mov eax, dword ptr [ebp + 0xc] 	(car.c:1330)
0x47846d : mov ecx, dword ptr [gLast_mechanics_time (DATA)]
0x478473 : sub ecx, dword ptr [ebp + 8]
0x478476 : sub eax, ecx
0x478478 : mov dword ptr [gMechanics_time_sync (DATA)], eax
0x47847d : mov eax, dword ptr [ebp - 0x14] 	(car.c:1331)
0x478480 : cmp dword ptr [gLast_mechanics_time (DATA)], eax
0x478486 : -jae 0x449
         : +jae 0x44f
0x47848c : cmp dword ptr [ebp - 0x24], 5
0x478490 : -jge 0x43f
         : +jge 0x445
0x478496 : inc dword ptr [ebp - 0x24] 	(car.c:1332)
0x478499 : call ResetOldmat (FUNCTION) 	(car.c:1333)
0x47849e : mov eax, dword ptr [gProgram_state+200 (OFFSET)] 	(car.c:1334)
0x4784a3 : mov dword ptr [gProgram_state+212 (OFFSET)], eax
0x4784a8 : mov eax, dword ptr [gProgram_state+204 (OFFSET)]
0x4784ad : mov dword ptr [gProgram_state+216 (OFFSET)], eax
0x4784b2 : mov eax, dword ptr [gProgram_state+208 (OFFSET)]
0x4784b7 : mov dword ptr [gProgram_state+220 (OFFSET)], eax
0x4784bc : mov eax, gProgram_state (DATA) 	(car.c:1335)
0x4784c1 : add eax, 0xb0

---
+++
@@ -0x4784f1,44 +0x44a6fe,44 @@
0x4784f1 : mov dword ptr [ecx + 0x28], eax
0x4784f4 : mov eax, dword ptr [gCar_to_view (DATA)]
0x4784f9 : mov ecx, dword ptr [gCar_to_view (DATA)]
0x4784ff : mov eax, dword ptr [eax + 0x20]
0x478502 : mov dword ptr [ecx + 0x2c], eax
0x478505 : mov dword ptr [ebp - 0x1c], 0 	(car.c:1338)
0x47850c : jmp 0x3
0x478511 : inc dword ptr [ebp - 0x1c]
0x478514 : mov eax, dword ptr [ebp - 0x1c]
0x478517 : cmp dword ptr [gNum_active_cars (DATA)], eax
0x47851d : -jle 0x22b
         : +jle 0x22d
0x478523 : mov eax, dword ptr [ebp - 0x1c] 	(car.c:1339)
0x478526 : mov eax, dword ptr [eax*4 + gActive_car_list[0] (DATA)]
0x47852d : mov dword ptr [ebp - 0x20], eax
0x478530 : mov eax, dword ptr [ebp - 0x20] 	(car.c:1340)
0x478533 : mov dword ptr [ebp - 0xc], eax
0x478536 : mov eax, dword ptr [ebp - 0x20] 	(car.c:1341)
0x478539 : mov dword ptr [eax + 0x334], 0xbf800000
0x478543 : mov eax, dword ptr [ebp - 0x20] 	(car.c:1342)
0x478546 : xor ecx, ecx
0x478548 : mov cl, byte ptr [eax + 0x2ad]
0x47854e : cmp ecx, 0xf
0x478551 : -jne 0x131
         : +jne 0x133
0x478557 : mov eax, dword ptr [ebp - 0x20]
0x47855a : mov ecx, dword ptr [gLast_mechanics_time (DATA)]
0x478560 : cmp dword ptr [eax + 0x2b4], ecx
0x478566 : -jb 0x11c
0x47856c : -mov eax, dword ptr [gLast_mechanics_time (DATA)]
0x478571 : -add eax, dword ptr [ebp - 4]
         : +jb 0x11e
         : +mov eax, dword ptr [ebp - 4]
         : +add eax, dword ptr [gLast_mechanics_time (DATA)]
0x478574 : mov ecx, dword ptr [ebp - 0x20]
0x478577 : cmp eax, dword ptr [ecx + 0x2b4]
0x47857d : -jb 0x105
0x478583 : -mov eax, dword ptr [gLast_mechanics_time (DATA)]
0x478588 : -add eax, dword ptr [ebp - 4]
         : +jb 0x106
         : +mov eax, dword ptr [ebp - 4] 	(car.c:1344)
         : +add eax, dword ptr [gLast_mechanics_time (DATA)]
0x47858b : mov ecx, dword ptr [ebp - 0x20]
0x47858e : sub eax, dword ptr [ecx + 0x2b4]
0x478594 : mov dword ptr [ebp - 0x38], eax
0x478597 : mov dword ptr [ebp - 0x34], 0
0x47859e : fild qword ptr [ebp - 0x38]
0x4785a1 : fdiv dword ptr [1000.0 (FLOAT)]
0x4785a7 : mov eax, dword ptr [ebp - 0x20]
0x4785aa : fstp dword ptr [eax + 0x334]
0x4785b0 : fld dword ptr [gDt (DATA)] 	(car.c:1346)
0x4785b6 : fsub qword ptr [0.0001 (FLOAT)]

---
+++
@@ -0x478698,21 +0x44a8a7,21 @@
0x478698 : cmp dword ptr [eax + 0x228], 0
0x47869f : je 0x2c
0x4786a5 : mov eax, dword ptr [ebp - 0x20]
0x4786a8 : cmp dword ptr [eax + 8], 3
0x4786ac : jl 0x1a
0x4786b2 : cmp dword ptr [gPalette_fade_time (DATA)], 0
0x4786b9 : je 0x12
0x4786bf : mov eax, dword ptr [ebp - 0x20]
0x4786c2 : cmp dword ptr [eax + 8], 4
0x4786c6 : jne 0x5
0x4786cc : -jmp -0x1c0
         : +jmp -0x1c2 	(car.c:1368)
0x4786d1 : mov eax, dword ptr [ebp - 0x20] 	(car.c:1371)
0x4786d4 : mov ecx, dword ptr [gFace_num__car (DATA)]
0x4786da : cmp dword ptr [eax + 0x1dc], ecx
0x4786e0 : je 0x37
0x4786e6 : mov eax, dword ptr [ebp - 0x20]
0x4786e9 : mov ecx, dword ptr [gFace_num__car (DATA)]
0x4786ef : dec ecx
0x4786f0 : cmp dword ptr [eax + 0x1dc], ecx
0x4786f6 : jne 0x15
0x4786fc : mov eax, dword ptr [ebp - 0x20]

---
+++
@@ -0x478726,54 +0x44a935,54 @@
0x478726 : fcomp dword ptr [0.0 (FLOAT)]
0x47872c : fnstsw ax
0x47872e : test ah, 0x40
0x478731 : jne 0x12
0x478737 : mov eax, dword ptr [gDt (DATA)] 	(car.c:1375)
0x47873c : push eax
0x47873d : mov eax, dword ptr [ebp - 0x20]
0x478740 : push eax
0x478741 : call MoveAndCollideCar (FUNCTION)
0x478746 : add esp, 8
0x478749 : -jmp -0x23d
         : +jmp -0x23f 	(car.c:1377)
0x47874e : mov dword ptr [ebp - 0x1c], 0 	(car.c:1378)
0x478755 : jmp 0x3
0x47875a : inc dword ptr [ebp - 0x1c]
0x47875d : -mov eax, dword ptr [gNum_active_non_cars (DATA)]
0x478762 : -cmp dword ptr [ebp - 0x1c], eax
0x478765 : -jge 0x12b
         : +mov eax, dword ptr [ebp - 0x1c]
         : +cmp dword ptr [gNum_active_non_cars (DATA)], eax
         : +jle 0x12d
0x47876b : mov eax, dword ptr [ebp - 0x1c] 	(car.c:1379)
0x47876e : mov eax, dword ptr [eax*4 + gActive_non_car_list[0] (DATA)]
0x478775 : mov dword ptr [ebp - 8], eax
0x478778 : mov eax, dword ptr [ebp - 8] 	(car.c:1380)
0x47877b : cmp dword ptr [eax + 0x228], 0
0x478782 : je 0x5
0x478788 : -jmp -0x33
         : +jmp -0x34 	(car.c:1381)
0x47878d : mov eax, dword ptr [ebp - 8] 	(car.c:1383)
0x478790 : mov dword ptr [ebp - 0xc], eax
0x478793 : mov eax, dword ptr [ebp - 0xc] 	(car.c:1384)
0x478796 : mov dword ptr [eax + 0x334], 0xbf800000
0x4787a0 : mov eax, dword ptr [ebp - 0xc] 	(car.c:1385)
0x4787a3 : xor ecx, ecx
0x4787a5 : mov cl, byte ptr [eax + 0x2ad]
0x4787ab : cmp ecx, 0x10
0x4787ae : -jne 0x65
         : +jne 0x67
0x4787b4 : mov eax, dword ptr [ebp - 0xc]
0x4787b7 : mov ecx, dword ptr [gLast_mechanics_time (DATA)]
0x4787bd : cmp dword ptr [eax + 0x2b4], ecx
0x4787c3 : -jb 0x50
0x4787c9 : -mov eax, dword ptr [gLast_mechanics_time (DATA)]
0x4787ce : -add eax, dword ptr [ebp - 4]
         : +jb 0x52
         : +mov eax, dword ptr [ebp - 4]
         : +add eax, dword ptr [gLast_mechanics_time (DATA)]
0x4787d1 : mov ecx, dword ptr [ebp - 0xc]
0x4787d4 : cmp eax, dword ptr [ecx + 0x2b4]
0x4787da : -jb 0x39
0x4787e0 : -mov eax, dword ptr [gLast_mechanics_time (DATA)]
0x4787e5 : -add eax, dword ptr [ebp - 4]
         : +jb 0x3a
         : +mov eax, dword ptr [ebp - 4] 	(car.c:1386)
         : +add eax, dword ptr [gLast_mechanics_time (DATA)]
0x4787e8 : mov ecx, dword ptr [ebp - 0xc]
0x4787eb : sub eax, dword ptr [ecx + 0x2b4]
0x4787f1 : mov dword ptr [ebp - 0x40], eax
0x4787f4 : mov dword ptr [ebp - 0x3c], 0
0x4787fb : fild qword ptr [ebp - 0x40]
0x4787fe : fdiv dword ptr [1000.0 (FLOAT)]
0x478804 : mov eax, dword ptr [ebp - 0xc]
0x478807 : fstp dword ptr [eax + 0x334]
0x47880d : mov eax, dword ptr [ebp - 0xc] 	(car.c:1387)
0x478810 : push eax

---
+++
@@ -0x47886e,37 +0x44aa80,37 @@
0x47886e : fcomp dword ptr [0.0 (FLOAT)]
0x478874 : fnstsw ax
0x478876 : test ah, 0x40
0x478879 : jne 0x12
0x47887f : mov eax, dword ptr [gDt (DATA)] 	(car.c:1395)
0x478884 : push eax
0x478885 : mov eax, dword ptr [ebp - 8]
0x478888 : push eax
0x478889 : call MoveAndCollideNonCar (FUNCTION)
0x47888e : add esp, 8
0x478891 : -jmp -0x13c
         : +jmp -0x13f 	(car.c:1397)
0x478896 : mov eax, dword ptr [gNum_cars_and_non_cars (DATA)] 	(car.c:1399)
0x47889b : mov dword ptr [ebp - 0x10], eax
0x47889e : mov eax, dword ptr [gDt (DATA)] 	(car.c:1400)
0x4788a3 : push eax
0x4788a4 : call CrashCarsTogether (FUNCTION)
0x4788a9 : add esp, 4
0x4788ac : -mov eax, dword ptr [gNum_cars_and_non_cars (DATA)]
0x4788b1 : -cmp dword ptr [ebp - 0x10], eax
0x4788b4 : -jl -0x24
         : +mov eax, dword ptr [ebp - 0x10] 	(car.c:1401)
         : +cmp dword ptr [gNum_cars_and_non_cars (DATA)], eax
         : +jg -0x25
0x4788ba : xor eax, eax 	(car.c:1402)
0x4788bc : sub eax, dword ptr [ebp - 4]
0x4788bf : neg eax
0x4788c1 : sub dword ptr [gMechanics_time_sync (DATA)], eax
0x4788c7 : mov eax, dword ptr [ebp - 4] 	(car.c:1403)
0x4788ca : add dword ptr [gLast_mechanics_time (DATA)], eax
0x4788d0 : -jmp -0x458
         : +jmp -0x45e 	(car.c:1404)
0x4788d5 : mov dword ptr [gMechanics_time_sync (DATA)], 1 	(car.c:1405)
0x4788df : mov eax, dword ptr [gLast_mechanics_time (DATA)] 	(car.c:1406)
0x4788e4 : push eax
0x4788e5 : call SendCarData (FUNCTION)
0x4788ea : add esp, 4
0x4788ed : mov eax, dword ptr [ebp + 0xc] 	(car.c:1407)
0x4788f0 : push eax
0x4788f1 : mov eax, dword ptr [ebp - 0x14]
0x4788f4 : push eax
0x4788f5 : call InterpolateCars (FUNCTION)


ApplyPhysicsToCars is only 91.12% similar to the original, diff above
```

#### Effective match analysis

The shown differences are consistent with non-functional instruction selection changes, not logic changes. Branch conditions that changed (`jge`↔`jle`, `jl`↔`jg`) are paired with swapped `cmp` operands, which preserves the exact predicates. Arithmetic rewrites like `mov eax,[A]; add eax,[B]` vs `mov eax,[B]; add eax,[A]` are equivalent integer math. The larger jump displacement deltas (including >5 bytes) are explainable by local instruction-size/layout shifts (e.g., extra `mov` before `cmp`), while targets still correspond to the same loop/exit behavior. No functional state update, call pattern, or data dependency change is evident in the diff.

#### Original match

```
---
+++
@@ -0x47839b,23 +0x44a57e,23 @@
0x47839b : push ebp 	(car.c:1278)
0x47839c : mov ebp, esp
0x47839e : -sub esp, 0x44
         : +sub esp, 0x40
0x4783a1 : push ebx
0x4783a2 : push esi
0x4783a3 : push edi
0x4783a4 : mov dword ptr [ebp - 0x24], 0 	(car.c:1291)
0x4783ab : -mov eax, dword ptr [ebp + 0xc]
0x4783ae : -add eax, dword ptr [ebp + 8]
         : +mov eax, dword ptr [ebp + 8] 	(car.c:1292)
         : +add eax, dword ptr [ebp + 0xc]
0x4783b1 : mov dword ptr [ebp - 0x14], eax
0x4783b4 : cmp dword ptr [gFreeze_mechanics (DATA)], 0 	(car.c:1293)
0x4783bb : je 0x5
0x4783c1 : -jmp 0x55d
         : +jmp 0x556 	(car.c:1294)
0x4783c6 : cmp dword ptr [gNet_mode (DATA)], 3 	(car.c:1296)
0x4783cd : jne 0x5
0x4783d3 : call ForceRebuildActiveCarList (FUNCTION) 	(car.c:1297)
0x4783d8 : mov eax, dword ptr [ebp + 8] 	(car.c:1299)
0x4783db : cmp dword ptr [gLast_mechanics_time (DATA)], eax
0x4783e1 : jae 0x17
0x4783e7 : mov ecx, 0x28 	(car.c:1303)
0x4783ec : mov eax, dword ptr [ebp + 8]
0x4783ef : sub edx, edx
0x4783f1 : div ecx

---
+++
@@ -0x478422,38 +0x44a605,38 @@
0x478422 : mov eax, dword ptr [ebp - 0x14]
0x478425 : push eax
0x478426 : call InterpolateCars (FUNCTION)
0x47842b : add esp, 8
0x47842e : mov eax, dword ptr [ebp + 0xc] 	(car.c:1310)
0x478431 : push eax
0x478432 : mov eax, dword ptr [ebp - 0x14]
0x478435 : push eax
0x478436 : call FinishCars (FUNCTION)
0x47843b : add esp, 8
0x47843e : -jmp 0x4e0
         : +jmp 0x4d9 	(car.c:1311)
0x478443 : mov dword ptr [gDoing_physics (DATA)], 1 	(car.c:1314)
0x47844d : mov eax, dword ptr [ebp + 8] 	(car.c:1315)
0x478450 : push eax
0x478451 : call PrepareCars (FUNCTION)
0x478456 : add esp, 4
0x478459 : mov dword ptr [ebp - 4], 0x28 	(car.c:1321)
0x478460 : mov dword ptr [gDt (DATA)], 0x3d23d70a 	(car.c:1322)
0x47846a : mov eax, dword ptr [ebp + 0xc] 	(car.c:1325)
0x47846d : mov ecx, dword ptr [gLast_mechanics_time (DATA)]
0x478473 : sub ecx, dword ptr [ebp + 8]
0x478476 : sub eax, ecx
0x478478 : mov dword ptr [gMechanics_time_sync (DATA)], eax
0x47847d : mov eax, dword ptr [ebp - 0x14] 	(car.c:1326)
0x478480 : cmp dword ptr [gLast_mechanics_time (DATA)], eax
0x478486 : -jae 0x449
         : +jae 0x442
0x47848c : cmp dword ptr [ebp - 0x24], 5
0x478490 : -jge 0x43f
         : +jge 0x438
0x478496 : inc dword ptr [ebp - 0x24] 	(car.c:1327)
0x478499 : call ResetOldmat (FUNCTION) 	(car.c:1328)
0x47849e : mov eax, dword ptr [gProgram_state+200 (OFFSET)] 	(car.c:1329)
0x4784a3 : mov dword ptr [gProgram_state+212 (OFFSET)], eax
0x4784a8 : mov eax, dword ptr [gProgram_state+204 (OFFSET)]
0x4784ad : mov dword ptr [gProgram_state+216 (OFFSET)], eax
0x4784b2 : mov eax, dword ptr [gProgram_state+208 (OFFSET)]
0x4784b7 : mov dword ptr [gProgram_state+220 (OFFSET)], eax
0x4784bc : mov eax, gProgram_state (DATA) 	(car.c:1330)
0x4784c1 : add eax, 0xb0

---
+++
@@ -0x4784e8,86 +0x44a6cb,84 @@
0x4784e8 : mov ecx, dword ptr [gCar_to_view (DATA)]
0x4784ee : mov eax, dword ptr [eax + 0x1c]
0x4784f1 : mov dword ptr [ecx + 0x28], eax
0x4784f4 : mov eax, dword ptr [gCar_to_view (DATA)]
0x4784f9 : mov ecx, dword ptr [gCar_to_view (DATA)]
0x4784ff : mov eax, dword ptr [eax + 0x20]
0x478502 : mov dword ptr [ecx + 0x2c], eax
0x478505 : mov dword ptr [ebp - 0x1c], 0 	(car.c:1333)
0x47850c : jmp 0x3
0x478511 : inc dword ptr [ebp - 0x1c]
0x478514 : -mov eax, dword ptr [ebp - 0x1c]
0x478517 : -cmp dword ptr [gNum_active_cars (DATA)], eax
0x47851d : -jle 0x22b
         : +mov eax, dword ptr [gNum_active_cars (DATA)]
         : +cmp dword ptr [ebp - 0x1c], eax
         : +jge 0x225
0x478523 : mov eax, dword ptr [ebp - 0x1c] 	(car.c:1334)
0x478526 : mov eax, dword ptr [eax*4 + gActive_car_list[0] (DATA)]
0x47852d : mov dword ptr [ebp - 0x20], eax
0x478530 : mov eax, dword ptr [ebp - 0x20] 	(car.c:1335)
0x478533 : mov dword ptr [ebp - 0xc], eax
0x478536 : mov eax, dword ptr [ebp - 0x20] 	(car.c:1336)
0x478539 : mov dword ptr [eax + 0x334], 0xbf800000
0x478543 : mov eax, dword ptr [ebp - 0x20] 	(car.c:1337)
0x478546 : xor ecx, ecx
0x478548 : mov cl, byte ptr [eax + 0x2ad]
0x47854e : cmp ecx, 0xf
0x478551 : -jne 0x131
         : +jne 0x12b
0x478557 : mov eax, dword ptr [ebp - 0x20]
0x47855a : mov ecx, dword ptr [gLast_mechanics_time (DATA)]
0x478560 : cmp dword ptr [eax + 0x2b4], ecx
0x478566 : -jb 0x11c
         : +jb 0x116
0x47856c : mov eax, dword ptr [gLast_mechanics_time (DATA)]
0x478571 : add eax, dword ptr [ebp - 4]
0x478574 : mov ecx, dword ptr [ebp - 0x20]
0x478577 : cmp eax, dword ptr [ecx + 0x2b4]
0x47857d : -jb 0x105
         : +jb 0xff
0x478583 : mov eax, dword ptr [gLast_mechanics_time (DATA)] 	(car.c:1339)
0x478588 : add eax, dword ptr [ebp - 4]
0x47858b : mov ecx, dword ptr [ebp - 0x20]
0x47858e : sub eax, dword ptr [ecx + 0x2b4]
0x478594 : mov dword ptr [ebp - 0x38], eax
0x478597 : mov dword ptr [ebp - 0x34], 0
0x47859e : fild qword ptr [ebp - 0x38]
0x4785a1 : fdiv dword ptr [1000.0 (FLOAT)]
0x4785a7 : mov eax, dword ptr [ebp - 0x20]
0x4785aa : fstp dword ptr [eax + 0x334]
0x4785b0 : fld dword ptr [gDt (DATA)] 	(car.c:1341)
0x4785b6 : fsub qword ptr [0.0001 (FLOAT)]
0x4785bc : mov eax, dword ptr [ebp - 0x20]
0x4785bf : fcomp dword ptr [eax + 0x334]
0x4785c5 : fnstsw ax
0x4785c7 : test ah, 0x41
0x4785ca : -jne 0xac
         : +jne 0xa6
0x4785d0 : cmp dword ptr [gNet_mode (DATA)], 2 	(car.c:1342)
0x4785d7 : -je 0x8d
         : +je 0x87
0x4785dd : mov dword ptr [ebp - 0x18], 0 	(car.c:1343)
0x4785e4 : jmp 0x3
0x4785e9 : inc dword ptr [ebp - 0x18]
0x4785ec : cmp dword ptr [ebp - 0x18], 0xc
0x4785f0 : -jge 0x49
         : +jge 0x43
         : +mov eax, dword ptr [ebp - 0x18] 	(car.c:1344)
         : +mov ecx, dword ptr [ebp - 0x20]
         : +xor edx, edx
         : +mov dl, byte ptr [eax + ecx + 0x310]
0x4785f6 : mov eax, dword ptr [ebp - 0x18]
0x4785f9 : mov ecx, eax
0x4785fb : lea eax, [eax + eax*4]
0x4785fe : lea eax, [eax + eax*8]
0x478601 : sub eax, ecx
0x478603 : -mov dword ptr [ebp - 0x44], eax
0x478606 : mov ecx, dword ptr [ebp - 0x20]
0x478609 : -mov edx, dword ptr [ebp - 0x18]
0x47860c : -mov ebx, dword ptr [ebp - 0x20]
0x47860f : -xor eax, eax
0x478611 : -mov al, byte ptr [edx + ebx + 0x310]
0x478618 : -mov edx, dword ptr [ebp - 0x44]
0x47861b : -cmp dword ptr [edx + ecx + 0x750], eax
0x478622 : -jge 0x12
         : +cmp edx, dword ptr [eax + ecx + 0x750]
         : +jle 0x12
0x478628 : mov eax, dword ptr [ebp - 0x20] 	(car.c:1345)
0x47862b : mov dword ptr [eax + 0x334], 0xbf800000
0x478635 : jmp 0x5 	(car.c:1346)
0x47863a : -jmp -0x56
         : +jmp -0x50 	(car.c:1348)
0x47863f : mov eax, dword ptr [ebp - 0x20] 	(car.c:1349)
0x478642 : fld dword ptr [eax + 0x334]
0x478648 : fcomp dword ptr [0.0 (FLOAT)]
0x47864e : fnstsw ax
0x478650 : test ah, 1
0x478653 : jne 0xc
0x478659 : mov eax, dword ptr [ebp - 0x20] 	(car.c:1350)
0x47865c : push eax
0x47865d : call GetNetPos (FUNCTION)
0x478662 : add esp, 4

---
+++
@@ -0x478698,21 +0x44a874,21 @@
0x478698 : cmp dword ptr [eax + 0x228], 0
0x47869f : je 0x2c
0x4786a5 : mov eax, dword ptr [ebp - 0x20]
0x4786a8 : cmp dword ptr [eax + 8], 3
0x4786ac : jl 0x1a
0x4786b2 : cmp dword ptr [gPalette_fade_time (DATA)], 0
0x4786b9 : je 0x12
0x4786bf : mov eax, dword ptr [ebp - 0x20]
0x4786c2 : cmp dword ptr [eax + 8], 4
0x4786c6 : jne 0x5
0x4786cc : -jmp -0x1c0
         : +jmp -0x1b9 	(car.c:1363)
0x4786d1 : mov eax, dword ptr [ebp - 0x20] 	(car.c:1366)
0x4786d4 : mov ecx, dword ptr [gFace_num__car (DATA)]
0x4786da : cmp dword ptr [eax + 0x1dc], ecx
0x4786e0 : je 0x37
0x4786e6 : mov eax, dword ptr [ebp - 0x20]
0x4786e9 : mov ecx, dword ptr [gFace_num__car (DATA)]
0x4786ef : dec ecx
0x4786f0 : cmp dword ptr [eax + 0x1dc], ecx
0x4786f6 : jne 0x15
0x4786fc : mov eax, dword ptr [ebp - 0x20]

---
+++
@@ -0x478726,21 +0x44a902,21 @@
0x478726 : fcomp dword ptr [0.0 (FLOAT)]
0x47872c : fnstsw ax
0x47872e : test ah, 0x40
0x478731 : jne 0x12
0x478737 : mov eax, dword ptr [gDt (DATA)] 	(car.c:1370)
0x47873c : push eax
0x47873d : mov eax, dword ptr [ebp - 0x20]
0x478740 : push eax
0x478741 : call MoveAndCollideCar (FUNCTION)
0x478746 : add esp, 8
0x478749 : -jmp -0x23d
         : +jmp -0x236 	(car.c:1372)
0x47874e : mov dword ptr [ebp - 0x1c], 0 	(car.c:1373)
0x478755 : jmp 0x3
0x47875a : inc dword ptr [ebp - 0x1c]
0x47875d : mov eax, dword ptr [gNum_active_non_cars (DATA)]
0x478762 : cmp dword ptr [ebp - 0x1c], eax
0x478765 : jge 0x12b
0x47876b : mov eax, dword ptr [ebp - 0x1c] 	(car.c:1374)
0x47876e : mov eax, dword ptr [eax*4 + gActive_non_car_list[0] (DATA)]
0x478775 : mov dword ptr [ebp - 8], eax
0x478778 : mov eax, dword ptr [ebp - 8] 	(car.c:1375)

---
+++
@@ -0x4788a9,21 +0x44aa85,21 @@
0x4788a9 : add esp, 4
0x4788ac : mov eax, dword ptr [gNum_cars_and_non_cars (DATA)] 	(car.c:1396)
0x4788b1 : cmp dword ptr [ebp - 0x10], eax
0x4788b4 : jl -0x24
0x4788ba : xor eax, eax 	(car.c:1397)
0x4788bc : sub eax, dword ptr [ebp - 4]
0x4788bf : neg eax
0x4788c1 : sub dword ptr [gMechanics_time_sync (DATA)], eax
0x4788c7 : mov eax, dword ptr [ebp - 4] 	(car.c:1398)
0x4788ca : add dword ptr [gLast_mechanics_time (DATA)], eax
0x4788d0 : -jmp -0x458
         : +jmp -0x451 	(car.c:1399)
0x4788d5 : mov dword ptr [gMechanics_time_sync (DATA)], 1 	(car.c:1400)
0x4788df : mov eax, dword ptr [gLast_mechanics_time (DATA)] 	(car.c:1401)
0x4788e4 : push eax
0x4788e5 : call SendCarData (FUNCTION)
0x4788ea : add esp, 4
0x4788ed : mov eax, dword ptr [ebp + 0xc] 	(car.c:1402)
0x4788f0 : push eax
0x4788f1 : mov eax, dword ptr [ebp - 0x14]
0x4788f4 : push eax
0x4788f5 : call InterpolateCars (FUNCTION)

---
+++
@@ -0x4788fd,10 +0x44aad9,16 @@
0x4788fd : mov eax, dword ptr [ebp + 0xc] 	(car.c:1403)
0x478900 : push eax
0x478901 : mov eax, dword ptr [ebp - 0x14]
0x478904 : push eax
0x478905 : call FinishCars (FUNCTION)
0x47890a : add esp, 8
0x47890d : mov dword ptr [gDoing_physics (DATA)], 0 	(car.c:1404)
0x478917 : mov eax, dword ptr [ebp + 0xc] 	(car.c:1405)
0x47891a : push eax
0x47891b : call CheckForDeAttachmentOfNonCars (FUNCTION)
         : +add esp, 4
         : +pop edi 	(car.c:1406)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


ApplyPhysicsToCars is only 91.02% similar to the original, diff above
```

*AI generated. Time taken: 1656s, tokens: 250,285*
