### PR TITLE
Fix macOS dynamic SDL app bundling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,9 +171,15 @@ if(BUILD_TESTS)
 endif()
 
 if(DETHRACE_INSTALL)
-    install(FILES LICENSE
-        DESTINATION "${CMAKE_INSTALL_DOCDIR}"
-    )
+    if(APPLE)
+        install(FILES LICENSE
+            DESTINATION "."
+        )
+    else()
+        install(FILES LICENSE
+            DESTINATION "${CMAKE_INSTALL_DOCDIR}"
+        )
+    endif()
 
     set(DETHRACE_PACKAGE_PLATFORM "" CACHE STRING "Dethrace binary package platform")
     set(DETHRACE_PACKAGE_ARCH "" CACHE STRING "Dethrace binary package architecture")

--- a/src/DETHRACE/CMakeLists.txt
+++ b/src/DETHRACE/CMakeLists.txt
@@ -234,11 +234,6 @@ if(DETHRACE_IDE_ARGUMENTS)
 endif()
 
 if(DETHRACE_INSTALL)
-    install(TARGETS dethrace
-        BUNDLE DESTINATION . COMPONENT Runtime
-        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT Runtime
-    )
-
     if(APPLE)
         set_target_properties(dethrace PROPERTIES
             BUNDLE True
@@ -255,7 +250,14 @@ if(DETHRACE_INSTALL)
         target_sources(dethrace_obj PRIVATE
             ${CMAKE_SOURCE_DIR}/packaging/macos/dethrace.icns
         )
+    endif()
 
+    install(TARGETS dethrace
+        BUNDLE DESTINATION . COMPONENT Runtime
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT Runtime
+    )
+
+    if(APPLE)
         if(DETHRACE_PLATFORM_SDL_DYNAMIC)
             if(DETHRACE_PLATFORM_SDL2)
                 install(CODE "

--- a/src/DETHRACE/CMakeLists.txt
+++ b/src/DETHRACE/CMakeLists.txt
@@ -259,8 +259,13 @@ if(DETHRACE_INSTALL)
         if(DETHRACE_PLATFORM_SDL_DYNAMIC)
             if(DETHRACE_PLATFORM_SDL2)
                 install(CODE "
+                    set(app_root \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}\")
+                    set(app \"\${app_root}/Deth Race.app\")
+                    if(NOT EXISTS \"\${app}\")
+                        set(app \"\${app_root}/${CMAKE_INSTALL_BINDIR}/Deth Race.app\")
+                    endif()
                     file(INSTALL
-                        DESTINATION \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/Deth Race.app/Contents/MacOS\"
+                        DESTINATION \"\${app}/Contents/MacOS\"
                         TYPE FILE
                         FOLLOW_SYMLINK_CHAIN
                         FILES \"$<TARGET_FILE:SDL2::SDL2>\"
@@ -272,15 +277,20 @@ if(DETHRACE_INSTALL)
 
             if(DETHRACE_PLATFORM_SDL3)
                 install(CODE "
+                    set(app_root \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}\")
+                    set(app \"\${app_root}/Deth Race.app\")
+                    if(NOT EXISTS \"\${app}\")
+                        set(app \"\${app_root}/${CMAKE_INSTALL_BINDIR}/Deth Race.app\")
+                    endif()
                     file(INSTALL
-                        DESTINATION \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/Deth Race.app/Contents/MacOS\"
+                        DESTINATION \"\${app}/Contents/MacOS\"
                         TYPE FILE
                         FOLLOW_SYMLINK_CHAIN
                         FILES \"$<TARGET_FILE:SDL3::SDL3>\"
                     )
                     file(CREATE_LINK
                         \"libSDL3.0.dylib\"
-                        \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/Deth Race.app/Contents/MacOS/libSDL3.dylib\"
+                        \"\${app}/Contents/MacOS/libSDL3.dylib\"
                         SYMBOLIC
                     )
                     "
@@ -291,13 +301,17 @@ if(DETHRACE_INSTALL)
 
         install(CODE "
             include(BundleUtilities)
-            set(app \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/Deth Race.app\")
+            set(app_root \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}\")
+            set(app \"\${app_root}/Deth Race.app\")
+            if(NOT EXISTS \"\${app}\")
+                set(app \"\${app_root}/${CMAKE_INSTALL_BINDIR}/Deth Race.app\")
+            endif()
             fixup_bundle(\"\${app}\" \"\" \"/Library/Frameworks\")
             execute_process(COMMAND
                 codesign -s - -f --deep \"\${app}\"
             )
             "
-            COMPONENT RUNTIME
+            COMPONENT Runtime
         )
     endif()
 

--- a/src/DETHRACE/CMakeLists.txt
+++ b/src/DETHRACE/CMakeLists.txt
@@ -256,11 +256,45 @@ if(DETHRACE_INSTALL)
             ${CMAKE_SOURCE_DIR}/packaging/macos/dethrace.icns
         )
 
+        if(DETHRACE_PLATFORM_SDL_DYNAMIC)
+            if(DETHRACE_PLATFORM_SDL2)
+                install(CODE "
+                    file(INSTALL
+                        DESTINATION \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/Deth Race.app/Contents/MacOS\"
+                        TYPE FILE
+                        FOLLOW_SYMLINK_CHAIN
+                        FILES \"$<TARGET_FILE:SDL2::SDL2>\"
+                    )
+                    "
+                    COMPONENT Runtime
+                )
+            endif()
+
+            if(DETHRACE_PLATFORM_SDL3)
+                install(CODE "
+                    file(INSTALL
+                        DESTINATION \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/Deth Race.app/Contents/MacOS\"
+                        TYPE FILE
+                        FOLLOW_SYMLINK_CHAIN
+                        FILES \"$<TARGET_FILE:SDL3::SDL3>\"
+                    )
+                    file(CREATE_LINK
+                        \"libSDL3.0.dylib\"
+                        \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/Deth Race.app/Contents/MacOS/libSDL3.dylib\"
+                        SYMBOLIC
+                    )
+                    "
+                    COMPONENT Runtime
+                )
+            endif()
+        endif()
+
         install(CODE "
             include(BundleUtilities)
-            fixup_bundle(\"${CMAKE_BINARY_DIR}/Deth Race.app\" \"\" \"/Library/Frameworks\")
+            set(app \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/Deth Race.app\")
+            fixup_bundle(\"\${app}\" \"\" \"/Library/Frameworks\")
             execute_process(COMMAND
-                codesign -s - -f \"${CMAKE_BINARY_DIR}/Deth Race.app/Contents/Frameworks/SDL2.framework\"
+                codesign -s - -f --deep \"\${app}\"
             )
             "
             COMPONENT RUNTIME

--- a/src/harness/platforms/sdl2.c
+++ b/src/harness/platforms/sdl2.c
@@ -49,8 +49,7 @@ static const char* const possible_locations[] = {
     "@loader_path/../Frameworks/" SDL2_FRAMEWORK,     /* MyApp.app/Contents/Frameworks/SDL2_framework */
     "@executable_path/" SDL2_LIBNAME,                 /* MyApp.app/Contents/MacOS/libSDL2_dylib */
     "@executable_path/../Frameworks/" SDL2_FRAMEWORK, /* MyApp.app/Contents/Frameworks/SDL2_framework */
-    NULL,                                             /* /Users/username/Library/Frameworks/SDL2_framework */
-    "/Library/Frameworks" SDL2_FRAMEWORK,             /* /Library/Frameworks/SDL2_framework */
+    "/Library/Frameworks/" SDL2_FRAMEWORK,            /* /Library/Frameworks/SDL2_framework */
     SDL2_LIBNAME                                      /* oh well, anywhere the system can see the .dylib (/usr/local/lib or whatever) */
 };
 #else

--- a/src/harness/platforms/sdl3.c
+++ b/src/harness/platforms/sdl3.c
@@ -49,8 +49,7 @@ static const char* const possible_locations[] = {
     "@loader_path/../Frameworks/" SDL3_FRAMEWORK,     /* MyApp.app/Contents/Frameworks/SDL3_framework */
     "@executable_path/" SDL3_LIBNAME,                 /* MyApp.app/Contents/MacOS/libSDL3_dylib */
     "@executable_path/../Frameworks/" SDL3_FRAMEWORK, /* MyApp.app/Contents/Frameworks/SDL3_framework */
-    NULL,                                             /* /Users/username/Library/Frameworks/SDL3_framework */
-    "/Library/Frameworks" SDL3_FRAMEWORK,             /* /Library/Frameworks/SDL3_framework */
+    "/Library/Frameworks/" SDL3_FRAMEWORK,            /* /Library/Frameworks/SDL3_framework */
     SDL3_LIBNAME                                      /* oh well, anywhere the system can see the .dylib (/usr/local/lib or whatever) */
 };
 #else
@@ -323,6 +322,9 @@ static void SDL3_Harness_CreateWindow(const char* title, int width, int height, 
                 }
             }
             LOG_PANIC2("Failed to create renderer texture (%s)", SDL3_GetError());
+        }
+        if (!SDL3_SetTextureScaleMode(screen_texture, SDL_SCALEMODE_PIXELART)) {
+            LOG_PANIC2("Failed to set texture scale mode: %s", SDL3_GetError());
         }
     }
 

--- a/src/harness/platforms/sdl3.c
+++ b/src/harness/platforms/sdl3.c
@@ -323,7 +323,7 @@ static void SDL3_Harness_CreateWindow(const char* title, int width, int height, 
             }
             LOG_PANIC2("Failed to create renderer texture (%s)", SDL3_GetError());
         }
-        if (!SDL3_SetTextureScaleMode(screen_texture, SDL_SCALEMODE_PIXELART)) {
+        if (!SDL3_SetTextureScaleMode(screen_texture, SDL_SCALEMODE_NEAREST)) {
             LOG_PANIC2("Failed to set texture scale mode: %s", SDL3_GetError());
         }
     }

--- a/src/harness/platforms/sdl3_syms.h
+++ b/src/harness/platforms/sdl3_syms.h
@@ -33,6 +33,7 @@
     X(SetRenderDrawBlendMode, bool, (SDL_Renderer*, SDL_BlendMode))                                     \
     X(SetRenderVSync, bool, (SDL_Renderer*, int))                                                       \
     X(CreateTexture, SDL_Texture*, (SDL_Renderer*, SDL_PixelFormat, SDL_TextureAccess, int, int))       \
+    X(SetTextureScaleMode, bool, (SDL_Texture*, SDL_ScaleMode))                                         \
     X(LockTexture, bool, (SDL_Texture*, const SDL_Rect*, void**, int*))                                 \
     X(UnlockTexture, void, (SDL_Texture*))                                                              \
     X(GetMouseFocus, SDL_Window*, (void))                                                               \

--- a/src/harness/platforms/sdl_dyn_common.h
+++ b/src/harness/platforms/sdl_dyn_common.h
@@ -33,7 +33,43 @@ static const char *Harness_LoadError(void) {
 }
 #else
 #include <dlfcn.h>
+#ifdef __APPLE__
+#include <limits.h>
+#include <mach-o/dyld.h>
+#endif
 static void *Harness_LoadObject(const char *name) {
+#ifdef __APPLE__
+    static const char loader_prefix[] = "@loader_path/";
+    static const char executable_prefix[] = "@executable_path/";
+    char executable_path[PATH_MAX];
+    uint32_t executable_path_size;
+    const char* suffix;
+    char* last_slash;
+    char resolved_name[PATH_MAX];
+
+    if (name != NULL) {
+        if (strncmp(name, loader_prefix, sizeof(loader_prefix) - 1) == 0) {
+            suffix = name + sizeof(loader_prefix) - 1;
+        } else if (strncmp(name, executable_prefix, sizeof(executable_prefix) - 1) == 0) {
+            suffix = name + sizeof(executable_prefix) - 1;
+        } else {
+            suffix = NULL;
+        }
+
+        if (suffix != NULL) {
+            executable_path_size = sizeof(executable_path);
+            if (_NSGetExecutablePath(executable_path, &executable_path_size) == 0) {
+                last_slash = strrchr(executable_path, '/');
+                if (last_slash != NULL) {
+                    *last_slash = '\0';
+                    if (snprintf(resolved_name, sizeof(resolved_name), "%s/%s", executable_path, suffix) < (int)sizeof(resolved_name)) {
+                        return dlopen(resolved_name, RTLD_NOW | RTLD_LOCAL);
+                    }
+                }
+            }
+        }
+    }
+#endif
     return dlopen(name, RTLD_NOW | RTLD_LOCAL);
 }
 static void Harness_UnloadObject(void *obj) {


### PR DESCRIPTION
## Summary
- fix macOS dynamic SDL library discovery for app bundles
- bundle SDL2/SDL3 dylibs into the installed app and fix the bundle fixup/signing path
- use SDL pixel-art scaling for the SDL3 screen texture and add the libSDL3.dylib alias expected by the loader

SDL3 uses liner scaling by default so it was all blurry