### PR TITLE
NonCarCalcForce equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -2059,17 +2059,17 @@ void NonCarCalcForce(tNon_car_spec* nc, br_scalar dt) {
     br_vector3 v;
 
     c = &nc->collision_info;
-    vol = nc->collision_info.last_special_volume;
-    if (nc->collision_info.car_master_actor->identifier[3] != '!') {
+    vol = c->last_special_volume;
+    if (c->car_master_actor->identifier[3] != '!') {
         if (c->car_master_actor->t.t.mat.m[1][1] < nc->snap_off_cosine || c->min_torque_squared == 0.0f) {
             c->car_master_actor->identifier[3] = '!';
             c->M = nc->free_mass;
             c->min_torque_squared = 0.0f;
-            BrVector3Sub(&v, &nc->free_cmpos, &c->cmpos);
-            BrVector3Cross(&tv, &c->omega, &v);
-            BrMatrix34ApplyV(&v, &tv, &c->car_master_actor->t.t.mat);
-            BrVector3Accumulate(&c->v, &v);
-            c->cmpos = nc->free_cmpos;
+            BrVector3Sub(&tv, &nc->free_cmpos, &c->cmpos);
+            BrVector3Cross(&v, &c->omega, &tv);
+            BrMatrix34ApplyV(&tv, &v, &c->car_master_actor->t.t.mat);
+            BrVector3Accumulate(&c->v, &tv);
+            BrVector3Copy(&c->cmpos, &nc->free_cmpos);
         } else {
             BrVector3SetFloat(&c->v, 0.0f, 0.0f, 0.0f);
             ts = BrVector3LengthSquared(&c->omega);
@@ -2079,7 +2079,7 @@ void NonCarCalcForce(tNon_car_spec* nc, br_scalar dt) {
     }
     if (c->car_master_actor->identifier[3] == '!') {
         if (vol != NULL) {
-            c->v.v[1] = c->v.v[1] - dt * 10.0f * vol->gravity_multiplier;
+            c->v.v[1] = c->v.v[1] - BR_MUL(BR_MUL(dt, 10.0f), vol->gravity_multiplier);
         } else {
             c->v.v[1] = c->v.v[1] - dt * 10.0f;
         }
@@ -2087,16 +2087,17 @@ void NonCarCalcForce(tNon_car_spec* nc, br_scalar dt) {
         if (vol != NULL) {
             ts = vol->viscosity_multiplier * ts;
         }
-        ts = -(dt * 0.0005f * ts) / c->M;
-        BrVector3Scale(&v, &c->v, ts);
-        BrVector3Accumulate(&c->v, &v);
+        ts = -BR_MUL(BR_MUL(dt, 0.0005f), ts);
+        ts = ts / c->M;
+        BrVector3Scale(&tv, &c->v, ts);
+        BrVector3Accumulate(&c->v, &tv);
         ts = BrVector3Length(&c->omega);
         if (vol != NULL) {
             ts = vol->viscosity_multiplier * ts;
         }
-        ts = -(dt * 0.0005 * ts);
-        BrVector3Scale(&v, &c->omega, ts);
-        ApplyTorque(CAR(c), &v);
+        ts = -BR_MUL(BR_MUL(dt, 0.0005f), ts);
+        BrVector3Scale(&tv, &c->omega, ts);
+        ApplyTorque(CAR(c), &tv);
     }
 }
 


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x47b73c,23 +0x44d410,23 @@
0x47b73c : fsub dword ptr [eax + 0xd8]
0x47b742 : fstp dword ptr [ebp - 0x20]
0x47b745 : mov eax, dword ptr [ebp + 8]
0x47b748 : fld dword ptr [eax + 0x34c]
0x47b74e : mov eax, dword ptr [ebp - 4]
0x47b751 : fsub dword ptr [eax + 0xdc]
0x47b757 : fstp dword ptr [ebp - 0x1c]
0x47b75a : mov eax, dword ptr [ebp - 4] 	(car.c:2072)
0x47b75d : fld dword ptr [eax + 0xac]
0x47b763 : fmul dword ptr [ebp - 0x1c]
         : +fld dword ptr [ebp - 0x20]
0x47b766 : mov eax, dword ptr [ebp - 4]
0x47b769 : -fld dword ptr [eax + 0xb0]
0x47b76f : -fmul dword ptr [ebp - 0x20]
         : +fmul dword ptr [eax + 0xb0]
0x47b772 : fsubp st(1)
0x47b774 : fstp dword ptr [ebp - 0x10]
0x47b777 : mov eax, dword ptr [ebp - 4]
0x47b77a : fld dword ptr [eax + 0xb0]
0x47b780 : fmul dword ptr [ebp - 0x24]
0x47b783 : mov eax, dword ptr [ebp - 4]
0x47b786 : fld dword ptr [eax + 0xa8]
0x47b78c : fmul dword ptr [ebp - 0x1c]
0x47b78f : fsubp st(1)
0x47b791 : fstp dword ptr [ebp - 0xc]

---
+++
@@ -0x47b82e,32 +0x44d502,32 @@
0x47b82e : jmp 0x76 	(car.c:2076)
0x47b833 : push 0 	(car.c:2077)
0x47b835 : push 0
0x47b837 : push 0
0x47b839 : mov eax, dword ptr [ebp - 4]
0x47b83c : add eax, 0x18
0x47b83f : push eax
0x47b840 : call BrVector3SetFloat (FUNCTION)
0x47b845 : add esp, 0x10
0x47b848 : mov eax, dword ptr [ebp - 4] 	(car.c:2078)
0x47b84b : -fld dword ptr [eax + 0xac]
0x47b851 : -mov eax, dword ptr [ebp - 4]
0x47b854 : -fmul dword ptr [eax + 0xac]
0x47b85a : -mov eax, dword ptr [ebp - 4]
0x47b85d : fld dword ptr [eax + 0xb0]
0x47b863 : mov eax, dword ptr [ebp - 4]
0x47b866 : fmul dword ptr [eax + 0xb0]
0x47b86c : -faddp st(1)
0x47b86e : mov eax, dword ptr [ebp - 4]
0x47b871 : fld dword ptr [eax + 0xa8]
0x47b877 : mov eax, dword ptr [ebp - 4]
0x47b87a : fmul dword ptr [eax + 0xa8]
         : +faddp st(1)
         : +mov eax, dword ptr [ebp - 4]
         : +fld dword ptr [eax + 0xac]
         : +mov eax, dword ptr [ebp - 4]
         : +fmul dword ptr [eax + 0xac]
0x47b880 : faddp st(1)
0x47b882 : fstp dword ptr [ebp - 0x18]
0x47b885 : push 0 	(car.c:2079)
0x47b887 : push 0
0x47b889 : push 0
0x47b88b : mov eax, dword ptr [ebp - 4]
0x47b88e : add eax, 0xa8
0x47b893 : push eax
0x47b894 : call BrVector3SetFloat (FUNCTION)
0x47b899 : add esp, 0x10

---
+++
@@ -0x47b8de,27 +0x44d5b2,27 @@
0x47b8de : mov eax, dword ptr [ebp - 4]
0x47b8e1 : fstp dword ptr [eax + 0x1c]
0x47b8e4 : jmp 0x15 	(car.c:2086)
0x47b8e9 : fld dword ptr [ebp + 0xc] 	(car.c:2087)
0x47b8ec : fmul dword ptr [10.0 (FLOAT)]
0x47b8f2 : mov eax, dword ptr [ebp - 4]
0x47b8f5 : fsubr dword ptr [eax + 0x1c]
0x47b8f8 : mov eax, dword ptr [ebp - 4]
0x47b8fb : fstp dword ptr [eax + 0x1c]
0x47b8fe : mov eax, dword ptr [ebp - 4] 	(car.c:2089)
         : +fld dword ptr [eax + 0x20]
         : +mov eax, dword ptr [ebp - 4]
         : +fmul dword ptr [eax + 0x20]
         : +mov eax, dword ptr [ebp - 4]
0x47b901 : fld dword ptr [eax + 0x1c]
0x47b904 : mov eax, dword ptr [ebp - 4]
0x47b907 : fmul dword ptr [eax + 0x1c]
0x47b90a : -mov eax, dword ptr [ebp - 4]
0x47b90d : -fld dword ptr [eax + 0x20]
0x47b910 : -mov eax, dword ptr [ebp - 4]
0x47b913 : -fmul dword ptr [eax + 0x20]
0x47b916 : faddp st(1)
0x47b918 : mov eax, dword ptr [ebp - 4]
0x47b91b : fld dword ptr [eax + 0x18]
0x47b91e : mov eax, dword ptr [ebp - 4]
0x47b921 : fmul dword ptr [eax + 0x18]
0x47b924 : faddp st(1)
0x47b926 : call __CIsqrt (FUNCTION)
0x47b92b : fstp dword ptr [ebp - 0x18]
0x47b92e : cmp dword ptr [ebp - 0x14], 0 	(car.c:2090)
0x47b932 : je 0xc

---
+++
@@ -0x47b997,32 +0x44d66b,32 @@
0x47b997 : fld dword ptr [eax + 0x1c]
0x47b99a : fadd dword ptr [ebp - 0x20]
0x47b99d : mov eax, dword ptr [ebp - 4]
0x47b9a0 : fstp dword ptr [eax + 0x1c]
0x47b9a3 : mov eax, dword ptr [ebp - 4]
0x47b9a6 : fld dword ptr [eax + 0x20]
0x47b9a9 : fadd dword ptr [ebp - 0x1c]
0x47b9ac : mov eax, dword ptr [ebp - 4]
0x47b9af : fstp dword ptr [eax + 0x20]
0x47b9b2 : mov eax, dword ptr [ebp - 4] 	(car.c:2097)
0x47b9b5 : -fld dword ptr [eax + 0xac]
0x47b9bb : -mov eax, dword ptr [ebp - 4]
0x47b9be : -fmul dword ptr [eax + 0xac]
0x47b9c4 : -mov eax, dword ptr [ebp - 4]
0x47b9c7 : fld dword ptr [eax + 0xb0]
0x47b9cd : mov eax, dword ptr [ebp - 4]
0x47b9d0 : fmul dword ptr [eax + 0xb0]
0x47b9d6 : -faddp st(1)
0x47b9d8 : mov eax, dword ptr [ebp - 4]
0x47b9db : fld dword ptr [eax + 0xa8]
0x47b9e1 : mov eax, dword ptr [ebp - 4]
0x47b9e4 : fmul dword ptr [eax + 0xa8]
         : +faddp st(1)
         : +mov eax, dword ptr [ebp - 4]
         : +fld dword ptr [eax + 0xac]
         : +mov eax, dword ptr [ebp - 4]
         : +fmul dword ptr [eax + 0xac]
0x47b9ea : faddp st(1)
0x47b9ec : call __CIsqrt (FUNCTION)
0x47b9f1 : fstp dword ptr [ebp - 0x18]
0x47b9f4 : cmp dword ptr [ebp - 0x14], 0 	(car.c:2098)
0x47b9f8 : je 0xc
0x47b9fe : mov eax, dword ptr [ebp - 0x14] 	(car.c:2099)
0x47ba01 : fld dword ptr [eax + 0x7c]
0x47ba04 : fmul dword ptr [ebp - 0x18]
0x47ba07 : fstp dword ptr [ebp - 0x18]
0x47ba0a : fld dword ptr [ebp + 0xc] 	(car.c:2101)


NonCarCalcForce is only 94.31% similar to the original, diff above
```

#### Effective match analysis

Yes. All shown differences are x87 stack/instruction reordering that preserve the same algebraic results: products and sums of the same terms are computed, just in a different order (e.g., moving `fld [ebp-0x20]` earlier, and reordering squared-term accumulation before `faddp`). The `fsubp st(1)` case still computes the same expression (`ac*... - b0*...`) with equivalent stack state at the subtraction point. Control flow appears unchanged in the diffed regions (same jumps/conditions; no evidence of meaningful branch-target reshuffling), and there are no semantic changes beyond operation ordering/temporary placement.

#### Original match

```
---
+++
@@ -0x47b68d,127 +0x44d31a,125 @@
0x47b68d : push ebp 	(car.c:2054)
0x47b68e : mov ebp, esp
0x47b690 : sub esp, 0x24
0x47b693 : push ebx
0x47b694 : push esi
0x47b695 : push edi
0x47b696 : mov eax, dword ptr [ebp + 8] 	(car.c:2061)
0x47b699 : mov dword ptr [ebp - 4], eax
0x47b69c : -mov eax, dword ptr [ebp - 4]
         : +mov eax, dword ptr [ebp + 8] 	(car.c:2062)
0x47b69f : mov eax, dword ptr [eax + 0x22c]
0x47b6a5 : mov dword ptr [ebp - 0x14], eax
0x47b6a8 : -mov eax, dword ptr [ebp - 4]
         : +mov eax, dword ptr [ebp + 8] 	(car.c:2063)
0x47b6ab : mov eax, dword ptr [eax + 0xc]
0x47b6ae : mov eax, dword ptr [eax + 0x14]
0x47b6b1 : movsx eax, byte ptr [eax + 3]
0x47b6b5 : cmp eax, 0x21
0x47b6b8 : -je 0x1eb
         : +je 0x1d6
0x47b6be : mov eax, dword ptr [ebp - 4] 	(car.c:2064)
0x47b6c1 : mov eax, dword ptr [eax + 0xc]
0x47b6c4 : fld dword ptr [eax + 0x3c]
0x47b6c7 : mov eax, dword ptr [ebp + 8]
0x47b6ca : fcomp dword ptr [eax + 0x360]
0x47b6d0 : fnstsw ax
0x47b6d2 : test ah, 1
0x47b6d5 : jne 0x17
0x47b6db : mov eax, dword ptr [ebp - 4]
0x47b6de : fld dword ptr [eax + 0x10]
0x47b6e1 : fcomp dword ptr [0.0 (FLOAT)]
0x47b6e7 : fnstsw ax
0x47b6e9 : test ah, 0x40
0x47b6ec : -je 0x141
         : +je 0x12c
0x47b6f2 : mov eax, dword ptr [ebp - 4] 	(car.c:2065)
0x47b6f5 : mov eax, dword ptr [eax + 0xc]
0x47b6f8 : mov eax, dword ptr [eax + 0x14]
0x47b6fb : mov byte ptr [eax + 3], 0x21
0x47b6ff : mov eax, dword ptr [ebp + 8] 	(car.c:2066)
0x47b702 : mov ecx, dword ptr [ebp - 4]
0x47b705 : mov eax, dword ptr [eax + 0x33c]
0x47b70b : mov dword ptr [ecx + 0xc0], eax
0x47b711 : mov eax, dword ptr [ebp - 4] 	(car.c:2067)
0x47b714 : mov dword ptr [eax + 0x10], 0
0x47b71b : mov eax, dword ptr [ebp + 8] 	(car.c:2068)
0x47b71e : fld dword ptr [eax + 0x344]
0x47b724 : mov eax, dword ptr [ebp - 4]
0x47b727 : fsub dword ptr [eax + 0xd4]
0x47b72d : -fstp dword ptr [ebp - 0x24]
         : +fstp dword ptr [ebp - 0x10]
0x47b730 : mov eax, dword ptr [ebp + 8]
0x47b733 : fld dword ptr [eax + 0x348]
0x47b739 : mov eax, dword ptr [ebp - 4]
0x47b73c : fsub dword ptr [eax + 0xd8]
0x47b742 : -fstp dword ptr [ebp - 0x20]
         : +fstp dword ptr [ebp - 0xc]
0x47b745 : mov eax, dword ptr [ebp + 8]
0x47b748 : fld dword ptr [eax + 0x34c]
0x47b74e : mov eax, dword ptr [ebp - 4]
0x47b751 : fsub dword ptr [eax + 0xdc]
0x47b757 : -fstp dword ptr [ebp - 0x1c]
         : +fstp dword ptr [ebp - 8]
0x47b75a : mov eax, dword ptr [ebp - 4] 	(car.c:2069)
0x47b75d : fld dword ptr [eax + 0xac]
0x47b763 : -fmul dword ptr [ebp - 0x1c]
         : +fmul dword ptr [ebp - 8]
0x47b766 : mov eax, dword ptr [ebp - 4]
0x47b769 : fld dword ptr [eax + 0xb0]
0x47b76f : -fmul dword ptr [ebp - 0x20]
         : +fmul dword ptr [ebp - 0xc]
0x47b772 : fsubp st(1)
0x47b774 : -fstp dword ptr [ebp - 0x10]
         : +fstp dword ptr [ebp - 0x24]
0x47b777 : mov eax, dword ptr [ebp - 4]
0x47b77a : fld dword ptr [eax + 0xb0]
0x47b780 : -fmul dword ptr [ebp - 0x24]
         : +fmul dword ptr [ebp - 0x10]
0x47b783 : mov eax, dword ptr [ebp - 4]
0x47b786 : fld dword ptr [eax + 0xa8]
0x47b78c : -fmul dword ptr [ebp - 0x1c]
         : +fmul dword ptr [ebp - 8]
0x47b78f : fsubp st(1)
0x47b791 : -fstp dword ptr [ebp - 0xc]
         : +fstp dword ptr [ebp - 0x20]
0x47b794 : mov eax, dword ptr [ebp - 4]
0x47b797 : fld dword ptr [eax + 0xa8]
0x47b79d : -fmul dword ptr [ebp - 0x20]
         : +fmul dword ptr [ebp - 0xc]
0x47b7a0 : mov eax, dword ptr [ebp - 4]
0x47b7a3 : fld dword ptr [eax + 0xac]
0x47b7a9 : -fmul dword ptr [ebp - 0x24]
         : +fmul dword ptr [ebp - 0x10]
0x47b7ac : fsubp st(1)
0x47b7ae : -fstp dword ptr [ebp - 8]
         : +fstp dword ptr [ebp - 0x1c]
0x47b7b1 : mov eax, dword ptr [ebp - 4] 	(car.c:2070)
0x47b7b4 : mov eax, dword ptr [eax + 0xc]
0x47b7b7 : add eax, 0x2c
0x47b7ba : push eax
         : +lea eax, [ebp - 0x24]
         : +push eax
0x47b7bb : lea eax, [ebp - 0x10]
0x47b7be : -push eax
0x47b7bf : -lea eax, [ebp - 0x24]
0x47b7c2 : push eax
0x47b7c3 : call BrMatrix34ApplyV (FUNCTION)
0x47b7c8 : add esp, 0xc
0x47b7cb : mov eax, dword ptr [ebp - 4] 	(car.c:2071)
0x47b7ce : fld dword ptr [eax + 0x18]
0x47b7d1 : -fadd dword ptr [ebp - 0x24]
         : +fadd dword ptr [ebp - 0x10]
0x47b7d4 : mov eax, dword ptr [ebp - 4]
0x47b7d7 : fstp dword ptr [eax + 0x18]
0x47b7da : mov eax, dword ptr [ebp - 4]
0x47b7dd : fld dword ptr [eax + 0x1c]
0x47b7e0 : -fadd dword ptr [ebp - 0x20]
         : +fadd dword ptr [ebp - 0xc]
0x47b7e3 : mov eax, dword ptr [ebp - 4]
0x47b7e6 : fstp dword ptr [eax + 0x1c]
0x47b7e9 : mov eax, dword ptr [ebp - 4]
0x47b7ec : fld dword ptr [eax + 0x20]
0x47b7ef : -fadd dword ptr [ebp - 0x1c]
         : +fadd dword ptr [ebp - 8]
0x47b7f2 : mov eax, dword ptr [ebp - 4]
0x47b7f5 : fstp dword ptr [eax + 0x20]
0x47b7f8 : mov eax, dword ptr [ebp + 8] 	(car.c:2072)
         : +add eax, 0x344
0x47b7fb : mov ecx, dword ptr [ebp - 4]
0x47b7fe : -mov eax, dword ptr [eax + 0x344]
0x47b804 : -mov dword ptr [ecx + 0xd4], eax
0x47b80a : -mov eax, dword ptr [ebp + 8]
0x47b80d : -mov ecx, dword ptr [ebp - 4]
0x47b810 : -mov eax, dword ptr [eax + 0x348]
0x47b816 : -mov dword ptr [ecx + 0xd8], eax
0x47b81c : -mov eax, dword ptr [ebp + 8]
0x47b81f : -mov ecx, dword ptr [ebp - 4]
0x47b822 : -mov eax, dword ptr [eax + 0x34c]
0x47b828 : -mov dword ptr [ecx + 0xdc], eax
         : +add ecx, 0xd4
         : +mov edx, dword ptr [eax]
         : +mov dword ptr [ecx], edx
         : +mov edx, dword ptr [eax + 4]
         : +mov dword ptr [ecx + 4], edx
         : +mov eax, dword ptr [eax + 8]
         : +mov dword ptr [ecx + 8], eax
0x47b82e : jmp 0x76 	(car.c:2073)
0x47b833 : push 0 	(car.c:2074)
0x47b835 : push 0
0x47b837 : push 0
0x47b839 : mov eax, dword ptr [ebp - 4]
0x47b83c : add eax, 0x18
0x47b83f : push eax
0x47b840 : call BrVector3SetFloat (FUNCTION)
0x47b845 : add esp, 0x10
0x47b848 : mov eax, dword ptr [ebp - 4] 	(car.c:2075)

---
+++
@@ -0x47b893,27 +0x44d50b,27 @@
0x47b893 : push eax
0x47b894 : call BrVector3SetFloat (FUNCTION)
0x47b899 : add esp, 0x10
0x47b89c : mov eax, dword ptr [ebp - 4] 	(car.c:2077)
0x47b89f : mov dword ptr [eax + 0x228], 1
0x47b8a9 : mov eax, dword ptr [ebp - 4] 	(car.c:2080)
0x47b8ac : mov eax, dword ptr [eax + 0xc]
0x47b8af : mov eax, dword ptr [eax + 0x14]
0x47b8b2 : movsx eax, byte ptr [eax + 3]
0x47b8b6 : cmp eax, 0x21
0x47b8b9 : -jne 0x199
         : +jne 0x196
0x47b8bf : cmp dword ptr [ebp - 0x14], 0 	(car.c:2081)
0x47b8c3 : je 0x20
0x47b8c9 : -fld dword ptr [ebp + 0xc]
         : +mov eax, dword ptr [ebp - 0x14] 	(car.c:2082)
         : +fld dword ptr [eax + 0x78]
         : +fmul dword ptr [ebp + 0xc]
0x47b8cc : fmul dword ptr [10.0 (FLOAT)]
0x47b8d2 : -mov eax, dword ptr [ebp - 0x14]
0x47b8d5 : -fmul dword ptr [eax + 0x78]
0x47b8d8 : mov eax, dword ptr [ebp - 4]
0x47b8db : fsubr dword ptr [eax + 0x1c]
0x47b8de : mov eax, dword ptr [ebp - 4]
0x47b8e1 : fstp dword ptr [eax + 0x1c]
0x47b8e4 : jmp 0x15 	(car.c:2083)
0x47b8e9 : fld dword ptr [ebp + 0xc] 	(car.c:2084)
0x47b8ec : fmul dword ptr [10.0 (FLOAT)]
0x47b8f2 : mov eax, dword ptr [ebp - 4]
0x47b8f5 : fsubr dword ptr [eax + 0x1c]
0x47b8f8 : mov eax, dword ptr [ebp - 4]

---
+++
@@ -0x47b921,53 +0x44d599,52 @@
0x47b921 : fmul dword ptr [eax + 0x18]
0x47b924 : faddp st(1)
0x47b926 : call __CIsqrt (FUNCTION)
0x47b92b : fstp dword ptr [ebp - 0x18]
0x47b92e : cmp dword ptr [ebp - 0x14], 0 	(car.c:2087)
0x47b932 : je 0xc
0x47b938 : mov eax, dword ptr [ebp - 0x14] 	(car.c:2088)
0x47b93b : fld dword ptr [eax + 0x7c]
0x47b93e : fmul dword ptr [ebp - 0x18]
0x47b941 : fstp dword ptr [ebp - 0x18]
0x47b944 : -fld dword ptr [ebp + 0xc]
         : +fld dword ptr [ebp - 0x18] 	(car.c:2090)
         : +fmul dword ptr [ebp + 0xc]
0x47b947 : fmul dword ptr [0.0005000000237487257 (FLOAT)]
0x47b94d : -fmul dword ptr [ebp - 0x18]
0x47b950 : -fchs 
0x47b952 : -fst dword ptr [ebp - 0x18]
0x47b955 : mov eax, dword ptr [ebp - 4]
0x47b958 : fdiv dword ptr [eax + 0xc0]
         : +fchs 
0x47b95e : fstp dword ptr [ebp - 0x18]
0x47b961 : mov eax, dword ptr [ebp - 4] 	(car.c:2091)
0x47b964 : fld dword ptr [eax + 0x18]
0x47b967 : fmul dword ptr [ebp - 0x18]
0x47b96a : -fstp dword ptr [ebp - 0x24]
         : +fstp dword ptr [ebp - 0x10]
0x47b96d : mov eax, dword ptr [ebp - 4]
0x47b970 : fld dword ptr [eax + 0x1c]
0x47b973 : fmul dword ptr [ebp - 0x18]
0x47b976 : -fstp dword ptr [ebp - 0x20]
         : +fstp dword ptr [ebp - 0xc]
0x47b979 : mov eax, dword ptr [ebp - 4]
0x47b97c : fld dword ptr [eax + 0x20]
0x47b97f : fmul dword ptr [ebp - 0x18]
0x47b982 : -fstp dword ptr [ebp - 0x1c]
         : +fstp dword ptr [ebp - 8]
0x47b985 : mov eax, dword ptr [ebp - 4] 	(car.c:2092)
0x47b988 : fld dword ptr [eax + 0x18]
0x47b98b : -fadd dword ptr [ebp - 0x24]
         : +fadd dword ptr [ebp - 0x10]
0x47b98e : mov eax, dword ptr [ebp - 4]
0x47b991 : fstp dword ptr [eax + 0x18]
0x47b994 : mov eax, dword ptr [ebp - 4]
0x47b997 : fld dword ptr [eax + 0x1c]
0x47b99a : -fadd dword ptr [ebp - 0x20]
         : +fadd dword ptr [ebp - 0xc]
0x47b99d : mov eax, dword ptr [ebp - 4]
0x47b9a0 : fstp dword ptr [eax + 0x1c]
0x47b9a3 : mov eax, dword ptr [ebp - 4]
0x47b9a6 : fld dword ptr [eax + 0x20]
0x47b9a9 : -fadd dword ptr [ebp - 0x1c]
         : +fadd dword ptr [ebp - 8]
0x47b9ac : mov eax, dword ptr [ebp - 4]
0x47b9af : fstp dword ptr [eax + 0x20]
0x47b9b2 : mov eax, dword ptr [ebp - 4] 	(car.c:2093)
0x47b9b5 : fld dword ptr [eax + 0xac]
0x47b9bb : mov eax, dword ptr [ebp - 4]
0x47b9be : fmul dword ptr [eax + 0xac]
0x47b9c4 : mov eax, dword ptr [ebp - 4]
0x47b9c7 : fld dword ptr [eax + 0xb0]
0x47b9cd : mov eax, dword ptr [ebp - 4]
0x47b9d0 : fmul dword ptr [eax + 0xb0]

---
+++
@@ -0x47b9e4,26 +0x44d659,38 @@
0x47b9e4 : fmul dword ptr [eax + 0xa8]
0x47b9ea : faddp st(1)
0x47b9ec : call __CIsqrt (FUNCTION)
0x47b9f1 : fstp dword ptr [ebp - 0x18]
0x47b9f4 : cmp dword ptr [ebp - 0x14], 0 	(car.c:2094)
0x47b9f8 : je 0xc
0x47b9fe : mov eax, dword ptr [ebp - 0x14] 	(car.c:2095)
0x47ba01 : fld dword ptr [eax + 0x7c]
0x47ba04 : fmul dword ptr [ebp - 0x18]
0x47ba07 : fstp dword ptr [ebp - 0x18]
0x47ba0a : -fld dword ptr [ebp + 0xc]
0x47ba0d : -fmul dword ptr [0.0005000000237487257 (FLOAT)]
0x47ba13 : -fmul dword ptr [ebp - 0x18]
         : +fld dword ptr [ebp - 0x18] 	(car.c:2097)
         : +fmul dword ptr [ebp + 0xc]
         : +fmul qword ptr [0.0005 (FLOAT)]
0x47ba16 : fchs 
0x47ba18 : fstp dword ptr [ebp - 0x18]
0x47ba1b : mov eax, dword ptr [ebp - 4] 	(car.c:2098)
0x47ba1e : fld dword ptr [eax + 0xa8]
0x47ba24 : fmul dword ptr [ebp - 0x18]
0x47ba27 : -fstp dword ptr [ebp - 0x24]
         : +fstp dword ptr [ebp - 0x10]
0x47ba2a : mov eax, dword ptr [ebp - 4]
0x47ba2d : fld dword ptr [eax + 0xac]
0x47ba33 : fmul dword ptr [ebp - 0x18]
0x47ba36 : -fstp dword ptr [ebp - 0x20]
         : +fstp dword ptr [ebp - 0xc]
0x47ba39 : mov eax, dword ptr [ebp - 4]
0x47ba3c : fld dword ptr [eax + 0xb0]
0x47ba42 : fmul dword ptr [ebp - 0x18]
         : +fstp dword ptr [ebp - 8]
         : +lea eax, [ebp - 0x10] 	(car.c:2099)
         : +push eax
         : +mov eax, dword ptr [ebp - 4]
         : +push eax
         : +call ApplyTorque (FUNCTION)
         : +add esp, 8
         : +pop edi 	(car.c:2101)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


NonCarCalcForce is only 80.07% similar to the original, diff above
```

*AI generated. Time taken: 496s, tokens: 55,067*
