### PR TITLE
AddFriction equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3278,9 +3278,9 @@ br_scalar AddFriction(tCollision_info* c, br_vector3* vel, br_vector3* normal_fo
     br_scalar point_vel;
 
     ts = BrVector3Dot(normal_force, vel) / BrVector3Dot(normal_force, normal_force);
-    BrVector3Scale(&tv, normal_force, ts);
-    BrVector3Sub(vel, vel, &tv);
-    point_vel = total_force * 0.35f * gCurrent_race.material_modifiers[gMaterial_index].car_wall_friction;
+    BrVector3Scale(&norm, normal_force, ts);
+    BrVector3Sub(vel, vel, &norm);
+    total_force = gCurrent_race.material_modifiers[gMaterial_index].car_wall_friction * total_force * 0.35f;
     ts = BrVector3Length(vel);
     if (ts < 0.0001f) {
         BrVector3Set(max_friction, 0.f, 0.f, 0.f);
@@ -3292,24 +3292,24 @@ br_scalar AddFriction(tCollision_info* c, br_vector3* vel, br_vector3* normal_fo
     ftau.v[0] = ftau.v[0] / c->I.v[0];
     ftau.v[1] = ftau.v[1] / c->I.v[1];
     ftau.v[2] = ftau.v[2] / c->I.v[2];
-    ts = 1.0 / c->M;
-    norm.v[0] = pos->v[2] * ftau.v[1] - pos->v[1] * ftau.v[2];
-    norm.v[1] = pos->v[0] * ftau.v[2] - pos->v[2] * ftau.v[0];
-    norm.v[2] = pos->v[1] * ftau.v[0] - pos->v[0] * ftau.v[1];
-    ts = max_friction->v[0] * norm.v[0] + max_friction->v[1] * norm.v[1] + max_friction->v[2] * norm.v[2] + ts;
+    ts = 1.0f / c->M;
+    tv.v[0] = pos->v[2] * ftau.v[1] - pos->v[1] * ftau.v[2];
+    tv.v[1] = pos->v[0] * ftau.v[2] - pos->v[2] * ftau.v[0];
+    tv.v[2] = pos->v[1] * ftau.v[0] - pos->v[0] * ftau.v[1];
+    ts = max_friction->v[0] * tv.v[0] + max_friction->v[1] * tv.v[1] + max_friction->v[2] * tv.v[2] + ts;
     if (fabs(ts) <= 0.0001f) {
         ts = 0.0f;
     } else {
         ts = -BrVector3Dot(max_friction, vel) / ts;
     }
-    if (ts > point_vel) {
-        ts = point_vel;
+    if (ts > total_force) {
+        ts = total_force;
     }
     BrVector3Scale(max_friction, max_friction, ts);
     BrVector3Cross(&tv, pos, max_friction);
     BrVector3Scale(&tv, &tv, c->M);
     ApplyTorque((tCar_spec*)c, &tv);
-    return point_vel;
+    return total_force;
 }
 
 // IDA: void __usercall AddFrictionCarToCar(tCollision_info *car1@<EAX>, tCollision_info *car2@<EDX>, br_vector3 *vel1@<EBX>, br_vector3 *vel2@<ECX>, br_vector3 *normal_force1, br_vector3 *pos1, br_vector3 *pos2, br_scalar total_force, br_vector3 *max_friction)

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3312,9 +3312,7 @@ br_scalar AddFriction(tCollision_info* c, br_vector3* vel, br_vector3* normal_fo
     ftau.v[1] = ftau.v[1] / c->I.v[1];
     ftau.v[2] = ftau.v[2] / c->I.v[2];
     ts = 1.0f / c->M;
-    tv.v[0] = pos->v[2] * ftau.v[1] - pos->v[1] * ftau.v[2];
-    tv.v[1] = pos->v[0] * ftau.v[2] - pos->v[2] * ftau.v[0];
-    tv.v[2] = pos->v[1] * ftau.v[0] - pos->v[0] * ftau.v[1];
+    BrVector3Cross(&tv, &ftau, pos);
     ts = BrVector3Dot(max_friction, &tv) + ts;
     if ((float)fabs(ts) > 0.0001f) {
         ts = -BrVector3Dot(max_friction, vel) / ts;

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -3280,13 +3280,14 @@ br_scalar AddFriction(tCollision_info* c, br_vector3* vel, br_vector3* normal_fo
     ts = BrVector3Dot(normal_force, vel) / BrVector3Dot(normal_force, normal_force);
     BrVector3Scale(&norm, normal_force, ts);
     BrVector3Sub(vel, vel, &norm);
-    total_force = gCurrent_race.material_modifiers[gMaterial_index].car_wall_friction * total_force * 0.35f;
-    ts = BrVector3Length(vel);
-    if (ts < 0.0001f) {
+    total_force = (total_force * 0.35f) * gCurrent_race.material_modifiers[gMaterial_index].car_wall_friction;
+    point_vel = BrVector3Length(vel);
+    if (point_vel < 0.0001f) {
         BrVector3Set(max_friction, 0.f, 0.f, 0.f);
         return 0.0;
     }
-    BrVector3InvScale(max_friction, vel, -ts);
+    ts = 1.0f / (-point_vel);
+    BrVector3Scale(max_friction, vel, ts);
     BrVector3Cross(&ftau, pos, max_friction);
     BrVector3Scale(&ftau, &ftau, c->M);
     ftau.v[0] = ftau.v[0] / c->I.v[0];
@@ -3296,19 +3297,19 @@ br_scalar AddFriction(tCollision_info* c, br_vector3* vel, br_vector3* normal_fo
     tv.v[0] = pos->v[2] * ftau.v[1] - pos->v[1] * ftau.v[2];
     tv.v[1] = pos->v[0] * ftau.v[2] - pos->v[2] * ftau.v[0];
     tv.v[2] = pos->v[1] * ftau.v[0] - pos->v[0] * ftau.v[1];
-    ts = max_friction->v[0] * tv.v[0] + max_friction->v[1] * tv.v[1] + max_friction->v[2] * tv.v[2] + ts;
-    if (fabs(ts) <= 0.0001f) {
-        ts = 0.0f;
-    } else {
+    ts = BrVector3Dot(max_friction, &tv) + ts;
+    if ((float)fabs(ts) > 0.0001f) {
         ts = -BrVector3Dot(max_friction, vel) / ts;
+    } else {
+        ts = 0.0f;
     }
     if (ts > total_force) {
         ts = total_force;
     }
     BrVector3Scale(max_friction, max_friction, ts);
-    BrVector3Cross(&tv, pos, max_friction);
-    BrVector3Scale(&tv, &tv, c->M);
-    ApplyTorque((tCar_spec*)c, &tv);
+    BrVector3Cross(&norm, pos, max_friction);
+    BrVector3Scale(&norm, &norm, c->M);
+    ApplyTorque((tCar_spec*)c, &norm);
     return total_force;
 }
 


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x481cb9,43 +0x4539ed,43 @@
0x481cb9 : push ebp 	(car.c:3278)
0x481cba : mov ebp, esp
0x481cbc : sub esp, 0x2c
0x481cbf : push ebx
0x481cc0 : push esi
0x481cc1 : push edi
0x481cc2 : mov eax, dword ptr [ebp + 0x10] 	(car.c:3285)
         : +fld dword ptr [eax]
         : +mov eax, dword ptr [ebp + 0xc]
         : +fmul dword ptr [eax]
         : +mov eax, dword ptr [ebp + 0x10]
0x481cc5 : fld dword ptr [eax + 4]
0x481cc8 : mov eax, dword ptr [ebp + 0xc]
0x481ccb : fmul dword ptr [eax + 4]
         : +faddp st(1)
0x481cce : mov eax, dword ptr [ebp + 0x10]
0x481cd1 : fld dword ptr [eax + 8]
0x481cd4 : mov eax, dword ptr [ebp + 0xc]
0x481cd7 : fmul dword ptr [eax + 8]
0x481cda : faddp st(1)
0x481cdc : mov eax, dword ptr [ebp + 0x10]
         : +fld dword ptr [eax + 8]
         : +mov eax, dword ptr [ebp + 0x10]
         : +fmul dword ptr [eax + 8]
         : +mov eax, dword ptr [ebp + 0x10]
0x481cdf : fld dword ptr [eax]
0x481ce1 : -mov eax, dword ptr [ebp + 0xc]
         : +mov eax, dword ptr [ebp + 0x10]
0x481ce4 : fmul dword ptr [eax]
0x481ce6 : faddp st(1)
0x481ce8 : mov eax, dword ptr [ebp + 0x10]
0x481ceb : fld dword ptr [eax + 4]
0x481cee : mov eax, dword ptr [ebp + 0x10]
0x481cf1 : fmul dword ptr [eax + 4]
0x481cf4 : -mov eax, dword ptr [ebp + 0x10]
0x481cf7 : -fld dword ptr [eax + 8]
0x481cfa : -mov eax, dword ptr [ebp + 0x10]
0x481cfd : -fmul dword ptr [eax + 8]
0x481d00 : -faddp st(1)
0x481d02 : -mov eax, dword ptr [ebp + 0x10]
0x481d05 : -fld dword ptr [eax]
0x481d07 : -mov eax, dword ptr [ebp + 0x10]
0x481d0a : -fmul dword ptr [eax]
0x481d0c : faddp st(1)
0x481d0e : fdivp st(1)
0x481d10 : fstp dword ptr [ebp - 0x20]
0x481d13 : mov eax, dword ptr [ebp + 0x10] 	(car.c:3286)
0x481d16 : fld dword ptr [eax]
0x481d18 : fmul dword ptr [ebp - 0x20]
0x481d1b : fstp dword ptr [ebp - 0xc]
0x481d1e : mov eax, dword ptr [ebp + 0x10]
0x481d21 : fld dword ptr [eax + 4]
0x481d24 : fmul dword ptr [ebp - 0x20]

---
+++
@@ -0x481d58,32 +0x453a8c,32 @@
0x481d58 : fsub dword ptr [ebp - 4]
0x481d5b : mov eax, dword ptr [ebp + 0xc]
0x481d5e : fstp dword ptr [eax + 8]
0x481d61 : fld dword ptr [ebp + 0x18] 	(car.c:3288)
0x481d64 : fmul dword ptr [0.3499999940395355 (FLOAT)]
0x481d6a : mov eax, dword ptr [gMaterial_index (DATA)]
0x481d6f : lea eax, [eax + eax*4]
0x481d72 : fmul dword ptr [eax*8 + gCurrent_race+4028 (OFFSET)]
0x481d79 : fstp dword ptr [ebp + 0x18]
0x481d7c : mov eax, dword ptr [ebp + 0xc] 	(car.c:3289)
         : +fld dword ptr [eax]
         : +mov eax, dword ptr [ebp + 0xc]
         : +fmul dword ptr [eax]
         : +mov eax, dword ptr [ebp + 0xc]
0x481d7f : fld dword ptr [eax + 4]
0x481d82 : mov eax, dword ptr [ebp + 0xc]
0x481d85 : fmul dword ptr [eax + 4]
         : +faddp st(1)
0x481d88 : mov eax, dword ptr [ebp + 0xc]
0x481d8b : fld dword ptr [eax + 8]
0x481d8e : mov eax, dword ptr [ebp + 0xc]
0x481d91 : fmul dword ptr [eax + 8]
0x481d94 : -faddp st(1)
0x481d96 : -mov eax, dword ptr [ebp + 0xc]
0x481d99 : -fld dword ptr [eax]
0x481d9b : -mov eax, dword ptr [ebp + 0xc]
0x481d9e : -fmul dword ptr [eax]
0x481da0 : faddp st(1)
0x481da2 : call __CIsqrt (FUNCTION)
0x481da7 : fcom dword ptr [9.999999747378752e-05 (FLOAT)] 	(car.c:3290)
0x481dad : fstp dword ptr [ebp - 0x10]
0x481db0 : fnstsw ax
0x481db2 : test ah, 1
0x481db5 : je 0x28
0x481dbb : mov eax, dword ptr [ebp + 0x1c] 	(car.c:3291)
0x481dbe : mov dword ptr [eax], 0
0x481dc4 : mov eax, dword ptr [ebp + 0x1c]

---
+++
@@ -0x481e0c,57 +0x453b40,57 @@
0x481e0c : fstp dword ptr [eax + 4]
0x481e0f : mov eax, dword ptr [ebp + 0xc]
0x481e12 : fld dword ptr [eax + 8]
0x481e15 : fmul dword ptr [ebp - 0x20]
0x481e18 : mov eax, dword ptr [ebp + 0x1c]
0x481e1b : fstp dword ptr [eax + 8]
0x481e1e : mov eax, dword ptr [ebp + 0x14] 	(car.c:3296)
0x481e21 : fld dword ptr [eax + 4]
0x481e24 : mov eax, dword ptr [ebp + 0x1c]
0x481e27 : fmul dword ptr [eax + 8]
         : +mov eax, dword ptr [ebp + 0x1c]
         : +fld dword ptr [eax + 4]
0x481e2a : mov eax, dword ptr [ebp + 0x14]
0x481e2d : -fld dword ptr [eax + 8]
0x481e30 : -mov eax, dword ptr [ebp + 0x1c]
0x481e33 : -fmul dword ptr [eax + 4]
         : +fmul dword ptr [eax + 8]
0x481e36 : fsubp st(1)
0x481e38 : fstp dword ptr [ebp - 0x1c]
0x481e3b : mov eax, dword ptr [ebp + 0x14]
0x481e3e : fld dword ptr [eax + 8]
0x481e41 : mov eax, dword ptr [ebp + 0x1c]
0x481e44 : fmul dword ptr [eax]
0x481e46 : mov eax, dword ptr [ebp + 0x14]
0x481e49 : fld dword ptr [eax]
0x481e4b : mov eax, dword ptr [ebp + 0x1c]
0x481e4e : fmul dword ptr [eax + 8]
0x481e51 : fsubp st(1)
0x481e53 : fstp dword ptr [ebp - 0x18]
         : +mov eax, dword ptr [ebp + 0x1c]
         : +fld dword ptr [eax + 4]
0x481e56 : mov eax, dword ptr [ebp + 0x14]
0x481e59 : -fld dword ptr [eax]
0x481e5b : -mov eax, dword ptr [ebp + 0x1c]
0x481e5e : -fmul dword ptr [eax + 4]
         : +fmul dword ptr [eax]
0x481e61 : mov eax, dword ptr [ebp + 0x14]
0x481e64 : fld dword ptr [eax + 4]
0x481e67 : mov eax, dword ptr [ebp + 0x1c]
0x481e6a : fmul dword ptr [eax]
0x481e6c : fsubp st(1)
0x481e6e : fstp dword ptr [ebp - 0x14]
         : +fld dword ptr [ebp - 0x1c] 	(car.c:3297)
0x481e71 : mov eax, dword ptr [ebp + 8]
0x481e74 : -fld dword ptr [eax + 0xc0]
0x481e7a : -fmul dword ptr [ebp - 0x1c]
         : +fmul dword ptr [eax + 0xc0]
0x481e7d : fstp dword ptr [ebp - 0x1c]
         : +fld dword ptr [ebp - 0x18]
0x481e80 : mov eax, dword ptr [ebp + 8]
0x481e83 : -fld dword ptr [eax + 0xc0]
0x481e89 : -fmul dword ptr [ebp - 0x18]
         : +fmul dword ptr [eax + 0xc0]
0x481e8c : fstp dword ptr [ebp - 0x18]
         : +fld dword ptr [ebp - 0x14]
0x481e8f : mov eax, dword ptr [ebp + 8]
0x481e92 : -fld dword ptr [eax + 0xc0]
0x481e98 : -fmul dword ptr [ebp - 0x14]
         : +fmul dword ptr [eax + 0xc0]
0x481e9b : fstp dword ptr [ebp - 0x14]
0x481e9e : fld dword ptr [ebp - 0x1c] 	(car.c:3298)
0x481ea1 : mov eax, dword ptr [ebp + 8]
0x481ea4 : fdiv dword ptr [eax + 0xc8]
0x481eaa : fstp dword ptr [ebp - 0x1c]
0x481ead : fld dword ptr [ebp - 0x18] 	(car.c:3299)
0x481eb0 : mov eax, dword ptr [ebp + 8]
0x481eb3 : fdiv dword ptr [eax + 0xcc]
0x481eb9 : fstp dword ptr [ebp - 0x18]
0x481ebc : fld dword ptr [ebp - 0x14] 	(car.c:3300)

---
+++
@@ -0x481f07,49 +0x453c3b,49 @@
0x481f07 : fstp dword ptr [ebp - 0x28]
0x481f0a : mov eax, dword ptr [ebp + 0x14] 	(car.c:3304)
0x481f0d : fld dword ptr [eax + 4]
0x481f10 : fmul dword ptr [ebp - 0x1c]
0x481f13 : mov eax, dword ptr [ebp + 0x14]
0x481f16 : fld dword ptr [eax]
0x481f18 : fmul dword ptr [ebp - 0x18]
0x481f1b : fsubp st(1)
0x481f1d : fstp dword ptr [ebp - 0x24]
0x481f20 : mov eax, dword ptr [ebp + 0x1c] 	(car.c:3305)
0x481f23 : -fld dword ptr [eax]
0x481f25 : -fmul dword ptr [ebp - 0x2c]
0x481f28 : -mov eax, dword ptr [ebp + 0x1c]
0x481f2b : fld dword ptr [eax + 4]
0x481f2e : fmul dword ptr [ebp - 0x28]
0x481f31 : -faddp st(1)
0x481f33 : mov eax, dword ptr [ebp + 0x1c]
0x481f36 : fld dword ptr [eax + 8]
0x481f39 : fmul dword ptr [ebp - 0x24]
         : +faddp st(1)
         : +mov eax, dword ptr [ebp + 0x1c]
         : +fld dword ptr [eax]
         : +fmul dword ptr [ebp - 0x2c]
0x481f3c : faddp st(1)
0x481f3e : fadd dword ptr [ebp - 0x20]
0x481f41 : fst dword ptr [ebp - 0x20]
0x481f44 : fabs  	(car.c:3306)
0x481f46 : fcomp dword ptr [9.999999747378752e-05 (FLOAT)]
0x481f4c : fnstsw ax
0x481f4e : test ah, 0x41
0x481f51 : jne 0x33
0x481f57 : mov eax, dword ptr [ebp + 0x1c] 	(car.c:3307)
0x481f5a : fld dword ptr [eax + 4]
0x481f5d : mov eax, dword ptr [ebp + 0xc]
0x481f60 : fmul dword ptr [eax + 4]
0x481f63 : mov eax, dword ptr [ebp + 0x1c]
0x481f66 : fld dword ptr [eax + 8]
0x481f69 : mov eax, dword ptr [ebp + 0xc]
0x481f6c : fmul dword ptr [eax + 8]
0x481f6f : faddp st(1)
         : +mov eax, dword ptr [ebp + 0xc]
         : +fld dword ptr [eax]
0x481f71 : mov eax, dword ptr [ebp + 0x1c]
0x481f74 : -fld dword ptr [eax]
0x481f76 : -mov eax, dword ptr [ebp + 0xc]
0x481f79 : fmul dword ptr [eax]
0x481f7b : faddp st(1)
0x481f7d : fdiv dword ptr [ebp - 0x20]
0x481f80 : fchs 
0x481f82 : fstp dword ptr [ebp - 0x20]
0x481f85 : jmp 0x7 	(car.c:3308)
0x481f8a : mov dword ptr [ebp - 0x20], 0 	(car.c:3309)
0x481f91 : fld dword ptr [ebp - 0x20] 	(car.c:3311)
0x481f94 : fcomp dword ptr [ebp + 0x18]
0x481f97 : fnstsw ax

---
+++
@@ -0x481fc1,57 +0x453cf5,57 @@
0x481fc1 : fstp dword ptr [eax + 4]
0x481fc4 : mov eax, dword ptr [ebp + 0x1c]
0x481fc7 : fld dword ptr [eax + 8]
0x481fca : fmul dword ptr [ebp - 0x20]
0x481fcd : mov eax, dword ptr [ebp + 0x1c]
0x481fd0 : fstp dword ptr [eax + 8]
0x481fd3 : mov eax, dword ptr [ebp + 0x14] 	(car.c:3315)
0x481fd6 : fld dword ptr [eax + 4]
0x481fd9 : mov eax, dword ptr [ebp + 0x1c]
0x481fdc : fmul dword ptr [eax + 8]
         : +mov eax, dword ptr [ebp + 0x1c]
         : +fld dword ptr [eax + 4]
0x481fdf : mov eax, dword ptr [ebp + 0x14]
0x481fe2 : -fld dword ptr [eax + 8]
0x481fe5 : -mov eax, dword ptr [ebp + 0x1c]
0x481fe8 : -fmul dword ptr [eax + 4]
         : +fmul dword ptr [eax + 8]
0x481feb : fsubp st(1)
0x481fed : fstp dword ptr [ebp - 0xc]
0x481ff0 : mov eax, dword ptr [ebp + 0x14]
0x481ff3 : fld dword ptr [eax + 8]
0x481ff6 : mov eax, dword ptr [ebp + 0x1c]
0x481ff9 : fmul dword ptr [eax]
0x481ffb : mov eax, dword ptr [ebp + 0x14]
0x481ffe : fld dword ptr [eax]
0x482000 : mov eax, dword ptr [ebp + 0x1c]
0x482003 : fmul dword ptr [eax + 8]
0x482006 : fsubp st(1)
0x482008 : fstp dword ptr [ebp - 8]
         : +mov eax, dword ptr [ebp + 0x1c]
         : +fld dword ptr [eax + 4]
0x48200b : mov eax, dword ptr [ebp + 0x14]
0x48200e : -fld dword ptr [eax]
0x482010 : -mov eax, dword ptr [ebp + 0x1c]
0x482013 : -fmul dword ptr [eax + 4]
         : +fmul dword ptr [eax]
0x482016 : mov eax, dword ptr [ebp + 0x14]
0x482019 : fld dword ptr [eax + 4]
0x48201c : mov eax, dword ptr [ebp + 0x1c]
0x48201f : fmul dword ptr [eax]
0x482021 : fsubp st(1)
0x482023 : fstp dword ptr [ebp - 4]
         : +fld dword ptr [ebp - 0xc] 	(car.c:3316)
0x482026 : mov eax, dword ptr [ebp + 8]
0x482029 : -fld dword ptr [eax + 0xc0]
0x48202f : -fmul dword ptr [ebp - 0xc]
         : +fmul dword ptr [eax + 0xc0]
0x482032 : fstp dword ptr [ebp - 0xc]
         : +fld dword ptr [ebp - 8]
0x482035 : mov eax, dword ptr [ebp + 8]
0x482038 : -fld dword ptr [eax + 0xc0]
0x48203e : -fmul dword ptr [ebp - 8]
         : +fmul dword ptr [eax + 0xc0]
0x482041 : fstp dword ptr [ebp - 8]
         : +fld dword ptr [ebp - 4]
0x482044 : mov eax, dword ptr [ebp + 8]
0x482047 : -fld dword ptr [eax + 0xc0]
0x48204d : -fmul dword ptr [ebp - 4]
         : +fmul dword ptr [eax + 0xc0]
0x482050 : fstp dword ptr [ebp - 4]
0x482053 : lea eax, [ebp - 0xc] 	(car.c:3317)
0x482056 : push eax
0x482057 : mov eax, dword ptr [ebp + 8]
0x48205a : push eax
0x48205b : call ApplyTorque (FUNCTION)
0x482060 : add esp, 8
0x482063 : fld dword ptr [ebp + 0x18] 	(car.c:3318)
0x482066 : jmp 0x0
0x48206b : pop edi 	(car.c:3319)


AddFriction is only 85.62% similar to the original, diff above
```

#### Effective match analysis

The diff appears functionally equivalent. All shown changes are local FPU instruction reordering/reassociation of the same algebraic terms (dot products, squared-length sums, cross-product components, and scalar multiplies), with loads/multiplies moved earlier or later but preserving the same values consumed and stored. I do not see any added/removed branches or changed jump targets/displacements in these snippets, so control flow is unchanged. Given your rules (ignore register allocation/reordering and minor FP rounding differences, ignore NaN behavior), this is an equivalence-preserving reshuffle rather than a semantic change.

#### Original match

```
---
+++
@@ -0x481d02,278 +0x4539ab,284 @@
0x481d02 : mov eax, dword ptr [ebp + 0x10]
0x481d05 : fld dword ptr [eax]
0x481d07 : mov eax, dword ptr [ebp + 0x10]
0x481d0a : fmul dword ptr [eax]
0x481d0c : faddp st(1)
0x481d0e : fdivp st(1)
0x481d10 : fstp dword ptr [ebp - 0x20]
0x481d13 : mov eax, dword ptr [ebp + 0x10] 	(car.c:3281)
0x481d16 : fld dword ptr [eax]
0x481d18 : fmul dword ptr [ebp - 0x20]
0x481d1b : -fstp dword ptr [ebp - 0xc]
         : +fstp dword ptr [ebp - 0x2c]
0x481d1e : mov eax, dword ptr [ebp + 0x10]
0x481d21 : fld dword ptr [eax + 4]
0x481d24 : fmul dword ptr [ebp - 0x20]
0x481d27 : -fstp dword ptr [ebp - 8]
         : +fstp dword ptr [ebp - 0x28]
0x481d2a : mov eax, dword ptr [ebp + 0x10]
0x481d2d : fld dword ptr [eax + 8]
0x481d30 : fmul dword ptr [ebp - 0x20]
0x481d33 : -fstp dword ptr [ebp - 4]
         : +fstp dword ptr [ebp - 0x24]
0x481d36 : mov eax, dword ptr [ebp + 0xc] 	(car.c:3282)
0x481d39 : fld dword ptr [eax]
0x481d3b : -fsub dword ptr [ebp - 0xc]
         : +fsub dword ptr [ebp - 0x2c]
0x481d3e : mov eax, dword ptr [ebp + 0xc]
0x481d41 : fstp dword ptr [eax]
0x481d43 : mov eax, dword ptr [ebp + 0xc]
0x481d46 : fld dword ptr [eax + 4]
0x481d49 : -fsub dword ptr [ebp - 8]
         : +fsub dword ptr [ebp - 0x28]
0x481d4c : mov eax, dword ptr [ebp + 0xc]
0x481d4f : fstp dword ptr [eax + 4]
0x481d52 : mov eax, dword ptr [ebp + 0xc]
0x481d55 : fld dword ptr [eax + 8]
0x481d58 : -fsub dword ptr [ebp - 4]
         : +fsub dword ptr [ebp - 0x24]
0x481d5b : mov eax, dword ptr [ebp + 0xc]
0x481d5e : fstp dword ptr [eax + 8]
0x481d61 : -fld dword ptr [ebp + 0x18]
0x481d64 : -fmul dword ptr [0.3499999940395355 (FLOAT)]
0x481d6a : mov eax, dword ptr [gMaterial_index (DATA)] 	(car.c:3283)
0x481d6f : lea eax, [eax + eax*4]
0x481d72 : -fmul dword ptr [eax*8 + gCurrent_race+4028 (OFFSET)]
0x481d79 : -fstp dword ptr [ebp + 0x18]
         : +fld dword ptr [eax*8 + gCurrent_race+4028 (OFFSET)]
         : +fmul dword ptr [ebp + 0x18]
         : +fmul dword ptr [0.3499999940395355 (FLOAT)]
         : +fstp dword ptr [ebp - 0x10]
0x481d7c : mov eax, dword ptr [ebp + 0xc] 	(car.c:3284)
0x481d7f : fld dword ptr [eax + 4]
0x481d82 : mov eax, dword ptr [ebp + 0xc]
0x481d85 : fmul dword ptr [eax + 4]
0x481d88 : mov eax, dword ptr [ebp + 0xc]
0x481d8b : fld dword ptr [eax + 8]
0x481d8e : mov eax, dword ptr [ebp + 0xc]
0x481d91 : fmul dword ptr [eax + 8]
0x481d94 : faddp st(1)
0x481d96 : mov eax, dword ptr [ebp + 0xc]
0x481d99 : fld dword ptr [eax]
0x481d9b : mov eax, dword ptr [ebp + 0xc]
0x481d9e : fmul dword ptr [eax]
0x481da0 : faddp st(1)
0x481da2 : call __CIsqrt (FUNCTION)
0x481da7 : fcom dword ptr [9.999999747378752e-05 (FLOAT)] 	(car.c:3285)
0x481dad : -fstp dword ptr [ebp - 0x10]
         : +fstp dword ptr [ebp - 0x20]
0x481db0 : fnstsw ax
0x481db2 : test ah, 1
0x481db5 : je 0x28
0x481dbb : mov eax, dword ptr [ebp + 0x1c] 	(car.c:3286)
0x481dbe : mov dword ptr [eax], 0
0x481dc4 : mov eax, dword ptr [ebp + 0x1c]
0x481dc7 : mov dword ptr [eax + 4], 0
0x481dce : mov eax, dword ptr [ebp + 0x1c]
0x481dd1 : mov dword ptr [eax + 8], 0
0x481dd8 : fld dword ptr [0.0 (FLOAT)] 	(car.c:3287)
0x481dde : -jmp 0x288
0x481de3 : -fld dword ptr [1.0 (FLOAT)]
0x481de9 : -fld dword ptr [ebp - 0x10]
         : +jmp 0x281
         : +mov eax, dword ptr [ebp + 0xc] 	(car.c:3289)
         : +fld dword ptr [eax]
         : +fld dword ptr [ebp - 0x20]
0x481dec : fchs 
0x481dee : fdivp st(1)
0x481df0 : -fstp dword ptr [ebp - 0x20]
0x481df3 : -mov eax, dword ptr [ebp + 0xc]
0x481df6 : -fld dword ptr [eax]
0x481df8 : -fmul dword ptr [ebp - 0x20]
0x481dfb : mov eax, dword ptr [ebp + 0x1c]
0x481dfe : fstp dword ptr [eax]
0x481e00 : mov eax, dword ptr [ebp + 0xc]
0x481e03 : fld dword ptr [eax + 4]
0x481e06 : -fmul dword ptr [ebp - 0x20]
         : +fld dword ptr [ebp - 0x20]
         : +fchs 
         : +fdivp st(1)
0x481e09 : mov eax, dword ptr [ebp + 0x1c]
0x481e0c : fstp dword ptr [eax + 4]
0x481e0f : mov eax, dword ptr [ebp + 0xc]
0x481e12 : fld dword ptr [eax + 8]
0x481e15 : -fmul dword ptr [ebp - 0x20]
         : +fld dword ptr [ebp - 0x20]
         : +fchs 
         : +fdivp st(1)
0x481e18 : mov eax, dword ptr [ebp + 0x1c]
0x481e1b : fstp dword ptr [eax + 8]
         : +mov eax, dword ptr [ebp + 0x1c] 	(car.c:3290)
         : +fld dword ptr [eax + 8]
0x481e1e : mov eax, dword ptr [ebp + 0x14]
         : +fmul dword ptr [eax + 4]
         : +mov eax, dword ptr [ebp + 0x1c]
0x481e21 : fld dword ptr [eax + 4]
0x481e24 : -mov eax, dword ptr [ebp + 0x1c]
         : +mov eax, dword ptr [ebp + 0x14]
0x481e27 : fmul dword ptr [eax + 8]
0x481e2a : -mov eax, dword ptr [ebp + 0x14]
0x481e2d : -fld dword ptr [eax + 8]
0x481e30 : -mov eax, dword ptr [ebp + 0x1c]
0x481e33 : -fmul dword ptr [eax + 4]
0x481e36 : fsubp st(1)
0x481e38 : fstp dword ptr [ebp - 0x1c]
0x481e3b : mov eax, dword ptr [ebp + 0x14]
0x481e3e : fld dword ptr [eax + 8]
0x481e41 : mov eax, dword ptr [ebp + 0x1c]
0x481e44 : fmul dword ptr [eax]
         : +mov eax, dword ptr [ebp + 0x1c]
         : +fld dword ptr [eax + 8]
0x481e46 : mov eax, dword ptr [ebp + 0x14]
0x481e49 : -fld dword ptr [eax]
0x481e4b : -mov eax, dword ptr [ebp + 0x1c]
0x481e4e : -fmul dword ptr [eax + 8]
         : +fmul dword ptr [eax]
0x481e51 : fsubp st(1)
0x481e53 : fstp dword ptr [ebp - 0x18]
         : +mov eax, dword ptr [ebp + 0x1c]
         : +fld dword ptr [eax + 4]
0x481e56 : mov eax, dword ptr [ebp + 0x14]
0x481e59 : -fld dword ptr [eax]
0x481e5b : -mov eax, dword ptr [ebp + 0x1c]
0x481e5e : -fmul dword ptr [eax + 4]
         : +fmul dword ptr [eax]
0x481e61 : mov eax, dword ptr [ebp + 0x14]
0x481e64 : fld dword ptr [eax + 4]
0x481e67 : mov eax, dword ptr [ebp + 0x1c]
0x481e6a : fmul dword ptr [eax]
0x481e6c : fsubp st(1)
0x481e6e : fstp dword ptr [ebp - 0x14]
0x481e71 : mov eax, dword ptr [ebp + 8] 	(car.c:3291)
0x481e74 : fld dword ptr [eax + 0xc0]
0x481e7a : fmul dword ptr [ebp - 0x1c]
0x481e7d : fstp dword ptr [ebp - 0x1c]
         : +fld dword ptr [ebp - 0x18]
0x481e80 : mov eax, dword ptr [ebp + 8]
0x481e83 : -fld dword ptr [eax + 0xc0]
0x481e89 : -fmul dword ptr [ebp - 0x18]
         : +fmul dword ptr [eax + 0xc0]
0x481e8c : fstp dword ptr [ebp - 0x18]
         : +fld dword ptr [ebp - 0x14]
0x481e8f : mov eax, dword ptr [ebp + 8]
0x481e92 : -fld dword ptr [eax + 0xc0]
0x481e98 : -fmul dword ptr [ebp - 0x14]
         : +fmul dword ptr [eax + 0xc0]
0x481e9b : fstp dword ptr [ebp - 0x14]
0x481e9e : fld dword ptr [ebp - 0x1c] 	(car.c:3292)
0x481ea1 : mov eax, dword ptr [ebp + 8]
0x481ea4 : fdiv dword ptr [eax + 0xc8]
0x481eaa : fstp dword ptr [ebp - 0x1c]
0x481ead : fld dword ptr [ebp - 0x18] 	(car.c:3293)
0x481eb0 : mov eax, dword ptr [ebp + 8]
0x481eb3 : fdiv dword ptr [eax + 0xcc]
0x481eb9 : fstp dword ptr [ebp - 0x18]
0x481ebc : fld dword ptr [ebp - 0x14] 	(car.c:3294)
0x481ebf : mov eax, dword ptr [ebp + 8]
0x481ec2 : fdiv dword ptr [eax + 0xd0]
0x481ec8 : fstp dword ptr [ebp - 0x14]
0x481ecb : -fld dword ptr [1.0 (FLOAT)]
         : +fld qword ptr [1.0 (FLOAT)] 	(car.c:3295)
0x481ed1 : mov eax, dword ptr [ebp + 8]
0x481ed4 : fdiv dword ptr [eax + 0xc0]
0x481eda : fstp dword ptr [ebp - 0x20]
         : +fld dword ptr [ebp - 0x18] 	(car.c:3296)
0x481edd : mov eax, dword ptr [ebp + 0x14]
0x481ee0 : -fld dword ptr [eax + 8]
0x481ee3 : -fmul dword ptr [ebp - 0x18]
         : +fmul dword ptr [eax + 8]
0x481ee6 : mov eax, dword ptr [ebp + 0x14]
0x481ee9 : fld dword ptr [eax + 4]
0x481eec : fmul dword ptr [ebp - 0x14]
0x481eef : fsubp st(1)
0x481ef1 : -fstp dword ptr [ebp - 0x2c]
         : +fstp dword ptr [ebp - 0xc]
0x481ef4 : mov eax, dword ptr [ebp + 0x14] 	(car.c:3297)
0x481ef7 : fld dword ptr [eax]
0x481ef9 : fmul dword ptr [ebp - 0x14]
0x481efc : mov eax, dword ptr [ebp + 0x14]
0x481eff : fld dword ptr [eax + 8]
0x481f02 : fmul dword ptr [ebp - 0x1c]
0x481f05 : fsubp st(1)
0x481f07 : -fstp dword ptr [ebp - 0x28]
         : +fstp dword ptr [ebp - 8]
0x481f0a : mov eax, dword ptr [ebp + 0x14] 	(car.c:3298)
0x481f0d : fld dword ptr [eax + 4]
0x481f10 : fmul dword ptr [ebp - 0x1c]
0x481f13 : mov eax, dword ptr [ebp + 0x14]
0x481f16 : fld dword ptr [eax]
0x481f18 : fmul dword ptr [ebp - 0x18]
0x481f1b : fsubp st(1)
0x481f1d : -fstp dword ptr [ebp - 0x24]
         : +fst dword ptr [ebp - 4]
         : +mov eax, dword ptr [ebp + 0x1c] 	(car.c:3299)
         : +fmul dword ptr [eax + 8]
         : +mov eax, dword ptr [ebp + 0x1c]
         : +fld dword ptr [eax + 4]
         : +fmul dword ptr [ebp - 8]
         : +faddp st(1)
0x481f20 : mov eax, dword ptr [ebp + 0x1c]
0x481f23 : fld dword ptr [eax]
0x481f25 : -fmul dword ptr [ebp - 0x2c]
0x481f28 : -mov eax, dword ptr [ebp + 0x1c]
0x481f2b : -fld dword ptr [eax + 4]
0x481f2e : -fmul dword ptr [ebp - 0x28]
0x481f31 : -faddp st(1)
0x481f33 : -mov eax, dword ptr [ebp + 0x1c]
0x481f36 : -fld dword ptr [eax + 8]
0x481f39 : -fmul dword ptr [ebp - 0x24]
         : +fmul dword ptr [ebp - 0xc]
0x481f3c : faddp st(1)
0x481f3e : fadd dword ptr [ebp - 0x20]
0x481f41 : fst dword ptr [ebp - 0x20]
0x481f44 : fabs  	(car.c:3300)
0x481f46 : -fcomp dword ptr [9.999999747378752e-05 (FLOAT)]
         : +fcomp qword ptr [9.999999747378752e-05 (FLOAT)]
0x481f4c : fnstsw ax
0x481f4e : test ah, 0x41
0x481f51 : -jne 0x33
         : +je 0xc
         : +mov dword ptr [ebp - 0x20], 0 	(car.c:3301)
         : +jmp 0x2e 	(car.c:3302)
         : +mov eax, dword ptr [ebp + 0xc] 	(car.c:3303)
         : +fld dword ptr [eax + 4]
0x481f57 : mov eax, dword ptr [ebp + 0x1c]
0x481f5a : -fld dword ptr [eax + 4]
0x481f5d : -mov eax, dword ptr [ebp + 0xc]
0x481f60 : fmul dword ptr [eax + 4]
0x481f63 : mov eax, dword ptr [ebp + 0x1c]
0x481f66 : fld dword ptr [eax + 8]
0x481f69 : mov eax, dword ptr [ebp + 0xc]
0x481f6c : fmul dword ptr [eax + 8]
0x481f6f : faddp st(1)
0x481f71 : mov eax, dword ptr [ebp + 0x1c]
0x481f74 : fld dword ptr [eax]
0x481f76 : mov eax, dword ptr [ebp + 0xc]
0x481f79 : fmul dword ptr [eax]
0x481f7b : faddp st(1)
0x481f7d : fdiv dword ptr [ebp - 0x20]
0x481f80 : fchs 
0x481f82 : fstp dword ptr [ebp - 0x20]
0x481f85 : -jmp 0x7
0x481f8a : -mov dword ptr [ebp - 0x20], 0
0x481f91 : fld dword ptr [ebp - 0x20] 	(car.c:3305)
0x481f94 : -fcomp dword ptr [ebp + 0x18]
         : +fcomp dword ptr [ebp - 0x10]
0x481f97 : fnstsw ax
0x481f99 : test ah, 0x41
0x481f9c : jne 0x6
0x481fa2 : -mov eax, dword ptr [ebp + 0x18]
         : +mov eax, dword ptr [ebp - 0x10] 	(car.c:3306)
0x481fa5 : mov dword ptr [ebp - 0x20], eax
0x481fa8 : mov eax, dword ptr [ebp + 0x1c] 	(car.c:3308)
0x481fab : fld dword ptr [eax]
0x481fad : fmul dword ptr [ebp - 0x20]
0x481fb0 : mov eax, dword ptr [ebp + 0x1c]
0x481fb3 : fstp dword ptr [eax]
0x481fb5 : mov eax, dword ptr [ebp + 0x1c]
0x481fb8 : fld dword ptr [eax + 4]
0x481fbb : fmul dword ptr [ebp - 0x20]
0x481fbe : mov eax, dword ptr [ebp + 0x1c]
0x481fc1 : fstp dword ptr [eax + 4]
0x481fc4 : mov eax, dword ptr [ebp + 0x1c]
0x481fc7 : fld dword ptr [eax + 8]
0x481fca : fmul dword ptr [ebp - 0x20]
0x481fcd : mov eax, dword ptr [ebp + 0x1c]
0x481fd0 : fstp dword ptr [eax + 8]
         : +mov eax, dword ptr [ebp + 0x1c] 	(car.c:3309)
         : +fld dword ptr [eax + 8]
0x481fd3 : mov eax, dword ptr [ebp + 0x14]
         : +fmul dword ptr [eax + 4]
         : +mov eax, dword ptr [ebp + 0x1c]
0x481fd6 : fld dword ptr [eax + 4]
0x481fd9 : -mov eax, dword ptr [ebp + 0x1c]
         : +mov eax, dword ptr [ebp + 0x14]
0x481fdc : fmul dword ptr [eax + 8]
0x481fdf : -mov eax, dword ptr [ebp + 0x14]
0x481fe2 : -fld dword ptr [eax + 8]
0x481fe5 : -mov eax, dword ptr [ebp + 0x1c]
0x481fe8 : -fmul dword ptr [eax + 4]
0x481feb : fsubp st(1)
0x481fed : -fstp dword ptr [ebp - 0xc]
         : +fstp dword ptr [ebp - 0x2c]
0x481ff0 : mov eax, dword ptr [ebp + 0x14]
0x481ff3 : fld dword ptr [eax + 8]
0x481ff6 : mov eax, dword ptr [ebp + 0x1c]
0x481ff9 : fmul dword ptr [eax]
         : +mov eax, dword ptr [ebp + 0x1c]
         : +fld dword ptr [eax + 8]
0x481ffb : mov eax, dword ptr [ebp + 0x14]
0x481ffe : -fld dword ptr [eax]
         : +fmul dword ptr [eax]
         : +fsubp st(1)
         : +fstp dword ptr [ebp - 0x28]
0x482000 : mov eax, dword ptr [ebp + 0x1c]
0x482003 : -fmul dword ptr [eax + 8]
0x482006 : -fsubp st(1)
0x482008 : -fstp dword ptr [ebp - 8]
         : +fld dword ptr [eax + 4]
0x48200b : mov eax, dword ptr [ebp + 0x14]
0x48200e : -fld dword ptr [eax]
0x482010 : -mov eax, dword ptr [ebp + 0x1c]
0x482013 : -fmul dword ptr [eax + 4]
         : +fmul dword ptr [eax]
0x482016 : mov eax, dword ptr [ebp + 0x14]
0x482019 : fld dword ptr [eax + 4]
0x48201c : mov eax, dword ptr [ebp + 0x1c]
0x48201f : fmul dword ptr [eax]
0x482021 : fsubp st(1)
0x482023 : -fstp dword ptr [ebp - 4]
         : +fstp dword ptr [ebp - 0x24]
0x482026 : mov eax, dword ptr [ebp + 8] 	(car.c:3310)
0x482029 : fld dword ptr [eax + 0xc0]
0x48202f : -fmul dword ptr [ebp - 0xc]
0x482032 : -fstp dword ptr [ebp - 0xc]
         : +fmul dword ptr [ebp - 0x2c]
         : +fstp dword ptr [ebp - 0x2c]
         : +fld dword ptr [ebp - 0x28]
0x482035 : mov eax, dword ptr [ebp + 8]
0x482038 : -fld dword ptr [eax + 0xc0]
0x48203e : -fmul dword ptr [ebp - 8]
0x482041 : -fstp dword ptr [ebp - 8]
         : +fmul dword ptr [eax + 0xc0]
         : +fstp dword ptr [ebp - 0x28]
         : +fld dword ptr [ebp - 0x24]
0x482044 : mov eax, dword ptr [ebp + 8]
0x482047 : -fld dword ptr [eax + 0xc0]
0x48204d : -fmul dword ptr [ebp - 4]
0x482050 : -fstp dword ptr [ebp - 4]
0x482053 : -lea eax, [ebp - 0xc]
         : +fmul dword ptr [eax + 0xc0]
         : +fstp dword ptr [ebp - 0x24]
         : +lea eax, [ebp - 0x2c] 	(car.c:3311)
0x482056 : push eax
0x482057 : mov eax, dword ptr [ebp + 8]
0x48205a : push eax
0x48205b : call ApplyTorque (FUNCTION)
0x482060 : add esp, 8
0x482063 : -fld dword ptr [ebp + 0x18]
         : +fld dword ptr [ebp - 0x10] 	(car.c:3312)
         : +jmp 0x0
         : +pop edi 	(car.c:3313)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


AddFriction is only 72.90% similar to the original, diff above
```

*AI generated. Time taken: 421s*
