### PR TITLE
AddDrag equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -2116,12 +2116,13 @@ void AddDrag(tCar_spec* c, br_scalar dt) {
         } else {
             drag_multiplier = vol->viscosity_multiplier * drag_multiplier;
         }
-        drag_multiplier = c->water_depth_factor * drag_multiplier;
+        drag_multiplier *= c->water_depth_factor;
     }
-    ts = BrVector3Length(&c->v) * drag_multiplier / c->M;
+    ts = drag_multiplier * BrVector3Length(&c->v);
+    ts /= c->M;
     BrVector3Scale(&b, &c->v, ts);
     BrVector3Accumulate(&c->v, &b);
-    ts = BrVector3Length(&c->omega) * drag_multiplier;
+    ts = drag_multiplier * BrVector3Length(&c->omega);
     BrVector3Scale(&b, &c->omega, ts);
     ApplyTorque(c, &b);
 }


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x47ecb2,27 +0x44d768,27 @@
0x47ecb2 : jmp 0xc 	(car.c:2119)
0x47ecb7 : mov eax, dword ptr [ebp - 0x14] 	(car.c:2120)
0x47ecba : fld dword ptr [eax + 0x7c]
0x47ecbd : fmul dword ptr [ebp - 0x10]
0x47ecc0 : fstp dword ptr [ebp - 0x10]
0x47ecc3 : mov eax, dword ptr [ebp + 8] 	(car.c:2122)
0x47ecc6 : fld dword ptr [eax + 0x2a8]
0x47eccc : fmul dword ptr [ebp - 0x10]
0x47eccf : fstp dword ptr [ebp - 0x10]
0x47ecd2 : mov eax, dword ptr [ebp + 8] 	(car.c:2124)
         : +fld dword ptr [eax + 0x20]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 0x20]
         : +mov eax, dword ptr [ebp + 8]
0x47ecd5 : fld dword ptr [eax + 0x1c]
0x47ecd8 : mov eax, dword ptr [ebp + 8]
0x47ecdb : fmul dword ptr [eax + 0x1c]
0x47ecde : -mov eax, dword ptr [ebp + 8]
0x47ece1 : -fld dword ptr [eax + 0x20]
0x47ece4 : -mov eax, dword ptr [ebp + 8]
0x47ece7 : -fmul dword ptr [eax + 0x20]
0x47ecea : faddp st(1)
0x47ecec : mov eax, dword ptr [ebp + 8]
0x47ecef : fld dword ptr [eax + 0x18]
0x47ecf2 : mov eax, dword ptr [ebp + 8]
0x47ecf5 : fmul dword ptr [eax + 0x18]
0x47ecf8 : faddp st(1)
0x47ecfa : call __CIsqrt (FUNCTION)
0x47ecff : fmul dword ptr [ebp - 0x10]
0x47ed02 : fst dword ptr [ebp - 0x18]
0x47ed05 : mov eax, dword ptr [ebp + 8] 	(car.c:2125)

---
+++
@@ -0x47ed47,32 +0x44d7fd,32 @@
0x47ed47 : fld dword ptr [eax + 0x1c]
0x47ed4a : fadd dword ptr [ebp - 8]
0x47ed4d : mov eax, dword ptr [ebp + 8]
0x47ed50 : fstp dword ptr [eax + 0x1c]
0x47ed53 : mov eax, dword ptr [ebp + 8]
0x47ed56 : fld dword ptr [eax + 0x20]
0x47ed59 : fadd dword ptr [ebp - 4]
0x47ed5c : mov eax, dword ptr [ebp + 8]
0x47ed5f : fstp dword ptr [eax + 0x20]
0x47ed62 : mov eax, dword ptr [ebp + 8] 	(car.c:2128)
         : +fld dword ptr [eax + 0xa8]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 0xa8]
         : +mov eax, dword ptr [ebp + 8]
0x47ed65 : fld dword ptr [eax + 0xac]
0x47ed6b : mov eax, dword ptr [ebp + 8]
0x47ed6e : fmul dword ptr [eax + 0xac]
         : +faddp st(1)
0x47ed74 : mov eax, dword ptr [ebp + 8]
0x47ed77 : fld dword ptr [eax + 0xb0]
0x47ed7d : mov eax, dword ptr [ebp + 8]
0x47ed80 : fmul dword ptr [eax + 0xb0]
0x47ed86 : -faddp st(1)
0x47ed88 : -mov eax, dword ptr [ebp + 8]
0x47ed8b : -fld dword ptr [eax + 0xa8]
0x47ed91 : -mov eax, dword ptr [ebp + 8]
0x47ed94 : -fmul dword ptr [eax + 0xa8]
0x47ed9a : faddp st(1)
0x47ed9c : call __CIsqrt (FUNCTION)
0x47eda1 : fmul dword ptr [ebp - 0x10]
0x47eda4 : fstp dword ptr [ebp - 0x18]
0x47eda7 : mov eax, dword ptr [ebp + 8] 	(car.c:2129)
0x47edaa : fld dword ptr [eax + 0xa8]
0x47edb0 : fmul dword ptr [ebp - 0x18]
0x47edb3 : fstp dword ptr [ebp - 0xc]
0x47edb6 : mov eax, dword ptr [ebp + 8]
0x47edb9 : fld dword ptr [eax + 0xac]


