### PR TITLE
Add Doom-style mouse/trackpad steering

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Dethrace generally expects to be placed into the top level Carmageddon folder. Y
 
 Alternatively, you may configure a different Carmageddon directory and settings by providing a [dethrace.ini file](docs/CONFIGURATION.md).
 
+### Mouse steering
+
+Dethrace can steer the car with the mouse or trackpad, Doom-style. Press the `` ` `` (backtick) or `Cmd`/`Win` key in-game to grab the mouse: the cursor is hidden and locked, and moving left/right steers the car. Press the same key again to release the mouse for the menus. Steering by keyboard keeps working at the same time, and mouse steering follows your key mapping (it drives whatever you've bound steer-left/right to, arrows or WASD).
+
+It is enabled by default; disable it with `--no-mouse-steering` (or `MouseSteering = 0` in the INI). Tune the responsiveness with `--mouse-steering-sensitivity=1.5` (or `MouseSteeringSensitivity` in the INI).
+
 ### CD audio
 
 Dethrace supports the GOG cd audio convention. If there is a `MUSIC` folder in the Carmageddon folder containing files `Track02.ogg`, `Track03.ogg` etc, then Dethrace will use those files in place of the original CD audio functions.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -37,6 +37,13 @@ Cutscenes = 0
 ; "hires" mode is 640x480, otherwise default 320x200
 Hires = 1
 
+; Steer the car with the mouse/trackpad (Doom-style). Press ` (backtick) or the
+; Cmd/Win key in-game to grab/release the mouse. Set to 0 to disable entirely.
+MouseSteering = 1
+
+; Mouse steering sensitivity multiplier (default 1.0)
+MouseSteeringSensitivity = 1.0
+
 ; Only used in 'demo' mode. Default demo time out is 240s (4 mins)
 DemoTimeout = 240
 

--- a/src/DETHRACE/pc-all/allsys.c
+++ b/src/DETHRACE/pc-all/allsys.c
@@ -99,6 +99,23 @@ int KeyDown(tU8 pScan_code) {
     return (gKeyboard_bits[pScan_code >> 5] >> (pScan_code & 0x1F)) & 1;
 }
 
