### PR TITLE
FindYVerticallyBelow equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/raycast.c
+++ b/src/DETHRACE/common/raycast.c
@@ -505,9 +505,10 @@ br_scalar FindYVerticallyBelow(br_vector3* pPosition) {
     track_spec = &gProgram_state.track_spec;
     XZToColumnXZ(&cx, &cz, pPosition->v[X], pPosition->v[Z], track_spec);
     gHighest_y_below = BR_SCALAR_MIN;
+    gY_picking_camera->t.t.translate.t = *pPosition;
     BrVector3Copy(&gY_picking_camera->t.t.translate.t, pPosition);
-    for (x = MAX(cx - 1, 0); x < MIN(cx + 2, track_spec->ncolumns_x); x++) {
-        for (z = MAX(cz - 1, 0); z < MIN(cz + 2, track_spec->ncolumns_z); z++) {
+    for (x = MAX(cx - 1, 0); x < cx + 2 && x < track_spec->ncolumns_x; x++) {
+        for (z = MAX(cz - 1, 0); z < cz + 2 && z < track_spec->ncolumns_z; z++) {
             if (track_spec->columns[z][x] != NULL) {
                 if (track_spec->blends[z][x] != NULL) {
                     track_spec->blends[z][x]->render_style = BR_RSTYLE_FACES;

--- a/src/DETHRACE/common/raycast.c
+++ b/src/DETHRACE/common/raycast.c
@@ -511,9 +511,8 @@ br_scalar FindYVerticallyBelow(br_vector3* pPosition) {
     XZToColumnXZ(&cx, &cz, pPosition->v[X], pPosition->v[Z], track_spec);
     gHighest_y_below = BR_SCALAR_MIN;
     gY_picking_camera->t.t.translate.t = *pPosition;
-    BrVector3Copy(&gY_picking_camera->t.t.translate.t, pPosition);
-    for (x = MAX(cx - 1, 0); x < cx + 2 && x < track_spec->ncolumns_x; x++) {
-        for (z = MAX(cz - 1, 0); z < cz + 2 && z < track_spec->ncolumns_z; z++) {
+    for (x = MAX(cx - 1, 0); x < MIN(cx + 2, track_spec->ncolumns_x); x++) {
+        for (z = MAX(cz - 1, 0); z < MIN(cz + 2, track_spec->ncolumns_z); z++) {
             if (track_spec->columns[z][x] != NULL) {
                 if (track_spec->blends[z][x] != NULL) {
                     track_spec->blends[z][x]->render_style = BR_RSTYLE_FACES;


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x495411,63 +0x4aa4c3,77 @@
0x495411 : mov dword ptr [gHighest_y_below (DATA)], 0xff7fffff 	(raycast.c:512)
0x49541b : mov eax, dword ptr [ebp + 8] 	(raycast.c:513)
0x49541e : mov ecx, dword ptr [gY_picking_camera (DATA)]
0x495424 : add ecx, 0x50
0x495427 : mov edx, dword ptr [eax]
0x495429 : mov dword ptr [ecx], edx
0x49542b : mov edx, dword ptr [eax + 4]
0x49542e : mov dword ptr [ecx + 4], edx
0x495431 : mov eax, dword ptr [eax + 8]
0x495434 : mov dword ptr [ecx + 8], eax
         : +mov eax, dword ptr [ebp + 8] 	(raycast.c:514)
         : +mov ecx, dword ptr [gY_picking_camera (DATA)]
         : +mov eax, dword ptr [eax]
         : +mov dword ptr [ecx + 0x50], eax
         : +mov eax, dword ptr [ebp + 8]
         : +mov ecx, dword ptr [gY_picking_camera (DATA)]
         : +mov eax, dword ptr [eax + 4]
         : +mov dword ptr [ecx + 0x54], eax
         : +mov eax, dword ptr [ebp + 8]
         : +mov ecx, dword ptr [gY_picking_camera (DATA)]
         : +mov eax, dword ptr [eax + 8]
         : +mov dword ptr [ecx + 0x58], eax
0x495437 : xor eax, eax 	(raycast.c:515)
0x495439 : mov al, byte ptr [ebp - 0x10]
0x49543c : dec eax
0x49543d : test eax, eax
0x49543f : jg 0x2
0x495445 : xor eax, eax
0x495447 : mov byte ptr [ebp - 8], al
0x49544a : jmp 0x3
0x49544f : inc byte ptr [ebp - 8]
0x495452 : xor eax, eax
0x495454 : mov al, byte ptr [ebp - 0x10]
0x495457 : add eax, 2
0x49545a : -mov ecx, dword ptr [ebp - 4]
0x49545d : -xor edx, edx
0x49545f : -mov dl, byte ptr [ecx]
0x495461 : -cmp eax, edx
0x495463 : -jl 0x2
0x495469 : -mov eax, edx
0x49546b : xor ecx, ecx
0x49546d : mov cl, byte ptr [ebp - 8]
0x495470 : cmp eax, ecx
0x495472 : -jle 0x103
         : +jle 0x11a
         : +mov eax, dword ptr [ebp - 4]
         : +xor ecx, ecx
         : +mov cl, byte ptr [eax]
         : +xor eax, eax
         : +mov al, byte ptr [ebp - 8]
         : +cmp ecx, eax
         : +jle 0x106
0x495478 : xor eax, eax 	(raycast.c:516)
0x49547a : mov al, byte ptr [ebp - 0x14]
0x49547d : dec eax
0x49547e : test eax, eax
0x495480 : jg 0x2
0x495486 : xor eax, eax
0x495488 : mov byte ptr [ebp - 0xc], al
0x49548b : jmp 0x3
0x495490 : inc byte ptr [ebp - 0xc]
0x495493 : xor eax, eax
0x495495 : mov al, byte ptr [ebp - 0x14]
0x495498 : add eax, 2
0x49549b : -mov ecx, dword ptr [ebp - 4]
0x49549e : -xor edx, edx
0x4954a0 : -mov dl, byte ptr [ecx + 1]
0x4954a3 : -cmp eax, edx
0x4954a5 : -jl 0x2
0x4954ab : -mov eax, edx
0x4954ad : xor ecx, ecx
0x4954af : mov cl, byte ptr [ebp - 0xc]
0x4954b2 : cmp eax, ecx
         : +jle 0xd1
         : +mov eax, dword ptr [ebp - 4]
         : +xor ecx, ecx
         : +mov cl, byte ptr [eax + 1]
         : +xor eax, eax
         : +mov al, byte ptr [ebp - 0xc]
         : +cmp ecx, eax
0x4954b4 : jle 0xbc
0x4954ba : xor eax, eax 	(raycast.c:517)
0x4954bc : mov al, byte ptr [ebp - 0xc]
0x4954bf : mov ecx, dword ptr [ebp - 4]
0x4954c2 : mov ecx, dword ptr [ecx + 0x18]
0x4954c5 : mov eax, dword ptr [ecx + eax*4]
0x4954c8 : xor ecx, ecx
0x4954ca : mov cl, byte ptr [ebp - 8]
0x4954cd : cmp dword ptr [eax + ecx*4], 0
0x4954d1 : je 0x9a

---
+++
@@ -0x495551,19 +0x4aa635,19 @@
0x495551 : je 0x1a
0x495557 : xor eax, eax 	(raycast.c:523)
0x495559 : mov al, byte ptr [ebp - 0xc]
0x49555c : mov ecx, dword ptr [ebp - 4]
0x49555f : mov ecx, dword ptr [ecx + 0x20]
0x495562 : mov eax, dword ptr [ecx + eax*4]
0x495565 : xor ecx, ecx
0x495567 : mov cl, byte ptr [ebp - 8]
0x49556a : mov eax, dword ptr [eax + ecx*4]
0x49556d : mov byte ptr [eax + 0x20], 1
0x495571 : -jmp -0xe6
0x495576 : -jmp -0x12c
         : +jmp -0xe9 	(raycast.c:526)
         : +jmp -0x132 	(raycast.c:527)
0x49557b : fld dword ptr [gHighest_y_below (DATA)] 	(raycast.c:528)
0x495581 : jmp 0x0
0x495586 : pop edi 	(raycast.c:529)
0x495587 : pop esi
0x495588 : pop ebx
0x495589 : leave 
0x49558a : ret 


FindYVerticallyBelow is only 85.62% similar to the original, diff above
```

#### Effective match analysis

The shown differences are consistent with equivalent logic rewritten into different basic-block structure. The camera-vector stores (`[src+0/4/8]` to `gY_picking_camera+0x50/54/58`) are the same values, just with repeated reloads instead of one base pointer. The two loop-bound checks were transformed from `min(limit+2, bound) <= idx` into two sequential checks (`limit+2 <= idx` OR `bound <= idx`), which is logically equivalent for integer comparisons here. The changed jump displacements appear to come from inserted instructions and shifted block layout, not changed outcomes. I do not see evidence in this diff of different final side effects or different accept/reject conditions.

#### Original match

```
---
+++
@@ -0x495400,70 +0x4a9f22,73 @@
0x495400 : push eax
0x495401 : lea eax, [ebp - 0x14]
0x495404 : push eax
0x495405 : lea eax, [ebp - 0x10]
0x495408 : push eax
0x495409 : call XZToColumnXZ (FUNCTION)
0x49540e : add esp, 0x14
0x495411 : mov dword ptr [gHighest_y_below (DATA)], 0xff7fffff 	(raycast.c:507)
0x49541b : mov eax, dword ptr [ebp + 8] 	(raycast.c:508)
0x49541e : mov ecx, dword ptr [gY_picking_camera (DATA)]
0x495424 : -add ecx, 0x50
0x495427 : -mov edx, dword ptr [eax]
0x495429 : -mov dword ptr [ecx], edx
0x49542b : -mov edx, dword ptr [eax + 4]
0x49542e : -mov dword ptr [ecx + 4], edx
         : +mov eax, dword ptr [eax]
         : +mov dword ptr [ecx + 0x50], eax
         : +mov eax, dword ptr [ebp + 8]
         : +mov ecx, dword ptr [gY_picking_camera (DATA)]
         : +mov eax, dword ptr [eax + 4]
         : +mov dword ptr [ecx + 0x54], eax
         : +mov eax, dword ptr [ebp + 8]
         : +mov ecx, dword ptr [gY_picking_camera (DATA)]
0x495431 : mov eax, dword ptr [eax + 8]
0x495434 : -mov dword ptr [ecx + 8], eax
         : +mov dword ptr [ecx + 0x58], eax
0x495437 : xor eax, eax 	(raycast.c:509)
0x495439 : mov al, byte ptr [ebp - 0x10]
0x49543c : dec eax
0x49543d : test eax, eax
0x49543f : jg 0x2
0x495445 : xor eax, eax
0x495447 : mov byte ptr [ebp - 8], al
0x49544a : jmp 0x3
0x49544f : inc byte ptr [ebp - 8]
         : +mov eax, dword ptr [ebp - 4]
         : +xor ecx, ecx
         : +mov cl, byte ptr [eax]
0x495452 : xor eax, eax
0x495454 : mov al, byte ptr [ebp - 0x10]
0x495457 : add eax, 2
0x49545a : -mov ecx, dword ptr [ebp - 4]
0x49545d : -xor edx, edx
0x49545f : -mov dl, byte ptr [ecx]
0x495461 : -cmp eax, edx
         : +cmp ecx, eax
0x495463 : jl 0x2
0x495469 : -mov eax, edx
0x49546b : -xor ecx, ecx
0x49546d : -mov cl, byte ptr [ebp - 8]
0x495470 : -cmp eax, ecx
         : +mov ecx, eax
         : +xor eax, eax
         : +mov al, byte ptr [ebp - 8]
         : +cmp ecx, eax
0x495472 : jle 0x103
0x495478 : xor eax, eax 	(raycast.c:510)
0x49547a : mov al, byte ptr [ebp - 0x14]
0x49547d : dec eax
0x49547e : test eax, eax
0x495480 : jg 0x2
0x495486 : xor eax, eax
0x495488 : mov byte ptr [ebp - 0xc], al
0x49548b : jmp 0x3
0x495490 : inc byte ptr [ebp - 0xc]
         : +mov eax, dword ptr [ebp - 4]
         : +xor ecx, ecx
         : +mov cl, byte ptr [eax + 1]
0x495493 : xor eax, eax
0x495495 : mov al, byte ptr [ebp - 0x14]
0x495498 : add eax, 2
0x49549b : -mov ecx, dword ptr [ebp - 4]
0x49549e : -xor edx, edx
0x4954a0 : -mov dl, byte ptr [ecx + 1]
0x4954a3 : -cmp eax, edx
         : +cmp ecx, eax
0x4954a5 : jl 0x2
0x4954ab : -mov eax, edx
0x4954ad : -xor ecx, ecx
0x4954af : -mov cl, byte ptr [ebp - 0xc]
0x4954b2 : -cmp eax, ecx
         : +mov ecx, eax
         : +xor eax, eax
         : +mov al, byte ptr [ebp - 0xc]
         : +cmp ecx, eax
0x4954b4 : jle 0xbc
0x4954ba : xor eax, eax 	(raycast.c:511)
0x4954bc : mov al, byte ptr [ebp - 0xc]
0x4954bf : mov ecx, dword ptr [ebp - 4]
0x4954c2 : mov ecx, dword ptr [ecx + 0x18]
0x4954c5 : mov eax, dword ptr [ecx + eax*4]
0x4954c8 : xor ecx, ecx
0x4954ca : mov cl, byte ptr [ebp - 8]
0x4954cd : cmp dword ptr [eax + ecx*4], 0
0x4954d1 : je 0x9a


FindYVerticallyBelow is only 84.07% similar to the original, diff above
```

*AI generated. Time taken: 1061s, tokens: 70,086*
