### PR TITLE
FlipUpCar equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/controls.c
+++ b/src/DETHRACE/common/controls.c
@@ -1803,8 +1803,8 @@ void FlipUpCar(tCar_spec* car) {
     car->doing_nothing_flag = 0;
     EnableCar(car);
     new_pos = 1;
-    for (i = 0; i < 4; ++i) {
-        if (car->susp_height[i >> 1] <= car->oldd[i]) {
+    for (j = 0; j < 4; ++j) {
+        if (car->susp_height[j >> 1] <= car->oldd[j]) {
             new_pos = 0;
         }
     }
@@ -1846,13 +1846,15 @@ void FlipUpCar(tCar_spec* car) {
         car->direction.v[0] = -car->oldmat.m[2][0];
         car->direction.v[1] = -car->oldmat.m[2][1];
         car->direction.v[2] = -car->oldmat.m[2][2];
-        for (i = 0; i <= new_pos; i++) {
-            for (j = 0; j < 4; j++) {
-                BrMatrix34Copy(&car->last_safe_positions[j], &car->last_safe_positions[j + 1]);
+        for (j = 0; j <= new_pos; j++) {
+            for (i = 0; i < 4; i++) {
+                BrMatrix34Copy(&car->last_safe_positions[i], &car->last_safe_positions[i + 1]);
             }
         }
-        for (l = 0; l < 10; l++) {
-            BrVector3Scale(&car->old_norm, &car->old_norm, 0.072463766);
+        l = 0;
+        while (!TestForCarInSensiblePlace(car) && l < 10) {
+            dist = 0.072463766f;
+            BrVector3Scale(&car->old_norm, &car->old_norm, dist);
             BrMatrix34ApplyV(&tv, &car->old_norm, &car->car_master_actor->t.t.mat);
             car->car_master_actor->t.t.mat.m[3][0] = car->car_master_actor->t.t.mat.m[3][0] + tv.v[0];
             car->car_master_actor->t.t.mat.m[3][1] = car->car_master_actor->t.t.mat.m[3][1] + tv.v[1];
@@ -1863,9 +1865,7 @@ void FlipUpCar(tCar_spec* car) {
             car->old_frame_mat.m[3][0] = car->car_master_actor->t.t.mat.m[3][0];
             car->old_frame_mat.m[3][1] = car->car_master_actor->t.t.mat.m[3][1];
             car->old_frame_mat.m[3][2] = car->car_master_actor->t.t.mat.m[3][2];
-            if (TestForCarInSensiblePlace(car)) {
-                break;
-            }
+            l++;
         }
         count++;
     } while (l == 10 && count < 3);
@@ -1873,8 +1873,8 @@ void FlipUpCar(tCar_spec* car) {
     car->oldmat.m[3][1] = car->car_master_actor->t.t.mat.m[3][1] * WORLD_SCALE;
     car->oldmat.m[3][2] = car->car_master_actor->t.t.mat.m[3][2] * WORLD_SCALE;
     car->curvature = 0.0;
-    for (j = 0; j < 4; ++j) {
-        car->oldd[j] = car->ride_height;
+    for (i = 0; i < 4; ++i) {
+        car->oldd[i] = car->ride_height;
     }
     car->revs = 0.0;
     car->gear = 0;


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4a2418,25 +0x467eaf,24 @@
0x4a2418 : mov eax, dword ptr [eax + 0xc]
0x4a241b : fld dword ptr [eax + 0x54]
0x4a241e : mov eax, dword ptr [ebp + 8]
0x4a2421 : fsub dword ptr [eax + 0x13d8]
0x4a2427 : fstp dword ptr [ebp - 0x34]
0x4a242a : mov eax, dword ptr [ebp + 8] 	(controls.c:1798)
0x4a242d : mov eax, dword ptr [eax + 0xc]
0x4a2430 : fld dword ptr [eax + 0x58]
0x4a2433 : mov eax, dword ptr [ebp + 8]
0x4a2436 : fsub dword ptr [eax + 0x13dc]
0x4a243c : -fstp dword ptr [ebp - 0x30]
         : +fst dword ptr [ebp - 0x30]
         : +fmul dword ptr [ebp - 0x30] 	(controls.c:1799)
0x4a243f : fld dword ptr [ebp - 0x34]
0x4a2442 : fmul dword ptr [ebp - 0x34]
0x4a2445 : -fld dword ptr [ebp - 0x30]
0x4a2448 : -fmul dword ptr [ebp - 0x30]
0x4a244b : faddp st(1)
0x4a244d : fld dword ptr [ebp - 0x38]
0x4a2450 : fmul dword ptr [ebp - 0x38]
0x4a2453 : faddp st(1)
0x4a2455 : fcomp dword ptr [8.301596641540527 (FLOAT)]
0x4a245b : fnstsw ax
0x4a245d : test ah, 0x41
0x4a2460 : jne 0x7
0x4a2466 : mov dword ptr [ebp - 4], 0 	(controls.c:1800)
0x4a246d : mov eax, dword ptr [ebp - 4] 	(controls.c:1802)

---
+++
@@ -0x4a266f,23 +0x468103,23 @@
0x4a266f : mov eax, dword ptr [ebp + 8]
0x4a2672 : fstp dword ptr [eax + 0x244]
0x4a2678 : mov eax, dword ptr [ebp + 8] 	(controls.c:1832)
0x4a267b : fld dword ptr [eax + 0x5c]
0x4a267e : fchs 
0x4a2680 : mov eax, dword ptr [ebp + 8]
0x4a2683 : fstp dword ptr [eax + 0x248]
0x4a2689 : mov dword ptr [ebp - 0x18], 0 	(controls.c:1833)
0x4a2690 : jmp 0x3
0x4a2695 : inc dword ptr [ebp - 0x18]
0x4a2698 : -mov eax, dword ptr [ebp - 4]
0x4a269b : -cmp dword ptr [ebp - 0x18], eax
0x4a269e : -jg 0x50
         : +mov eax, dword ptr [ebp - 0x18]
         : +cmp dword ptr [ebp - 4], eax
         : +jl 0x50
0x4a26a4 : mov dword ptr [ebp - 0x14], 0 	(controls.c:1834)
0x4a26ab : jmp 0x3
0x4a26b0 : inc dword ptr [ebp - 0x14]
0x4a26b3 : cmp dword ptr [ebp - 0x14], 4
0x4a26b7 : jge 0x32
0x4a26bd : mov eax, dword ptr [ebp - 0x14] 	(controls.c:1835)
0x4a26c0 : inc eax
0x4a26c1 : shl eax, 4
0x4a26c4 : lea eax, [eax + eax*2]
0x4a26c7 : add eax, dword ptr [ebp + 8]

---
+++
@@ -0x4a2823,21 +0x4682b7,21 @@
0x4a2823 : mov eax, dword ptr [eax + 0xc]
0x4a2826 : mov ecx, dword ptr [ebp + 8]
0x4a2829 : mov eax, dword ptr [eax + 0x58]
0x4a282c : mov dword ptr [ecx + 0x98], eax
0x4a2832 : inc dword ptr [ebp - 0x20] 	(controls.c:1852)
0x4a2835 : jmp -0x13f 	(controls.c:1853)
0x4a283a : inc dword ptr [ebp - 0x10] 	(controls.c:1854)
0x4a283d : cmp dword ptr [ebp - 0x20], 0xa 	(controls.c:1855)
0x4a2841 : jne 0xa
0x4a2847 : cmp dword ptr [ebp - 0x10], 3
0x4a284b : -jl -0x451
         : +jl -0x44e
0x4a2851 : mov eax, dword ptr [ebp + 8] 	(controls.c:1856)
0x4a2854 : mov eax, dword ptr [eax + 0xc]
0x4a2857 : fld dword ptr [eax + 0x50]
0x4a285a : fmul dword ptr [6.900000095367432 (FLOAT)]
0x4a2860 : mov eax, dword ptr [ebp + 8]
0x4a2863 : fstp dword ptr [eax + 0x60]
0x4a2866 : mov eax, dword ptr [ebp + 8] 	(controls.c:1857)
0x4a2869 : mov eax, dword ptr [eax + 0xc]
0x4a286c : fld dword ptr [eax + 0x54]
0x4a286f : fmul dword ptr [6.900000095367432 (FLOAT)]

---
+++
@@ -0x4a28fb,10 +0x46838f,13 @@
0x4a28fb : cmp dword ptr [eax + 8], 4
0x4a28ff : jne 0x13
0x4a2905 : call InitialiseExternalCamera (FUNCTION) 	(controls.c:1867)
0x4a290a : push 0x64 	(controls.c:1868)
0x4a290c : mov eax, dword ptr [ebp + 8]
0x4a290f : push eax
0x4a2910 : call PositionExternalCamera (FUNCTION)
0x4a2915 : add esp, 8
0x4a2918 : pop edi 	(controls.c:1870)
0x4a2919 : pop esi
         : +pop ebx
         : +leave 
         : +ret 


FlipUpCar is only 98.03% similar to the original, diff above
```

#### Effective match analysis

The shown changes are functionally equivalent. In the FP block, `fstp [ebp-0x30]; ... fld [ebp-0x30]; fmul [ebp-0x30]` was replaced with `fst [ebp-0x30]; fmul [ebp-0x30]`, which computes the same square term and preserves the same accumulated value before the later `faddp`. The loop condition change (`cmp i,limit; jg exit` -> `cmp limit,i; jl exit`) is an algebraically equivalent signed comparison (`i > limit` in both cases). The `jl` displacement change from `-0x451` to `-0x44e` is only a 3-byte shift, consistent with nearby instruction-size changes, not a control-flow rewrite. The added `pop ebx; leave; ret` at the end appears to be epilogue alignment/context expansion, not a behavioral change in logic.

#### Original match

```
---
+++
@@ -0x4a2383,31 +0x467c2b,31 @@
0x4a2383 : test eax, eax
0x4a2385 : je 0x5
0x4a238b : jmp -0x17 	(controls.c:1801)
0x4a2390 : mov eax, dword ptr [ebp + 8] 	(controls.c:1803)
0x4a2393 : mov dword ptr [eax + 0x228], 0
0x4a239d : mov eax, dword ptr [ebp + 8] 	(controls.c:1804)
0x4a23a0 : push eax
0x4a23a1 : call EnableCar (FUNCTION)
0x4a23a6 : add esp, 4
0x4a23a9 : mov dword ptr [ebp - 4], 1 	(controls.c:1805)
0x4a23b0 : -mov dword ptr [ebp - 0x18], 0
         : +mov dword ptr [ebp - 0x14], 0 	(controls.c:1806)
0x4a23b7 : jmp 0x3
0x4a23bc : -inc dword ptr [ebp - 0x18]
0x4a23bf : -cmp dword ptr [ebp - 0x18], 4
         : +inc dword ptr [ebp - 0x14]
         : +cmp dword ptr [ebp - 0x14], 4
0x4a23c3 : jge 0x37
0x4a23c9 : -mov eax, dword ptr [ebp - 0x18]
         : +mov eax, dword ptr [ebp - 0x14] 	(controls.c:1807)
0x4a23cc : and eax, 0xfffffffe
0x4a23cf : sar eax, 0
0x4a23d2 : mov ecx, dword ptr [ebp + 8]
0x4a23d5 : fld dword ptr [ecx + eax*2 + 0x14c0]
0x4a23dc : -mov eax, dword ptr [ebp - 0x18]
         : +mov eax, dword ptr [ebp - 0x14]
0x4a23df : mov ecx, dword ptr [ebp + 8]
0x4a23e2 : fcomp dword ptr [ecx + eax*4 + 0x1508]
0x4a23e9 : fnstsw ax
0x4a23eb : test ah, 0x41
0x4a23ee : je 0x7
0x4a23f4 : mov dword ptr [ebp - 4], 0 	(controls.c:1808)
0x4a23fb : jmp -0x44 	(controls.c:1810)
0x4a2400 : mov eax, dword ptr [ebp + 8] 	(controls.c:1812)
0x4a2403 : mov eax, dword ptr [eax + 0xc]
0x4a2406 : fld dword ptr [eax + 0x50]

---
+++
@@ -0x4a2418,25 +0x467cc0,24 @@
0x4a2418 : mov eax, dword ptr [eax + 0xc]
0x4a241b : fld dword ptr [eax + 0x54]
0x4a241e : mov eax, dword ptr [ebp + 8]
0x4a2421 : fsub dword ptr [eax + 0x13d8]
0x4a2427 : fstp dword ptr [ebp - 0x34]
0x4a242a : mov eax, dword ptr [ebp + 8] 	(controls.c:1814)
0x4a242d : mov eax, dword ptr [eax + 0xc]
0x4a2430 : fld dword ptr [eax + 0x58]
0x4a2433 : mov eax, dword ptr [ebp + 8]
0x4a2436 : fsub dword ptr [eax + 0x13dc]
0x4a243c : -fstp dword ptr [ebp - 0x30]
         : +fst dword ptr [ebp - 0x30]
         : +fmul dword ptr [ebp - 0x30] 	(controls.c:1815)
0x4a243f : fld dword ptr [ebp - 0x34]
0x4a2442 : fmul dword ptr [ebp - 0x34]
0x4a2445 : -fld dword ptr [ebp - 0x30]
0x4a2448 : -fmul dword ptr [ebp - 0x30]
0x4a244b : faddp st(1)
0x4a244d : fld dword ptr [ebp - 0x38]
0x4a2450 : fmul dword ptr [ebp - 0x38]
0x4a2453 : faddp st(1)
0x4a2455 : fcomp dword ptr [8.301596641540527 (FLOAT)]
0x4a245b : fnstsw ax
0x4a245d : test ah, 0x41
0x4a2460 : jne 0x7
0x4a2466 : mov dword ptr [ebp - 4], 0 	(controls.c:1816)
0x4a246d : mov eax, dword ptr [ebp - 4] 	(controls.c:1818)

---
+++
@@ -0x4a2667,71 +0x467f0c,66 @@
0x4a2667 : mov eax, dword ptr [ebp + 8] 	(controls.c:1847)
0x4a266a : fld dword ptr [eax + 0x58]
0x4a266d : fchs 
0x4a266f : mov eax, dword ptr [ebp + 8]
0x4a2672 : fstp dword ptr [eax + 0x244]
0x4a2678 : mov eax, dword ptr [ebp + 8] 	(controls.c:1848)
0x4a267b : fld dword ptr [eax + 0x5c]
0x4a267e : fchs 
0x4a2680 : mov eax, dword ptr [ebp + 8]
0x4a2683 : fstp dword ptr [eax + 0x248]
         : +mov dword ptr [ebp - 0x14], 0 	(controls.c:1849)
         : +jmp 0x3
         : +inc dword ptr [ebp - 0x14]
         : +mov eax, dword ptr [ebp - 4]
         : +cmp dword ptr [ebp - 0x14], eax
         : +jg 0x50
0x4a2689 : mov dword ptr [ebp - 0x18], 0 	(controls.c:1850)
0x4a2690 : jmp 0x3
0x4a2695 : inc dword ptr [ebp - 0x18]
0x4a2698 : -mov eax, dword ptr [ebp - 4]
0x4a269b : -cmp dword ptr [ebp - 0x18], eax
0x4a269e : -jg 0x50
0x4a26a4 : -mov dword ptr [ebp - 0x14], 0
0x4a26ab : -jmp 0x3
0x4a26b0 : -inc dword ptr [ebp - 0x14]
0x4a26b3 : -cmp dword ptr [ebp - 0x14], 4
         : +cmp dword ptr [ebp - 0x18], 4
0x4a26b7 : jge 0x32
0x4a26bd : -mov eax, dword ptr [ebp - 0x14]
         : +mov eax, dword ptr [ebp - 0x18] 	(controls.c:1851)
0x4a26c0 : inc eax
0x4a26c1 : shl eax, 4
0x4a26c4 : lea eax, [eax + eax*2]
0x4a26c7 : add eax, dword ptr [ebp + 8]
0x4a26ca : add eax, 0x13b0
0x4a26cf : push eax
0x4a26d0 : -mov eax, dword ptr [ebp - 0x14]
         : +mov eax, dword ptr [ebp - 0x18]
0x4a26d3 : shl eax, 4
0x4a26d6 : lea eax, [eax + eax*2]
0x4a26d9 : add eax, dword ptr [ebp + 8]
0x4a26dc : add eax, 0x13b0
0x4a26e1 : push eax
0x4a26e2 : call BrMatrix34Copy (FUNCTION)
0x4a26e7 : add esp, 8
0x4a26ea : jmp -0x3f 	(controls.c:1852)
0x4a26ef : jmp -0x5f 	(controls.c:1853)
0x4a26f4 : mov dword ptr [ebp - 0x20], 0 	(controls.c:1854)
0x4a26fb : -mov eax, dword ptr [ebp + 8]
0x4a26fe : -push eax
0x4a26ff : -call TestForCarInSensiblePlace (FUNCTION)
0x4a2704 : -add esp, 4
0x4a2707 : -test eax, eax
0x4a2709 : -jne 0x12b
         : +jmp 0x3
         : +inc dword ptr [ebp - 0x20]
0x4a270f : cmp dword ptr [ebp - 0x20], 0xa
0x4a2713 : -jge 0x121
0x4a2719 : -mov dword ptr [ebp - 0xc], 0x3d9467e2
         : +jge 0x139
0x4a2720 : mov eax, dword ptr [ebp + 8] 	(controls.c:1855)
0x4a2723 : fld dword ptr [eax + 0x1c8]
0x4a2729 : -fmul dword ptr [ebp - 0xc]
         : +fmul qword ptr [0.072463766 (FLOAT)]
0x4a272c : mov eax, dword ptr [ebp + 8]
0x4a272f : fstp dword ptr [eax + 0x1c8]
0x4a2735 : mov eax, dword ptr [ebp + 8]
0x4a2738 : fld dword ptr [eax + 0x1cc]
0x4a273e : -fmul dword ptr [ebp - 0xc]
         : +fmul qword ptr [0.072463766 (FLOAT)]
0x4a2741 : mov eax, dword ptr [ebp + 8]
0x4a2744 : fstp dword ptr [eax + 0x1cc]
0x4a274a : mov eax, dword ptr [ebp + 8]
0x4a274d : fld dword ptr [eax + 0x1d0]
0x4a2753 : -fmul dword ptr [ebp - 0xc]
         : +fmul qword ptr [0.072463766 (FLOAT)]
0x4a2756 : mov eax, dword ptr [ebp + 8]
0x4a2759 : fstp dword ptr [eax + 0x1d0]
0x4a275f : mov eax, dword ptr [ebp + 8] 	(controls.c:1856)
0x4a2762 : mov eax, dword ptr [eax + 0xc]
0x4a2765 : add eax, 0x2c
0x4a2768 : push eax
0x4a2769 : mov eax, dword ptr [ebp + 8]
0x4a276c : add eax, 0x1c8
0x4a2771 : push eax
0x4a2772 : lea eax, [ebp - 0x38]

---
+++
@@ -0x4a280e,54 +0x4680a9,60 @@
0x4a280e : mov eax, dword ptr [ebp + 8] 	(controls.c:1864)
0x4a2811 : mov eax, dword ptr [eax + 0xc]
0x4a2814 : mov ecx, dword ptr [ebp + 8]
0x4a2817 : mov eax, dword ptr [eax + 0x54]
0x4a281a : mov dword ptr [ecx + 0x94], eax
0x4a2820 : mov eax, dword ptr [ebp + 8] 	(controls.c:1865)
0x4a2823 : mov eax, dword ptr [eax + 0xc]
0x4a2826 : mov ecx, dword ptr [ebp + 8]
0x4a2829 : mov eax, dword ptr [eax + 0x58]
0x4a282c : mov dword ptr [ecx + 0x98], eax
0x4a2832 : -inc dword ptr [ebp - 0x20]
0x4a2835 : -jmp -0x13f
         : +mov eax, dword ptr [ebp + 8] 	(controls.c:1866)
         : +push eax
         : +call TestForCarInSensiblePlace (FUNCTION)
         : +add esp, 4
         : +test eax, eax
         : +je 0x5
         : +jmp 0x5 	(controls.c:1867)
         : +jmp -0x146 	(controls.c:1869)
0x4a283a : inc dword ptr [ebp - 0x10] 	(controls.c:1870)
0x4a283d : cmp dword ptr [ebp - 0x20], 0xa 	(controls.c:1871)
0x4a2841 : jne 0xa
0x4a2847 : cmp dword ptr [ebp - 0x10], 3
0x4a284b : -jl -0x451
         : +jl -0x45a
0x4a2851 : mov eax, dword ptr [ebp + 8] 	(controls.c:1872)
0x4a2854 : mov eax, dword ptr [eax + 0xc]
0x4a2857 : fld dword ptr [eax + 0x50]
0x4a285a : fmul dword ptr [6.900000095367432 (FLOAT)]
0x4a2860 : mov eax, dword ptr [ebp + 8]
0x4a2863 : fstp dword ptr [eax + 0x60]
0x4a2866 : mov eax, dword ptr [ebp + 8] 	(controls.c:1873)
0x4a2869 : mov eax, dword ptr [eax + 0xc]
0x4a286c : fld dword ptr [eax + 0x54]
0x4a286f : fmul dword ptr [6.900000095367432 (FLOAT)]
0x4a2875 : mov eax, dword ptr [ebp + 8]
0x4a2878 : fstp dword ptr [eax + 0x64]
0x4a287b : mov eax, dword ptr [ebp + 8] 	(controls.c:1874)
0x4a287e : mov eax, dword ptr [eax + 0xc]
0x4a2881 : fld dword ptr [eax + 0x58]
0x4a2884 : fmul dword ptr [6.900000095367432 (FLOAT)]
0x4a288a : mov eax, dword ptr [ebp + 8]
0x4a288d : fstp dword ptr [eax + 0x68]
0x4a2890 : mov eax, dword ptr [ebp + 8] 	(controls.c:1875)
0x4a2893 : mov dword ptr [eax + 0x14fc], 0
0x4a289d : -mov dword ptr [ebp - 0x14], 0
         : +mov dword ptr [ebp - 0x18], 0 	(controls.c:1876)
0x4a28a4 : jmp 0x3
0x4a28a9 : -inc dword ptr [ebp - 0x14]
0x4a28ac : -cmp dword ptr [ebp - 0x14], 4
         : +inc dword ptr [ebp - 0x18]
         : +cmp dword ptr [ebp - 0x18], 4
0x4a28b0 : jge 0x1b
0x4a28b6 : mov eax, dword ptr [ebp + 8] 	(controls.c:1877)
0x4a28b9 : -mov ecx, dword ptr [ebp - 0x14]
         : +mov ecx, dword ptr [ebp - 0x18]
0x4a28bc : mov edx, dword ptr [ebp + 8]
0x4a28bf : mov eax, dword ptr [eax + 0x14c8]
0x4a28c5 : mov dword ptr [edx + ecx*4 + 0x1508], eax
0x4a28cc : jmp -0x28 	(controls.c:1878)
0x4a28d1 : mov eax, dword ptr [ebp + 8] 	(controls.c:1879)
0x4a28d4 : mov dword ptr [eax + 0x15cc], 0
0x4a28de : mov eax, dword ptr [ebp + 8] 	(controls.c:1880)
0x4a28e1 : mov dword ptr [eax + 0x15e8], 0
0x4a28eb : mov eax, dword ptr [ebp + 8] 	(controls.c:1881)
0x4a28ee : mov dword ptr [eax + 0x230], 0


FlipUpCar is only 91.42% similar to the original, diff above
```

*AI generated. Time taken: 591s, tokens: 78,373*
