### PR TITLE
Only apply mine/powerup side effects to the car that triggered it

### DIFF
--- a/src/DETHRACE/common/powerup.c
+++ b/src/DETHRACE/common/powerup.c
@@ -240,6 +240,18 @@ int GotPowerupX(tCar_spec* pCar, int pIndex, int pTell_net_players, int pDisplay
     if (the_powerup->type == ePowerup_dummy) {
         return -1;
     }
+#ifdef DETHRACE_FIX_BUGS
+    // Only the local player owns the headup messages, the pratcam, the icon list
+    // and the powerup slots. When another car triggers a powerup - in practice an
+    // opponent or a cop driving over a mine, see CheckPedestrianDeathScenario() -
+    // apply the effect to that car only, and leave our own dashboard alone.
+    if (pCar->driver != eDriver_local_human) {
+        if (the_powerup->got_proc == NULL) {
+            return -1;
+        }
+        return the_powerup->got_proc(the_powerup, pCar);
+    }
+#endif
     if (the_powerup->got_proc == NULL) {
         NewTextHeadupSlot(eHeadupSlot_misc, 0, 3000, -kFont_MEDIUMHD, GetMiscString(kMiscString_UNAVAILABLE_IN_DEMO));
         return -1;


### PR DESCRIPTION
## Problem
When an opponent or a cop drives over a mine, the local player reacts:
the pratcam plays the powerup animation and the "Mine" headup message
pops up, even though our car is nowhere near the explosion.

## Cause
Mines are the only powerup that can be picked up by a car other than
ours: `CheckPedestrianDeathScenario()` calls `GotPowerup()` for any car
when the ped `ref_number` is 114 (pedestrn.c), so that opponents get
blown up too.

`GotPowerupX()` however assumes the powerup belongs to the player. Its
only guard is `if (pCar->driver <= eDriver_non_car)`, and
`eDriver_oppo` (2) is greater than `eDriver_non_car` (1), so for an
opponent it still runs, on the *player's* state:
- `NewTextHeadupSlot()` — the "Mine" message,
- `PratcamEvent(the_powerup->prat_cam_event)` — the pratcam reaction,
- `LoseAllSimilarPowerups()` — drops our own active powerups sharing a
  group,
- `gProgram_state.current_car.powerups[]` + the headup icon list,
- in netgames, a `ePowerup_gained` message sent under `gLocal_net_ID`.

## Fix
Under `DETHRACE_FIX_BUGS`, when the car is not the local human, run only
the got proc (`HitMine`, which damages and kicks the car passed in) and
return. Original behaviour is unchanged when the flag is off, so binary
accuracy is preserved.

## Testing
Builds clean. The change is a logic-only guard; I have not been able to
run a full in-game repro yet — happy to if a maintainer prefers.
