### PR TITLE
CrushModel equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -303,7 +303,7 @@ void CrushModel(tCar_spec* pCar, int pModel_index, br_actor* pActor, br_vector3*
     nearest_index = -1;
     for (i = 0; i < pCrush_data->number_of_crush_points; i++) {
         the_vertex = &vertices[pCrush_data->crush_points[i].vertex_index];
-        this_distance = (impact_point_model.v[2] - the_vertex->p.v[2]) * (impact_point_model.v[2] - the_vertex->p.v[2]) + (impact_point_model.v[1] - the_vertex->p.v[1]) * (impact_point_model.v[1] - the_vertex->p.v[1]) + (impact_point_model.v[0] - the_vertex->p.v[0]) * (impact_point_model.v[0] - the_vertex->p.v[0]);
+        this_distance = Vector3DistanceSquared(&impact_point_model, &the_vertex->p);
         if (this_distance < nearest_so_far) {
             nearest_so_far = this_distance;
             nearest_index = i;

--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -288,19 +288,16 @@ void CrushModel(tCar_spec* pCar, int pModel_index, br_actor* pActor, br_vector3*
     br_vertex* the_vertex;
     br_matrix34 inverse_transform;
 
-    if (gArrow_mode) {
-        return;
-    }
-    if (pCrush_data->number_of_crush_points == 0) {
+    if (gArrow_mode || pCrush_data->number_of_crush_points == 0) {
         return;
     }
     BrVector3Sub(&impact_point_model, pImpact_point, (br_vector3*)pActor->t.t.mat.m[3]);
-    BrVector3Scale(&energy_vector_model, pEnergy_vector, pCrush_data->softness_factor * gCar_crush_softness);
-    total_energy = BrVector3Length(&energy_vector_model);
+    BrVector3Scale(&energy_vector_scaled, pEnergy_vector, pCrush_data->softness_factor * gCar_crush_softness);
+    total_energy = BrVector3Length(&energy_vector_scaled);
     if (total_energy < 0.06f) {
         return;
     }
-    BrVector3Scale(&energy_vector_scaled, &energy_vector_model, (total_energy - 0.06f) / total_energy);
+    BrVector3Scale(&energy_vector_scaled, &energy_vector_scaled, (total_energy - 0.06) / total_energy);
     nearest_so_far = BR_SCALAR_MAX;
     vertices = pActor->model->vertices;
     nearest_index = -1;


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4bd947,24 +0x46b071,24 @@
0x4bd947 : fmul dword ptr [gCar_crush_softness (DATA)]
0x4bd94d : mov eax, dword ptr [ebp + 0x18]
0x4bd950 : fmul dword ptr [eax + 4]
0x4bd953 : fstp dword ptr [ebp - 0x64]
0x4bd956 : mov eax, dword ptr [ebp + 0x1c]
0x4bd959 : fld dword ptr [eax + 4]
0x4bd95c : fmul dword ptr [gCar_crush_softness (DATA)]
0x4bd962 : mov eax, dword ptr [ebp + 0x18]
0x4bd965 : fmul dword ptr [eax + 8]
0x4bd968 : fstp dword ptr [ebp - 0x60]
         : +fld dword ptr [ebp - 0x64] 	(crush.c:296)
         : +fmul dword ptr [ebp - 0x64]
0x4bd96b : fld dword ptr [ebp - 0x60]
0x4bd96e : fmul dword ptr [ebp - 0x60]
0x4bd971 : -fld dword ptr [ebp - 0x64]
0x4bd974 : -fmul dword ptr [ebp - 0x64]
0x4bd977 : faddp st(1)
0x4bd979 : fld dword ptr [ebp - 0x68]
0x4bd97c : fmul dword ptr [ebp - 0x68]
0x4bd97f : faddp st(1)
0x4bd981 : call __CIsqrt (FUNCTION)
0x4bd986 : fcom dword ptr [0.05999999865889549 (FLOAT)] 	(crush.c:297)
0x4bd98c : fstp dword ptr [ebp - 0x14]
0x4bd98f : fnstsw ax
0x4bd991 : test ah, 1
0x4bd994 : je 0x5


CrushModel is only 98.79% similar to the original, diff above
```

#### Effective match analysis

The diff only reorders two independent x87 square computations before the sum: `(-0x64)^2` and `(-0x60)^2`. In both versions, `faddp st(1)` adds the same two squared values and leaves the same result on the FP stack for subsequent code. No control-flow instructions changed (same jumps/calls/targets shown), so there is no control-flow reshuffling issue. Ignoring NaN/signed-zero edge behavior and micro FP effects as requested, the functional result is the same.

#### Original match

```
---
+++
@@ -0x4bd8da,18 +0x46b034,19 @@
0x4bd8da : push ebp 	(crush.c:278)
0x4bd8db : mov ebp, esp
0x4bd8dd : sub esp, 0x70
0x4bd8e0 : push ebx
0x4bd8e1 : push esi
0x4bd8e2 : push edi
0x4bd8e3 : cmp dword ptr [gArrow_mode (DATA)], 0 	(crush.c:291)
0x4bd8ea : -jne 0xc
         : +je 0x5
         : +jmp 0x1e4 	(crush.c:292)
0x4bd8f0 : mov eax, dword ptr [ebp + 0x1c] 	(crush.c:294)
0x4bd8f3 : cmp dword ptr [eax], 0
0x4bd8f6 : jne 0x5
0x4bd8fc : jmp 0x1d3 	(crush.c:295)
0x4bd901 : mov eax, dword ptr [ebp + 0x14] 	(crush.c:297)
0x4bd904 : fld dword ptr [eax]
0x4bd906 : mov eax, dword ptr [ebp + 0x10]
0x4bd909 : fsub dword ptr [eax + 0x50]
0x4bd90c : fstp dword ptr [ebp - 0x50]
0x4bd90f : mov eax, dword ptr [ebp + 0x14]

---
+++
@@ -0x4bd91e,101 +0x46b07d,101 @@
0x4bd91e : mov eax, dword ptr [ebp + 0x14]
0x4bd921 : fld dword ptr [eax + 8]
0x4bd924 : mov eax, dword ptr [ebp + 0x10]
0x4bd927 : fsub dword ptr [eax + 0x58]
0x4bd92a : fstp dword ptr [ebp - 0x48]
0x4bd92d : mov eax, dword ptr [ebp + 0x1c] 	(crush.c:298)
0x4bd930 : fld dword ptr [eax + 4]
0x4bd933 : fmul dword ptr [gCar_crush_softness (DATA)]
0x4bd939 : mov eax, dword ptr [ebp + 0x18]
0x4bd93c : fmul dword ptr [eax]
0x4bd93e : -fstp dword ptr [ebp - 0x68]
         : +fstp dword ptr [ebp - 0xc]
0x4bd941 : mov eax, dword ptr [ebp + 0x1c]
0x4bd944 : fld dword ptr [eax + 4]
0x4bd947 : fmul dword ptr [gCar_crush_softness (DATA)]
0x4bd94d : mov eax, dword ptr [ebp + 0x18]
0x4bd950 : fmul dword ptr [eax + 4]
0x4bd953 : -fstp dword ptr [ebp - 0x64]
         : +fstp dword ptr [ebp - 8]
0x4bd956 : mov eax, dword ptr [ebp + 0x1c]
0x4bd959 : fld dword ptr [eax + 4]
0x4bd95c : fmul dword ptr [gCar_crush_softness (DATA)]
0x4bd962 : mov eax, dword ptr [ebp + 0x18]
0x4bd965 : fmul dword ptr [eax + 8]
0x4bd968 : -fstp dword ptr [ebp - 0x60]
0x4bd96b : -fld dword ptr [ebp - 0x60]
0x4bd96e : -fmul dword ptr [ebp - 0x60]
0x4bd971 : -fld dword ptr [ebp - 0x64]
0x4bd974 : -fmul dword ptr [ebp - 0x64]
         : +fstp dword ptr [ebp - 4]
         : +fld dword ptr [ebp - 0xc] 	(crush.c:299)
         : +fmul dword ptr [ebp - 0xc]
         : +fld dword ptr [ebp - 8]
         : +fmul dword ptr [ebp - 8]
0x4bd977 : faddp st(1)
0x4bd979 : -fld dword ptr [ebp - 0x68]
0x4bd97c : -fmul dword ptr [ebp - 0x68]
         : +fld dword ptr [ebp - 4]
         : +fmul dword ptr [ebp - 4]
0x4bd97f : faddp st(1)
0x4bd981 : call __CIsqrt (FUNCTION)
0x4bd986 : fcom dword ptr [0.05999999865889549 (FLOAT)] 	(crush.c:300)
0x4bd98c : fstp dword ptr [ebp - 0x14]
0x4bd98f : fnstsw ax
0x4bd991 : test ah, 1
0x4bd994 : je 0x5
0x4bd99a : jmp 0x135 	(crush.c:301)
0x4bd99f : fld dword ptr [ebp - 0x14] 	(crush.c:303)
0x4bd9a2 : -fsub qword ptr [0.06 (FLOAT)]
         : +fsub dword ptr [0.05999999865889549 (FLOAT)]
0x4bd9a8 : fdiv dword ptr [ebp - 0x14]
0x4bd9ab : -fmul dword ptr [ebp - 0x68]
         : +fmul dword ptr [ebp - 0xc]
0x4bd9ae : fstp dword ptr [ebp - 0x68]
0x4bd9b1 : fld dword ptr [ebp - 0x14]
0x4bd9b4 : -fsub qword ptr [0.06 (FLOAT)]
         : +fsub dword ptr [0.05999999865889549 (FLOAT)]
0x4bd9ba : fdiv dword ptr [ebp - 0x14]
0x4bd9bd : -fmul dword ptr [ebp - 0x64]
         : +fmul dword ptr [ebp - 8]
0x4bd9c0 : fstp dword ptr [ebp - 0x64]
0x4bd9c3 : fld dword ptr [ebp - 0x14]
0x4bd9c6 : -fsub qword ptr [0.06 (FLOAT)]
         : +fsub dword ptr [0.05999999865889549 (FLOAT)]
0x4bd9cc : fdiv dword ptr [ebp - 0x14]
0x4bd9cf : -fmul dword ptr [ebp - 0x60]
         : +fmul dword ptr [ebp - 4]
0x4bd9d2 : fstp dword ptr [ebp - 0x60]
0x4bd9d5 : mov dword ptr [ebp - 0x6c], 0x7f7fffff 	(crush.c:304)
0x4bd9dc : mov eax, dword ptr [ebp + 0x10] 	(crush.c:305)
0x4bd9df : mov eax, dword ptr [eax + 0x18]
0x4bd9e2 : mov eax, dword ptr [eax + 8]
0x4bd9e5 : mov dword ptr [ebp - 0x10], eax
0x4bd9e8 : mov dword ptr [ebp - 0x58], 0xffffffff 	(crush.c:306)
0x4bd9ef : mov dword ptr [ebp - 0x5c], 0 	(crush.c:307)
0x4bd9f6 : jmp 0x3
0x4bd9fb : inc dword ptr [ebp - 0x5c]
0x4bd9fe : mov eax, dword ptr [ebp + 0x1c]
0x4bda01 : mov ecx, dword ptr [ebp - 0x5c]
0x4bda04 : cmp dword ptr [eax], ecx
0x4bda06 : jle 0x82
0x4bda0c : -mov eax, dword ptr [ebp + 0x1c]
0x4bda0f : -mov eax, dword ptr [eax + 0x20]
0x4bda12 : -mov ecx, dword ptr [ebp - 0x5c]
0x4bda15 : -mov edx, ecx
0x4bda17 : -shl ecx, 3
0x4bda1a : -sub ecx, edx
         : +mov eax, dword ptr [ebp - 0x5c] 	(crush.c:308)
         : +mov ecx, eax
         : +shl eax, 3
         : +sub eax, ecx
         : +mov ecx, dword ptr [ebp + 0x1c]
         : +mov ecx, dword ptr [ecx + 0x20]
0x4bda1c : xor edx, edx
0x4bda1e : -mov dx, word ptr [eax + ecx*8]
         : +mov dx, word ptr [ecx + eax*8]
0x4bda22 : lea eax, [edx + edx*4]
0x4bda25 : shl eax, 3
0x4bda28 : add eax, dword ptr [ebp - 0x10]
0x4bda2b : mov dword ptr [ebp - 0x70], eax
         : +fld dword ptr [ebp - 0x4c] 	(crush.c:309)
         : +mov eax, dword ptr [ebp - 0x70]
         : +fsub dword ptr [eax + 4]
         : +fld dword ptr [ebp - 0x4c]
         : +mov eax, dword ptr [ebp - 0x70]
         : +fsub dword ptr [eax + 4]
         : +fmulp st(1)
0x4bda2e : fld dword ptr [ebp - 0x48]
0x4bda31 : mov eax, dword ptr [ebp - 0x70]
0x4bda34 : fsub dword ptr [eax + 8]
0x4bda37 : fld dword ptr [ebp - 0x48]
0x4bda3a : mov eax, dword ptr [ebp - 0x70]
0x4bda3d : fsub dword ptr [eax + 8]
0x4bda40 : -fmulp st(1)
0x4bda42 : -fld dword ptr [ebp - 0x4c]
0x4bda45 : -mov eax, dword ptr [ebp - 0x70]
0x4bda48 : -fsub dword ptr [eax + 4]
0x4bda4b : -fld dword ptr [ebp - 0x4c]
0x4bda4e : -mov eax, dword ptr [ebp - 0x70]
0x4bda51 : -fsub dword ptr [eax + 4]
0x4bda54 : fmulp st(1)
0x4bda56 : faddp st(1)
0x4bda58 : fld dword ptr [ebp - 0x50]
0x4bda5b : mov eax, dword ptr [ebp - 0x70]
0x4bda5e : fsub dword ptr [eax]
0x4bda60 : fld dword ptr [ebp - 0x50]
0x4bda63 : mov eax, dword ptr [ebp - 0x70]
0x4bda66 : fsub dword ptr [eax]
0x4bda68 : fmulp st(1)
0x4bda6a : faddp st(1)


CrushModel is only 81.57% similar to the original, diff above
```

*AI generated. Time taken: 720s, tokens: 84,107*
