### PR TITLE
ci: let the reccmp GitHub bot re-use the latest message

### DIFF
--- a/.github/workflows/reccmp-comment.yaml
+++ b/.github/workflows/reccmp-comment.yaml
@@ -44,6 +44,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh pr comment ${{ steps.pr.outputs.number }} \
+            --edit-last \
             --repo "${{ github.repository }}" \
             --body "## reccmp report
 


### PR DESCRIPTION
This reduces bot spam