AddDrag is only 92.44% similar to the original, diff above
```

#### Effective match analysis

The shown changes are arithmetic reordering only, not control-flow reshuffling. In both hunks, the code still computes the same sums of squared components before `__CIsqrt` (just in a different operand/order sequence on the x87 stack): first hunk keeps `(v1c^2 + v20^2 + v18^2)`, second keeps `(vac^2 + vb0^2 + va8^2)`. No branch/jump structure changes are present in the diff, and the inserted/removed instructions are equivalent term permutations. Under your stated rules (ignore register allocation/reordering and FP rounding/NaN differences), this is functionally equivalent.

#### Original match

```
---
+++
@@ -0x47ecb2,36 +0x44d721,35 @@
0x47ecb2 : jmp 0xc 	(car.c:2116)
0x47ecb7 : mov eax, dword ptr [ebp - 0x14] 	(car.c:2117)
0x47ecba : fld dword ptr [eax + 0x7c]
0x47ecbd : fmul dword ptr [ebp - 0x10]
0x47ecc0 : fstp dword ptr [ebp - 0x10]
0x47ecc3 : mov eax, dword ptr [ebp + 8] 	(car.c:2119)
0x47ecc6 : fld dword ptr [eax + 0x2a8]
0x47eccc : fmul dword ptr [ebp - 0x10]
0x47eccf : fstp dword ptr [ebp - 0x10]
0x47ecd2 : mov eax, dword ptr [ebp + 8] 	(car.c:2121)
         : +fld dword ptr [eax + 0x18]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 0x18]
         : +mov eax, dword ptr [ebp + 8]
0x47ecd5 : fld dword ptr [eax + 0x1c]
0x47ecd8 : mov eax, dword ptr [ebp + 8]
0x47ecdb : fmul dword ptr [eax + 0x1c]
         : +faddp st(1)
0x47ecde : mov eax, dword ptr [ebp + 8]
0x47ece1 : fld dword ptr [eax + 0x20]
0x47ece4 : mov eax, dword ptr [ebp + 8]
0x47ece7 : fmul dword ptr [eax + 0x20]
0x47ecea : faddp st(1)
0x47ecec : -mov eax, dword ptr [ebp + 8]
0x47ecef : -fld dword ptr [eax + 0x18]
0x47ecf2 : -mov eax, dword ptr [ebp + 8]
0x47ecf5 : -fmul dword ptr [eax + 0x18]
0x47ecf8 : -faddp st(1)
0x47ecfa : call __CIsqrt (FUNCTION)
0x47ecff : fmul dword ptr [ebp - 0x10]
0x47ed02 : -fst dword ptr [ebp - 0x18]
0x47ed05 : mov eax, dword ptr [ebp + 8]
0x47ed08 : fdiv dword ptr [eax + 0xc0]
0x47ed0e : fstp dword ptr [ebp - 0x18]
0x47ed11 : mov eax, dword ptr [ebp + 8] 	(car.c:2122)
0x47ed14 : fld dword ptr [eax + 0x18]
0x47ed17 : fmul dword ptr [ebp - 0x18]
0x47ed1a : fstp dword ptr [ebp - 0xc]
0x47ed1d : mov eax, dword ptr [ebp + 8]
0x47ed20 : fld dword ptr [eax + 0x1c]
0x47ed23 : fmul dword ptr [ebp - 0x18]

---
+++
@@ -0x47ed47,27 +0x44d7b3,27 @@
0x47ed47 : fld dword ptr [eax + 0x1c]
0x47ed4a : fadd dword ptr [ebp - 8]
0x47ed4d : mov eax, dword ptr [ebp + 8]
0x47ed50 : fstp dword ptr [eax + 0x1c]
0x47ed53 : mov eax, dword ptr [ebp + 8]
0x47ed56 : fld dword ptr [eax + 0x20]
0x47ed59 : fadd dword ptr [ebp - 4]
0x47ed5c : mov eax, dword ptr [ebp + 8]
0x47ed5f : fstp dword ptr [eax + 0x20]
0x47ed62 : mov eax, dword ptr [ebp + 8] 	(car.c:2124)
         : +fld dword ptr [eax + 0xb0]
         : +mov eax, dword ptr [ebp + 8]
         : +fmul dword ptr [eax + 0xb0]
         : +mov eax, dword ptr [ebp + 8]
0x47ed65 : fld dword ptr [eax + 0xac]
0x47ed6b : mov eax, dword ptr [ebp + 8]
0x47ed6e : fmul dword ptr [eax + 0xac]
0x47ed74 : -mov eax, dword ptr [ebp + 8]
0x47ed77 : -fld dword ptr [eax + 0xb0]
0x47ed7d : -mov eax, dword ptr [ebp + 8]
0x47ed80 : -fmul dword ptr [eax + 0xb0]
0x47ed86 : faddp st(1)
0x47ed88 : mov eax, dword ptr [ebp + 8]
0x47ed8b : fld dword ptr [eax + 0xa8]
0x47ed91 : mov eax, dword ptr [ebp + 8]
0x47ed94 : fmul dword ptr [eax + 0xa8]
0x47ed9a : faddp st(1)
0x47ed9c : call __CIsqrt (FUNCTION)
0x47eda1 : fmul dword ptr [ebp - 0x10]
0x47eda4 : fstp dword ptr [ebp - 0x18]
0x47eda7 : mov eax, dword ptr [ebp + 8] 	(car.c:2125)

---
+++
@@ -0x47edce,10 +0x44d83a,13 @@
0x47edce : fmul dword ptr [ebp - 0x18]
0x47edd1 : fstp dword ptr [ebp - 4]
0x47edd4 : lea eax, [ebp - 0xc] 	(car.c:2126)
0x47edd7 : push eax
0x47edd8 : mov eax, dword ptr [ebp + 8]
0x47eddb : push eax
0x47eddc : call ApplyTorque (FUNCTION)
0x47ede1 : add esp, 8
0x47ede4 : pop edi 	(car.c:2127)
0x47ede5 : pop esi
         : +pop ebx
         : +leave 
         : +ret 


AddDrag is only 90.60% similar to the original, diff above
```

*AI generated. Time taken: 923s, tokens: 64,327*
