### PR TITLE
-Wall is for C/C++ compilers only

### DIFF
--- a/src/DETHRACE/CMakeLists.txt
+++ b/src/DETHRACE/CMakeLists.txt
@@ -27,7 +27,7 @@ elseif(MSVC)
     )
 else()
     target_compile_options(dethrace_obj PRIVATE
-        -Wall
+        $<$<COMPILE_LANGUAGE:C,CXX>:-Wall>
     )
     add_compile_flags_if_supported(dethrace_obj
         -Wformat


### PR DESCRIPTION
I was experimenting a bit with ispc for accelerating a few things, and `-Wall` is not supported by the ispc compiler.