### PR TITLE
oldMoveOurCar equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -215,9 +215,14 @@ int gInTheSea;
 
 // GLOBAL: CARM95 0x0053a524
 int gCamera_mode;
+
+// GLOBAL: CARM95 0x0053a514
 br_scalar gOur_yaw__car;            // suffix added to avoid duplicate symbol
 br_scalar gGravity__car;            // suffix added to avoid duplicate symbol
+
+// GLOBAL: CARM95 0x0053a530
 br_vector3 gNew_ground_normal__car; // suffix added to avoid duplicate symbol
+
 // GLOBAL: CARM95 0x00550750
 char gNon_car_spec_list[100];
 
@@ -4359,34 +4364,28 @@ int GetBoundsEdge(br_vector3* pos, br_vector3* edge, br_bounds* pB, int plane1, 
 // IDA: void __usercall oldMoveOurCar(br_scalar pNew_y@<EAX>, tU32 pTime_difference@<EDX>, br_model *pThe_model@<EBX>, int pFace_index@<ECX>)
 // FUNCTION: CARM95 0x00485bea
 void oldMoveOurCar(br_scalar pNew_y, tU32 pTime_difference, br_model* pThe_model, int pFace_index) {
-    int below_face_index;
-    int above_face_index;
-    br_scalar speed;
-    br_matrix34 direction_matrix;
+    br_transform direction_transform;
     br_vector3 thrust_vector;
+    br_scalar speed;
 
     speed = (gSelf->t.t.translate.t.v[1] - pNew_y) * 100.0f;
     if (pTime_difference == 0
-        || speed / pTime_difference > 0.6f) {
-        gSelf->t.t.translate.t.v[1] -= pTime_difference * 0.6f / 100.0f;
+        || speed / (br_scalar)pTime_difference > 0.6f) {
+        gSelf->t.t.translate.t.v[1] -= (br_scalar)pTime_difference * 0.6f / 100.0f;
     } else {
         gSelf->t.t.translate.t.v[1] = pNew_y;
         gGround_normal__car = gNew_ground_normal__car;
     }
 
-    below_face_index = ((int)BrDegreeToAngle(gOur_yaw__car)) & 0xffff;
-    thrust_vector.v[0] = -cos(BrAngleToRadian(below_face_index));
+    thrust_vector.v[0] = -cos(BrAngleToRadian(BrDegreeToAngle(gOur_yaw__car)));
     thrust_vector.v[1] = 0.f;
-    above_face_index = ((int)BrDegreeToAngle(gOur_yaw__car)) & 0xffff;
-    thrust_vector.v[2] = sin(BrAngleToRadian(above_face_index));
+    thrust_vector.v[2] = sin(BrAngleToRadian(BrDegreeToAngle(gOur_yaw__car)));
 
-    ((br_transform*)&direction_matrix)->type = BR_TRANSFORM_LOOK_UP;
-    ((br_transform*)&direction_matrix)->t.look_up.look.v[0] = thrust_vector.v[1] * gGround_normal__car.v[2] - thrust_vector.v[2] * gGround_normal__car.v[1];
-    ((br_transform*)&direction_matrix)->t.look_up.look.v[1] = thrust_vector.v[2] * gGround_normal__car.v[0] - gGround_normal__car.v[2] * thrust_vector.v[0];
-    ((br_transform*)&direction_matrix)->t.look_up.look.v[2] = gGround_normal__car.v[1] * thrust_vector.v[0] - thrust_vector.v[1] * gGround_normal__car.v[0];
-    ((br_transform*)&direction_matrix)->t.look_up.up = gGround_normal__car;
-    ((br_transform*)&direction_matrix)->t.look_up.t = gSelf->t.t.translate.t;
-    BrTransformToTransform(&gSelf->t, (br_transform*)&direction_matrix);
+    direction_transform.type = BR_TRANSFORM_LOOK_UP;
+    BrVector3Cross(&direction_transform.t.look_up.look, &thrust_vector, &gGround_normal__car);
+    direction_transform.t.look_up.up = gGround_normal__car;
+    direction_transform.t.look_up.t = gSelf->t.t.translate.t;
+    BrTransformToTransform(&gSelf->t, &direction_transform);
 }
 
 // IDA: void __cdecl ToggleCollisionDetection()

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -4329,21 +4329,37 @@ int GetBoundsEdge(br_vector3* pos, br_vector3* edge, br_bounds* pB, int plane1, 
     return 1;
 }
 
-// IDA: void __usercall oldMoveOurCar(tU32 pTime_difference@<EAX>)
+// IDA: void __usercall oldMoveOurCar(br_scalar pNew_y@<EAX>, tU32 pTime_difference@<EDX>, br_model *pThe_model@<EBX>, int pFace_index@<ECX>)
 // FUNCTION: CARM95 0x00485bea
-void oldMoveOurCar(tU32 pTime_difference) {
-    br_vector3 thrust_vector;
-    br_matrix34 direction_matrix;
-    br_matrix34 old_mat;
-    double rotate_amount;
-    br_scalar nearest_y_above;
-    br_scalar nearest_y_below;
-    br_scalar speed;
+void oldMoveOurCar(br_scalar pNew_y, tU32 pTime_difference, br_model* pThe_model, int pFace_index) {
     int below_face_index;
     int above_face_index;
-    br_model* below_model;
-    br_model* above_model;
-    NOT_IMPLEMENTED();
+    br_scalar speed;
+    br_matrix34 direction_matrix;
+    br_vector3 thrust_vector;
+
+    speed = (gSelf->t.t.translate.t.v[1] - pNew_y) * 100.0f;
+    if (pTime_difference == 0
+        || speed / pTime_difference > 0.6f) {
+        gSelf->t.t.translate.t.v[1] -= pTime_difference * 0.6f / 100.0f;
+    } else {
+        gSelf->t.t.translate.t.v[1] = pNew_y;
+        gGround_normal__car = gNew_ground_normal__car;
+    }
+
+    below_face_index = ((int)BrDegreeToAngle(gOur_yaw__car)) & 0xffff;
+    thrust_vector.v[0] = -cos(BrAngleToRadian(below_face_index));
+    thrust_vector.v[1] = 0.f;
+    above_face_index = ((int)BrDegreeToAngle(gOur_yaw__car)) & 0xffff;
+    thrust_vector.v[2] = sin(BrAngleToRadian(above_face_index));
+
+    ((br_transform*)&direction_matrix)->type = BR_TRANSFORM_LOOK_UP;
+    ((br_transform*)&direction_matrix)->t.look_up.look.v[0] = thrust_vector.v[1] * gGround_normal__car.v[2] - thrust_vector.v[2] * gGround_normal__car.v[1];
+    ((br_transform*)&direction_matrix)->t.look_up.look.v[1] = thrust_vector.v[2] * gGround_normal__car.v[0] - gGround_normal__car.v[2] * thrust_vector.v[0];
+    ((br_transform*)&direction_matrix)->t.look_up.look.v[2] = gGround_normal__car.v[1] * thrust_vector.v[0] - thrust_vector.v[1] * gGround_normal__car.v[0];
+    ((br_transform*)&direction_matrix)->t.look_up.up = gGround_normal__car;
+    ((br_transform*)&direction_matrix)->t.look_up.t = gSelf->t.t.translate.t;
+    BrTransformToTransform(&gSelf->t, (br_transform*)&direction_matrix);
 }
 
 // IDA: void __cdecl ToggleCollisionDetection()

--- a/src/DETHRACE/common/car.h
+++ b/src/DETHRACE/common/car.h
@@ -247,7 +247,7 @@ void GetPlaneNormal(br_vector3* n, int p);
 
 int GetBoundsEdge(br_vector3* pos, br_vector3* edge, br_bounds* pB, int plane1, int plane2, br_vector3* a, br_vector3* b, br_vector3* c, int flag);
 
-void oldMoveOurCar(tU32 pTime_difference);
+void oldMoveOurCar(br_scalar pNew_y, tU32 pTime_difference, br_model* pThe_model, int pFace_index);
 
 void ToggleCollisionDetection(void);
 


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x485bea,111 +0x4578d6,115 @@
0x485bea : push ebp 	(car.c:4347)
0x485beb : mov ebp, esp
0x485bed : -sub esp, 0x5c
         : +sub esp, 0x60
0x485bf0 : push ebx
0x485bf1 : push esi
0x485bf2 : push edi
0x485bf3 : mov eax, dword ptr [gSelf (DATA)] 	(car.c:4354)
0x485bf8 : fld dword ptr [eax + 0x54]
0x485bfb : fsub dword ptr [ebp + 8]
0x485bfe : fmul dword ptr [100.0 (FLOAT)]
0x485c04 : -fstp dword ptr [ebp - 0x44]
         : +fstp dword ptr [ebp - 0x34]
0x485c07 : cmp dword ptr [ebp + 0xc], 0 	(car.c:4356)
0x485c0b : je 0x24
0x485c11 : mov eax, dword ptr [ebp + 0xc]
0x485c14 : -mov dword ptr [ebp - 0x4c], eax
0x485c17 : -mov dword ptr [ebp - 0x48], 0
0x485c1e : -fild qword ptr [ebp - 0x4c]
0x485c21 : -fdivr dword ptr [ebp - 0x44]
         : +mov dword ptr [ebp - 0x50], eax
         : +mov dword ptr [ebp - 0x4c], 0
         : +fild qword ptr [ebp - 0x50]
         : +fdivr dword ptr [ebp - 0x34]
0x485c24 : fcomp dword ptr [0.6000000238418579 (FLOAT)]
0x485c2a : fnstsw ax
0x485c2c : test ah, 0x41
0x485c2f : jne 0x31
0x485c35 : mov eax, dword ptr [ebp + 0xc] 	(car.c:4357)
0x485c38 : -mov dword ptr [ebp - 0x54], eax
0x485c3b : -mov dword ptr [ebp - 0x50], 0
0x485c42 : -fild qword ptr [ebp - 0x54]
         : +mov dword ptr [ebp - 0x58], eax
         : +mov dword ptr [ebp - 0x54], 0
         : +fild qword ptr [ebp - 0x58]
0x485c45 : fmul dword ptr [0.6000000238418579 (FLOAT)]
0x485c4b : fdiv dword ptr [100.0 (FLOAT)]
0x485c51 : mov eax, dword ptr [gSelf (DATA)]
0x485c56 : fsubr dword ptr [eax + 0x54]
0x485c59 : mov eax, dword ptr [gSelf (DATA)]
0x485c5e : fstp dword ptr [eax + 0x54]
0x485c61 : jmp 0x25 	(car.c:4358)
0x485c66 : mov eax, dword ptr [gSelf (DATA)] 	(car.c:4359)
0x485c6b : mov ecx, dword ptr [ebp + 8]
0x485c6e : mov dword ptr [eax + 0x54], ecx
0x485c71 : -mov eax, <OFFSET4>
         : +mov eax, gNew_ground_normal__car (DATA) 	(car.c:4360)
0x485c76 : mov ecx, gGround_normal__car (DATA)
0x485c7b : mov edx, dword ptr [eax]
0x485c7d : mov dword ptr [ecx], edx
0x485c7f : mov edx, dword ptr [eax + 4]
0x485c82 : mov dword ptr [ecx + 4], edx
0x485c85 : mov eax, dword ptr [eax + 8]
0x485c88 : mov dword ptr [ecx + 8], eax
0x485c8b : -fld dword ptr [<OFFSET6>]
         : +fld dword ptr [gOur_yaw__car (DATA)] 	(car.c:4363)
0x485c91 : fmul qword ptr [182.04444444444445 (FLOAT)]
0x485c97 : call __ftol (FUNCTION)
0x485c9c : and eax, 0xffff
0x485ca1 : -mov dword ptr [ebp - 0x58], eax
0x485ca4 : -fild dword ptr [ebp - 0x58]
         : +mov dword ptr [ebp - 0x3c], eax
         : +mov eax, dword ptr [ebp - 0x3c] 	(car.c:4364)
         : +mov dword ptr [ebp - 0x5c], eax
         : +fild dword ptr [ebp - 0x5c]
0x485ca7 : fmul qword ptr [9.587379924285257e-05 (FLOAT)]
0x485cad : call __CIcos (FUNCTION)
0x485cb2 : fchs 
0x485cb4 : -fstp dword ptr [ebp - 0xc]
0x485cb7 : -mov dword ptr [ebp - 8], 0
0x485cbe : -fld dword ptr [<OFFSET6>]
         : +fstp dword ptr [ebp - 0x48]
         : +mov dword ptr [ebp - 0x44], 0 	(car.c:4365)
         : +fld dword ptr [gOur_yaw__car (DATA)] 	(car.c:4366)
0x485cc4 : fmul qword ptr [182.04444444444445 (FLOAT)]
0x485cca : call __ftol (FUNCTION)
0x485ccf : and eax, 0xffff
0x485cd4 : -mov dword ptr [ebp - 0x5c], eax
0x485cd7 : -fild dword ptr [ebp - 0x5c]
         : +mov dword ptr [ebp - 0x38], eax
         : +mov eax, dword ptr [ebp - 0x38] 	(car.c:4367)
         : +mov dword ptr [ebp - 0x60], eax
         : +fild dword ptr [ebp - 0x60]
0x485cda : fmul qword ptr [9.587379924285257e-05 (FLOAT)]
0x485ce0 : call __CIsin (FUNCTION)
0x485ce5 : -fstp dword ptr [ebp - 4]
0x485ce8 : -mov word ptr [ebp - 0x40], 4
0x485cee : -fld dword ptr [ebp - 8]
         : +fstp dword ptr [ebp - 0x40]
         : +mov word ptr [ebp - 0x30], 4 	(car.c:4369)
         : +fld dword ptr [ebp - 0x44] 	(car.c:4370)
0x485cf1 : fmul dword ptr [gGround_normal__car+8 (OFFSET)]
0x485cf7 : -fld dword ptr [ebp - 4]
         : +fld dword ptr [ebp - 0x40]
0x485cfa : fmul dword ptr [gGround_normal__car+4 (OFFSET)]
0x485d00 : fsubp st(1)
0x485d02 : -fstp dword ptr [ebp - 0x3c]
0x485d05 : -fld dword ptr [ebp - 4]
         : +fstp dword ptr [ebp - 0x2c]
         : +fld dword ptr [ebp - 0x40] 	(car.c:4371)
0x485d08 : fmul dword ptr [gGround_normal__car (DATA)]
0x485d0e : fld dword ptr [gGround_normal__car+8 (OFFSET)]
0x485d14 : -fmul dword ptr [ebp - 0xc]
         : +fmul dword ptr [ebp - 0x48]
0x485d17 : fsubp st(1)
0x485d19 : -fstp dword ptr [ebp - 0x38]
         : +fstp dword ptr [ebp - 0x28]
0x485d1c : fld dword ptr [gGround_normal__car+4 (OFFSET)] 	(car.c:4372)
0x485d22 : -fmul dword ptr [ebp - 0xc]
0x485d25 : -fld dword ptr [ebp - 8]
         : +fmul dword ptr [ebp - 0x48]
         : +fld dword ptr [ebp - 0x44]
0x485d28 : fmul dword ptr [gGround_normal__car (DATA)]
0x485d2e : fsubp st(1)
0x485d30 : -fstp dword ptr [ebp - 0x34]
         : +fstp dword ptr [ebp - 0x24]
0x485d33 : mov eax, gGround_normal__car (DATA) 	(car.c:4373)
0x485d38 : -lea ecx, [ebp - 0x30]
         : +lea ecx, [ebp - 0x20]
0x485d3b : mov edx, dword ptr [eax]
0x485d3d : mov dword ptr [ecx], edx
0x485d3f : mov edx, dword ptr [eax + 4]
0x485d42 : mov dword ptr [ecx + 4], edx
0x485d45 : mov eax, dword ptr [eax + 8]
0x485d48 : mov dword ptr [ecx + 8], eax
0x485d4b : mov eax, dword ptr [gSelf (DATA)] 	(car.c:4374)
0x485d50 : add eax, 0x50
0x485d53 : -lea ecx, [ebp - 0x18]
         : +lea ecx, [ebp - 8]
0x485d56 : mov edx, dword ptr [eax]
0x485d58 : mov dword ptr [ecx], edx
0x485d5a : mov edx, dword ptr [eax + 4]
0x485d5d : mov dword ptr [ecx + 4], edx
0x485d60 : mov eax, dword ptr [eax + 8]
0x485d63 : mov dword ptr [ecx + 8], eax
0x485d66 : -lea eax, [ebp - 0x40]
         : +lea eax, [ebp - 0x30] 	(car.c:4375)
0x485d69 : push eax
0x485d6a : mov eax, dword ptr [gSelf (DATA)]
0x485d6f : add eax, 0x28
0x485d72 : push eax
0x485d73 : call BrTransformToTransform (FUNCTION)
0x485d78 : add esp, 8
0x485d7b : pop edi 	(car.c:4376)
0x485d7c : pop esi
0x485d7d : pop ebx
0x485d7e : leave 


oldMoveOurCar is only 70.18% similar to the original, diff above
```

#### Effective match analysis

The diff appears functionally equivalent. All branch instructions and conditions are preserved (`je`, `jne`, `jmp`) with the same relative displacements shown, so there is no control-flow reshuffling signal here. The changes are consistent with stack-frame/local-variable reallocation (`sub esp 0x5c` -> `0x60`, different `[ebp-...]` slots), symbolized addresses replacing raw offsets, and a few redundant register/memory moves that do not alter values. Floating-point math sequence and side effects (updates to `gSelf`, `gGround_normal__car`, trigonometric path, and `BrTransformToTransform` call arguments) remain semantically the same, just with relocated temporaries.

#### Original match

```
---
+++
@@ -0x485bea,9 +0x457896,12 @@
0x485bea : push ebp 	(car.c:4334)
0x485beb : mov ebp, esp
0x485bed : -sub esp, 0x5c
         : +sub esp, 0x90
0x485bf0 : push ebx
0x485bf1 : push esi
0x485bf2 : push edi
0x485bf3 : -mov eax, dword ptr [gSelf (DATA)]
0x485bf8 : -fld dword ptr [eax + 0x54]
0x485bfb : -fsub dword ptr [ebp + 8]
         : +call abort (FUNCTION) 	(car.c:4346)
         : +pop edi 	(car.c:4347)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


oldMoveOurCar is only 47.62% similar to the original, diff above
```

*AI generated. Time taken: 1825s, tokens: 96,923*
