### PR TITLE
PickBoundsTestRay__finteray equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -73,7 +73,7 @@ int PickBoundsTestRay__finteray(br_bounds* b, br_vector3* rp, br_vector3* rd, br
     float t;
 
     for (i = 0; i < 3; i++) {
-        if (rd->v[i] < -0.00000023841858f) {
+        if (rd->v[i] < -2 * BR_SCALAR_EPSILON) {
             s = -1.0f / rd->v[i];
             t = (rp->v[i] - b->max.v[i]) * s;
             if (t > BR_SCALAR_MAX) {
@@ -87,7 +87,7 @@ int PickBoundsTestRay__finteray(br_bounds* b, br_vector3* rp, br_vector3* rd, br
             } else if (t < t_far) {
                 t_far = t;
             }
-        } else if (rd->v[i] > 0.00000023841858f) {
+        } else if (rd->v[i] > 2 * BR_SCALAR_EPSILON) {
             s = -1.0f / rd->v[i];
             t = (rp->v[i] - b->max.v[i]) * s;
             if (t < BR_SCALAR_MIN) {

--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -72,54 +72,45 @@ int PickBoundsTestRay__finteray(br_bounds* b, br_vector3* rp, br_vector3* rd, br
     float t;
 
     for (i = 0; i < 3; i++) {
-        if (rd->v[i] >= -0.00000023841858) {
-            if (rd->v[i] <= 0.00000023841858) {
-                if (b->max.v[i] < rp->v[i] || rp->v[i] < b->min.v[i]) {
-                    return 0;
-                }
-            } else {
-                s = (-1.0f / rd->v[i]) * (rp->v[i] - b->max.v[i]);
-                if (s >= BR_SCALAR_MIN) {
-                    if (s < t_far) {
-                        t_far = (-1.0f / rd->v[i]) * (rp->v[i] - b->max.v[i]);
-                    }
-                } else {
-                    t_far = BR_SCALAR_MIN;
-                }
-                t = (-1.0f / rd->v[i]) * (rp->v[i] - b->min.v[i]);
-                if (t <= BR_SCALAR_MAX) {
-                    if (t > t_near) {
-                        t_near = (-1.0f / rd->v[i]) * (rp->v[i] - b->min.v[i]);
-                    }
-                } else {
-                    t_near = BR_SCALAR_MAX;
-                }
-            }
-        } else {
-            s = (-1.0f / rd->v[i]) * (rp->v[i] - b->max.v[i]);
-            if (s <= BR_SCALAR_MAX) {
-                if (s > t_near) {
-                    t_near = (-1.0f / rd->v[i]) * (rp->v[i] - b->max.v[i]);
-                }
-            } else {
+        if (rd->v[i] < -0.00000023841858f) {
+            s = -1.0f / rd->v[i];
+            t = (rp->v[i] - b->max.v[i]) * s;
+            if (t > BR_SCALAR_MAX) {
                 t_near = BR_SCALAR_MAX;
+            } else if (t > t_near) {
+                t_near = t;
             }
-            t = (-1.0f / rd->v[i]) * (rp->v[i] - b->min.v[i]);
-            if (t >= BR_SCALAR_MIN) {
-                if (t < t_far) {
-                    t_far = (-1.0f / rd->v[i]) * (rp->v[i] - b->min.v[i]);
-                }
-            } else {
+            t = (rp->v[i] - b->min.v[i]) * s;
+            if (t < BR_SCALAR_MIN) {
                 t_far = BR_SCALAR_MIN;
+            } else if (t < t_far) {
+                t_far = t;
             }
+        } else if (rd->v[i] > 0.00000023841858f) {
+            s = -1.0f / rd->v[i];
+            t = (rp->v[i] - b->max.v[i]) * s;
+            if (t < BR_SCALAR_MIN) {
+                t_far = BR_SCALAR_MIN;
+            } else if (t < t_far) {
+                t_far = t;
+            }
+            t = (rp->v[i] - b->min.v[i]) * s;
+            if (t > BR_SCALAR_MAX) {
+                t_near = BR_SCALAR_MAX;
+            } else if (t > t_near) {
+                t_near = t;
+            }
+        } else if (rp->v[i] > b->max.v[i] || rp->v[i] < b->min.v[i]) {
+            return 0;
         }
     }
-    if (t_far < t_near) {
+    if (t_far >= t_near) {
+        *new_t_near = t_near;
+        *new_t_far = t_far;
+        return 1;
+    } else {
         return 0;
     }
-    *new_t_near = t_near;
-    *new_t_far = t_far;
-    return 1;
 }
 
 // IDA: int __usercall ActorRayPick2D@<EAX>(br_actor *ap@<EAX>, br_vector3 *pPosition@<EDX>, br_vector3 *pDir@<EBX>, br_model *model@<ECX>, br_material *material, dr_pick2d_cbfn *callback)


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4ab29e,46 +0x47664b,46 @@
0x4ab29e : mov ecx, dword ptr [ebp + 8]
0x4ab2a1 : fsub dword ptr [ecx + eax*4 + 0xc]
0x4ab2a5 : fmul dword ptr [ebp - 4]
0x4ab2a8 : fcom dword ptr [3.4028234663852886e+38 (FLOAT)] 	(finteray.c:79)
0x4ab2ae : fstp dword ptr [ebp - 8]
0x4ab2b1 : fnstsw ax
0x4ab2b3 : test ah, 0x41
0x4ab2b6 : jne 0xc
0x4ab2bc : mov dword ptr [ebp + 0x14], 0x7f7fffff 	(finteray.c:80)
0x4ab2c3 : jmp 0x17 	(finteray.c:81)
0x4ab2c8 : -fld dword ptr [ebp + 0x14]
0x4ab2cb : -fcomp dword ptr [ebp - 8]
         : +fld dword ptr [ebp - 8]
         : +fcomp dword ptr [ebp + 0x14]
0x4ab2ce : fnstsw ax
0x4ab2d0 : -test ah, 1
0x4ab2d3 : -je 0x6
         : +test ah, 0x41
         : +jne 0x6
0x4ab2d9 : mov eax, dword ptr [ebp - 8] 	(finteray.c:82)
0x4ab2dc : mov dword ptr [ebp + 0x14], eax
0x4ab2df : mov eax, dword ptr [ebp - 0xc] 	(finteray.c:84)
0x4ab2e2 : mov ecx, dword ptr [ebp + 0xc]
0x4ab2e5 : fld dword ptr [ecx + eax*4]
0x4ab2e8 : mov eax, dword ptr [ebp - 0xc]
0x4ab2eb : mov ecx, dword ptr [ebp + 8]
0x4ab2ee : fsub dword ptr [ecx + eax*4]
0x4ab2f1 : fmul dword ptr [ebp - 4]
0x4ab2f4 : fcom dword ptr [-3.4028234663852886e+38 (FLOAT)] 	(finteray.c:85)
0x4ab2fa : fstp dword ptr [ebp - 8]
0x4ab2fd : fnstsw ax
0x4ab2ff : test ah, 1
0x4ab302 : je 0xc
0x4ab308 : mov dword ptr [ebp + 0x18], 0xff7fffff 	(finteray.c:86)
0x4ab30f : jmp 0x17 	(finteray.c:87)
0x4ab314 : -fld dword ptr [ebp + 0x18]
0x4ab317 : -fcomp dword ptr [ebp - 8]
         : +fld dword ptr [ebp - 8]
         : +fcomp dword ptr [ebp + 0x18]
0x4ab31a : fnstsw ax
0x4ab31c : -test ah, 0x41
0x4ab31f : -jne 0x6
         : +test ah, 1
         : +je 0x6
0x4ab325 : mov eax, dword ptr [ebp - 8] 	(finteray.c:88)
0x4ab328 : mov dword ptr [ebp + 0x18], eax
0x4ab32b : jmp 0x10c 	(finteray.c:90)
0x4ab330 : mov eax, dword ptr [ebp - 0xc]
0x4ab333 : mov ecx, dword ptr [ebp + 0x10]
0x4ab336 : fld dword ptr [ecx + eax*4]
0x4ab339 : fcomp dword ptr [2.384185791015625e-07 (FLOAT)]
0x4ab33f : fnstsw ax
0x4ab341 : test ah, 0x41
0x4ab344 : jne 0xb0

---
+++
@@ -0x4ab368,46 +0x476715,46 @@
0x4ab368 : mov ecx, dword ptr [ebp + 8]
0x4ab36b : fsub dword ptr [ecx + eax*4 + 0xc]
0x4ab36f : fmul dword ptr [ebp - 4]
0x4ab372 : fcom dword ptr [-3.4028234663852886e+38 (FLOAT)] 	(finteray.c:93)
0x4ab378 : fstp dword ptr [ebp - 8]
0x4ab37b : fnstsw ax
0x4ab37d : test ah, 1
0x4ab380 : je 0xc
0x4ab386 : mov dword ptr [ebp + 0x18], 0xff7fffff 	(finteray.c:94)
0x4ab38d : jmp 0x17 	(finteray.c:95)
0x4ab392 : -fld dword ptr [ebp + 0x18]
0x4ab395 : -fcomp dword ptr [ebp - 8]
         : +fld dword ptr [ebp - 8]
         : +fcomp dword ptr [ebp + 0x18]
0x4ab398 : fnstsw ax
0x4ab39a : -test ah, 0x41
0x4ab39d : -jne 0x6
         : +test ah, 1
         : +je 0x6
0x4ab3a3 : mov eax, dword ptr [ebp - 8] 	(finteray.c:96)
0x4ab3a6 : mov dword ptr [ebp + 0x18], eax
0x4ab3a9 : mov eax, dword ptr [ebp - 0xc] 	(finteray.c:98)
0x4ab3ac : mov ecx, dword ptr [ebp + 0xc]
0x4ab3af : fld dword ptr [ecx + eax*4]
0x4ab3b2 : mov eax, dword ptr [ebp - 0xc]
0x4ab3b5 : mov ecx, dword ptr [ebp + 8]
0x4ab3b8 : fsub dword ptr [ecx + eax*4]
0x4ab3bb : fmul dword ptr [ebp - 4]
0x4ab3be : fcom dword ptr [3.4028234663852886e+38 (FLOAT)] 	(finteray.c:99)
0x4ab3c4 : fstp dword ptr [ebp - 8]
0x4ab3c7 : fnstsw ax
0x4ab3c9 : test ah, 0x41
0x4ab3cc : jne 0xc
0x4ab3d2 : mov dword ptr [ebp + 0x14], 0x7f7fffff 	(finteray.c:100)
0x4ab3d9 : jmp 0x17 	(finteray.c:101)
0x4ab3de : -fld dword ptr [ebp + 0x14]
0x4ab3e1 : -fcomp dword ptr [ebp - 8]
         : +fld dword ptr [ebp - 8]
         : +fcomp dword ptr [ebp + 0x14]
0x4ab3e4 : fnstsw ax
0x4ab3e6 : -test ah, 1
0x4ab3e9 : -je 0x6
         : +test ah, 0x41
         : +jne 0x6
0x4ab3ef : mov eax, dword ptr [ebp - 8] 	(finteray.c:102)
0x4ab3f2 : mov dword ptr [ebp + 0x14], eax
0x4ab3f5 : jmp 0x42 	(finteray.c:104)
0x4ab3fa : mov eax, dword ptr [ebp - 0xc]
0x4ab3fd : mov ecx, dword ptr [ebp + 8]
0x4ab400 : fld dword ptr [ecx + eax*4 + 0xc]
0x4ab404 : mov eax, dword ptr [ebp - 0xc]
0x4ab407 : mov ecx, dword ptr [ebp + 0xc]
0x4ab40a : fcomp dword ptr [ecx + eax*4]
0x4ab40d : fnstsw ax


PickBoundsTestRay__finteray is only 90.18% similar to the original, diff above
```

#### Effective match analysis

The changed blocks preserve semantics. Each modified compare swaps `fcomp` operand order (e.g., `old ? new` becomes `new ? old`) and correspondingly changes the post-`fnstsw` condition test/branch (`test ah,1` vs `test ah,0x41` with opposite jump sense) so the same update decision is made for ordered values. In effect, the code still updates the min/max bound only when the new candidate is better, and skips on worse-or-equal. The surrounding control flow shape and jump structure are unchanged in these hunks (no meaningful CFG reshuffle indicated), so this is functionally equivalent under your stated rules (including ignoring NaN behavior).

#### Original match

```
---
+++
@@ -0x4ab244,163 +0x476541,208 @@
0x4ab244 : push ebp 	(finteray.c:69)
0x4ab245 : mov ebp, esp
0x4ab247 : sub esp, 0xc
0x4ab24a : push ebx
0x4ab24b : push esi
0x4ab24c : push edi
0x4ab24d : mov dword ptr [ebp - 0xc], 0 	(finteray.c:74)
0x4ab254 : jmp 0x3
0x4ab259 : inc dword ptr [ebp - 0xc]
0x4ab25c : cmp dword ptr [ebp - 0xc], 3
0x4ab260 : -jge 0x1db
         : +jge 0x271
0x4ab266 : mov eax, dword ptr [ebp - 0xc] 	(finteray.c:75)
0x4ab269 : mov ecx, dword ptr [ebp + 0x10]
0x4ab26c : fld dword ptr [ecx + eax*4]
0x4ab26f : -fcomp dword ptr [-2.384185791015625e-07 (FLOAT)]
         : +fcomp qword ptr [-2.3841858e-07 (FLOAT)]
0x4ab275 : fnstsw ax
0x4ab277 : test ah, 1
0x4ab27a : -je 0xb0
0x4ab280 : -fld dword ptr [-1.0 (FLOAT)]
         : +jne 0x15c
0x4ab286 : mov eax, dword ptr [ebp - 0xc] 	(finteray.c:76)
0x4ab289 : mov ecx, dword ptr [ebp + 0x10]
0x4ab28c : -fdiv dword ptr [ecx + eax*4]
0x4ab28f : -fstp dword ptr [ebp - 4]
         : +fld dword ptr [ecx + eax*4]
         : +fcomp qword ptr [2.3841858e-07 (FLOAT)]
         : +fnstsw ax
         : +test ah, 0x41
         : +je 0x47
0x4ab292 : mov eax, dword ptr [ebp - 0xc] 	(finteray.c:77)
0x4ab295 : mov ecx, dword ptr [ebp + 0xc]
0x4ab298 : fld dword ptr [ecx + eax*4]
0x4ab29b : mov eax, dword ptr [ebp - 0xc]
0x4ab29e : mov ecx, dword ptr [ebp + 8]
0x4ab2a1 : -fsub dword ptr [ecx + eax*4 + 0xc]
0x4ab2a5 : -fmul dword ptr [ebp - 4]
0x4ab2a8 : -fcom dword ptr [3.4028234663852886e+38 (FLOAT)]
0x4ab2ae : -fstp dword ptr [ebp - 8]
         : +fcomp dword ptr [ecx + eax*4 + 0xc]
0x4ab2b1 : fnstsw ax
0x4ab2b3 : test ah, 0x41
0x4ab2b6 : -jne 0xc
0x4ab2bc : -mov dword ptr [ebp + 0x14], 0x7f7fffff
0x4ab2c3 : -jmp 0x17
0x4ab2c8 : -fld dword ptr [ebp + 0x14]
0x4ab2cb : -fcomp dword ptr [ebp - 8]
0x4ab2ce : -fnstsw ax
0x4ab2d0 : -test ah, 1
0x4ab2d3 : -je 0x6
0x4ab2d9 : -mov eax, dword ptr [ebp - 8]
0x4ab2dc : -mov dword ptr [ebp + 0x14], eax
0x4ab2df : -mov eax, dword ptr [ebp - 0xc]
0x4ab2e2 : -mov ecx, dword ptr [ebp + 0xc]
0x4ab2e5 : -fld dword ptr [ecx + eax*4]
0x4ab2e8 : -mov eax, dword ptr [ebp - 0xc]
0x4ab2eb : -mov ecx, dword ptr [ebp + 8]
0x4ab2ee : -fsub dword ptr [ecx + eax*4]
0x4ab2f1 : -fmul dword ptr [ebp - 4]
0x4ab2f4 : -fcom dword ptr [-3.4028234663852886e+38 (FLOAT)]
0x4ab2fa : -fstp dword ptr [ebp - 8]
0x4ab2fd : -fnstsw ax
0x4ab2ff : -test ah, 1
0x4ab302 : -je 0xc
0x4ab308 : -mov dword ptr [ebp + 0x18], 0xff7fffff
0x4ab30f : -jmp 0x17
0x4ab314 : -fld dword ptr [ebp + 0x18]
0x4ab317 : -fcomp dword ptr [ebp - 8]
0x4ab31a : -fnstsw ax
0x4ab31c : -test ah, 0x41
0x4ab31f : -jne 0x6
0x4ab325 : -mov eax, dword ptr [ebp - 8]
0x4ab328 : -mov dword ptr [ebp + 0x18], eax
0x4ab32b : -jmp 0x10c
0x4ab330 : -mov eax, dword ptr [ebp - 0xc]
0x4ab333 : -mov ecx, dword ptr [ebp + 0x10]
0x4ab336 : -fld dword ptr [ecx + eax*4]
0x4ab339 : -fcomp dword ptr [2.384185791015625e-07 (FLOAT)]
0x4ab33f : -fnstsw ax
0x4ab341 : -test ah, 0x41
0x4ab344 : -jne 0xb0
0x4ab34a : -fld dword ptr [-1.0 (FLOAT)]
0x4ab350 : -mov eax, dword ptr [ebp - 0xc]
0x4ab353 : -mov ecx, dword ptr [ebp + 0x10]
0x4ab356 : -fdiv dword ptr [ecx + eax*4]
0x4ab359 : -fstp dword ptr [ebp - 4]
0x4ab35c : -mov eax, dword ptr [ebp - 0xc]
0x4ab35f : -mov ecx, dword ptr [ebp + 0xc]
0x4ab362 : -fld dword ptr [ecx + eax*4]
0x4ab365 : -mov eax, dword ptr [ebp - 0xc]
0x4ab368 : -mov ecx, dword ptr [ebp + 8]
0x4ab36b : -fsub dword ptr [ecx + eax*4 + 0xc]
0x4ab36f : -fmul dword ptr [ebp - 4]
0x4ab372 : -fcom dword ptr [-3.4028234663852886e+38 (FLOAT)]
0x4ab378 : -fstp dword ptr [ebp - 8]
0x4ab37b : -fnstsw ax
0x4ab37d : -test ah, 1
0x4ab380 : -je 0xc
0x4ab386 : -mov dword ptr [ebp + 0x18], 0xff7fffff
0x4ab38d : -jmp 0x17
0x4ab392 : -fld dword ptr [ebp + 0x18]
0x4ab395 : -fcomp dword ptr [ebp - 8]
0x4ab398 : -fnstsw ax
0x4ab39a : -test ah, 0x41
0x4ab39d : -jne 0x6
0x4ab3a3 : -mov eax, dword ptr [ebp - 8]
0x4ab3a6 : -mov dword ptr [ebp + 0x18], eax
0x4ab3a9 : -mov eax, dword ptr [ebp - 0xc]
0x4ab3ac : -mov ecx, dword ptr [ebp + 0xc]
0x4ab3af : -fld dword ptr [ecx + eax*4]
0x4ab3b2 : -mov eax, dword ptr [ebp - 0xc]
0x4ab3b5 : -mov ecx, dword ptr [ebp + 8]
0x4ab3b8 : -fsub dword ptr [ecx + eax*4]
0x4ab3bb : -fmul dword ptr [ebp - 4]
0x4ab3be : -fcom dword ptr [3.4028234663852886e+38 (FLOAT)]
0x4ab3c4 : -fstp dword ptr [ebp - 8]
0x4ab3c7 : -fnstsw ax
0x4ab3c9 : -test ah, 0x41
0x4ab3cc : -jne 0xc
0x4ab3d2 : -mov dword ptr [ebp + 0x14], 0x7f7fffff
0x4ab3d9 : -jmp 0x17
0x4ab3de : -fld dword ptr [ebp + 0x14]
0x4ab3e1 : -fcomp dword ptr [ebp - 8]
0x4ab3e4 : -fnstsw ax
0x4ab3e6 : -test ah, 1
0x4ab3e9 : -je 0x6
0x4ab3ef : -mov eax, dword ptr [ebp - 8]
0x4ab3f2 : -mov dword ptr [ebp + 0x14], eax
0x4ab3f5 : -jmp 0x42
0x4ab3fa : -mov eax, dword ptr [ebp - 0xc]
0x4ab3fd : -mov ecx, dword ptr [ebp + 8]
0x4ab400 : -fld dword ptr [ecx + eax*4 + 0xc]
0x4ab404 : -mov eax, dword ptr [ebp - 0xc]
0x4ab407 : -mov ecx, dword ptr [ebp + 0xc]
0x4ab40a : -fcomp dword ptr [ecx + eax*4]
0x4ab40d : -fnstsw ax
0x4ab40f : -test ah, 1
0x4ab412 : -jne 0x1d
         : +je 0x1d
0x4ab418 : mov eax, dword ptr [ebp - 0xc]
0x4ab41b : mov ecx, dword ptr [ebp + 0xc]
0x4ab41e : fld dword ptr [ecx + eax*4]
0x4ab421 : mov eax, dword ptr [ebp - 0xc]
0x4ab424 : mov ecx, dword ptr [ebp + 8]
0x4ab427 : fcomp dword ptr [ecx + eax*4]
0x4ab42a : fnstsw ax
0x4ab42c : test ah, 1
0x4ab42f : je 0x7
0x4ab435 : xor eax, eax 	(finteray.c:78)
0x4ab437 : -jmp 0x3c
0x4ab43c : -jmp -0x1e8
         : +jmp 0x22d
         : +jmp 0xf6 	(finteray.c:80)
         : +mov eax, dword ptr [ebp - 0xc] 	(finteray.c:81)
         : +mov ecx, dword ptr [ebp + 0xc]
         : +fld dword ptr [ecx + eax*4]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 8]
         : +fsub dword ptr [ecx + eax*4 + 0xc]
         : +fld dword ptr [-1.0 (FLOAT)]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 0x10]
         : +fdiv dword ptr [ecx + eax*4]
         : +fmulp st(1)
         : +fcom dword ptr [-3.4028234663852886e+38 (FLOAT)] 	(finteray.c:82)
         : +fstp dword ptr [ebp - 4]
         : +fnstsw ax
         : +test ah, 1
         : +jne 0x3d
         : +fld dword ptr [ebp - 4] 	(finteray.c:83)
         : +fcomp dword ptr [ebp + 0x18]
         : +fnstsw ax
         : +test ah, 1
         : +je 0x27
         : +mov eax, dword ptr [ebp - 0xc] 	(finteray.c:84)
         : +mov ecx, dword ptr [ebp + 0xc]
         : +fld dword ptr [ecx + eax*4]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 8]
         : +fsub dword ptr [ecx + eax*4 + 0xc]
         : +fld dword ptr [-1.0 (FLOAT)]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 0x10]
         : +fdiv dword ptr [ecx + eax*4]
         : +fmulp st(1)
         : +fstp dword ptr [ebp + 0x18]
         : +jmp 0x7 	(finteray.c:86)
         : +mov dword ptr [ebp + 0x18], 0xff7fffff 	(finteray.c:87)
         : +mov eax, dword ptr [ebp - 0xc] 	(finteray.c:89)
         : +mov ecx, dword ptr [ebp + 0xc]
         : +fld dword ptr [ecx + eax*4]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 8]
         : +fsub dword ptr [ecx + eax*4]
         : +fld dword ptr [-1.0 (FLOAT)]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 0x10]
         : +fdiv dword ptr [ecx + eax*4]
         : +fmulp st(1)
         : +fcom dword ptr [3.4028234663852886e+38 (FLOAT)] 	(finteray.c:90)
         : +fstp dword ptr [ebp - 8]
         : +fnstsw ax
         : +test ah, 0x41
         : +je 0x3c
         : +fld dword ptr [ebp - 8] 	(finteray.c:91)
         : +fcomp dword ptr [ebp + 0x14]
         : +fnstsw ax
         : +test ah, 0x41
         : +jne 0x26
         : +mov eax, dword ptr [ebp - 0xc] 	(finteray.c:92)
         : +mov ecx, dword ptr [ebp + 0xc]
         : +fld dword ptr [ecx + eax*4]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 8]
         : +fsub dword ptr [ecx + eax*4]
         : +fld dword ptr [-1.0 (FLOAT)]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 0x10]
         : +fdiv dword ptr [ecx + eax*4]
         : +fmulp st(1)
         : +fstp dword ptr [ebp + 0x14]
         : +jmp 0x7 	(finteray.c:94)
         : +mov dword ptr [ebp + 0x14], 0x7f7fffff 	(finteray.c:95)
         : +jmp 0xf6 	(finteray.c:98)
         : +mov eax, dword ptr [ebp - 0xc] 	(finteray.c:99)
         : +mov ecx, dword ptr [ebp + 0xc]
         : +fld dword ptr [ecx + eax*4]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 8]
         : +fsub dword ptr [ecx + eax*4 + 0xc]
         : +fld dword ptr [-1.0 (FLOAT)]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 0x10]
         : +fdiv dword ptr [ecx + eax*4]
         : +fmulp st(1)
         : +fcom dword ptr [3.4028234663852886e+38 (FLOAT)] 	(finteray.c:100)
         : +fstp dword ptr [ebp - 4]
         : +fnstsw ax
         : +test ah, 0x41
         : +je 0x3d
         : +fld dword ptr [ebp - 4] 	(finteray.c:101)
         : +fcomp dword ptr [ebp + 0x14]
         : +fnstsw ax
         : +test ah, 0x41
         : +jne 0x27
         : +mov eax, dword ptr [ebp - 0xc] 	(finteray.c:102)
         : +mov ecx, dword ptr [ebp + 0xc]
         : +fld dword ptr [ecx + eax*4]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 8]
         : +fsub dword ptr [ecx + eax*4 + 0xc]
         : +fld dword ptr [-1.0 (FLOAT)]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 0x10]
         : +fdiv dword ptr [ecx + eax*4]
         : +fmulp st(1)
         : +fstp dword ptr [ebp + 0x14]
         : +jmp 0x7 	(finteray.c:104)
         : +mov dword ptr [ebp + 0x14], 0x7f7fffff 	(finteray.c:105)
         : +mov eax, dword ptr [ebp - 0xc] 	(finteray.c:107)
         : +mov ecx, dword ptr [ebp + 0xc]
         : +fld dword ptr [ecx + eax*4]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 8]
         : +fsub dword ptr [ecx + eax*4]
         : +fld dword ptr [-1.0 (FLOAT)]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 0x10]
         : +fdiv dword ptr [ecx + eax*4]
         : +fmulp st(1)
         : +fcom dword ptr [-3.4028234663852886e+38 (FLOAT)] 	(finteray.c:108)
         : +fstp dword ptr [ebp - 8]
         : +fnstsw ax
         : +test ah, 1
         : +jne 0x3c
         : +fld dword ptr [ebp - 8] 	(finteray.c:109)
         : +fcomp dword ptr [ebp + 0x18]
         : +fnstsw ax
         : +test ah, 1
         : +je 0x26
         : +mov eax, dword ptr [ebp - 0xc] 	(finteray.c:110)
         : +mov ecx, dword ptr [ebp + 0xc]
         : +fld dword ptr [ecx + eax*4]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 8]
         : +fsub dword ptr [ecx + eax*4]
         : +fld dword ptr [-1.0 (FLOAT)]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov ecx, dword ptr [ebp + 0x10]
         : +fdiv dword ptr [ecx + eax*4]
         : +fmulp st(1)
         : +fstp dword ptr [ebp + 0x18]
         : +jmp 0x7 	(finteray.c:112)
         : +mov dword ptr [ebp + 0x18], 0xff7fffff 	(finteray.c:113)
         : +jmp -0x27e 	(finteray.c:116)
