### PR TITLE
RotateCar 100% match

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -1996,19 +1996,22 @@ void RotateCar(tCollision_info* c, br_scalar dt) {
     int steps;
     int i;
 
-    rad_squared = BrVector3LengthSquared(&c->omega) * dt;
+    rad_squared = ((c->omega.v[1] * c->omega.v[1] - -(c->omega.v[2] * c->omega.v[2])) + c->omega.v[0] * c->omega.v[0]) * dt;
     BrVector3Copy(&c->oldomega, &c->omega);
 
-    if (rad_squared < .0000001f) {
+    if (rad_squared < .0000001) {
         return;
     }
 
     if (rad_squared > .008f) {
-        steps = sqrt(rad_squared / .032f) + 1;
+        steps = (int)sqrt(rad_squared / .032f) + 1;
         dt = dt / steps;
 
         for (i = 0; i < steps && i < 20; i++) {
             RotateCarSecondOrder(c, dt);
+        }
+        if (i == 20) {
+            i = 21;
         }
     } else {
         RotateCarFirstOrder(c, dt);

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -2006,7 +2006,7 @@ void RotateCar(tCollision_info* c, br_scalar dt) {
     int steps;
     int i;
 
-    rad_squared = ((c->omega.v[1] * c->omega.v[1] - -(c->omega.v[2] * c->omega.v[2])) + c->omega.v[0] * c->omega.v[0]) * dt;
+    rad_squared = BrVector3LengthSquared(&c->omega) * dt;
     BrVector3Copy(&c->oldomega, &c->omega);
 
     if (rad_squared < .0000001) {


### PR DESCRIPTION
## Match result

```
0x47b2fd: RotateCar 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x47b2fd,24 +0x44d03b,24 @@
0x47b2fd : push ebp 	(car.c:1994)
0x47b2fe : mov ebp, esp
0x47b300 : sub esp, 0x10
0x47b303 : push ebx
0x47b304 : push esi
0x47b305 : push edi
0x47b306 : mov eax, dword ptr [ebp + 8] 	(car.c:1999)
         : +fld dword ptr [eax + 0xb0]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 0xb0]
         : +mov eax, dword ptr [ebp + 8]
0x47b309 : fld dword ptr [eax + 0xac]
0x47b30f : mov eax, dword ptr [ebp + 8]
0x47b312 : fmul dword ptr [eax + 0xac]
0x47b318 : -mov eax, dword ptr [ebp + 8]
0x47b31b : -fld dword ptr [eax + 0xb0]
0x47b321 : -mov eax, dword ptr [ebp + 8]
0x47b324 : -fmul dword ptr [eax + 0xb0]
0x47b32a : faddp st(1)
0x47b32c : mov eax, dword ptr [ebp + 8]
0x47b32f : fld dword ptr [eax + 0xa8]
0x47b335 : mov eax, dword ptr [ebp + 8]
0x47b338 : fmul dword ptr [eax + 0xa8]
0x47b33e : faddp st(1)
0x47b340 : fmul dword ptr [ebp + 0xc]
0x47b343 : fstp dword ptr [ebp - 0xc]
0x47b346 : mov eax, dword ptr [ebp + 8] 	(car.c:2000)
0x47b349 : mov ecx, dword ptr [ebp + 8]

---
+++
@@ -0x47b352,35 +0x44d090,35 @@
0x47b352 : mov dword ptr [ecx + 0xb4], eax
0x47b358 : mov eax, dword ptr [ebp + 8]
0x47b35b : mov ecx, dword ptr [ebp + 8]
0x47b35e : mov eax, dword ptr [eax + 0xac]
0x47b364 : mov dword ptr [ecx + 0xb8], eax
0x47b36a : mov eax, dword ptr [ebp + 8]
0x47b36d : mov ecx, dword ptr [ebp + 8]
0x47b370 : mov eax, dword ptr [eax + 0xb0]
0x47b376 : mov dword ptr [ecx + 0xbc], eax
0x47b37c : fld dword ptr [ebp - 0xc] 	(car.c:2002)
0x47b37f : -fcomp qword ptr [1e-07 (FLOAT)]
         : +fcomp dword ptr [1.0000000116860974e-07 (FLOAT)]
0x47b385 : fnstsw ax
0x47b387 : test ah, 1
0x47b38a : je 0x5
0x47b390 : -jmp 0x9a
         : +jmp 0x8e 	(car.c:2003)
0x47b395 : fld dword ptr [ebp - 0xc] 	(car.c:2006)
0x47b398 : fcomp dword ptr [0.00800000037997961 (FLOAT)]
0x47b39e : fnstsw ax
0x47b3a0 : test ah, 0x41
0x47b3a3 : -jne 0x76
         : +jne 0x6a
0x47b3a9 : fld dword ptr [ebp - 0xc] 	(car.c:2007)
0x47b3ac : fdiv dword ptr [0.03200000151991844 (FLOAT)]
0x47b3b2 : call __CIsqrt (FUNCTION)
         : +fadd qword ptr [1.0 (FLOAT)]
0x47b3b7 : call __ftol (FUNCTION)
0x47b3bc : -inc eax
0x47b3bd : mov dword ptr [ebp - 4], eax
0x47b3c0 : mov eax, dword ptr [ebp - 4] 	(car.c:2008)
0x47b3c3 : mov dword ptr [ebp - 0x10], eax
0x47b3c6 : fild dword ptr [ebp - 0x10]
0x47b3c9 : fdivr dword ptr [ebp + 0xc]
0x47b3cc : fstp dword ptr [ebp + 0xc]
0x47b3cf : mov dword ptr [ebp - 8], 0 	(car.c:2010)
0x47b3d6 : jmp 0x3
0x47b3db : inc dword ptr [ebp - 8]
0x47b3de : mov eax, dword ptr [ebp - 4]

---
+++
@@ -0x47b3e4,18 +0x44d127,22 @@
0x47b3e4 : jge 0x1f
0x47b3ea : cmp dword ptr [ebp - 8], 0x14
0x47b3ee : jge 0x15
0x47b3f4 : mov eax, dword ptr [ebp + 0xc] 	(car.c:2011)
0x47b3f7 : push eax
0x47b3f8 : mov eax, dword ptr [ebp + 8]
0x47b3fb : push eax
0x47b3fc : call RotateCarSecondOrder (FUNCTION)
0x47b401 : add esp, 8
0x47b404 : jmp -0x2e 	(car.c:2012)
0x47b409 : -cmp dword ptr [ebp - 8], 0x14
0x47b40d : -jne 0x7
0x47b413 : -mov dword ptr [ebp - 8], 0x15
0x47b41a : jmp 0x10 	(car.c:2013)
0x47b41f : mov eax, dword ptr [ebp + 0xc] 	(car.c:2014)
0x47b422 : push eax
0x47b423 : mov eax, dword ptr [ebp + 8]
0x47b426 : push eax
         : +call RotateCarFirstOrder (FUNCTION)
         : +add esp, 8
         : +pop edi 	(car.c:2016)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


RotateCar is only 83.95% similar to the original, diff above
```

*AI generated. Time taken: 637s, tokens: 49,320*
