### PR TITLE
SetFacesGroup 100% match

### DIFF
--- a/src/DETHRACE/common/finteray.c
+++ b/src/DETHRACE/common/finteray.c
@@ -1306,7 +1306,22 @@ void SetFacesGroup(int pFace) {
     int f;
     int v;
     int i;
-    NOT_IMPLEMENTED();
+
+    gSelected_model->faces[pFace].material = gSub_material;
+    for (f = 0; f < gSelected_model->nfaces; f++) {
+        if (gSelected_model->faces[f].material != gReal_material) {
+            continue;
+        }
+        for (i = 0; i < 3; i++) {
+            v = gSelected_model->faces[pFace].vertices[i];
+            if (CompVert(gSelected_model->faces[f].vertices[0], v)
+                || CompVert(gSelected_model->faces[f].vertices[1], v)
+                || CompVert(gSelected_model->faces[f].vertices[2], v)) {
+                SetFacesGroup(f);
+                break;
+            }
+        }
+    }
 }
 
 // IDA: void __usercall SelectFace(br_vector3 *pDir@<EAX>)


### PR DESCRIPTION
## Match result

```
0x4af7d4: SetFacesGroup 100% match.

✨ OK! ✨
```

#### Original match

```
---
+++
@@ -0x4af7d4,7 +0x47a8d8,12 @@
0x4af7d4 : push ebp 	(finteray.c:1305)
0x4af7d5 : mov ebp, esp
0x4af7d7 : sub esp, 0xc
0x4af7da : push ebx
0x4af7db : push esi
0x4af7dc : push edi
0x4af7dd : -mov eax, dword ptr [gSub_material (DATA)]
         : +call abort (FUNCTION) 	(finteray.c:1309)
         : +pop edi 	(finteray.c:1310)
         : +pop esi
         : +pop ebx
         : +leave 
         : +ret 


SetFacesGroup is only 63.16% similar to the original, diff above
```

*AI generated. Time taken: 1007s, tokens: 127,525*