0x4ab441 : fld dword ptr [ebp + 0x18] 	(finteray.c:117)
0x4ab444 : fcomp dword ptr [ebp + 0x14]
0x4ab447 : fnstsw ax
0x4ab449 : test ah, 1
0x4ab44c : -jne 0x1f
         : +je 0x7
         : +xor eax, eax 	(finteray.c:118)
         : +jmp 0x1a
0x4ab452 : mov eax, dword ptr [ebp + 0x1c] 	(finteray.c:120)
0x4ab455 : mov ecx, dword ptr [ebp + 0x14]
0x4ab458 : mov dword ptr [eax], ecx
0x4ab45a : mov eax, dword ptr [ebp + 0x20] 	(finteray.c:121)
0x4ab45d : mov ecx, dword ptr [ebp + 0x18]
0x4ab460 : mov dword ptr [eax], ecx
0x4ab462 : mov eax, 1 	(finteray.c:122)
0x4ab467 : -jmp 0xc
0x4ab46c : -jmp 0x7
0x4ab471 : -xor eax, eax
0x4ab473 : jmp 0x0
0x4ab478 : pop edi 	(finteray.c:123)
0x4ab479 : pop esi
0x4ab47a : pop ebx
0x4ab47b : leave 
0x4ab47c : ret 


PickBoundsTestRay__finteray is only 27.49% similar to the original, diff above
```

*AI generated. Time taken: 606s, tokens: 93,174*
