### PR TITLE
SteeringSelfCentre equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -2034,18 +2034,22 @@ void SteeringSelfCentre(tCar_spec* c, br_scalar dt, br_vector3* n) {
     if (-c->maxcurve > c->curvature) {
         c->curvature = -c->maxcurve;
     }
-    if (!c->keys.left && c->joystick.left <= 0 && !c->keys.right && c->joystick.right <= 0 && !c->keys.holdw) {
-        if (c->susp_height[1] > c->oldd[2] || c->susp_height[1] > c->oldd[3]) {
-            ts = -((c->omega.v[2] * n->v[2] + c->omega.v[1] * n->v[1] + c->omega.v[0] * n->v[0]) * (dt / (c->wpos[0].v[2] - c->wpos[2].v[2])));
-            ts2 = -(c->curvature * dt);
-            if (fabs(ts) < fabs(ts2) || (ts * ts2 < 0.0f)) {
-                ts = ts2;
-            }
-            c->curvature = c->curvature + ts;
-            if (c->curvature * ts > 0.0f) {
-                c->curvature = 0.0;
-            }
+    if (c->keys.left || c->joystick.left > 0 || c->keys.right || c->joystick.right > 0 || c->keys.holdw) {
+        return;
+    }
+    if (c->susp_height[1] <= c->oldd[2]) {
+        if (c->susp_height[1] <= c->oldd[3]) {
+            return;
         }
+    }
+    ts = -((c->omega.v[1] * n->v[1] + c->omega.v[2] * n->v[2] + c->omega.v[0] * n->v[0]) * (dt / (c->wpos[0].v[2] - c->wpos[2].v[2])));
+    ts2 = -(c->curvature * dt);
+    if (fabs(ts) < fabs(ts2) || (ts2 * ts < 0.0f)) {
+        ts = ts2;
+    }
+    c->curvature = c->curvature + ts;
+    if (c->curvature * ts > 0.0f) {
+        c->curvature = 0.0;
     }
 }
 


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x47eb78,24 +0x44d280,24 @@
0x47eb78 : mov eax, dword ptr [ebp + 8]
0x47eb7b : fcomp dword ptr [eax + 0x1514]
0x47eb81 : fnstsw ax
0x47eb83 : test ah, 0x41
0x47eb86 : je 0x5
0x47eb8c : jmp 0xcd 	(car.c:2045)
0x47eb91 : mov eax, dword ptr [ebp + 8] 	(car.c:2048)
0x47eb94 : fld dword ptr [eax + 0xb0]
0x47eb9a : mov eax, dword ptr [ebp + 0x10]
0x47eb9d : fmul dword ptr [eax + 8]
         : +mov eax, dword ptr [ebp + 0x10]
         : +fld dword ptr [eax + 4]
0x47eba0 : mov eax, dword ptr [ebp + 8]
0x47eba3 : -fld dword ptr [eax + 0xac]
0x47eba9 : -mov eax, dword ptr [ebp + 0x10]
0x47ebac : -fmul dword ptr [eax + 4]
         : +fmul dword ptr [eax + 0xac]
0x47ebaf : faddp st(1)
0x47ebb1 : mov eax, dword ptr [ebp + 8]
0x47ebb4 : fld dword ptr [eax + 0xa8]
0x47ebba : mov eax, dword ptr [ebp + 0x10]
0x47ebbd : fmul dword ptr [eax]
0x47ebbf : faddp st(1)
0x47ebc1 : mov eax, dword ptr [ebp + 8]
0x47ebc4 : fld dword ptr [eax + 0x14d4]
0x47ebca : mov eax, dword ptr [ebp + 8]
0x47ebcd : fsub dword ptr [eax + 0x14ec]


SteeringSelfCentre is only 97.66% similar to the original, diff above
```

#### Effective match analysis

The diff preserves control flow and computes the same value. The changed block only swaps the order of loading operands for one multiply-add term: original computes `(car->0xb0 * in->8) + (car->0xac * in->4)`, while new computes `(car->0xb0 * in->8) + (in->4 * car->0xac)`. Since multiplication is commutative and the x87 stack use (`faddp`) combines the same two products, the functional result is unchanged (ignoring minor FP ordering effects as requested). No meaningful branch restructuring is introduced.

#### Original match

```
---
+++
@@ -0x47ead7,61 +0x44d198,59 @@
0x47ead7 : jne 0x14
0x47eadd : mov eax, dword ptr [ebp + 8] 	(car.c:2035)
0x47eae0 : fld dword ptr [eax + 0x1500]
0x47eae6 : fchs 
0x47eae8 : mov eax, dword ptr [ebp + 8]
0x47eaeb : fstp dword ptr [eax + 0x14fc]
0x47eaf1 : mov eax, dword ptr [ebp + 8] 	(car.c:2037)
0x47eaf4 : mov eax, dword ptr [eax + 0x1574]
0x47eafa : shr eax, 0x10
0x47eafd : test al, 1
0x47eaff : -jne 0x48
         : +jne 0x14f
0x47eb05 : mov eax, dword ptr [ebp + 8]
0x47eb08 : cmp dword ptr [eax + 0x1578], 0
0x47eb0f : -jg 0x38
         : +jg 0x13f
0x47eb15 : mov eax, dword ptr [ebp + 8]
0x47eb18 : mov eax, dword ptr [eax + 0x1574]
0x47eb1e : shr eax, 0x11
0x47eb21 : test al, 1
0x47eb23 : -jne 0x24
         : +jne 0x12b
0x47eb29 : mov eax, dword ptr [ebp + 8]
0x47eb2c : cmp dword ptr [eax + 0x157c], 0
0x47eb33 : -jg 0x14
         : +jg 0x11b
0x47eb39 : mov eax, dword ptr [ebp + 8]
0x47eb3c : mov eax, dword ptr [eax + 0x1574]
0x47eb42 : shr eax, 0x17
0x47eb45 : test al, 1
0x47eb47 : -je 0x5
0x47eb4d : -jmp 0x10c
         : +jne 0x107
0x47eb52 : mov eax, dword ptr [ebp + 8] 	(car.c:2038)
0x47eb55 : fld dword ptr [eax + 0x14c4]
0x47eb5b : mov eax, dword ptr [ebp + 8]
0x47eb5e : fcomp dword ptr [eax + 0x1510]
0x47eb64 : fnstsw ax
0x47eb66 : test ah, 0x41
0x47eb69 : -je 0x22
         : +je 0x1d
0x47eb6f : mov eax, dword ptr [ebp + 8]
0x47eb72 : fld dword ptr [eax + 0x14c4]
0x47eb78 : mov eax, dword ptr [ebp + 8]
0x47eb7b : fcomp dword ptr [eax + 0x1514]
0x47eb81 : fnstsw ax
0x47eb83 : test ah, 0x41
0x47eb86 : -je 0x5
0x47eb8c : -jmp 0xcd
         : +jne 0xcd
         : +mov eax, dword ptr [ebp + 8] 	(car.c:2039)
         : +fld dword ptr [eax + 0xac]
         : +mov eax, dword ptr [ebp + 0x10]
         : +fmul dword ptr [eax + 4]
0x47eb91 : mov eax, dword ptr [ebp + 8]
0x47eb94 : fld dword ptr [eax + 0xb0]
0x47eb9a : mov eax, dword ptr [ebp + 0x10]
0x47eb9d : fmul dword ptr [eax + 8]
0x47eba0 : -mov eax, dword ptr [ebp + 8]
0x47eba3 : -fld dword ptr [eax + 0xac]
0x47eba9 : -mov eax, dword ptr [ebp + 0x10]
0x47ebac : -fmul dword ptr [eax + 4]
0x47ebaf : faddp st(1)
0x47ebb1 : mov eax, dword ptr [ebp + 8]
0x47ebb4 : fld dword ptr [eax + 0xa8]
0x47ebba : mov eax, dword ptr [ebp + 0x10]
0x47ebbd : fmul dword ptr [eax]
0x47ebbf : faddp st(1)
0x47ebc1 : mov eax, dword ptr [ebp + 8]
0x47ebc4 : fld dword ptr [eax + 0x14d4]
0x47ebca : mov eax, dword ptr [ebp + 8]
0x47ebcd : fsub dword ptr [eax + 0x14ec]

---
+++
@@ -0x47ebe6,31 +0x44d29d,37 @@
0x47ebe6 : fmul dword ptr [ebp + 0xc]
0x47ebe9 : fchs 
0x47ebeb : fst dword ptr [ebp - 8]
0x47ebee : fabs  	(car.c:2041)
0x47ebf0 : fld dword ptr [ebp - 4]
0x47ebf3 : fabs 
0x47ebf5 : fcompp 
0x47ebf7 : fnstsw ax
0x47ebf9 : test ah, 1
0x47ebfc : jne 0x17
0x47ec02 : -fld dword ptr [ebp - 8]
0x47ec05 : -fmul dword ptr [ebp - 4]
         : +fld dword ptr [ebp - 4]
         : +fmul dword ptr [ebp - 8]
0x47ec08 : fcomp dword ptr [0.0 (FLOAT)]
0x47ec0e : fnstsw ax
0x47ec10 : test ah, 1
0x47ec13 : je 0x6
0x47ec19 : mov eax, dword ptr [ebp - 8] 	(car.c:2042)
0x47ec1c : mov dword ptr [ebp - 4], eax
0x47ec1f : mov eax, dword ptr [ebp + 8] 	(car.c:2044)
0x47ec22 : fld dword ptr [eax + 0x14fc]
0x47ec28 : fadd dword ptr [ebp - 4]
0x47ec2b : mov eax, dword ptr [ebp + 8]
0x47ec2e : fstp dword ptr [eax + 0x14fc]
0x47ec34 : mov eax, dword ptr [ebp + 8] 	(car.c:2045)
0x47ec37 : fld dword ptr [eax + 0x14fc]
0x47ec3d : fmul dword ptr [ebp - 4]
0x47ec40 : fcomp dword ptr [0.0 (FLOAT)]
0x47ec46 : fnstsw ax
0x47ec48 : test ah, 0x41
0x47ec4b : jne 0xd
0x47ec51 : mov eax, dword ptr [ebp + 8] 	(car.c:2046)
         : +mov dword ptr [eax + 0x14fc], 0
         : +pop edi 	(car.c:2050)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


SteeringSelfCentre is only 86.29% similar to the original, diff above
```

*AI generated. Time taken: 598s, tokens: 49,634*