+// Resolve the keyboard scan code currently bound to a control action (steer left is
+// index 46, steer right is 47 - see PollCarControls). Returns 0 when the action is
+// unbound or mapped to a joystick axis. Lets the harness inject mouse/trackpad
+// steering as the correct key regardless of the player's key mapping.
+tU8 GetBoundScanCode(int pControl_index) {
+    int key;
+
+    if (pControl_index < 0 || pControl_index >= COUNT_OF(gKey_mapping)) {
+        return 0;
+    }
+    key = gKey_mapping[pControl_index];
+    if (key < 0 || key >= COUNT_OF(gScan_code)) {
+        return 0;
+    }
+    return gScan_code[key][0];
+}
+
 // IDA: void __usercall KeyTranslation(tU8 pKey_index@<EAX>, tU8 pScan_code_1@<EDX>, tU8 pScan_code_2@<EBX>)
 void KeyTranslation(tU8 pKey_index, tU8 pScan_code_1, tU8 pScan_code_2) {
     NOT_IMPLEMENTED();

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -293,6 +293,9 @@ int Harness_Init(int* argc, char* argv[]) {
     harness_game_config.volume_multiplier = 1.0f;
     // start window in windowed mode
     harness_game_config.start_full_screen = 1;
+    // allow steering the car with the mouse/trackpad (Doom-style). Inert until grabbed with the toggle key
+    harness_game_config.mouse_steering = 1;
+    harness_game_config.mouse_steering_sensitivity = 1.0f;
     // Disable gore check emulation
     harness_game_config.gore_check = 0;
     // Disable "Sound Options" menu
@@ -434,6 +437,17 @@ int Harness_ProcessCommandLine(int* argc, char* argv[]) {
         } else if (strcasecmp(argv[i], "--window") == 0) {
             harness_game_config.start_full_screen = 0;
             consumed = 1;
+        } else if (strcasecmp(argv[i], "--mouse-steering") == 0) {
+            harness_game_config.mouse_steering = 1;
+            consumed = 1;
+        } else if (strcasecmp(argv[i], "--no-mouse-steering") == 0) {
+            harness_game_config.mouse_steering = 0;
+            consumed = 1;
+        } else if (strstr(argv[i], "--mouse-steering-sensitivity=") != NULL) {
+            char* s = strstr(argv[i], "=");
+            harness_game_config.mouse_steering_sensitivity = atof(s + 1);
+            LOG_INFO2("Mouse steering sensitivity set to %f", harness_game_config.mouse_steering_sensitivity);
+            consumed = 1;
         } else if (strcasecmp(argv[i], "--gore-check") == 0) {
             harness_game_config.gore_check = 1;
             consumed = 1;
@@ -510,6 +524,10 @@ static int Harness_Ini_Callback(void* user, const char* section, const char* nam
         gGraf_spec_index = (value[0] == '1');
     } else if (MATCH("General", "PhysicsPerFrame")) {
         harness_game_config.physics_per_frame = (value[0] == '1');
+    } else if (MATCH("General", "MouseSteering")) {
+        harness_game_config.mouse_steering = (value[0] == '1');
+    } else if (MATCH("General", "MouseSteeringSensitivity")) {
+        harness_game_config.mouse_steering_sensitivity = atof(value);
     }
 
     else if (MATCH("Cheats", "EditMode")) {

--- a/src/harness/include/harness/config.h
+++ b/src/harness/include/harness/config.h
@@ -58,6 +58,9 @@ typedef struct tHarness_game_config {
     int opengl_3dfx_mode;
     int game_completed;
 
+    int mouse_steering;
+    float mouse_steering_sensitivity;
+
     int install_signalhandler;
     int no_bind;
     char network_adapter_name[256];

--- a/src/harness/platforms/sdl2.c
+++ b/src/harness/platforms/sdl2.c
@@ -26,6 +26,13 @@ static void (*gKeyHandler_func)(void);
 // 32 bytes, 1 bit per key. Matches dos executable behavior
 static br_uint_32 key_state[8];
 
+// Mouse/trackpad steering (Doom-style). `key_state` only ever reflects the real
+// keyboard; the synthesized steering arrow is OR-ed in when the keyboard state is
+// read, so it never clobbers a real key press.
+static int mouse_steer_grabbed = 0;
+static float mouse_steer_charge = 0.0f;
+static int mouse_steer_dir = 0;
+
 static struct {
     int x, y;
     float scale_x, scale_y;
@@ -34,6 +41,8 @@ static struct {
 // Callbacks back into original game code
 extern void QuitGame(void);
 extern br_pixelmap* gBack_screen;
+// Resolves the scan code currently bound to a control action (steer left/right = 46/47)
+extern br_uint_8 GetBoundScanCode(int pControl_index);
 
 #ifdef DETHRACE_SDL_DYNAMIC
 #ifdef _WIN32
@@ -127,6 +136,32 @@ static int is_only_key_modifier(int modifier_flags, int flag_check) {
     return (modifier_flags & flag_check) && (modifier_flags & (KMOD_CTRL | KMOD_SHIFT | KMOD_ALT | KMOD_GUI)) == (modifier_flags & flag_check);
 }
 
+// How fast the steering charge bleeds back to centre each poll, the minimum charge
+// that counts as a turn, and the cap a single flick can build up.
+#define MOUSE_STEER_DECAY 0.55f
+#define MOUSE_STEER_DEADZONE 1.5f
+#define MOUSE_STEER_MAX 40.0f
+
+static void SDL2_SetMouseSteeringGrab(int grab) {
+    if (grab == mouse_steer_grabbed) {
+        return;
+    }
+    mouse_steer_grabbed = grab;
+    // Relative mode hides and locks the cursor so a trackpad never runs out of travel.
+    SDL2_SetRelativeMouseMode(grab ? SDL_TRUE : SDL_FALSE);
+    if (grab) {
+        LOG_INFO("Mouse steering grabbed - move the mouse to steer (press ` or Cmd/Win to release)");
+    } else {
+        // Release any held steering so the car stops turning.
+        mouse_steer_charge = 0.0f;
+        mouse_steer_dir = 0;
+        if (gKeyHandler_func != NULL) {
+            gKeyHandler_func();
+        }
+        LOG_INFO("Mouse steering released");
+    }
+}
+
 static void SDL2_Harness_ProcessWindowMessages(void) {
     SDL_Event event;
 
@@ -136,6 +171,14 @@ static void SDL2_Harness_ProcessWindowMessages(void) {
         case SDL_KEYUP:
             if (event.key.windowID != SDL2_GetWindowID(window)) {
                 continue;
+            }
+            if (harness_game_config.mouse_steering && (event.key.keysym.scancode == SDL_SCANCODE_GRAVE || event.key.keysym.scancode == SDL_SCANCODE_LGUI || event.key.keysym.scancode == SDL_SCANCODE_RGUI)) {
+                // Toggle key for mouse steering, consumed so the game never sees it.
+                // The Cmd/Win keys are reliable alternatives where ` is a dead key (e.g. macOS FR).
+                if (event.type == SDL_KEYDOWN) {
+                    SDL2_SetMouseSteeringGrab(!mouse_steer_grabbed);
+                }
+                break;
             }
             if (event.key.keysym.sym == SDLK_RETURN) {
                 if (event.key.type == SDL_KEYDOWN) {
@@ -165,6 +208,21 @@ static void SDL2_Harness_ProcessWindowMessages(void) {
             gKeyHandler_func();
             break;
 
+        case SDL_MOUSEMOTION:
+            if (mouse_steer_grabbed) {
+                float sensitivity = harness_game_config.mouse_steering_sensitivity;
+                if (sensitivity <= 0.0f) {
+                    sensitivity = 1.0f;
+                }
+                mouse_steer_charge += event.motion.xrel * sensitivity;
+                if (mouse_steer_charge > MOUSE_STEER_MAX) {
+                    mouse_steer_charge = MOUSE_STEER_MAX;
+                } else if (mouse_steer_charge < -MOUSE_STEER_MAX) {
+                    mouse_steer_charge = -MOUSE_STEER_MAX;
+                }
+            }
+            break;
+
         case SDL_WINDOWEVENT:
             if (event.window.event == SDL_WINDOWEVENT_RESIZED) {
                 calculate_viewport(event.window.data1, event.window.data2);
@@ -175,6 +233,23 @@ static void SDL2_Harness_ProcessWindowMessages(void) {
             QuitGame();
         }
     }
+
+    if (mouse_steer_grabbed) {
+        // Bleed the charge back towards centre so the wheel recentres once the mouse
+        // stops, then turn what is left into a held left/right arrow. This runs every
+        // poll (not just on motion events) so a stationary mouse releases the steering.
+        mouse_steer_charge *= MOUSE_STEER_DECAY;
+        if (mouse_steer_charge > MOUSE_STEER_DEADZONE) {
+            mouse_steer_dir = 1;
+        } else if (mouse_steer_charge < -MOUSE_STEER_DEADZONE) {
+            mouse_steer_dir = -1;
+        } else {
+            mouse_steer_dir = 0;
+        }
+        if (gKeyHandler_func != NULL) {
+            gKeyHandler_func();
+        }
+    }
 }
 
 static void SDL2_Harness_SetKeyHandler(void (*handler_func)(void)) {
@@ -183,6 +258,15 @@ static void SDL2_Harness_SetKeyHandler(void (*handler_func)(void)) {
 
 static void SDL2_Harness_GetKeyboardState(br_uint_32* buffer) {
     memcpy(buffer, key_state, sizeof(key_state));
+    if (mouse_steer_grabbed && mouse_steer_dir != 0) {
+        // OR in the key the player has actually bound to steer left/right, so mouse
+        // steering follows the key mapping (arrows, WASD, ...). key_state is untouched,
+        // so real key presses keep working alongside it.
+        br_uint_8 scancode = GetBoundScanCode(mouse_steer_dir < 0 ? 46 : 47);
+        if (scancode != 0) {
+            buffer[scancode >> 5] |= (1u << (scancode & 0x1F));
+        }
+    }
 }
 
 static int SDL2_Harness_GetMouseButtons(int* pButton1, int* pButton2) {

--- a/src/harness/platforms/sdl2_syms.h
+++ b/src/harness/platforms/sdl2_syms.h
@@ -31,6 +31,7 @@
     X(UnlockTexture, void, (SDL_Texture*))                                              \
     X(GetMouseFocus, SDL_Window*, (void))                                               \
     X(GetMouseState, Uint32, (int*, int*))                                              \
+    X(SetRelativeMouseMode, int, (SDL_bool))                                            \
     X(ShowCursor, int, (int))                                                           \
     X(GetPixelFormatName, const char*, (Uint32))                                        \
     X(GetScancodeName, const char*, (SDL_Scancode))                                     \

--- a/src/harness/platforms/sdl3.c
+++ b/src/harness/platforms/sdl3.c
@@ -26,6 +26,13 @@ static void (*gKeyHandler_func)(void);
 // 32 bytes, 1 bit per key. Matches dos executable behavior
 static br_uint_32 key_state[8];
 
+// Mouse/trackpad steering (Doom-style). `key_state` only ever reflects the real
+// keyboard; the synthesized steering arrow is OR-ed in when the keyboard state is
+// read, so it never clobbers a real key press.
+static int mouse_steer_grabbed = 0;
+static float mouse_steer_charge = 0.0f;
+static int mouse_steer_dir = 0;
+
 static struct {
     int x, y;
     float scale_x, scale_y;
@@ -34,6 +41,8 @@ static struct {
 // Callbacks back into original game code
 extern void QuitGame(void);
 extern br_pixelmap* gBack_screen;
+// Resolves the scan code currently bound to a control action (steer left/right = 46/47)
+extern br_uint_8 GetBoundScanCode(int pControl_index);
 
 #ifdef DETHRACE_SDL_DYNAMIC
 #ifdef _WIN32
@@ -127,6 +136,32 @@ static int is_only_key_modifier(SDL_Keymod modifier_flags, SDL_Keymod flag_check
     return (modifier_flags & flag_check) && (modifier_flags & (SDL_KMOD_CTRL | SDL_KMOD_SHIFT | SDL_KMOD_ALT | SDL_KMOD_GUI)) == (modifier_flags & flag_check);
 }
 
+// How fast the steering charge bleeds back to centre each poll, the minimum charge
+// that counts as a turn, and the cap a single flick can build up.
+#define MOUSE_STEER_DECAY 0.55f
+#define MOUSE_STEER_DEADZONE 1.5f
+#define MOUSE_STEER_MAX 40.0f
+
+static void SDL3_SetMouseSteeringGrab(int grab) {
+    if (grab == mouse_steer_grabbed) {
+        return;
+    }
+    mouse_steer_grabbed = grab;
+    // Relative mode hides and locks the cursor so a trackpad never runs out of travel.
+    SDL3_SetWindowRelativeMouseMode(window, grab ? true : false);
+    if (grab) {
+        LOG_INFO("Mouse steering grabbed - move the mouse to steer (press ` or Cmd/Win to release)");
+    } else {
+        // Release any held steering so the car stops turning.
+        mouse_steer_charge = 0.0f;
+        mouse_steer_dir = 0;
+        if (gKeyHandler_func != NULL) {
+            gKeyHandler_func();
+        }
+        LOG_INFO("Mouse steering released");
+    }
+}
+
 static void SDL3_Harness_ProcessWindowMessages(void) {
     SDL_Event event;
 
@@ -136,6 +171,14 @@ static void SDL3_Harness_ProcessWindowMessages(void) {
         case SDL_EVENT_KEY_UP:
             if (event.key.windowID != SDL3_GetWindowID(window)) {
                 continue;
+            }
+            if (harness_game_config.mouse_steering && (event.key.scancode == SDL_SCANCODE_GRAVE || event.key.scancode == SDL_SCANCODE_LGUI || event.key.scancode == SDL_SCANCODE_RGUI)) {
+                // Toggle key for mouse steering, consumed so the game never sees it.
+                // The Cmd/Win keys are reliable alternatives where ` is a dead key (e.g. macOS FR).
+                if (event.type == SDL_EVENT_KEY_DOWN) {
+                    SDL3_SetMouseSteeringGrab(!mouse_steer_grabbed);
+                }
+                break;
             }
             if (event.key.key == SDLK_RETURN) {
                 if (event.key.type == SDL_EVENT_KEY_DOWN) {
@@ -165,12 +208,44 @@ static void SDL3_Harness_ProcessWindowMessages(void) {
             gKeyHandler_func();
             break;
 
+        case SDL_EVENT_MOUSE_MOTION:
+            if (mouse_steer_grabbed) {
+                float sensitivity = harness_game_config.mouse_steering_sensitivity;
+                if (sensitivity <= 0.0f) {
+                    sensitivity = 1.0f;
+                }
+                mouse_steer_charge += event.motion.xrel * sensitivity;
+                if (mouse_steer_charge > MOUSE_STEER_MAX) {
+                    mouse_steer_charge = MOUSE_STEER_MAX;
+                } else if (mouse_steer_charge < -MOUSE_STEER_MAX) {
+                    mouse_steer_charge = -MOUSE_STEER_MAX;
+                }
+            }
+            break;
+
         case SDL_EVENT_WINDOW_RESIZED:
             calculate_viewport(event.window.data1, event.window.data2);
             break;
 
         case SDL_EVENT_QUIT:
             QuitGame();
+        }
+    }
+
+    if (mouse_steer_grabbed) {
+        // Bleed the charge back towards centre so the wheel recentres once the mouse
+        // stops, then turn what is left into a held left/right arrow. This runs every
+        // poll (not just on motion events) so a stationary mouse releases the steering.
+        mouse_steer_charge *= MOUSE_STEER_DECAY;
+        if (mouse_steer_charge > MOUSE_STEER_DEADZONE) {
+            mouse_steer_dir = 1;
+        } else if (mouse_steer_charge < -MOUSE_STEER_DEADZONE) {
+            mouse_steer_dir = -1;
+        } else {
+            mouse_steer_dir = 0;
+        }
+        if (gKeyHandler_func != NULL) {
+            gKeyHandler_func();
         }
     }
 }
@@ -181,6 +256,15 @@ static void SDL3_Harness_SetKeyHandler(void (*handler_func)(void)) {
 
 static void SDL3_Harness_GetKeyboardState(br_uint_32* buffer) {
     memcpy(buffer, key_state, sizeof(key_state));
+    if (mouse_steer_grabbed && mouse_steer_dir != 0) {
+        // OR in the key the player has actually bound to steer left/right, so mouse
+        // steering follows the key mapping (arrows, WASD, ...). key_state is untouched,
+        // so real key presses keep working alongside it.
+        br_uint_8 scancode = GetBoundScanCode(mouse_steer_dir < 0 ? 46 : 47);
+        if (scancode != 0) {
+            buffer[scancode >> 5] |= (1u << (scancode & 0x1F));
+        }
+    }
 }
 
 static int SDL3_Harness_GetMouseButtons(int* pButton1, int* pButton2) {

--- a/src/harness/platforms/sdl3_syms.h
+++ b/src/harness/platforms/sdl3_syms.h
@@ -37,6 +37,7 @@
     X(UnlockTexture, void, (SDL_Texture*))                                                              \
     X(GetMouseFocus, SDL_Window*, (void))                                                               \
     X(GetMouseState, SDL_MouseButtonFlags, (float*, float*))                                            \
+    X(SetWindowRelativeMouseMode, bool, (SDL_Window*, bool))                                            \
     X(ShowCursor, bool, (void))                                                                         \
     X(GetPixelFormatName, const char*, (SDL_PixelFormat))                                               \
     X(GetScancodeName, const char *, (SDL_Scancode))                                                    \


### PR DESCRIPTION
## What

Lets you steer the car with the mouse or trackpad, Doom-style. Press `` ` `` (backtick) or the `Cmd`/`Win` key in-game to grab the mouse — the cursor is hidden and locked in relative mode, and horizontal movement steers the car. Press the same key again to release it for the menus. Keyboard steering keeps working at the same time.

## How

Implemented in the SDL harness (plus one small read-only helper), so **no existing byte-matched game function is modified**:

- Relative mouse motion accumulates into a "steering charge" that decays back to centre on every poll — so the wheel recentres when you stop moving, and a stationary mouse releases the steering even though SDL only sends motion events while the mouse is moving.
- That charge becomes a held steer-left/right key press by OR-ing the **currently bound** steer scancode into the keyboard state the game reads in `GetKeyboardState`. It follows the player's key mapping (arrows, WASD, …) instead of assuming a fixed binding. The underlying `key_state` is never modified, so real key presses are untouched and keyboard steering works alongside it.
- A new `GetBoundScanCode()` helper resolves the bound steer keys from `gKey_mapping`; it only reads game state.
- Mirrored across both the SDL2 and SDL3 drivers.

## Config

Enabled by default.

- Disable: `--no-mouse-steering`, or `MouseSteering = 0` in `dethrace.ini`.
- Sensitivity: `--mouse-steering-sensitivity=1.5`, or `MouseSteeringSensitivity` in the INI.

## Notes

- The grab key accepts `` ` `` and `Cmd`/`Win` because backtick is a dead key on some layouts (e.g. macOS French), where the `Cmd` key is a reliable alternative.
- Built and tested in-game on macOS (arm64) with SDL2; also compiles cleanly against SDL3.

