### PR TITLE
SpendCredits equivalent match (review carefully)

### DIFF
--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -1543,11 +1543,12 @@ int SpendCredits(int pAmount) {
         return 0;
     }
     amount = gProgram_state.credits_earned - gProgram_state.credits_lost;
-    if (gProgram_state.credits_earned - gProgram_state.credits_lost >= 0) {
+    if (amount >= 0) {
         return 0;
+    } else {
+        gProgram_state.credits_lost = gProgram_state.credits_earned;
+        return amount;
     }
-    gProgram_state.credits_lost = gProgram_state.credits_earned;
-    return amount;
 }
 
 // IDA: void __usercall AwardTime(tU32 pTime@<EAX>)

--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -1535,11 +1535,7 @@ int SpendCredits(int pAmount) {
     int amount;
 
     gProgram_state.credits_lost += pAmount;
-    if (gNet_mode == eNet_mode_none) {
-        return 0;
-    }
-    amount = gProgram_state.credits_earned - gProgram_state.credits_lost;
-    if (amount >= 0) {
+    if (gNet_mode == eNet_mode_none || (amount = gProgram_state.credits_earned - gProgram_state.credits_lost) >= 0) {
         return 0;
     } else {
         gProgram_state.credits_lost = gProgram_state.credits_earned;


### PR DESCRIPTION
## Match result

```
---
+++
@@ -0x4c78c4,20 +0x475592,22 @@
0x4c78c4 : push ebp 	(displays.c:1534)
0x4c78c5 : mov ebp, esp
0x4c78c7 : sub esp, 4
0x4c78ca : push ebx
0x4c78cb : push esi
0x4c78cc : push edi
0x4c78cd : mov eax, dword ptr [ebp + 8] 	(displays.c:1537)
0x4c78d0 : add dword ptr [gProgram_state+8 (OFFSET)], eax
0x4c78d6 : cmp dword ptr [gNet_mode (DATA)], 0 	(displays.c:1538)
0x4c78dd : -je 0x18
         : +jne 0x7
         : +xor eax, eax 	(displays.c:1539)
         : +jmp 0x36
0x4c78e3 : mov eax, dword ptr [gProgram_state+4 (OFFSET)] 	(displays.c:1541)
0x4c78e8 : sub eax, dword ptr [gProgram_state+8 (OFFSET)]
0x4c78ee : mov dword ptr [ebp - 4], eax
0x4c78f1 : cmp dword ptr [ebp - 4], 0 	(displays.c:1542)
0x4c78f5 : jl 0xc
0x4c78fb : xor eax, eax 	(displays.c:1543)
0x4c78fd : jmp 0x17
0x4c7902 : jmp 0x12 	(displays.c:1544)
0x4c7907 : mov eax, dword ptr [gProgram_state+4 (OFFSET)] 	(displays.c:1545)
0x4c790c : mov dword ptr [gProgram_state+8 (OFFSET)], eax


SpendCredits is only 92.86% similar to the original, diff above
```

#### Effective match analysis

The shown change appears to be a control-flow inversion/reshuffle, not a functional change. In both versions, `gProgram_state+8` is incremented first, then `gNet_mode` is tested. The new code uses `jne` to enter the existing main path and adds an explicit `xor eax, eax; jmp ...` early-return path for the `gNet_mode == 0` case, which matches the old branch behavior (where `je` jumped to a return-0 path). The remaining arithmetic/updates (`gProgram_state+4 - gProgram_state+8`, sign check, and potential write-back) are unchanged in effect. So the observable result is the same despite different branch layout and jump distances.

#### Original match

```
---
+++
@@ -0x4c78c4,27 +0x4755fc,29 @@
0x4c78c4 : push ebp 	(displays.c:1525)
0x4c78c5 : mov ebp, esp
0x4c78c7 : sub esp, 4
0x4c78ca : push ebx
0x4c78cb : push esi
0x4c78cc : push edi
0x4c78cd : mov eax, dword ptr [ebp + 8] 	(displays.c:1528)
0x4c78d0 : add dword ptr [gProgram_state+8 (OFFSET)], eax
0x4c78d6 : cmp dword ptr [gNet_mode (DATA)], 0 	(displays.c:1529)
0x4c78dd : -je 0x18
         : +jne 0x7
         : +xor eax, eax 	(displays.c:1530)
         : +jmp 0x38
0x4c78e3 : mov eax, dword ptr [gProgram_state+4 (OFFSET)] 	(displays.c:1532)
0x4c78e8 : sub eax, dword ptr [gProgram_state+8 (OFFSET)]
0x4c78ee : mov dword ptr [ebp - 4], eax
0x4c78f1 : -cmp dword ptr [ebp - 4], 0
0x4c78f5 : -jl 0xc
         : +mov eax, dword ptr [gProgram_state+4 (OFFSET)] 	(displays.c:1533)
         : +sub eax, dword ptr [gProgram_state+8 (OFFSET)]
         : +js 0x7
0x4c78fb : xor eax, eax 	(displays.c:1534)
0x4c78fd : -jmp 0x17
0x4c7902 : jmp 0x12
0x4c7907 : mov eax, dword ptr [gProgram_state+4 (OFFSET)] 	(displays.c:1536)
0x4c790c : mov dword ptr [gProgram_state+8 (OFFSET)], eax
0x4c7911 : mov eax, dword ptr [ebp - 4] 	(displays.c:1537)
0x4c7914 : jmp 0x0
0x4c7919 : pop edi 	(displays.c:1538)
0x4c791a : pop esi
0x4c791b : pop ebx
0x4c791c : leave 
0x4c791d : ret 


SpendCredits is only 82.14% similar to the original, diff above
```

*AI generated. Time taken: 1351s, tokens: 115,681*
