### PR TITLE
FastFloatSin equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/trig.c
+++ b/src/DETHRACE/common/trig.c
@@ -116,21 +116,20 @@ br_matrix34 mattmp2__trig; // suffix added to avoid duplicate symbol
 // FUNCTION: CARM95 0x004aa0d0
 float FastFloatSin(int pAngle_in_degrees) {
 
-    if (pAngle_in_degrees >= 0) {
-        pAngle_in_degrees = pAngle_in_degrees % 360;
-    } else {
+    if (pAngle_in_degrees < 0) {
         pAngle_in_degrees = 360 - -pAngle_in_degrees % 360;
+    } else {
+        pAngle_in_degrees = pAngle_in_degrees % 360;
     }
     if (pAngle_in_degrees > 270) {
         return -gFloat_sine_table[360 - pAngle_in_degrees];
-    }
-    if (pAngle_in_degrees > 180) {
+    } else if (pAngle_in_degrees > 180) {
         return -gFloat_sine_table[pAngle_in_degrees - 180];
-    }
-    if (pAngle_in_degrees <= 90) {
+    } else if (pAngle_in_degrees > 90) {
+        return gFloat_sine_table[180 - pAngle_in_degrees];
+    } else {
         return gFloat_sine_table[pAngle_in_degrees];
     }
-    return gFloat_sine_table[180 - pAngle_in_degrees];
 }
 
 // IDA: float __usercall FastFloatCos@<ST0>(int pAngle_in_degrees@<EAX>)


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4aa111,21 +0x4b81b1,21 @@
0x4aa111 : jle 0x1b
0x4aa117 : mov eax, 0x168 	(trig.c:125)
0x4aa11c : sub eax, dword ptr [ebp + 8]
0x4aa11f : fld dword ptr [eax*4 + gFloat_sine_table[0] (DATA)]
0x4aa126 : fchs 
0x4aa128 : jmp 0x5a
0x4aa12d : jmp 0x55 	(trig.c:126)
0x4aa132 : cmp dword ptr [ebp + 8], 0xb4
0x4aa139 : jle 0x16
0x4aa13f : mov eax, dword ptr [ebp + 8] 	(trig.c:127)
0x4aa142 : -fld dword ptr [eax*4 + " format" (STRING)]
         : +fld dword ptr [eax*4 + "IN GRID SCREEN" (STRING)]
0x4aa149 : fchs 
0x4aa14b : jmp 0x37
0x4aa150 : jmp 0x32 	(trig.c:128)
0x4aa155 : cmp dword ptr [ebp + 8], 0x5a
0x4aa159 : jle 0x19
0x4aa15f : mov eax, 0xb4 	(trig.c:129)
0x4aa164 : sub eax, dword ptr [ebp + 8]
0x4aa167 : fld dword ptr [eax*4 + gFloat_sine_table[0] (DATA)]
0x4aa16e : jmp 0x14
0x4aa173 : jmp 0xf 	(trig.c:130)


FastFloatSin is only 98.04% similar to the original, diff above
```

#### Effective match analysis

The control flow appears unchanged (same branch structure and no meaningful jump-layout reshuffle). The only shown delta is the symbolic name of the memory base in `fld dword ptr [eax*4 + ...]`, while the instruction form and surrounding math (`fchs`, same compares/jumps) are unchanged. This looks like differing symbol resolution for the same indexed float-table access, not a behavioral change.

#### Original match

```
---
+++
@@ -0x4aa0d0,44 +0x4b7d50,48 @@
0x4aa0d0 : push ebp 	(trig.c:117)
0x4aa0d1 : mov ebp, esp
0x4aa0d3 : push ebx
0x4aa0d4 : push esi
0x4aa0d5 : push edi
0x4aa0d6 : cmp dword ptr [ebp + 8], 0 	(trig.c:119)
0x4aa0da : -jge 0x1c
         : +jl 0x13
         : +mov ecx, 0x168 	(trig.c:120)
         : +mov eax, dword ptr [ebp + 8]
         : +cdq 
         : +idiv ecx
         : +mov dword ptr [ebp + 8], edx
         : +jmp 0x17 	(trig.c:121)
0x4aa0e0 : mov ecx, 0x168 	(trig.c:122)
0x4aa0e5 : mov eax, dword ptr [ebp + 8]
0x4aa0e8 : neg eax
0x4aa0ea : mov ebx, 0x168
0x4aa0ef : cdq 
0x4aa0f0 : idiv ebx
0x4aa0f2 : sub ecx, edx
0x4aa0f4 : mov dword ptr [ebp + 8], ecx
0x4aa0f7 : -jmp 0xe
0x4aa0fc : -mov ecx, 0x168
0x4aa101 : -mov eax, dword ptr [ebp + 8]
0x4aa104 : -cdq 
0x4aa105 : -idiv ecx
0x4aa107 : -mov dword ptr [ebp + 8], edx
0x4aa10a : cmp dword ptr [ebp + 8], 0x10e 	(trig.c:124)
0x4aa111 : -jle 0x1b
         : +jle 0x16
0x4aa117 : mov eax, 0x168 	(trig.c:125)
0x4aa11c : sub eax, dword ptr [ebp + 8]
0x4aa11f : fld dword ptr [eax*4 + gFloat_sine_table[0] (DATA)]
0x4aa126 : fchs 
0x4aa128 : -jmp 0x5a
0x4aa12d : -jmp 0x55
         : +jmp 0x4b
0x4aa132 : cmp dword ptr [ebp + 8], 0xb4 	(trig.c:127)
0x4aa139 : -jle 0x16
         : +jle 0x11
0x4aa13f : mov eax, dword ptr [ebp + 8] 	(trig.c:128)
0x4aa142 : -fld dword ptr [eax*4 + " format" (STRING)]
         : +fld dword ptr [eax*4 + "IN GRID SCREEN" (STRING)]
0x4aa149 : fchs 
0x4aa14b : -jmp 0x37
0x4aa150 : -jmp 0x32
         : +jmp 0x2d
0x4aa155 : cmp dword ptr [ebp + 8], 0x5a 	(trig.c:130)
0x4aa159 : -jle 0x19
         : +jg 0xf
         : +mov eax, dword ptr [ebp + 8] 	(trig.c:131)
         : +fld dword ptr [eax*4 + gFloat_sine_table[0] (DATA)]
         : +jmp 0x14
0x4aa15f : mov eax, 0xb4 	(trig.c:133)
0x4aa164 : sub eax, dword ptr [ebp + 8]
0x4aa167 : fld dword ptr [eax*4 + gFloat_sine_table[0] (DATA)]
0x4aa16e : -jmp 0x14
0x4aa173 : -jmp 0xf
0x4aa178 : -mov eax, dword ptr [ebp + 8]
         : +jmp 0x0
         : +pop edi 	(trig.c:134)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


FastFloatSin is only 56.52% similar to the original, diff above
```

*AI generated. Time taken: 565s, tokens: 151,844*
