### PR TITLE
RepairCar2 equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -429,14 +429,10 @@ float RepairCar2(tCar_spec* pCar, tU32 pFrame_period, br_scalar* pTotal_deflecti
     amount = 0.0;
 
     for (i = 0, the_car_actor = pCar->car_model_actors; i < gProgram_state.current_car.car_actor_count; i++, the_car_actor++) {
-        if (the_car_actor->min_distance_squared != 0.0f) {
-            if (the_car_actor->undamaged_vertices) {
-                RepairModel(pCar, i, the_car_actor->actor, the_car_actor->undamaged_vertices, pFrame_period * 0.00005, &dummy);
-            }
-        } else {
-            if (the_car_actor->undamaged_vertices) {
-                amount = RepairModel(pCar, i, the_car_actor->actor, the_car_actor->undamaged_vertices, pFrame_period * 0.00005, pTotal_deflection);
-            }
+        if (the_car_actor->min_distance_squared != 0.0f && the_car_actor->undamaged_vertices != NULL) {
+            RepairModel(pCar, i, the_car_actor->actor, the_car_actor->undamaged_vertices, pFrame_period * 0.00005, &dummy);
+        } else if (the_car_actor->undamaged_vertices != NULL) {
+            amount = RepairModel(pCar, i, the_car_actor->actor, the_car_actor->undamaged_vertices, pFrame_period * 0.00005, pTotal_deflection);
         }
     }
     pCar->repair_time += pFrame_period;

--- a/src/DETHRACE/common/crush.c
+++ b/src/DETHRACE/common/crush.c
@@ -431,14 +431,15 @@ float RepairCar2(tCar_spec* pCar, tU32 pFrame_period, br_scalar* pTotal_deflecti
     *pTotal_deflection = 0.0;
     amount = 0.0;
 
-    for (i = 0; i < gProgram_state.current_car.car_actor_count; i++) {
-        the_car_actor = &pCar->car_model_actors[i];
-        if (the_car_actor->min_distance_squared == 0.0 || !the_car_actor->undamaged_vertices) {
+    for (i = 0, the_car_actor = pCar->car_model_actors; i < gProgram_state.current_car.car_actor_count; i++, the_car_actor++) {
+        if (the_car_actor->min_distance_squared != 0.0f) {
             if (the_car_actor->undamaged_vertices) {
-                amount = RepairModel(pCar, i, the_car_actor->actor, the_car_actor->undamaged_vertices, pFrame_period * 0.00005f, pTotal_deflection);
+                RepairModel(pCar, i, the_car_actor->actor, the_car_actor->undamaged_vertices, pFrame_period * 0.00005, &dummy);
             }
         } else {
-            RepairModel(pCar, i, the_car_actor->actor, the_car_actor->undamaged_vertices, pFrame_period * 0.00005f, &dummy);
+            if (the_car_actor->undamaged_vertices) {
+                amount = RepairModel(pCar, i, the_car_actor->actor, the_car_actor->undamaged_vertices, pFrame_period * 0.00005, pTotal_deflection);
+            }
         }
     }
     pCar->repair_time += pFrame_period;


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4bdd8d,21 +0x46b79a,21 @@
0x4bdd8d : cmp dword ptr [gProgram_state+1812 (OFFSET)], eax
0x4bdd93 : jle 0xba
0x4bdd99 : mov eax, dword ptr [ebp - 0xc] 	(crush.c:435)
0x4bdd9c : fld dword ptr [eax + 4]
0x4bdd9f : fcomp dword ptr [0.0 (FLOAT)]
0x4bdda5 : fnstsw ax
0x4bdda7 : test ah, 0x40
0x4bddaa : jne 0x51
0x4bddb0 : mov eax, dword ptr [ebp - 0xc] 	(crush.c:436)
0x4bddb3 : cmp dword ptr [eax + 0x2c], 0
0x4bddb7 : -je 0x44
         : +je 0x3f
0x4bddbd : lea eax, [ebp - 8] 	(crush.c:437)
0x4bddc0 : push eax
0x4bddc1 : mov eax, dword ptr [ebp + 0xc]
0x4bddc4 : mov dword ptr [ebp - 0x18], eax
0x4bddc7 : mov dword ptr [ebp - 0x14], 0
0x4bddce : fild qword ptr [ebp - 0x18]
0x4bddd1 : fmul qword ptr [5e-05 (FLOAT)]
0x4bddd7 : sub esp, 4
0x4bddda : fstp dword ptr [esp]
0x4bdddd : mov eax, dword ptr [ebp - 0xc]


RepairCar2 is only 98.90% similar to the original, diff above
```

#### Effective match analysis

Based on the shown snippet, the only change is the `je` relative displacement (`0x44` -> `0x3f`), which is exactly a 5-byte shift. That is consistent with code-size/layout movement rather than a control-flow reshuffle to a different logical block. The surrounding compare/test sequence and subsequent operations are otherwise identical, so there is no evidence here of a functional behavior change.

#### Original match

```
---
+++
@@ -0x4bdd3b,91 +0x46b778,93 @@
0x4bdd3b : push ebp 	(crush.c:422)
0x4bdd3c : mov ebp, esp
0x4bdd3e : sub esp, 0x20
0x4bdd41 : push ebx
0x4bdd42 : push esi
0x4bdd43 : push edi
0x4bdd44 : cmp dword ptr [gArrow_mode (DATA)], 0 	(crush.c:428)
0x4bdd4b : je 0xb
0x4bdd51 : fld dword ptr [0.0 (FLOAT)] 	(crush.c:429)
0x4bdd57 : -jmp 0x10b
         : +jmp 0x110
0x4bdd5c : mov eax, dword ptr [ebp + 0x10] 	(crush.c:431)
0x4bdd5f : mov dword ptr [eax], 0
0x4bdd65 : mov dword ptr [ebp - 4], 0 	(crush.c:432)
0x4bdd6c : mov dword ptr [ebp - 0x10], 0 	(crush.c:434)
0x4bdd73 : -mov eax, dword ptr [ebp + 8]
         : +jmp 0x3
         : +inc dword ptr [ebp - 0x10]
         : +mov eax, dword ptr [ebp - 0x10]
         : +cmp dword ptr [gProgram_state+1812 (OFFSET)], eax
         : +jle 0xce
         : +mov eax, dword ptr [ebp - 0x10] 	(crush.c:435)
         : +shl eax, 4
         : +lea eax, [eax + eax*2]
         : +add eax, dword ptr [ebp + 8]
0x4bdd76 : add eax, 0x12b8
0x4bdd7b : mov dword ptr [ebp - 0xc], eax
0x4bdd7e : -jmp 0x7
0x4bdd83 : -inc dword ptr [ebp - 0x10]
0x4bdd86 : -add dword ptr [ebp - 0xc], 0x30
0x4bdd8a : -mov eax, dword ptr [ebp - 0x10]
0x4bdd8d : -cmp dword ptr [gProgram_state+1812 (OFFSET)], eax
0x4bdd93 : -jle 0xba
0x4bdd99 : mov eax, dword ptr [ebp - 0xc] 	(crush.c:436)
0x4bdd9c : fld dword ptr [eax + 4]
0x4bdd9f : -fcomp dword ptr [0.0 (FLOAT)]
         : +fcomp qword ptr [0.0 (FLOAT)]
0x4bdda5 : fnstsw ax
0x4bdda7 : test ah, 0x40
0x4bddaa : -jne 0x51
         : +jne 0xd
0x4bddb0 : mov eax, dword ptr [ebp - 0xc]
0x4bddb3 : cmp dword ptr [eax + 0x2c], 0
0x4bddb7 : -je 0x44
0x4bddbd : -lea eax, [ebp - 8]
         : +jne 0x52
         : +mov eax, dword ptr [ebp - 0xc] 	(crush.c:437)
         : +cmp dword ptr [eax + 0x2c], 0
         : +je 0x40
         : +mov eax, dword ptr [ebp + 0x10] 	(crush.c:438)
0x4bddc0 : push eax
0x4bddc1 : mov eax, dword ptr [ebp + 0xc]
0x4bddc4 : mov dword ptr [ebp - 0x18], eax
0x4bddc7 : mov dword ptr [ebp - 0x14], 0
0x4bddce : fild qword ptr [ebp - 0x18]
0x4bddd1 : -fmul qword ptr [5e-05 (FLOAT)]
         : +fmul dword ptr [4.999999873689376e-05 (FLOAT)]
         : +sub esp, 4
         : +fstp dword ptr [esp]
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov eax, dword ptr [eax + 0x2c]
         : +push eax
         : +mov eax, dword ptr [ebp - 0xc]
         : +mov eax, dword ptr [eax]
         : +push eax
         : +mov eax, dword ptr [ebp - 0x10]
         : +push eax
         : +mov eax, dword ptr [ebp + 8]
         : +push eax
         : +call RepairModel (FUNCTION)
         : +add esp, 0x18
         : +fstp dword ptr [ebp - 4]
         : +jmp 0x3f 	(crush.c:440)
         : +lea eax, [ebp - 8] 	(crush.c:441)
         : +push eax
         : +mov eax, dword ptr [ebp + 0xc]
         : +mov dword ptr [ebp - 0x20], eax
         : +mov dword ptr [ebp - 0x1c], 0
         : +fild qword ptr [ebp - 0x20]
         : +fmul dword ptr [4.999999873689376e-05 (FLOAT)]
0x4bddd7 : sub esp, 4
0x4bddda : fstp dword ptr [esp]
0x4bdddd : mov eax, dword ptr [ebp - 0xc]
0x4bdde0 : mov eax, dword ptr [eax + 0x2c]
0x4bdde3 : push eax
0x4bdde4 : mov eax, dword ptr [ebp - 0xc]
0x4bdde7 : mov eax, dword ptr [eax]
0x4bdde9 : push eax
0x4bddea : mov eax, dword ptr [ebp - 0x10]
0x4bdded : push eax
0x4bddee : mov eax, dword ptr [ebp + 8]
0x4bddf1 : push eax
0x4bddf2 : call RepairModel (FUNCTION)
0x4bddf7 : add esp, 0x18
0x4bddfa : fstp st(0)
0x4bddfc : -jmp 0x4d
0x4bde01 : -mov eax, dword ptr [ebp - 0xc]
0x4bde04 : -cmp dword ptr [eax + 0x2c], 0
0x4bde08 : -je 0x40
0x4bde0e : -mov eax, dword ptr [ebp + 0x10]
0x4bde11 : -push eax
0x4bde12 : -mov eax, dword ptr [ebp + 0xc]
0x4bde15 : -mov dword ptr [ebp - 0x20], eax
0x4bde18 : -mov dword ptr [ebp - 0x1c], 0
0x4bde1f : -fild qword ptr [ebp - 0x20]
0x4bde22 : -fmul qword ptr [5e-05 (FLOAT)]
0x4bde28 : -sub esp, 4
0x4bde2b : -fstp dword ptr [esp]
0x4bde2e : -mov eax, dword ptr [ebp - 0xc]
0x4bde31 : -mov eax, dword ptr [eax + 0x2c]
0x4bde34 : -push eax
0x4bde35 : -mov eax, dword ptr [ebp - 0xc]
0x4bde38 : -mov eax, dword ptr [eax]
0x4bde3a : -push eax
0x4bde3b : -mov eax, dword ptr [ebp - 0x10]
0x4bde3e : -push eax
0x4bde3f : -mov eax, dword ptr [ebp + 8]
0x4bde42 : -push eax
0x4bde43 : -call RepairModel (FUNCTION)
0x4bde48 : -add esp, 0x18
0x4bde4b : -fstp dword ptr [ebp - 4]
0x4bde4e : -jmp -0xd0
         : +jmp -0xe0 	(crush.c:443)
0x4bde53 : mov eax, dword ptr [ebp + 0xc] 	(crush.c:444)
0x4bde56 : mov ecx, dword ptr [ebp + 8]
0x4bde59 : add dword ptr [ecx + 0x1a88], eax
0x4bde5f : fld dword ptr [ebp - 4] 	(crush.c:445)
0x4bde62 : jmp 0x0
0x4bde67 : pop edi 	(crush.c:446)
0x4bde68 : pop esi
0x4bde69 : pop ebx
0x4bde6a : leave 
0x4bde6b : ret 


RepairCar2 is only 55.43% similar to the original, diff above
```

*AI generated. Time taken: 486s, tokens: 40,017*
